### PR TITLE
Convert withViewport decorator to use hooks

### DIFF
--- a/change/office-ui-fabric-react-2020-02-04-12-44-21-viewport-hooks.json
+++ b/change/office-ui-fabric-react-2020-02-04-12-44-21-viewport-hooks.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Convert withViewport decorator to use hooks and memoization",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "355038c22ab9e7b91db9ff1893085a5e517ce1be",
+  "dependentChangeType": "patch",
+  "date": "2020-02-04T20:44:21.590Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -402,7 +402,7 @@ describe('DetailsList', () => {
     columns[0].onColumnResize = jest.fn();
     columns[1].onColumnResize = jest.fn();
 
-    mount(
+    const list = mount(
       <DetailsList
         items={mockData(2)}
         columns={columns}
@@ -410,6 +410,13 @@ describe('DetailsList', () => {
         onShouldVirtualize={() => false}
       />,
     );
+
+    list.setProps({
+      viewport: {
+        width: 600,
+        height: 400
+      }
+    });
 
     expect(columns[0].onColumnResize).toHaveBeenCalledTimes(1);
     expect(columns[1].onColumnResize).toHaveBeenCalledTimes(1);

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.scss
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.scss
@@ -1,0 +1,3 @@
+.root {
+  display: none;
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -40,7 +40,6 @@ export interface IWithViewportProps {
 }
 
 const RESIZE_DELAY = 500;
-const MAX_RESIZE_ATTEMPTS = 3;
 
 /**
  * A decorator to update decorated component on viewport or window resize events.
@@ -50,149 +49,121 @@ const MAX_RESIZE_ATTEMPTS = 3;
 export function withViewport<TProps extends { viewport?: IViewport }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>,
 ): any {
-  return class WithViewportComponent extends BaseDecorator<TProps, IWithViewportState> {
-    private _root = React.createRef<HTMLDivElement>();
-    private _resizeAttempts: number;
-    private _viewportResizeObserver: any;
-    private _async: Async;
-    private _events: EventGroup;
+  /**
+   * Hook-based wrapper component which measures the size of a 'viewport' div within its scrollable
+   * region and passes the measured size to its wrapped content.
+   */
+  // tslint:disable-next-line:function-name max-line-length
+  function WithViewportBase(props: TProps, forwardedRef: React.Ref<React.Component<TProps, TState>>): JSX.Element {
+    const { skipViewportMeasures } = props as IWithViewportProps;
 
-    constructor(props: TProps) {
-      super(props);
+    const [viewport, setViewport] = React.useState<IViewport | undefined>();
 
-      this._async = new Async(this);
-      this._events = new EventGroup(this);
-      this._resizeAttempts = 0;
+    const setViewportRef = React.useRef<typeof setViewport>();
+    setViewportRef.current = setViewport;
 
-      this.state = {
-        viewport: {
-          width: 0,
-          height: 0,
-        },
+    React.useEffect(() => {
+      return () => {
+        setViewportRef.current = undefined;
       };
+    }, []);
+
+    const rootRef = React.useRef<HTMLDivElement | null>(null);
+
+    function updateViewport(): void {
+      const viewportElement = rootRef.current;
+      const scrollElement = viewportElement && findScrollableParent(viewportElement);
+      const scrollRect = scrollElement && getRect(scrollElement);
+      const clientRect = viewportElement && getRect(viewportElement);
+
+      const width = clientRect && clientRect.width;
+      const height = scrollRect && scrollRect.height;
+
+      if (setViewportRef.current) {
+        setViewportRef.current((previousViewport: IViewport | undefined) => {
+          if (!previousViewport ||
+            (width && width !== previousViewport.width) ||
+            (height && height !== previousViewport.height)) {
+            if (width && height) {
+              return {
+                width,
+                height
+              };
+            }
+          }
+
+          return previousViewport;
+        });
+      }
     }
 
-    public componentDidMount(): void {
-      const { skipViewportMeasures } = this.props as IWithViewportProps;
-      const win = getWindow(this._root.current);
-
-      this._onAsyncResize = this._async.debounce(this._onAsyncResize, RESIZE_DELAY, {
-        leading: false,
-      });
-
-      // ResizeObserver seems always fire even window is not resized. This is
-      // particularly bad when skipViewportMeasures is set when optimizing fixed layout lists.
-      // It will measure and update and re-render the entire list after list is fully rendered.
-      // So fallback to listen to resize event when skipViewportMeasures is set.
-      if (!skipViewportMeasures && this._isResizeObserverAvailable()) {
-        this._registerResizeObserver();
-      } else {
-        this._events.on(win, 'resize', this._onAsyncResize);
-      }
-
+    React.useLayoutEffect(() => {
+      // Use a layout effect for compatibility with existing unit tests.
       if (!skipViewportMeasures) {
-        this._updateViewport();
+        updateViewport();
       }
-    }
+    }, [skipViewportMeasures]);
 
-    public componentDidUpdate(newProps: TProps) {
-      const { skipViewportMeasures: oldSkipViewportMeasures } = this.props as IWithViewportProps;
-      const { skipViewportMeasures: newSkipViewportMeasures } = newProps as IWithViewportProps;
-      const win = getWindow(this._root.current);
+    React.useLayoutEffect(() => {
+      // Use a layout effect for compatibility with existing unit tests.
+      const viewportElement = rootRef.current;
+      const currentWindow = viewportElement && getWindow(viewportElement);
 
-      if (oldSkipViewportMeasures !== newSkipViewportMeasures) {
-        if (newSkipViewportMeasures) {
-          this._unregisterResizeObserver();
-          this._events.on(win, 'resize', this._onAsyncResize);
-        } else if (!newSkipViewportMeasures && this._isResizeObserverAvailable()) {
-          this._events.off(win, 'resize', this._onAsyncResize);
-          this._registerResizeObserver();
+      const isResizeObserverAvailable = !!currentWindow && !!(currentWindow as any).ResizeObserver;
+
+      if (!skipViewportMeasures && isResizeObserverAvailable) {
+        if (currentWindow && viewportElement) {
+          const async = new Async();
+
+          const onAsyncResize = async.debounce(updateViewport, RESIZE_DELAY, { leading: false });
+
+          const resizeObserver = new (currentWindow as any).ResizeObserver(onAsyncResize);
+          resizeObserver.observe(viewportElement);
+
+          return () => {
+            async.dispose();
+            resizeObserver.disconnect();
+          };
         }
-      }
-
-      if (!!newSkipViewportMeasures) {
-        this._updateViewport();
-      }
-    }
-
-    public componentWillUnmount(): void {
-      this._events.dispose();
-      this._async.dispose();
-      this._unregisterResizeObserver();
-    }
-
-    public render(): JSX.Element {
-      const { viewport } = this.state;
-      const newViewport = viewport!.width > 0 && viewport!.height > 0 ? viewport : undefined;
-
-      return (
-        <div className="ms-Viewport" ref={this._root} style={{ minWidth: 1, minHeight: 1 }}>
-          <ComposedComponent ref={this._updateComposedComponentRef} viewport={newViewport} {...(this.props as any)} />
-        </div>
-      );
-    }
-
-    public forceUpdate(): void {
-      this._updateViewport(true);
-    }
-
-    private _onAsyncResize(): void {
-      this._updateViewport();
-    }
-
-    private _isResizeObserverAvailable(): boolean {
-      const win = getWindow(this._root.current);
-
-      return win && (win as any).ResizeObserver;
-    }
-
-    private _registerResizeObserver = () => {
-      const win = getWindow(this._root.current);
-
-      this._viewportResizeObserver = new (win as any).ResizeObserver(this._onAsyncResize);
-      this._viewportResizeObserver.observe(this._root.current);
-    };
-
-    private _unregisterResizeObserver = () => {
-      if (this._viewportResizeObserver) {
-        this._viewportResizeObserver.disconnect();
-        delete this._viewportResizeObserver;
-      }
-    };
-
-    /* Note: using lambda here because decorators don't seem to work in decorators. */
-    private _updateViewport = (withForceUpdate?: boolean) => {
-      const { viewport } = this.state;
-      const viewportElement = this._root.current;
-      const scrollElement = findScrollableParent(viewportElement);
-      const scrollRect = getRect(scrollElement);
-      const clientRect = getRect(viewportElement);
-      const updateComponent = () => {
-        if (withForceUpdate && this._composedComponentInstance) {
-          this._composedComponentInstance.forceUpdate();
-        }
-      };
-
-      const isSizeChanged =
-        (clientRect && clientRect.width) !== viewport!.width || (scrollRect && scrollRect.height) !== viewport!.height;
-
-      if (isSizeChanged && this._resizeAttempts < MAX_RESIZE_ATTEMPTS && clientRect && scrollRect) {
-        this._resizeAttempts++;
-        this.setState(
-          {
-            viewport: {
-              width: clientRect.width,
-              height: scrollRect.height,
-            },
-          },
-          () => {
-            this._updateViewport(withForceUpdate);
-          },
-        );
       } else {
-        this._resizeAttempts = 0;
-        updateComponent();
+        if (currentWindow) {
+          const events = new EventGroup(null);
+          const async = new Async();
+
+          const onAsyncResize = async.debounce(updateViewport, RESIZE_DELAY, { leading: false });
+
+          events.on(currentWindow, 'resize', onAsyncResize);
+
+          return () => {
+            events.dispose();
+            async.dispose();
+          };
+        }
       }
-    };
-  };
+    }, [skipViewportMeasures]);
+
+    const componentElement = React.useMemo(() => {
+      return <ComposedComponent ref={forwardedRef} viewport={viewport} {...props} />;
+    }, [viewport, props, forwardedRef]);
+
+    return (
+      <div className="ms-Viewport" ref={rootRef} style={{ minWidth: 1, minHeight: 1 }}>
+        {componentElement}
+      </div>
+    );
+  }
+
+  const WithViewport = React.forwardRef(WithViewportBase);
+
+  /**
+   * Old-style React component used to wrap hook-based logic to avoid
+   * changing the contract for callers.
+   */
+  class WithViewportComponent extends BaseDecorator<TProps, IWithViewportState> {
+    public render(): JSX.Element {
+      return <WithViewport {...(this.props as any)} ref={this._updateComposedComponentRef} />;
+    }
+  }
+
+  return WithViewportComponent;
 }


### PR DESCRIPTION
Converted the `withViewport` decorator component to use hooks, which ensures that it better-manages subscriptions to `resize` events using `ResizeObserver` or `window`. Also, added memoization of the render output against the `props` change to try to prevent 'thrashing'. Leveraged the new `useEffect` to move the layout measurement out of the critical phase of the React render pipeline as another attempt to cut down on re-renders.

Converted `withResponsiveMode` to use hooks for similar performance improvements, and added an `initializeResponsiveMode()` function which can be used to set the default responsive mode based on the current window size. This avoids having the default `responsiveMode` be used during the first render pass.

Unfortunately, in order to get access to the current `window` for the instance of `withResponsiveMode`, we need to insert a dummy `<div />` (with `display: none`) into the DOM. This triggers a round of snapshot updates.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11870)