### PR TITLE
GroupedList: Fix header click toggling group selection when !SelectionMode.multiple

### DIFF
--- a/change/office-ui-fabric-react-2020-01-15-16-53-30-keco-groupedlist.json
+++ b/change/office-ui-fabric-react-2020-01-15-16-53-30-keco-groupedlist.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "GroupedList: Only invoke range selection on header click when in multiple selection mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "acb240ee8505ba72dc4a2644e9809600d597a2d7",
+  "date": "2020-01-16T00:53:30.385Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -280,8 +280,10 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   };
 
   private _onToggleSelectGroup = (group: IGroup): void => {
-    if (group) {
-      this.props.selection!.toggleRangeSelected(group.startIndex, group.count);
+    const { selection, selectionMode } = this.props;
+
+    if (group && selection && selectionMode === SelectionMode.multiple) {
+      selection.toggleRangeSelected(group.startIndex, group.count);
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, there's a bug with `GroupedList` where header clicks toggle selection of the group regardless of SelectionMode passed via props. We even hide the "Toggle all" check input, but allow the programmatic selection toggle.

**Bug repro:** https://codepen.io/kevintcoughlin/pen/KKwxdaG

@kevincheng6040 discovered this bug while working on SPO. We are using this mitigation for now: https://codepen.io/kevintcoughlin/pen/bGNxVWM?editors=1010.

#### Focus areas to test

- CI should pass.
- Modify `GroupedList` basic example to pass-in `selectionMode={SelectionMode.single}`
- Click a group header
- __Before__ these changes, the group's selection is toggled.
- __After__ these changes, the group's selection is toggled _only_ when `selectionMode === SelectionMode.multiple`

cc: @patmill @kevincheng6040


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11726)