### PR TITLE
Combobox: Fix selected text not appearing to be selected

### DIFF
--- a/change/office-ui-fabric-react-2020-02-07-11-59-59-fix-comboboxhighlight.json
+++ b/change/office-ui-fabric-react-2020-02-07-11-59-59-fix-comboboxhighlight.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Combobox: fix selected item not appearing with different background color",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "84410c47013bc59c4e79c9676ee1f74c41c3f877",
+  "dependentChangeType": "patch",
+  "date": "2020-02-07T19:59:59.414Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -71,7 +71,7 @@ export const getOptionStyles = memoizeFunction(
     theme: ITheme,
     customStylesForAllOptions?: Partial<IComboBoxOptionStyles>,
     customOptionStylesForCurrentOption?: Partial<IComboBoxOptionStyles>,
-    isPending?: boolean,
+    isSelected?: boolean,
     isHidden?: boolean
   ): Partial<IComboBoxOptionStyles> => {
     const { palette, semanticColors } = theme;
@@ -89,7 +89,7 @@ export const getOptionStyles = memoizeFunction(
       root: [
         theme.fonts.medium,
         {
-          backgroundColor: isPending ? option.backgroundHoveredColor : 'transparent',
+          backgroundColor: isSelected ? option.backgroundSelectedColor : 'transparent',
           boxSizing: 'border-box',
           cursor: 'pointer',
           display: isHidden ? 'none' : 'block',
@@ -127,20 +127,14 @@ export const getOptionStyles = memoizeFunction(
         backgroundColor: option.backgroundHoveredColor,
         color: option.textHoveredColor
       },
-      rootFocused: {
-        backgroundColor: option.backgroundHoveredColor
-      },
       rootChecked: [
         {
-          backgroundColor: option.backgroundSelectedColor,
+          // The currently selected item should always have a background color. Otherwise it should be transparent.
+          // Root can be checked to indicate the current pending option that will be selected when enter is pressed.
+          backgroundColor: isSelected ? option.backgroundSelectedColor : 'transparent',
           color: option.textSelectedColor,
           selectors: {
-            ':hover': [
-              {
-                backgroundColor: option.backgroundHoveredColor
-              },
-              listOptionHighContrastStyles
-            ]
+            ':hover': [{ backgroundColor: option.backgroundHoveredColor }, listOptionHighContrastStyles]
           }
         },
         getFocusStyle(theme, { inset: -1, isFocusedOnly: false }),

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -81,6 +81,7 @@ export const getOptionStyles = memoizeFunction(
       textSelectedColor: palette.neutralDark,
       textDisabledColor: semanticColors.disabledText,
       backgroundHoveredColor: semanticColors.menuItemBackgroundHovered,
+      backgroundSelectedColor: semanticColors.menuItemBackgroundChecked,
       backgroundPressedColor: semanticColors.menuItemBackgroundPressed
     };
 
@@ -131,7 +132,7 @@ export const getOptionStyles = memoizeFunction(
       },
       rootChecked: [
         {
-          backgroundColor: 'transparent',
+          backgroundColor: option.backgroundSelectedColor,
           color: option.textSelectedColor,
           selectors: {
             ':hover': [

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1359,16 +1359,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * we do not have a valid index and we currently have a pending input value,
    * otherwise use the selected index
    * */
+  // return index === this._getFirstSelectedIndex() || this._getPendingSelectedIndex(true /* includePendingValue */) === index;
   private _isOptionSelected(index: number | undefined): boolean {
-    const { currentPendingValueValidIndexOnHover } = this.state;
-
-    // If the hover state is set to clearAll, don't show a selected index.
-    // Note, this happens when the user moused out of the menu items
-    if (currentPendingValueValidIndexOnHover === HoverStatus.clearAll) {
-      return false;
-    }
-
-    return this._getPendingSelectedIndex(true /* includePendingValue */) === index ? true : false;
+    return index === this._getFirstSelectedIndex() || this._getPendingSelectedIndex(true /* includePendingValue */) === index;
   }
 
   private _isOptionChecked(index: number | undefined): boolean {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -2031,9 +2031,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &:hover .ms-Button-icon {
                           color: #0078d4;
                         }
-                        &:focus {
-                          background-color: #f3f2f1;
-                        }
                         &:active {
                           color: #000000;
                         }
@@ -2108,7 +2105,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
-                          background-color: transparent;
+                          background-color: #edebe9;
                           border-color: transparent;
                           border-radius: 0px;
                           border-style: solid;
@@ -2349,9 +2346,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &:hover .ms-Button-icon {
                           color: #0078d4;
                         }
-                        &:focus {
-                          background-color: #f3f2f1;
-                        }
                         &:active {
                           color: #000000;
                         }
@@ -2505,9 +2499,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
-                        }
-                        &:focus {
-                          background-color: #f3f2f1;
                         }
                         &:active {
                           color: #000000;
@@ -2711,9 +2702,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
-                        }
-                        &:focus {
-                          background-color: #f3f2f1;
                         }
                         &:active {
                           color: #000000;
@@ -3017,9 +3005,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &:hover .ms-Button-icon {
                           color: #0078d4;
                         }
-                        &:focus {
-                          background-color: #f3f2f1;
-                        }
                         &:active {
                           color: #000000;
                         }
@@ -3173,9 +3158,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
-                        }
-                        &:focus {
-                          background-color: #f3f2f1;
                         }
                         &:active {
                           color: #000000;
@@ -3331,9 +3313,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &:hover .ms-Button-icon {
                           color: #0078d4;
                         }
-                        &:focus {
-                          background-color: #f3f2f1;
-                        }
                         &:active {
                           color: #000000;
                         }
@@ -3487,9 +3466,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
-                        }
-                        &:focus {
-                          background-color: #f3f2f1;
                         }
                         &:active {
                           color: #000000;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #4992
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The currently selected option now appears selected.

Before:
![image](https://user-images.githubusercontent.com/20801176/74061766-9d8c4780-49a1-11ea-8940-3b464adfc293.png)

After:
![image](https://user-images.githubusercontent.com/20801176/74061786-a8df7300-49a1-11ea-92e2-82e4bc9ad613.png)

Needs design assistance with the image below. Basically the selected option (current value) and the current active item (the one activated by keyboarding) have the same style. I am uncertain as to what the expected behavior is. Pressing escape with revert to the current value, so it makes sense that it should still be highlighted, but what color should it be? Overall this is still an improvement in clarity. @betrue-final-final or @jspurlin  could you weigh in on expected colors/behavior?

![image](https://user-images.githubusercontent.com/20801176/74061815-b8f75280-49a1-11ea-8a94-275f4097e781.png)




#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11900)