### PR TITLE
Remove lightrail worker from the build definition

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -46,3 +46,14 @@ jobs:
         inputs:
           PathtoPublish: 'packages/office-ui-fabric-react/dist/office-ui-fabric-react.js'
           ArtifactName: oufrdrop
+
+  # - job: lightrail
+  #   pool: server
+  #   dependsOn: build
+  #   steps:
+  #     - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
+  #       displayName: 'Size Auditor Check on LightRail'
+  #       inputs:
+  #         connectedServiceName: lowimpact
+  #         sourceVersionMessage: '$(Build.SourceVersionMessage)'
+  #         sizeTolerance: 1024


### PR DESCRIPTION
Removing lightrail worker from the build definition to get some down time for debugging failing lightrail jobs. Will bring it back on as soon as we figure this out.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10283)