### PR TITLE
Add `domRef` property to most components to allow access to underlying DOM elements without need for deprecated `React.findDOMNode`

### DIFF
--- a/change/@uifabric-utilities-2020-02-13-10-35-17-add-dom-ref.json
+++ b/change/@uifabric-utilities-2020-02-13-10-35-17-add-dom-ref.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add utility to merge several `IRefObject`s into one `IRefObject` to pass to a JSX.Element",
+  "packageName": "@uifabric/utilities",
+  "email": "miclo@microsoft.com",
+  "commit": "a9a43652e0200a11ac209b1921c383016ce515e9",
+  "dependentChangeType": "patch",
+  "date": "2020-02-13T18:35:17.650Z"
+}

--- a/change/office-ui-fabric-react-2020-02-13-10-35-17-add-dom-ref.json
+++ b/change/office-ui-fabric-react-2020-02-13-10-35-17-add-dom-ref.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add `domRef` property to most components, allowing access to underlying DOMElements without using the deprecated `ReactDOM.findDOMNode()`",
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com",
+  "commit": "a9a43652e0200a11ac209b1921c383016ce515e9",
+  "dependentChangeType": "patch",
+  "date": "2020-02-13T18:34:30.669Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1474,6 +1474,7 @@ export interface IActivityItemProps extends React.AllHTMLAttributes<HTMLElement>
     comments?: React.ReactNode[] | React.ReactNode;
     // @deprecated
     commentText?: string;
+    domRef?: IRefObject<HTMLDivElement>;
     isCompact?: boolean;
     onRenderActivityDescription?: IRenderFunction<IActivityItemProps>;
     onRenderComments?: IRenderFunction<IActivityItemProps>;
@@ -1536,6 +1537,7 @@ export interface IAutofill {
 export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputElement | Autofill> {
     componentRef?: IRefObject<IAutofill>;
     defaultVisibleValue?: string;
+    domRef?: IRefObject<HTMLInputElement>;
     enableAutofillOnKeyPress?: KeyCodes[];
     onInputChange?: (value: string, composing: boolean) => string;
     onInputValueChange?: (newValue?: string, composing?: boolean) => void;
@@ -1587,6 +1589,7 @@ export interface IBaseExtendedPickerProps<T> {
     currentRenderedQueryString?: string;
     defaultSelectedItems?: T[];
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     floatingPickerProps: IBaseFloatingPickerProps<T>;
     focusZoneProps?: IFocusZoneProps;
     headerComponent?: JSX.Element;
@@ -1633,6 +1636,7 @@ export interface IBaseFloatingPickerProps<T> extends React.ClassAttributes<any> 
     // (undocumented)
     componentRef?: IRefObject<IBaseFloatingPicker>;
     createGenericItem?: (input: string, isValid: boolean) => ISuggestionModel<T>;
+    domRef?: IRefObject<HTMLDivElement>;
     getTextFromItem?: (item: T, currentValue?: string) => string;
     inputElement?: HTMLInputElement | null;
     onChange?: (item: T) => void;
@@ -1684,6 +1688,7 @@ export interface IBasePickerProps<T> extends React.Props<any> {
     createGenericItem?: (input: string, ValidationState: ValidationState) => ISuggestionModel<T> | T;
     defaultSelectedItems?: T[];
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     enableSelectedSuggestionAlert?: boolean;
     getTextFromItem?: (item: T, currentValue?: string) => string;
     inputProps?: IInputProps;
@@ -1825,6 +1830,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     className?: string;
     componentRef?: IRefObject<IBreadcrumb>;
     dividerAs?: IComponentAs<IDividerAsProps>;
+    domRef?: IRefObject<HTMLDivElement>;
     focusZoneProps?: IFocusZoneProps;
     items: IBreadcrumbItem[];
     maxDisplayedItems?: number;
@@ -1891,6 +1897,7 @@ export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement 
     // @deprecated
     description?: IStyle;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
     // Warning: (ae-forgotten-export) The symbol "IButtonClassNames" needs to be exported by the entry point index.d.ts
     getClassNames?: (theme: ITheme, className: string, variantClassName: string, iconClassName: string | undefined, menuIconClassName: string | undefined, disabled: boolean, checked: boolean, expanded: boolean, hasMenu: boolean, isSplit: boolean | undefined, allowDisabledFocus: boolean) => IButtonClassNames;
     // Warning: (ae-forgotten-export) The symbol "ISplitButtonClassNames" needs to be exported by the entry point index.d.ts
@@ -2019,6 +2026,7 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
     componentRef?: IRefObject<ICalendar>;
     dateRangeType?: DateRangeType;
     dateTimeFormatter?: ICalendarFormatDateCallbacks;
+    domRef?: IRefObject<HTMLDivElement>;
     firstDayOfWeek?: DayOfWeek;
     firstWeekOfYear?: FirstWeekOfYear;
     highlightCurrentMonth?: boolean;
@@ -2111,6 +2119,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
     directionalHint?: DirectionalHint;
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
+    domRef?: IRefObject<HTMLDivElement>;
     doNotLayer?: boolean;
     finalHeight?: number;
     gapSpace?: number;
@@ -2168,6 +2177,7 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
     defaultChecked?: boolean;
     defaultIndeterminate?: boolean;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     indeterminate?: boolean;
     inputProps?: React.ButtonHTMLAttributes<HTMLElement | HTMLButtonElement>;
     keytipProps?: IKeytipProps;
@@ -2220,6 +2230,7 @@ export interface ICheckProps {
     checked?: boolean;
     className?: string;
     componentRef?: IRefObject<ICheckProps>;
+    domRef?: IRefObject<HTMLDivElement>;
     styles?: IStyleFunctionOrObject<ICheckStyleProps, ICheckStyles>;
     theme?: ITheme;
     useFastIcons?: boolean;
@@ -2323,6 +2334,7 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
     ariaLabelledBy?: string;
     componentRef?: IRefObject<IChoiceGroup>;
     defaultSelectedKey?: string | number;
+    domRef?: IRefObject<HTMLDivElement>;
     label?: string;
     onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption) => void;
     // @deprecated
@@ -2390,6 +2402,7 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
     componentRef?: IRefObject<ICoachmark>;
     delayBeforeCoachmarkAnimation?: number;
     delayBeforeMouseOpen?: number;
+    domRef?: IRefObject<HTMLDivElement>;
     // @deprecated
     height?: number;
     isCollapsed?: boolean;
@@ -2494,6 +2507,7 @@ export interface IColorPickerGridCellProps {
     circle?: boolean;
     color?: string;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
     height?: number;
     // @deprecated
     id?: string;
@@ -2548,6 +2562,7 @@ export interface IColorPickerProps {
     className?: string;
     color: IColor | string;
     componentRef?: IRefObject<IColorPicker>;
+    domRef?: IRefObject<HTMLDivElement>;
     // @deprecated
     greenLabel?: string;
     // @deprecated
@@ -2784,6 +2799,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
     caretDownButtonStyles?: Partial<IButtonStyles>;
     comboBoxOptionStyles?: Partial<IComboBoxOptionStyles>;
     componentRef?: IRefObject<IComboBox>;
+    domRef?: IRefObject<HTMLDivElement>;
     dropdownMaxWidth?: number;
     dropdownWidth?: number;
     // Warning: (ae-forgotten-export) The symbol "IComboBoxClassNames" needs to be exported by the entry point index.d.ts
@@ -2879,6 +2895,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<ICommandBar>;
     dataDidRender?: (renderedData: any) => void;
+    domRef?: IRefObject<HTMLDivElement>;
     farItems?: ICommandBarItemProps[];
     items: ICommandBarItemProps[];
     onDataGrown?: (movedItem: ICommandBarItemProps) => void;
@@ -3061,6 +3078,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     directionalHint?: DirectionalHint;
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
+    domRef?: IRefObject<HTMLDivElement>;
     doNotLayer?: boolean;
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
@@ -3186,6 +3204,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
     dateTimeFormatter?: ICalendarFormatDateCallbacks;
     disableAutoFocus?: boolean;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     firstDayOfWeek?: DayOfWeek;
     firstWeekOfYear?: FirstWeekOfYear;
     formatDate?: (date?: Date) => string;
@@ -3496,6 +3515,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
     componentRef?: IRefObject<IDetailsList>;
     constrainMode?: ConstrainMode;
     disableSelectionZone?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     dragDropEvents?: IDragDropEvents;
     enableUpdateAnimations?: boolean;
     enterModalSelectionOnTouch?: boolean;
@@ -3848,6 +3868,7 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
     // @deprecated
     contentClassName?: string;
     dialogContentProps?: IDialogContentProps;
+    domRef?: IRefObject<HTMLDivElement>;
     hidden?: boolean;
     // @deprecated
     isBlocking?: boolean;
@@ -4196,6 +4217,7 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
     children?: React.ReactNode;
     className?: string;
     componentRef?: IRefObject<IDocumentCard>;
+    domRef?: IRefObject<HTMLDivElement>;
     onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
     onClickHref?: string;
     role?: string;
@@ -4352,6 +4374,7 @@ export interface IDropdownOption extends ISelectableOption {
 // @public (undocumented)
 export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement> {
     defaultSelectedKeys?: string[] | number[];
+    domRef?: IRefObject<HTMLDivElement>;
     dropdownWidth?: number;
     // @deprecated
     isDisabled?: boolean;
@@ -4482,6 +4505,7 @@ export interface IExpandingCard {
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
+    domRef?: IRefObject<HTMLDivElement>;
     expandedCardHeight?: number;
     mode?: ExpandingCardMode;
     onRenderCompactCard?: IRenderFunction<any>;
@@ -4590,6 +4614,7 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
     chevronButtonProps?: IButtonProps;
     className?: string;
     componentRef?: IRefObject<IFacepile>;
+    domRef?: IRefObject<HTMLDivElement>;
     getPersonaProps?: (persona: IFacepilePersona) => IPersonaSharedProps;
     maxDisplayablePersonas?: number;
     onRenderPersona?: IRenderFunction<IFacepilePersona>;
@@ -4650,6 +4675,7 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
     componentRef?: IRefObject<IFocusTrapZone>;
     disabled?: boolean;
     disableFirstFocus?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     elementToFocusOnDismiss?: HTMLElement;
     firstFocusableSelector?: string | (() => string);
     focusPreviouslyFocusedInnerElement?: boolean;
@@ -4727,6 +4753,7 @@ export interface IGridCellProps<T> {
     cellIsSelectedStyle?: string[];
     className?: string;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
     getClassNames?: (theme: ITheme, className: string, variantClassName: string, iconClassName: string | undefined, menuIconClassName: string | undefined, disabled: boolean, checked: boolean, expanded: boolean, isSplit: boolean | undefined) => IButtonClassNames;
     id: string;
     index?: number;
@@ -4753,6 +4780,7 @@ export interface IGridProps extends React.TableHTMLAttributes<HTMLTableElement> 
     componentRef?: IRefObject<IGrid>;
     // @deprecated
     containerClassName?: string;
+    domRef?: IRefObject<HTMLTableElement>;
     doNotContainWithinFocusZone?: boolean;
     items: any[];
     onBlur?: () => void;
@@ -4838,6 +4866,7 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
     className?: string;
     compact?: boolean;
     componentRef?: IRefObject<IGroupedList>;
+    domRef?: IRefObject<HTMLDivElement>;
     dragDropEvents?: IDragDropEvents;
     dragDropHelper?: IDragDropHelper;
     eventsToRegister?: {
@@ -5001,6 +5030,7 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement> {
     cardOpenDelay?: number;
     className?: string;
     componentRef?: IRefObject<IHoverCard>;
+    domRef?: IRefObject<HTMLDivElement>;
     eventListenerTarget?: HTMLElement | string | null;
     expandedCardOpenDelay?: number;
     expandingCardProps?: IExpandingCardProps;
@@ -5070,6 +5100,7 @@ export interface IIconContent {
 export interface IIconProps extends IBaseProps, React.HTMLAttributes<HTMLElement> {
     // @deprecated
     ariaLabel?: string;
+    domRef?: IRefObject<HTMLSpanElement | HTMLImageElement>;
     iconName?: string;
     // @deprecated
     iconType?: IconType;
@@ -5124,6 +5155,7 @@ export interface IImageIconProps extends React.HTMLAttributes<HTMLElement> {
 export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
     className?: string;
     coverStyle?: ImageCoverStyle;
+    domRef?: IRefObject<HTMLDivElement>;
     // @deprecated
     errorSrc?: string;
     imageFit?: ImageFit;
@@ -5221,6 +5253,7 @@ export interface IKeytipProps {
     calloutProps?: ICalloutProps;
     content: string;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     hasDynamicChildren?: boolean;
     hasMenu?: boolean;
     keySequences: string[];
@@ -5406,6 +5439,7 @@ export interface IList {
 export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<IList>;
+    domRef?: IRefObject<HTMLDivElement>;
     getItemCountForPage?: (itemIndex?: number, visibleRect?: IRectangle) => number;
     getKey?: (item: T, index?: number) => string;
     getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle, itemCount?: number) => number;
@@ -5490,6 +5524,7 @@ export interface IMarqueeSelection {
 export interface IMarqueeSelectionProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<IMarqueeSelection>;
+    domRef?: IRefObject<HTMLDivElement>;
     isDraggingConstrainedToRoot?: boolean;
     isEnabled?: boolean;
     onShouldStartSelection?: (ev: MouseEvent) => boolean;
@@ -5549,6 +5584,7 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement> {
     componentRef?: IRefObject<IMessageBar>;
     dismissButtonAriaLabel?: string;
     dismissIconProps?: IIconProps;
+    domRef?: IRefObject<HTMLDivElement>;
     isMultiline?: boolean;
     messageBarIconProps?: IIconProps;
     messageBarType?: MessageBarType;
@@ -5607,6 +5643,7 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
     className?: string;
     componentRef?: IRefObject<IModal>;
     containerClassName?: string;
+    domRef?: IRefObject<HTMLDivElement>;
     dragOptions?: IDragOptions;
     isBlocking?: boolean;
     isDarkOverlay?: boolean;
@@ -5703,6 +5740,7 @@ export interface INavProps {
     ariaLabel?: string;
     className?: string;
     componentRef?: IRefObject<INav>;
+    domRef?: IRefObject<HTMLDivElement>;
     // @deprecated
     expandButtonAriaLabel?: string;
     groups: INavLinkGroup[] | null;
@@ -5789,6 +5827,7 @@ export interface IOverflowSetItemProps {
 export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase> {
     className?: string;
     componentRef?: IRefObject<IOverflowSet>;
+    domRef?: IRefObject<HTMLDivElement>;
     // @deprecated
     doNotContainWithinFocusZone?: boolean;
     // @deprecated
@@ -5823,6 +5862,7 @@ export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
     allowTouchBodyScroll?: boolean;
     className?: string;
     componentRef?: IRefObject<IOverlay>;
+    domRef?: IRefObject<HTMLDivElement>;
     isDarkThemed?: boolean;
     // (undocumented)
     onClick?: () => void;
@@ -5907,6 +5947,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     componentId?: string;
     componentRef?: IRefObject<IPanel>;
     customWidth?: string;
+    domRef?: IRefObject<HTMLDivElement>;
     elementToFocusOnDismiss?: HTMLElement;
     // @deprecated
     firstFocusableSelector?: string;
@@ -6117,6 +6158,7 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
     allowPhoneInitials?: boolean;
     coinProps?: IPersonaCoinProps;
     coinSize?: number;
+    domRef?: IRefObject<HTMLDivElement>;
     hidePersonaDetails?: boolean;
     imageAlt?: string;
     imageInitials?: string;
@@ -6220,6 +6262,7 @@ export interface IPivot {
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
+    domRef?: IRefObject<HTMLDivElement>;
     headerButtonProps?: {
         [key: string]: string | number | boolean;
     };
@@ -6239,6 +6282,7 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
     componentRef?: IRefObject<IPivot>;
     defaultSelectedIndex?: number;
     defaultSelectedKey?: string;
+    domRef?: IRefObject<HTMLDivElement>;
     getTabId?: (itemKey: string, index: number) => string;
     headersOnly?: boolean;
     // @deprecated
@@ -6291,6 +6335,7 @@ export interface IPlainCard {
 
 // @public
 export interface IPlainCardProps extends IBaseCardProps<IPlainCard, IPlainCardStyles, IPlainCardStyleProps> {
+    domRef?: IRefObject<HTMLDivElement>;
     onRenderPlainCard?: IRenderFunction<any>;
 }
 
@@ -6308,6 +6353,7 @@ export interface IPopupProps extends React.HTMLAttributes<Popup> {
     ariaLabel?: string;
     ariaLabelledBy?: string;
     className?: string;
+    domRef?: IRefObject<HTMLDivElement>;
     onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => any;
     role?: string;
     shouldRestoreFocus?: boolean;
@@ -6336,6 +6382,7 @@ export interface IPositioningContainerProps extends IBaseProps<IPositioningConta
     directionalHint?: DirectionalHint;
     directionalHintFixed?: boolean;
     directionalHintForRTL?: DirectionalHint;
+    domRef?: IRefObject<HTMLDivElement>;
     doNotLayer?: boolean;
     finalHeight?: number;
     minPagePadding?: number;
@@ -6371,6 +6418,7 @@ export interface IProgressIndicatorProps extends React.ClassAttributes<ProgressI
     barHeight?: number;
     className?: string;
     description?: React.ReactNode;
+    domRef?: IRefObject<HTMLDivElement>;
     label?: React.ReactNode;
     onRenderProgress?: IRenderFunction<IProgressIndicatorProps>;
     percentComplete?: number;
@@ -6417,6 +6465,7 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
     // @deprecated
     ariaLabelId?: string;
     componentRef?: IRefObject<IRating>;
+    domRef?: IRefObject<HTMLDivElement>;
     // (undocumented)
     getAriaLabel?: (rating: number, max: number) => string;
     icon?: string;
@@ -6488,6 +6537,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
     data: any;
     dataDidRender?: (renderedData: any) => void;
     direction?: ResizeGroupDirection;
+    domRef?: IRefObject<HTMLDivElement>;
     onGrowData?: (prevData: any) => any;
     onReduceData: (prevData: any) => any;
     onRenderData: (data: any) => JSX.Element;
@@ -6548,6 +6598,7 @@ export interface IScrollablePaneContext {
 export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement | ScrollablePaneBase> {
     className?: string;
     componentRef?: IRefObject<IScrollablePane>;
+    domRef?: IRefObject<HTMLDivElement>;
     initialScrollPosition?: number;
     // (undocumented)
     scrollbarVisibility?: ScrollbarVisibility;
@@ -6602,6 +6653,7 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
     // @deprecated
     defaultValue?: string;
     disableAnimation?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     iconProps?: Pick<IIconProps, Exclude<keyof IIconProps, 'className'>>;
     // @deprecated
     labelText?: string;
@@ -6769,6 +6821,7 @@ export interface ISeparator {
 // @public (undocumented)
 export interface ISeparatorProps extends React.HTMLAttributes<HTMLElement> {
     alignContent?: 'start' | 'center' | 'end';
+    domRef?: IRefObject<HTMLDivElement>;
     styles?: IStyleFunctionOrObject<ISeparatorStyleProps, ISeparatorStyles>;
     theme?: ITheme;
     vertical?: boolean;
@@ -6941,6 +6994,7 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
     className?: string;
     componentRef?: IRefObject<IShimmer>;
     customElementsGroup?: React.ReactNode;
+    domRef?: IRefObject<HTMLDivElement>;
     isDataLoaded?: boolean;
     shimmerColors?: IShimmerColors;
     shimmerElements?: IShimmerElement[];
@@ -6990,6 +7044,7 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
     componentRef?: IRefObject<ISlider>;
     defaultValue?: number;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     label?: string;
     max?: number;
     min?: number;
@@ -7057,6 +7112,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
     decrementButtonIcon?: IIconProps;
     defaultValue?: string;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     downArrowButtonStyles?: Partial<IButtonStyles>;
     // Warning: (ae-forgotten-export) The symbol "ISpinButtonClassNames" needs to be exported by the entry point index.d.ts
     getClassNames?: (theme: ITheme, disabled: boolean, isFocused: boolean, keyboardSpinDirection: KeyboardSpinDirection, labelPosition?: Position, className?: string) => ISpinButtonClassNames;
@@ -7129,6 +7185,7 @@ export interface ISpinnerProps extends React.HTMLAttributes<HTMLElement> {
     ariaLive?: 'assertive' | 'polite' | 'off';
     className?: string;
     componentRef?: IRefObject<ISpinner>;
+    domRef?: IRefObject<HTMLDivElement>;
     label?: string;
     labelPosition?: SpinnerLabelPosition;
     size?: SpinnerSize;
@@ -7254,6 +7311,7 @@ export interface IStickyContext {
 // @public (undocumented)
 export interface IStickyProps extends React.Props<Sticky> {
     componentRef?: IRefObject<IStickyProps>;
+    domRef?: IRefObject<HTMLDivElement>;
     isScrollSynced?: boolean;
     stickyBackgroundColor?: string;
     stickyClassName?: string;
@@ -7471,6 +7529,7 @@ export interface ISwatchColorPickerProps {
     colorCells: IColorCellProps[];
     columnCount: number;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLTableElement>;
     doNotContainWithinFocusZone?: boolean;
     focusOnHover?: boolean;
     getColorGridCellStyles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
@@ -7565,6 +7624,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     ariaLabelledBy?: string;
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITeachingBubble>;
+    domRef?: IRefObject<HTMLDivElement>;
     footerContent?: string | JSX.Element;
     hasCloseButton?: boolean;
     // @deprecated (undocumented)
@@ -7662,6 +7722,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     deferredValidationTime?: number;
     description?: string;
     disabled?: boolean;
+    domRef?: IRefObject<HTMLDivElement>;
     errorMessage?: string | JSX.Element;
     iconProps?: IIconProps;
     inputClassName?: string;
@@ -7868,6 +7929,7 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
     delay?: TooltipDelay;
     directionalHint?: DirectionalHint;
     directionalHintForRTL?: DirectionalHint;
+    domRef?: IRefObject<HTMLDivElement>;
     hostClassName?: string;
     id?: string;
     onTooltipToggle?(isTooltipVisible: boolean): void;
@@ -7907,6 +7969,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
     delay?: TooltipDelay;
     directionalHint?: DirectionalHint;
     directionalHintForRTL?: DirectionalHint;
+    domRef?: IRefObject<HTMLDivElement>;
     maxWidth?: string | null;
     onRenderContent?: IRenderFunction<ITooltipProps>;
     styles?: IStyleFunctionOrObject<ITooltipStyleProps, ITooltipStyles>;
@@ -7943,6 +8006,7 @@ export interface IVerticalDividerClassNames {
 // @public
 export interface IVerticalDividerProps {
     className?: string;
+    domRef?: IRefObject<HTMLSpanElement>;
     // @deprecated (undocumented)
     getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
     styles?: IStyleFunctionOrObject<IVerticalDividerPropsStyles, IVerticalDividerStyles>;

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.tsx
@@ -27,7 +27,7 @@ export class ActivityItem extends React.Component<IActivityItemProps, {}> {
     const classNames = this._getClassNames(this.props);
 
     return (
-      <div className={classNames.root} style={this.props.style}>
+      <div className={classNames.root} style={this.props.style} ref={this.props.domRef}>
         {(this.props.activityPersonas || this.props.activityIcon || this.props.onRenderIcon) && (
           <div className={classNames.activityTypeIcon}>
             {animateBeaconSignal && isCompact && <div className={classNames.pulsingBeacon} />}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyle } from '../../Styling';
-import { IRenderFunction } from '../../Utilities';
+import { IRenderFunction, IRefObject } from '../../Utilities';
 import { IPersonaSharedProps } from '../../Persona';
 
 /**
@@ -94,6 +94,11 @@ export interface IActivityItemProps extends React.AllHTMLAttributes<HTMLElement>
    * @defaultvalue false
    */
   animateBeaconSignal?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IAutofillProps, IAutofill } from './Autofill.types';
-import { BaseComponent, KeyCodes, getNativeProps, inputProperties, isIE11 } from '../../Utilities';
+import { BaseComponent, KeyCodes, getNativeProps, inputProperties, isIE11, mergeRefs } from '../../Utilities';
 
 export interface IAutofillState {
   displayValue?: string;
@@ -123,7 +123,7 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
         autoComplete="off"
         aria-autocomplete={'both'}
         {...nativeProps}
-        ref={this._inputElement}
+        ref={mergeRefs(this._inputElement, this.props.domRef)}
         value={displayValue}
         onCompositionStart={this._onCompositionStart}
         onCompositionUpdate={this._onCompositionUpdate}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.types.ts
@@ -114,6 +114,11 @@ export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputEleme
    * In IE11, selecting a input will also focus the input, causing other element's focus to be stolen.
    */
   preventValueSelection?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLInputElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -87,7 +87,9 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       theme: theme!
     });
 
-    return <ResizeGroup onRenderData={this._onRenderBreadcrumb} onReduceData={onReduceData} data={breadcrumbData} />;
+    return (
+      <ResizeGroup onRenderData={this._onRenderBreadcrumb} onReduceData={onReduceData} data={breadcrumbData} domRef={this.props.domRef} />
+    );
   }
 
   private _onReduceData = (data: IBreadcrumbData): IBreadcrumbData | undefined => {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -96,6 +96,11 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    * Extra props for the TooltipHost which wraps each breadcrumb item.
    */
   tooltipHostProps?: ITooltipHostProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -292,7 +292,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     const Button = (keytipAttributes?: any): JSX.Element => (
-      <Tag {...buttonProps} {...keytipAttributes}>
+      <Tag {...buttonProps} {...keytipAttributes} ref={buttonProps.domRef}>
         <span className={this._classNames.flexContainer} data-automationid="splitbuttonprimary">
           {onRenderIcon(props, this._onRenderIcon)}
           {this._onRenderTextContents()}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -12,7 +12,8 @@ import {
   mergeAriaAttributeValues,
   portalContainsElement,
   memoizeFunction,
-  nullRender
+  nullRender,
+  mergeRefs
 } from '../../Utilities';
 import { Icon, FontIcon, ImageIcon } from '../../Icon';
 import { DirectionalHint } from '../../common/DirectionalHint';
@@ -273,7 +274,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     this._openMenu(shouldFocusOnContainer, shouldFocusOnMount);
   }
 
-  private _onRenderContent(tag: any, buttonProps: IButtonProps): JSX.Element {
+  private _onRenderContent(tag: any, buttonProps: IButtonProps & { ref?: any }): JSX.Element {
     const props = this.props;
     const Tag = tag;
     const {
@@ -292,7 +293,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
 
     const Button = (keytipAttributes?: any): JSX.Element => (
-      <Tag {...buttonProps} {...keytipAttributes} ref={buttonProps.domRef}>
+      <Tag {...buttonProps} {...keytipAttributes} ref={mergeRefs(buttonProps.domRef, buttonProps.ref)}>
         <span className={this._classNames.flexContainer} data-automationid="splitbuttonprimary">
           {onRenderIcon(props, this._onRenderIcon)}
           {this._onRenderTextContents()}

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -330,6 +330,11 @@ export interface IButtonProps
    * Optional props to be applied only to the primary action button of SplitButton and not to the overall SplitButton container
    */
   primaryActionButtonProps?: IButtonProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -137,7 +137,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
       showCloseButton,
       allFocusable,
       yearPickerHidden,
-      today
+      today,
+      domRef
     } = this.props;
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['value']);
 
@@ -157,7 +158,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     }
 
     return (
-      <div className={css(rootClass, styles.root, className)} role="application">
+      <div className={css(rootClass, styles.root, className)} role="application" ref={domRef}>
         <div
           {...nativeProps}
           className={css(

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -189,6 +189,11 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
    * @defaultvalue false
    */
   yearPickerHidden?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { IPoint, IRectangle, IStyleFunctionOrObject } from '../../Utilities';
+import { IPoint, IRectangle, IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 import { ICalloutPositionedInfo } from '../../utilities/positioning';
 import { ILayerProps } from '../../Layer';
 
@@ -249,6 +249,11 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
    * @defaultvalue true;
    */
   shouldRestoreFocus?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -14,7 +14,8 @@ import {
   getNativeProps,
   getWindow,
   on,
-  shallowCompare
+  shallowCompare,
+  mergeRefs
 } from '../../Utilities';
 import {
   positionCallout,
@@ -195,6 +196,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
       backgroundColor,
       calloutMaxHeight,
       onScroll,
+      domRef,
       shouldRestoreFocus = true
     } = this.props;
     target = this._getTarget();
@@ -226,7 +228,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     const visibilityStyle: React.CSSProperties | undefined = this.props.hidden ? { visibility: 'hidden' } : undefined;
     // React.CSSProperties does not understand IRawStyle, so the inline animations will need to be cast as any for now.
     const content = (
-      <div ref={this._hostElement} className={this._classNames.container} style={visibilityStyle}>
+      <div ref={mergeRefs(this._hostElement, domRef)} className={this._classNames.container} style={visibilityStyle}>
         <div
           {...getNativeProps(this.props, divProperties, ARIA_ROLE_ATTRIBUTES)}
           className={css(this._classNames.root, positions && positions.targetEdge && ANIMATIONS[positions.targetEdge!])}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.base.tsx
@@ -7,13 +7,13 @@ import { ICheckStyleProps, ICheckStyles } from './Check.types';
 const getClassNames = classNamesFunction<ICheckStyleProps, ICheckStyles>();
 
 export const CheckBase: React.FunctionComponent<ICheckProps> = props => {
-  const { checked = false, className, theme, styles, useFastIcons = true } = props;
+  const { checked = false, className, theme, styles, domRef, useFastIcons = true } = props;
 
   const classNames = getClassNames(styles!, { theme: theme!, className, checked });
   const IconComponent = useFastIcons ? FontIcon : Icon;
 
   return (
-    <div className={classNames.root}>
+    <div className={classNames.root} ref={domRef}>
       <IconComponent iconName="CircleRing" className={classNames.circle} />
       <IconComponent iconName="StatusCircleCheckmark" className={classNames.check} />
     </div>

--- a/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.types.ts
@@ -42,6 +42,11 @@ export interface ICheckProps {
    * @defaultvalue true
    */
   useFastIcons?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -86,7 +86,8 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
       ariaSetSize,
       keytipProps,
       title,
-      label
+      label,
+      domRef
     } = this.props;
 
     const { isChecked, isIndeterminate } = this.state;
@@ -104,7 +105,7 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
     return (
       <KeytipData keytipProps={keytipProps} disabled={disabled}>
         {(keytipAttributes: any): JSX.Element => (
-          <div className={this._classNames.root} title={title}>
+          <div className={this._classNames.root} title={title} ref={domRef}>
             <input
               type="checkbox"
               {...inputProps}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.types.ts
@@ -142,6 +142,11 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
    * and after the user's first click it will be removed exposing the true state of the checkbox.
    */
   defaultIndeterminate?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -88,7 +88,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
   }
 
   public render(): JSX.Element {
-    const { className, theme, styles, options = [], label, required, disabled, name } = this.props;
+    const { className, theme, styles, options = [], label, required, disabled, name, domRef } = this.props;
     const { keyChecked, keyFocused } = this.state;
 
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onChange', 'className', 'required']);
@@ -105,7 +105,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     // TODO (Fabric 8?) - if possible, move `root` class to the actual root and eliminate
     // `applicationRole` class (but the div structure will stay the same by necessity)
     return (
-      <div className={classNames.applicationRole} {...divProps}>
+      <div className={classNames.applicationRole} {...divProps} ref={domRef}>
         <div className={classNames.root} role="radiogroup" {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}>
           {label && (
             <Label className={classNames.label} required={required} id={labelId} disabled={disabled}>

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -78,6 +78,11 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
    * ID of an element to use as the aria label for this ChoiceGroup.
    */
   ariaLabelledBy?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -191,7 +191,8 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
       styles,
       theme,
       className,
-      persistentBeak
+      persistentBeak,
+      domRef
     } = this.props;
 
     const {
@@ -242,6 +243,7 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
         finalHeight={finalHeight}
         onPositioned={this._onPositioned}
         bounds={this._getBounds()}
+        domRef={domRef}
         {...positioningContainerProps}
       >
         <div className={classNames.root}>

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.types.ts
@@ -199,6 +199,11 @@ export interface ICoachmarkProps extends React.ClassAttributes<CoachmarkBase> {
    * Theme provided by higher order component.
    */
   theme?: ITheme;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -14,7 +14,8 @@ import {
   elementContains,
   focusFirstChild,
   getWindow,
-  getDocument
+  getDocument,
+  mergeRefs
 } from '../../../Utilities';
 
 import { getMaxHeight, positionElement, IPositionedData, IPositionProps, IPosition, RectangleEdge } from '../../../utilities/positioning';
@@ -138,7 +139,7 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
       return null;
     }
 
-    const { className, positioningContainerWidth, positioningContainerMaxHeight, children } = this.props;
+    const { className, positioningContainerWidth, positioningContainerMaxHeight, children, domRef } = this.props;
     const { positions } = this.state;
 
     const styles = getClassNames();
@@ -152,7 +153,7 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
         ? getContentMaxHeight
         : positioningContainerMaxHeight!;
     const content = (
-      <div ref={this._positionedHost} className={css('ms-PositioningContainer', styles.container)}>
+      <div ref={mergeRefs(domRef, this._positionedHost)} className={css('ms-PositioningContainer', styles.container)}>
         <div
           className={mergeStyles(
             'ms-PositioningContainer-layerHost',

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -166,6 +166,11 @@ export interface IPositioningContainerProps extends IBaseProps<IPositioningConta
    * When not set the positioningContainer will expand with contents up to the bottom of the screen
    */
   positioningContainerMaxHeight?: number;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -118,7 +118,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     const props = this.props;
     const strings = this._strings;
     const textLabels = this._textLabels;
-    const { theme, className, styles, alphaSliderHidden } = props;
+    const { theme, className, styles, alphaSliderHidden, domRef } = props;
     const { color } = this.state;
 
     const classNames = getClassNames(styles!, {
@@ -137,7 +137,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     const ariaLabel = strings.rootAriaLabelFormat.replace('{0}', selectedColorAria);
 
     return (
-      <div className={classNames.root} role="group" aria-label={ariaLabel}>
+      <div className={classNames.root} role="group" aria-label={ariaLabel} ref={domRef}>
         <div className={classNames.panel}>
           <ColorRectangle
             color={color}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
@@ -96,6 +96,11 @@ export interface IColorPickerProps {
    * @defaultvalue false
    */
   showPreview?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 export interface IColorPickerStrings {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -14,7 +14,8 @@ import {
   isMac,
   KeyCodes,
   shallowCompare,
-  mergeAriaAttributeValues
+  mergeAriaAttributeValues,
+  mergeRefs
 } from '../../Utilities';
 import { Callout } from '../../Callout';
 import { Checkbox } from '../../Checkbox';
@@ -341,7 +342,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       autofill,
       persistMenu,
       iconButtonProps,
-      multiSelect
+      multiSelect,
+      domRef
     } = this.props;
     const { isOpen, focused, suggestedDisplayValue } = this.state;
     this._currentVisibleValue = this._getVisibleValue();
@@ -377,7 +379,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         );
 
     return (
-      <div {...divProps} ref={this._root} className={this._classNames.container}>
+      <div {...divProps} ref={mergeRefs(this._root, domRef)} className={this._classNames.container}>
         {onRenderLabel({ props: this.props, multiselectAccessibleText }, this._onRenderLabel)}
         <KeytipData keytipProps={keytipProps} disabled={disabled}>
           {(keytipAttributes: any): JSX.Element => (

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -251,6 +251,11 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
    * Custom render function for the label text.
    */
   onRenderLabel?: IRenderFunction<IOnRenderComboBoxLabelProps>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -54,6 +54,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       styles,
       theme,
       dataDidRender,
+      domRef,
       onReduceData = this._onReduceData,
       onGrowData = this._onGrowData
     } = this.props;
@@ -81,6 +82,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
         onGrowData={onGrowData}
         onRenderData={this._onRenderData}
         dataDidRender={dataDidRender}
+        domRef={domRef}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -119,6 +119,11 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Theme provided by HOC.
    */
   theme?: ITheme;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -238,7 +238,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
       onRenderSubMenu = this._onRenderSubMenu,
       onRenderMenuList = this._onRenderMenuList,
       focusZoneProps,
-      getMenuClassNames
+      getMenuClassNames,
+      domRef
     } = this.props;
 
     this._classNames = getMenuClassNames
@@ -324,6 +325,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
           directionalHintFixed={directionalHintFixed}
           alignTargetEdge={alignTargetEdge}
           hidden={this.props.hidden}
+          domRef={domRef}
         >
           <div
             aria-label={ariaLabel}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -261,6 +261,11 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * @defaultvalue null
    */
   delayUpdateFocusOnHover?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -152,7 +152,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       underlined,
       allFocusable,
       calendarAs: CalendarType = Calendar,
-      tabIndex
+      tabIndex,
+      domRef
     } = this.props;
     const { isDatePickerShown, formattedDate, selectedDate } = this.state;
 
@@ -169,7 +170,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     const iconProps = textFieldProps && textFieldProps.iconProps;
 
     return (
-      <div {...nativeProps} className={classNames.root}>
+      <div {...nativeProps} className={classNames.root} ref={domRef}>
         <div ref={this._datePickerDiv} aria-haspopup="true" aria-owns={isDatePickerShown ? calloutId : undefined}>
           <TextField
             role="combobox"

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -241,6 +241,11 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
    * The tabIndex of the TextField
    */
   tabIndex?: number;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -9,7 +9,8 @@ import {
   getRTLSafeKeyCode,
   IRenderFunction,
   classNamesFunction,
-  memoizeFunction
+  memoizeFunction,
+  mergeRefs
 } from '../../Utilities';
 import {
   CheckboxVisibility,
@@ -335,7 +336,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       theme,
       cellStyleProps = DEFAULT_CELL_STYLE_PROPS,
       onRenderCheckbox,
-      useFastIcons
+      useFastIcons,
+      domRef
     } = this.props;
     const { adjustedColumns, isCollapsed, isSizing, isSomeGroupExpanded } = this.state;
     const { _selection: selection, _dragDropHelper: dragDropHelper } = this;
@@ -415,7 +417,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       // If shouldApplyApplicationRole is true, role application will be applied to make arrow keys work
       // with JAWS.
       <div
-        ref={this._root}
+        ref={mergeRefs(this._root, domRef)}
         className={classNames.root}
         data-automationid="DetailsList"
         data-is-scrollable="false"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -328,6 +328,11 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    * @defaultvalue true
    */
   useFastIcons?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -86,7 +86,8 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
       type,
       minWidth,
       maxWidth,
-      modalProps
+      modalProps,
+      domRef
     } = this.props;
 
     const mergedLayerProps: ILayerProps = {
@@ -155,6 +156,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         onDismiss={onDismiss ? onDismiss : mergedModalProps.onDismiss}
         subtitleAriaId={this._getSubTextId()}
         titleAriaId={this._getTitleTextId()}
+        domRef={domRef}
       >
         <DialogContent
           subTextId={this._defaultSubTextId}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.types.ts
@@ -163,6 +163,11 @@ export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithRe
    * than the value specified in max-width.
    */
   maxWidth?: ICSSRule | ICSSPixelUnitRule;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.base.tsx
@@ -4,10 +4,10 @@ import { classNamesFunction } from '../../Utilities';
 const getClassNames = classNamesFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles>();
 
 export const VerticalDividerBase = (props: IVerticalDividerProps) => {
-  const { styles, theme, getClassNames: deprecatedGetClassNames, className } = props;
+  const { styles, theme, getClassNames: deprecatedGetClassNames, className, domRef } = props;
   const classNames = getClassNames(styles, { theme: theme, getClassNames: deprecatedGetClassNames, className });
   return (
-    <span className={classNames.wrapper}>
+    <span className={classNames.wrapper} ref={domRef}>
       <span className={classNames.divider} />
     </span>
   );

--- a/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Divider/VerticalDivider.types.ts
@@ -1,5 +1,5 @@
 import { ITheme, IStyle } from '../../Styling';
-import { IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory VerticalDivider}
@@ -23,6 +23,11 @@ export interface IVerticalDividerProps {
    * className that will be placed on the divider wrapper div
    */
   className?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLSpanElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IProcessedStyleSet } from '../../Styling';
-import { BaseComponent, classNamesFunction, KeyCodes, getNativeProps, divProperties } from '../../Utilities';
+import { BaseComponent, classNamesFunction, KeyCodes, getNativeProps, divProperties, mergeRefs } from '../../Utilities';
 import { DocumentCardType, IDocumentCard, IDocumentCardProps, IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 
 const getClassNames = classNamesFunction<IDocumentCardStyleProps, IDocumentCardStyles>();
@@ -25,7 +25,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
   }
 
   public render(): JSX.Element {
-    const { onClick, onClickHref, children, type, accentColor, styles, theme, className } = this.props;
+    const { onClick, onClickHref, children, type, accentColor, styles, theme, className, domRef } = this.props;
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, [
       'className',
       'onClick',
@@ -55,7 +55,7 @@ export class DocumentCardBase extends BaseComponent<IDocumentCardProps, any> imp
 
     return (
       <div
-        ref={this._rootElement}
+        ref={mergeRefs(this._rootElement, domRef)}
         tabIndex={tabIndex}
         data-is-focusable={actionable}
         role={role}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -74,6 +74,11 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
    * Optional override class name
    */
   className?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -205,7 +205,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       onRenderTitle = this._onRenderTitle,
       onRenderContainer = this._onRenderContainer,
       onRenderCaretDown = this._onRenderCaretDown,
-      onRenderLabel = this._onRenderLabel
+      onRenderLabel = this._onRenderLabel,
+      domRef
     } = props;
     const { isOpen, selectedIndices, calloutRenderEdge } = this.state;
     const onRenderPlaceholder = props.onRenderPlaceholder || props.onRenderPlaceHolder || this._onRenderPlaceholder;
@@ -252,7 +253,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     const hasErrorMessage: boolean = !!errorMessage && errorMessage.length > 0;
 
     return (
-      <div className={this._classNames.root}>
+      <div className={this._classNames.root} ref={domRef}>
         {onRenderLabel(this.props, this._onRenderLabel)}
         <KeytipData keytipProps={keytipProps} disabled={disabled}>
           {(keytipAttributes: any): JSX.Element => (

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
+import { IRenderFunction, IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 import { IStyle, ITheme } from '../../Styling';
 import { ISelectableOption } from '../../utilities/selectableOption/SelectableOption.types';
 import { ISelectableDroppableTextProps } from '../../utilities/selectableOption/SelectableDroppableText.types';
@@ -139,6 +139,11 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IDropdownStyleProps, IDropdownStyles>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, mergeRefs } from '../../Utilities';
 import { Autofill } from '../../Autofill';
 import { IInputProps } from '../../Pickers';
 import * as stylesImport from './BaseExtendedPicker.scss';
@@ -96,7 +96,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
   }
 
   public render(): JSX.Element {
-    const { className, inputProps, disabled, focusZoneProps } = this.props;
+    const { className, inputProps, disabled, focusZoneProps, domRef } = this.props;
     const activeDescendant =
       this.floatingPicker.current && this.floatingPicker.current.currentSelectedSuggestionIndex !== -1
         ? 'sug-' + this.floatingPicker.current.currentSelectedSuggestionIndex
@@ -105,7 +105,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
 
     return (
       <div
-        ref={this.root}
+        ref={mergeRefs(this.root, domRef)}
         className={css('ms-BasePicker ms-BaseExtendedPicker', className ? className : '')}
         onKeyDown={this.onBackspace}
         onCopy={this.onCopy}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.types.ts
@@ -132,4 +132,9 @@ export interface IBaseExtendedPickerProps<T> {
    * Current rendered query string that's corealte to current rendered result
    **/
   currentRenderedQueryString?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -35,7 +35,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
   }
 
   public render(): JSX.Element {
-    let { overflowButtonProps, domRef } = this.props;
+    let { overflowButtonProps } = this.props;
     const { chevronButtonProps, maxDisplayablePersonas, personas, overflowPersonas, showAddButton, ariaLabel } = this.props;
 
     const { _classNames } = this;
@@ -54,7 +54,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     const personasOverflow: IFacepilePersona[] = (hasOverflowPersonas ? overflowPersonas : personas.slice(numPersonasToShow)) || [];
 
     return (
-      <div className={_classNames.root} ref={domRef}>
+      <div className={_classNames.root} ref={this.props.domRef}>
         {this.onRenderAriaDescription()}
         <div className={_classNames.itemContainer}>
           {showAddButton ? this._getAddNewElement() : null}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.base.tsx
@@ -35,7 +35,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
   }
 
   public render(): JSX.Element {
-    let { overflowButtonProps } = this.props;
+    let { overflowButtonProps, domRef } = this.props;
     const { chevronButtonProps, maxDisplayablePersonas, personas, overflowPersonas, showAddButton, ariaLabel } = this.props;
 
     const { _classNames } = this;
@@ -54,7 +54,7 @@ export class FacepileBase extends BaseComponent<IFacepileProps, {}> {
     const personasOverflow: IFacepilePersona[] = (hasOverflowPersonas ? overflowPersonas : personas.slice(numPersonasToShow)) || [];
 
     return (
-      <div className={_classNames.root}>
+      <div className={_classNames.root} ref={domRef}>
         {this.onRenderAriaDescription()}
         <div className={_classNames.itemContainer}>
           {showAddButton ? this._getAddNewElement() : null}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.types.ts
@@ -87,6 +87,11 @@ export interface IFacepileProps extends React.ClassAttributes<FacepileBase> {
 
   /** Method to access properties on the underlying Persona control */
   getPersonaProps?: (persona: IFacepilePersona) => IPersonaSharedProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as stylesImport from './BaseFloatingPicker.scss';
-import { BaseComponent, css, KeyCodes } from '../../Utilities';
+import { BaseComponent, css, KeyCodes, mergeRefs } from '../../Utilities';
 import { Callout, DirectionalHint } from '../../Callout';
 import { IBaseFloatingPicker, IBaseFloatingPickerProps } from './BaseFloatingPicker.types';
 import { ISuggestionModel } from '../../Pickers';
@@ -145,9 +145,9 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
   }
 
   public render(): JSX.Element {
-    const { className } = this.props;
+    const { className, domRef } = this.props;
     return (
-      <div ref={this.root} className={css('ms-BasePicker ms-BaseFloatingPicker', className ? className : '')}>
+      <div ref={mergeRefs(this.root, domRef)} className={css('ms-BasePicker ms-BaseFloatingPicker', className ? className : '')}>
         {this.renderSuggestions()}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -147,6 +147,11 @@ export interface IBaseFloatingPickerProps<T> extends React.ClassAttributes<any> 
    * If using as a controlled component, the items to show in the suggestion list
    */
   suggestionItems?: T[];
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -9,7 +9,8 @@ import {
   getDocument,
   focusAsync,
   initializeComponentRef,
-  on
+  on,
+  mergeRefs
 } from '../../Utilities';
 import { IFocusTrapZone, IFocusTrapZoneProps } from './FocusTrapZone.types';
 
@@ -90,7 +91,7 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
   }
 
   public render(): JSX.Element {
-    const { className, disabled = false, ariaLabelledBy } = this.props;
+    const { className, disabled = false, ariaLabelledBy, domRef } = this.props;
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     const bumperProps = {
@@ -106,7 +107,7 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
       <div
         {...divProps}
         className={className}
-        ref={this._root}
+        ref={mergeRefs(this._root, domRef)}
         aria-labelledby={ariaLabelledBy}
         onFocusCapture={this._onFocusCapture}
         onFocus={this._onRootFocus}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
@@ -78,4 +78,9 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
    * @defaultvalue false
    */
   focusPreviouslyFocusedInnerElement?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -88,7 +88,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   public render(): JSX.Element {
-    const { className, usePageCache, onShouldVirtualize, theme, styles, compact, listProps = {} } = this.props;
+    const { className, usePageCache, onShouldVirtualize, theme, styles, compact, listProps = {}, domRef } = this.props;
     const { groups } = this.state;
     this._classNames = getClassNames(styles, {
       theme: theme!,
@@ -99,7 +99,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     const { version } = listProps;
 
     return (
-      <div className={this._classNames.root} data-automationid="GroupedList" data-is-scrollable="false" role="presentation">
+      <div className={this._classNames.root} data-automationid="GroupedList" data-is-scrollable="false" role="presentation" ref={domRef}>
         {!groups ? (
           this._renderGroup(undefined, 0)
         ) : (

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -116,6 +116,11 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
    * Optional function to override default group height calculation used by list virtualization.
    */
   getGroupHeight?: (group: IGroup, groupIndex: number) => number;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { divProperties, getNativeProps } from '../../../Utilities';
+import { divProperties, getNativeProps, IRefObject } from '../../../Utilities';
 import { DirectionalHint } from '../../../common/DirectionalHint';
 import { IBaseCardProps } from '../BaseCard.types';
 import { Callout, FocusTrapCallout, ICalloutProps } from '../../../Callout';
@@ -8,6 +8,11 @@ import { Callout, FocusTrapCallout, ICalloutProps } from '../../../Callout';
 export interface ICardCalloutProps extends IBaseCardProps<{}, {}, {}> {
   finalHeight?: number;
   content?: JSX.Element;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 export const CardCallout = (props: ICardCalloutProps) => {
@@ -22,7 +27,8 @@ export const CardCallout = (props: ICardCalloutProps) => {
     className,
     finalHeight,
     content,
-    calloutProps
+    calloutProps,
+    domRef
   } = props;
 
   const mergedCalloutProps: ICalloutProps = {
@@ -49,11 +55,14 @@ export const CardCallout = (props: ICardCalloutProps) => {
             isClickableOutsideFocusTrap: true,
             disableFirstFocus: !firstFocus
           }}
+          domRef={domRef}
         >
           {content}
         </FocusTrapCallout>
       ) : (
-        <Callout {...mergedCalloutProps}>{content}</Callout>
+        <Callout {...mergedCalloutProps} domRef={domRef}>
+          {content}
+        </Callout>
       )}
     </React.Fragment>
   );

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.base.tsx
@@ -39,7 +39,7 @@ export class ExpandingCardBase extends BaseComponent<IExpandingCardProps, IExpan
   }
 
   public render(): JSX.Element {
-    const { styles, compactCardHeight, expandedCardHeight, theme, mode, className } = this.props;
+    const { styles, compactCardHeight, expandedCardHeight, theme, mode, className, domRef } = this.props;
     const { needsScroll, firstFrameRendered } = this.state;
 
     const finalHeight = compactCardHeight! + expandedCardHeight!;
@@ -60,7 +60,7 @@ export class ExpandingCardBase extends BaseComponent<IExpandingCardProps, IExpan
       </div>
     );
 
-    return <CardCallout {...this.props} content={content} finalHeight={finalHeight} className={this._classNames.root} />;
+    return <CardCallout {...this.props} content={content} finalHeight={finalHeight} className={this._classNames.root} domRef={domRef} />;
   }
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/ExpandingCard.types.ts
@@ -1,5 +1,5 @@
 import { IBaseCardProps, IBaseCardStyles, IBaseCardStyleProps } from './BaseCard.types';
-import { IRenderFunction } from '../../Utilities';
+import { IRenderFunction, IRefObject } from '../../Utilities';
 import { IStyle } from '../../Styling';
 
 /**
@@ -39,6 +39,11 @@ export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExp
    *  Render function to populate expanded content area
    */
   onRenderExpandedCard?: IRenderFunction<any>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { BaseComponent, divProperties, getNativeProps, getId, KeyCodes, getDocument, classNamesFunction } from '../../Utilities';
+import { BaseComponent, divProperties, getNativeProps, getId, KeyCodes, getDocument, classNamesFunction, mergeRefs } from '../../Utilities';
 import { IHoverCardProps, IHoverCardStyles, IHoverCardStyleProps, OpenCardMode, HoverCardType, IHoverCard } from './HoverCard.types';
 import { ExpandingCard } from './ExpandingCard';
 import { ExpandingCardMode, IExpandingCardProps } from './ExpandingCard.types';
@@ -108,7 +108,8 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
       type,
       plainCardProps,
       trapFocus,
-      setInitialFocus
+      setInitialFocus,
+      domRef
     } = this.props;
     const { isHoverCardVisible, mode, openMode } = this.state;
     const hoverCardId = id || getId('hoverCard');
@@ -135,7 +136,7 @@ export class HoverCardBase extends BaseComponent<IHoverCardProps, IHoverCardStat
     return (
       <div
         className={this._classNames.host}
-        ref={this._hoverCard}
+        ref={mergeRefs(this._hoverCard, domRef)}
         aria-describedby={setAriaDescribedBy && isHoverCardVisible ? hoverCardId : undefined}
         data-is-focusable={!Boolean(this.props.target)}
       >

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -149,6 +149,11 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement> {
    * @defaultvalue HoverCardType.expanding
    */
   type?: HoverCardType;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.base.tsx
@@ -10,7 +10,7 @@ export class PlainCardBase extends BaseComponent<IPlainCardProps, {}> {
   private _classNames: { [key in keyof IPlainCardStyles]: string };
 
   public render(): JSX.Element {
-    const { styles, theme, className } = this.props;
+    const { styles, theme, className, domRef } = this.props;
 
     this._classNames = getClassNames(styles!, {
       theme: theme!,
@@ -23,7 +23,7 @@ export class PlainCardBase extends BaseComponent<IPlainCardProps, {}> {
       </div>
     );
 
-    return <CardCallout {...this.props} content={content} className={this._classNames.root} />;
+    return <CardCallout {...this.props} content={content} className={this._classNames.root} domRef={domRef} />;
   }
 
   private _onKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/PlainCard/PlainCard.types.ts
@@ -1,5 +1,5 @@
 import { IBaseCardProps, IBaseCardStyles, IBaseCardStyleProps } from '../BaseCard.types';
-import { IRenderFunction } from '../../../Utilities';
+import { IRenderFunction, IRefObject } from '../../../Utilities';
 
 /**
  * {@docCategory HoverCard}
@@ -15,6 +15,11 @@ export interface IPlainCardProps extends IBaseCardProps<IPlainCard, IPlainCardSt
    *  Render function to populate compact content area
    */
   onRenderPlainCard?: IRenderFunction<any>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -23,7 +23,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
   }
 
   public render() {
-    const { className, styles, iconName, imageErrorAs, theme } = this.props;
+    const { className, styles, iconName, imageErrorAs, theme, domRef } = this.props;
     const isPlaceholder = typeof iconName === 'string' && iconName.length === 0;
     const isImage = this.props.iconType === IconType.image || this.props.iconType === IconType.Image || !!this.props.imageProps;
     const iconContent = getIconContent(iconName) || {};
@@ -56,7 +56,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
         };
 
     return (
-      <RootType data-icon-name={iconName} {...containerProps} {...nativeProps} className={classNames.root}>
+      <RootType data-icon-name={iconName} {...containerProps} {...nativeProps} className={classNames.root} ref={domRef}>
         {isImage ? <ImageType {...imageProps} /> : children}
       </RootType>
     );

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IImageProps } from '../Image/Image.types';
 import { IStyle, ITheme } from '../../Styling';
-import { IBaseProps, IStyleFunctionOrObject } from '../../Utilities';
+import { IBaseProps, IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
 /**
  * @deprecated Icon type is inferred based on presence of `IIconProps.imageProps`
@@ -70,6 +70,11 @@ export interface IIconProps extends IBaseProps, React.HTMLAttributes<HTMLElement
    */
   styles?: IStyleFunctionOrObject<IIconStyleProps, IIconStyles>;
   theme?: ITheme;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLSpanElement | HTMLImageElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, getNativeProps, imageProperties } from '../../Utilities';
+import { classNamesFunction, getNativeProps, imageProperties, mergeRefs } from '../../Utilities';
 import { IImageProps, IImageStyleProps, IImageStyles, ImageCoverStyle, ImageFit, ImageLoadState } from './Image.types';
 
 const getClassNames = classNamesFunction<IImageStyleProps, IImageStyles>();
@@ -64,7 +64,8 @@ export class ImageBase extends React.Component<IImageProps, IImageState> {
       role,
       maximizeFrame,
       styles,
-      theme
+      theme,
+      domRef
     } = this.props;
     const { loadState } = this.state;
     const coverStyle = this.props.coverStyle !== undefined ? this.props.coverStyle : this._coverStyle;
@@ -90,7 +91,7 @@ export class ImageBase extends React.Component<IImageProps, IImageState> {
 
     // If image dimensions aren't specified, the natural size of the image is used.
     return (
-      <div className={classNames.root} style={{ width: width, height: height }} ref={this._frameElement}>
+      <div className={classNames.root} style={{ width: width, height: height }} ref={mergeRefs(this._frameElement, domRef)}>
         <img
           {...imageProps}
           onLoad={this._onImageLoaded}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory Image}
@@ -73,6 +73,11 @@ export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
    * aspect ratio for the image.
    */
   coverStyle?: ImageCoverStyle;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.tsx
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.tsx
@@ -11,7 +11,7 @@ import { getCalloutStyles, getCalloutOffsetStyles } from './Keytip.styles';
  */
 export class Keytip extends React.Component<IKeytipProps, {}> {
   public render(): JSX.Element {
-    const { keySequences, offset, overflowSetSequence } = this.props;
+    const { keySequences, offset, overflowSetSequence, domRef } = this.props;
     let { calloutProps } = this.props;
 
     let keytipTarget: string;
@@ -49,6 +49,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
         styles={offset ? getCalloutOffsetStyles(offset) : getCalloutStyles}
         preventDismissOnScroll={true}
         target={keytipTarget}
+        domRef={domRef}
       >
         <KeytipContent {...this.props} />
       </Callout>

--- a/packages/office-ui-fabric-react/src/components/Keytip/Keytip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Keytip/Keytip.types.ts
@@ -1,6 +1,6 @@
 import { ICalloutProps } from '../../Callout';
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject, IPoint } from '../../Utilities';
+import { IStyleFunctionOrObject, IPoint, IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory Keytips}
@@ -78,6 +78,11 @@ export interface IKeytipProps {
    * Keytip mode will stay on when a menu is opened, even if the items in that menu have no keytips
    */
   hasMenu?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -11,7 +11,8 @@ import {
   getNativeProps,
   getParent,
   getWindow,
-  initializeComponentRef
+  initializeComponentRef,
+  mergeRefs
 } from '../../Utilities';
 import { IList, IListProps, IPage, IPageProps, ScrollToMode } from './List.types';
 
@@ -388,7 +389,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   }
 
   public render(): JSX.Element {
-    const { className, role = 'list' } = this.props;
+    const { className, role = 'list', domRef } = this.props;
     const { pages = [] } = this.state;
     const pageElements: JSX.Element[] = [];
     const divProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(this.props, divProperties);
@@ -398,7 +399,12 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     }
 
     return (
-      <div ref={this._root} {...divProps} role={pageElements.length > 0 ? role : undefined} className={css('ms-List', className)}>
+      <div
+        ref={mergeRefs(this._root, domRef)}
+        {...divProps}
+        role={pageElements.length > 0 ? role : undefined}
+        className={css('ms-List', className)}
+      >
         <div ref={this._surface} className={'ms-List-surface'} role="presentation">
           {pageElements}
         </div>

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -184,6 +184,11 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * An object which can be passed in as a fresh instance to 'force update' the list.
    */
   version?: {};
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -8,7 +8,8 @@ import {
   classNamesFunction,
   findScrollableParent,
   getDistanceBetweenPoints,
-  getRTL
+  getRTL,
+  mergeRefs
 } from '../../Utilities';
 
 import { IMarqueeSelectionProps, IMarqueeSelectionStyleProps, IMarqueeSelectionStyles } from './MarqueeSelection.types';
@@ -79,7 +80,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
   }
 
   public render(): JSX.Element {
-    const { rootProps, children, theme, className, styles } = this.props;
+    const { rootProps, children, theme, className, styles, domRef } = this.props;
     const { dragRect } = this.state;
 
     const classNames = getClassNames(styles!, {
@@ -88,7 +89,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     });
 
     return (
-      <div {...rootProps} className={classNames.root} ref={this._root}>
+      <div {...rootProps} className={classNames.root} ref={mergeRefs(this._root, domRef)}>
         {children}
         {dragRect && <div className={classNames.dragMask} />}
         {dragRect && (

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.types.ts
@@ -64,6 +64,11 @@ export interface IMarqueeSelectionProps extends React.HTMLAttributes<HTMLDivElem
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunction<IMarqueeSelectionStyleProps, IMarqueeSelectionStyles>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -112,10 +112,10 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderMultiLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const { theme } = this.props;
+    const { theme, domRef } = this.props;
 
     return (
-      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+      <div style={{ background: theme!.semanticColors.bodyBackground }} ref={domRef}>
         <div className={this._classNames.root} {...this._getRegionProps()}>
           <div className={this._classNames.content}>
             {this._getIconSpan()}
@@ -129,9 +129,9 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const { theme } = this.props;
+    const { theme, domRef } = this.props;
     return (
-      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+      <div style={{ background: theme!.semanticColors.bodyBackground }} ref={domRef}>
         <div className={this._classNames.root} {...this._getRegionProps()}>
           <div className={this._classNames.content}>
             {this._getIconSpan()}

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.types.ts
@@ -94,6 +94,11 @@ export interface IMessageBarProps extends React.HTMLAttributes<HTMLElement> {
    * If unset, default will be the icon set by messageBarType.
    */
   messageBarIconProps?: IIconProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -164,7 +164,8 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
       topOffsetFixed,
       onLayerDidMount,
       isModeless,
-      dragOptions
+      dragOptions,
+      domRef
     } = this.props;
     const { isOpen, isVisible, hasBeenOpened, modalRectangleTop, x, y, isInKeyboardMoveMode } = this.state;
 
@@ -249,6 +250,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
             ariaDescribedBy={subtitleAriaId}
             onDismiss={onDismiss}
             shouldRestoreFocus={!ignoreExternalFocusing}
+            domRef={domRef}
           >
             <div className={classNames.root}>
               {!isModeless && (

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.types.ts
@@ -159,6 +159,11 @@ export interface IModalProps extends React.ClassAttributes<ModalBase>, IWithResp
    * @defaultvalue false
    */
   allowTouchBodyScroll?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -46,7 +46,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   }
 
   public render(): JSX.Element | null {
-    const { styles, groups, className, isOnTop, theme } = this.props;
+    const { styles, groups, className, isOnTop, theme, domRef } = this.props;
 
     if (!groups) {
       return null;
@@ -56,8 +56,16 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
     const classNames = getClassNames(styles!, { theme: theme!, className, isOnTop, groups });
 
+    const focusZoneAs =
+      domRef &&
+      ((props: React.HTMLAttributes<HTMLDivElement>) => (
+        <div {...props} ref={domRef}>
+          {props.children}
+        </div>
+      ));
+
     return (
-      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone}>
+      <FocusZone direction={FocusZoneDirection.vertical} componentRef={this._focusZone} as={focusZoneAs}>
         <nav role="navigation" className={classNames.root} aria-label={this.props.ariaLabel}>
           {groupElements}
         </nav>

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -114,6 +114,11 @@ export interface INavProps {
    * (Optional) The nav link selected state aria label.
    */
   selectedAriaLabel?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -2,7 +2,15 @@ import * as React from 'react';
 
 import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { IKeytipProps } from '../../Keytip';
-import { BaseComponent, classNamesFunction, divProperties, elementContains, focusFirstChild, getNativeProps } from '../../Utilities';
+import {
+  BaseComponent,
+  classNamesFunction,
+  divProperties,
+  elementContains,
+  focusFirstChild,
+  getNativeProps,
+  mergeRefs
+} from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { IOverflowSet, IOverflowSetItemProps, IOverflowSetProps, IOverflowSetStyles, IOverflowSetStyleProps } from './OverflowSet.types';
@@ -27,7 +35,7 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
   }
 
   public render(): JSX.Element {
-    const { items, overflowItems, className, focusZoneProps, styles, vertical, doNotContainWithinFocusZone, role } = this.props;
+    const { items, overflowItems, className, focusZoneProps, styles, vertical, doNotContainWithinFocusZone, role, domRef } = this.props;
 
     this._classNames = getClassNames(styles, { className, vertical });
 
@@ -38,7 +46,7 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
       Tag = 'div';
       uniqueComponentProps = {
         ...getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties),
-        ref: this._divContainer
+        ref: mergeRefs(this._divContainer, domRef)
       };
     } else {
       Tag = FocusZone;
@@ -46,7 +54,8 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
         ...getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties),
         ...focusZoneProps,
         componentRef: this._focusZone,
-        direction: vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal
+        direction: vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal,
+        domRef
       };
     }
 

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -109,6 +109,11 @@ export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IOverflowSetProps, IOverflowSetStyles>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.base.tsx
@@ -23,7 +23,7 @@ export class OverlayBase extends BaseComponent<IOverlayProps, {}> {
   }
 
   public render(): JSX.Element {
-    const { isDarkThemed: isDark, className, theme, styles } = this.props;
+    const { isDarkThemed: isDark, className, theme, styles, domRef } = this.props;
 
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
@@ -33,6 +33,6 @@ export class OverlayBase extends BaseComponent<IOverlayProps, {}> {
       isDark
     });
 
-    return <div {...divProps} className={classNames.root} />;
+    return <div {...divProps} className={classNames.root} ref={domRef} />;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Overlay/Overlay.types.ts
@@ -45,6 +45,11 @@ export interface IOverlayProps extends React.HTMLAttributes<HTMLElement> {
    * @defaultvalue false
    */
   allowTouchBodyScroll?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -14,7 +14,8 @@ import {
   getId,
   getNativeProps,
   getRTL,
-  css
+  css,
+  mergeRefs
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
@@ -142,6 +143,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       styles,
       theme,
       customWidth,
+      domRef,
       onLightDismissClick = this._onPanelClick,
       onRenderNavigation = this._onRenderNavigation,
       onRenderHeader = this._onRenderHeader,
@@ -203,7 +205,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}
         >
-          <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>
+          <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={mergeRefs(this._panel, domRef)} className={_classNames.root}>
             {overlay}
             <FocusTrapZone
               ignoreExternalFocusing={ignoreExternalFocusing}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -236,6 +236,11 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
    * @defaultvalue false
    */
   allowTouchBodyScroll?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -71,7 +71,8 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
       presenceTitle,
       showInitialsUntilImageLoads,
       showSecondaryText,
-      theme
+      theme,
+      domRef
     } = this.props;
 
     const personaCoinProps: IPersonaCoinProps = {
@@ -116,7 +117,7 @@ export class PersonaBase extends React.Component<IPersonaProps, {}> {
     );
 
     return (
-      <div {...divProps} className={classNames.root} style={coinSize ? { height: coinSize, minWidth: coinSize } : undefined}>
+      <div {...divProps} className={classNames.root} style={coinSize ? { height: coinSize, minWidth: coinSize } : undefined} ref={domRef}>
         {onRenderPersonaCoin(personaCoinProps, this._onRenderPersonaCoin)}
         {(!hidePersonaDetails || size === PersonaSize.size8 || size === PersonaSize.size10 || size === PersonaSize.tiny) && personaDetails}
       </div>

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -163,6 +163,11 @@ export interface IPersonaSharedProps extends React.HTMLAttributes<PersonaBase | 
    * @deprecated Use `text` instead.
    */
   primaryText?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -90,7 +90,7 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     this._classNames = this._getClassNames(this.props);
 
     return (
-      <div role="toolbar" {...divProps}>
+      <div role="toolbar" {...divProps} ref={this.props.domRef}>
         {this._renderPivotLinks(linkCollection, selectedKey)}
         {selectedKey && this._renderPivotItem(linkCollection, selectedKey)}
       </div>

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -106,6 +106,11 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.tsx
@@ -12,6 +12,10 @@ export class PivotItem extends BaseComponent<IPivotItemProps, {}> {
   }
 
   public render(): JSX.Element {
-    return <div {...getNativeProps(this.props, divProperties)}>{this.props.children}</div>;
+    return (
+      <div {...getNativeProps(this.props, divProperties)} ref={this.props.domRef}>
+        {this.props.children}
+      </div>
+    );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -62,4 +62,9 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional keytip for this PivotItem
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
-import { Async, KeyCodes, divProperties, doesElementContainFocus, getDocument, getNativeProps, on, getWindow } from '../../Utilities';
+import {
+  Async,
+  KeyCodes,
+  divProperties,
+  doesElementContainFocus,
+  getDocument,
+  getNativeProps,
+  on,
+  getWindow,
+  mergeRefs
+} from '../../Utilities';
 import { IPopupProps } from './Popup.types';
 
 export interface IPopupState {
@@ -72,11 +82,11 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
   }
 
   public render(): JSX.Element {
-    const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style } = this.props;
+    const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style, domRef } = this.props;
 
     return (
       <div
-        ref={this._root}
+        ref={mergeRefs(this._root, domRef)}
         {...getNativeProps(this.props, divProperties)}
         className={className}
         role={role}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Popup } from './Popup';
+import { IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory Popup}
@@ -41,4 +42,9 @@ export interface IPopupProps extends React.HTMLAttributes<Popup> {
    * @defaultvalue true
    */
   shouldRestoreFocus?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.base.tsx
@@ -28,6 +28,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
       styles,
       theme,
       progressHidden,
+      domRef,
       onRenderProgress = this._onRenderProgress
     } = this.props;
 
@@ -42,7 +43,7 @@ export class ProgressIndicatorBase extends React.Component<IProgressIndicatorPro
     });
 
     return (
-      <div className={classNames.root}>
+      <div className={classNames.root} ref={domRef}>
         {label ? <div className={classNames.itemName}>{label}</div> : null}
         {!progressHidden
           ? onRenderProgress(

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ProgressIndicatorBase } from './ProgressIndicator.base';
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject, IRenderFunction } from '../../Utilities';
+import { IStyleFunctionOrObject, IRenderFunction, IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory ProgressIndicator}
@@ -65,6 +65,11 @@ export interface IProgressIndicatorProps extends React.ClassAttributes<ProgressI
    * @defaultvalue 2
    */
   barHeight?: number;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -78,6 +78,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       readOnly,
       size,
       theme,
+      domRef,
       icon = 'FavoriteStarFill',
       unselectedIcon = 'FavoriteStar'
     } = this.props;
@@ -152,6 +153,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
         aria-label={!readOnly ? ariaLabel : ''}
         id={id}
         {...divProps}
+        ref={domRef}
       >
         <FocusZone
           direction={FocusZoneDirection.horizontal}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.types.ts
@@ -99,6 +99,11 @@ export interface IRatingProps extends React.AllHTMLAttributes<HTMLElement> {
    * Theme (provided through customization.)
    */
   theme?: ITheme;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, divProperties, getNativeProps } from '../../Utilities';
+import { BaseComponent, divProperties, getNativeProps, mergeRefs } from '../../Utilities';
 import { IResizeGroupProps, ResizeGroupDirection } from './ResizeGroup.types';
 
 const RESIZE_DELAY = 16;
@@ -339,7 +339,7 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     // we mount a second version of the component just for measurement purposes and leave the rendered content untouched until we know the
     // next state sto show to the user.
     return (
-      <div {...divProps} className={className} ref={this._root}>
+      <div {...divProps} className={className} ref={mergeRefs(this._root, this.props.domRef)}>
         <div style={hiddenParentStyles}>
           {dataNeedsMeasuring && !isInitialMeasure && (
             <div style={hiddenDivStyles} ref={this._updateHiddenDiv}>

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -89,6 +89,11 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * onReduceData triggers.
    */
   dataDidRender?: (renderedData: any) => void;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, divProperties, getNativeProps, getRTL } from '../../Utilities';
+import { BaseComponent, classNamesFunction, divProperties, getNativeProps, getRTL, mergeRefs } from '../../Utilities';
 import {
   IScrollablePane,
   IScrollablePaneContext,
@@ -164,7 +164,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   }
 
   public render(): JSX.Element {
-    const { className, theme, styles } = this.props;
+    const { className, theme, styles, domRef } = this.props;
     const { stickyTopHeight, stickyBottomHeight } = this.state;
     const classNames = getClassNames(styles!, {
       theme: theme!,
@@ -173,7 +173,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
     });
 
     return (
-      <div {...getNativeProps(this.props, divProperties)} ref={this._root} className={classNames.root}>
+      <div {...getNativeProps(this.props, divProperties)} ref={mergeRefs(this._root, domRef)} className={classNames.root}>
         <div
           aria-hidden="true"
           ref={this._stickyAboveRef}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.types.ts
@@ -47,6 +47,11 @@ export interface IScrollablePaneProps extends React.HTMLAttributes<HTMLElement |
   initialScrollPosition?: number;
 
   scrollbarVisibility?: ScrollbarVisibility;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -8,7 +8,8 @@ import {
   KeyCodes,
   classNamesFunction,
   getNativeProps,
-  inputProperties
+  inputProperties,
+  mergeRefs
 } from '../../Utilities';
 
 import { IconButton } from '../../Button';
@@ -84,6 +85,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
       clearButtonProps,
       disableAnimation,
       iconProps,
+      domRef,
       id = this._fallbackId
     } = this.props;
     const { value, hasFocus } = this.state;
@@ -108,7 +110,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     ]);
 
     return (
-      <div role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
+      <div role="search" ref={mergeRefs(this._rootElement, domRef)} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon iconName="Search" {...iconProps} className={classNames.icon} />
         </div>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -119,6 +119,11 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
    * @defaultvalue false
    */
   disableAnimation?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Separator/Separator.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Separator/Separator.base.tsx
@@ -5,7 +5,7 @@ import { ISeparatorProps, ISeparatorStyles, ISeparatorStyleProps } from './Separ
 const getClassNames = classNamesFunction<ISeparatorStyleProps, ISeparatorStyles>();
 
 export const SeparatorBase: React.FunctionComponent<ISeparatorProps> = (props: ISeparatorProps): JSX.Element => {
-  const { styles, theme, className, vertical, alignContent } = props;
+  const { styles, theme, className, vertical, alignContent, domRef } = props;
 
   const _classNames = getClassNames(styles!, {
     theme: theme!,
@@ -15,7 +15,7 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps> = (props: I
   });
 
   return (
-    <div className={_classNames.root}>
+    <div className={_classNames.root} ref={domRef}>
       <div className={_classNames.content} role="separator" aria-orientation={vertical ? 'vertical' : 'horizontal'}>
         {props.children}
       </div>

--- a/packages/office-ui-fabric-react/src/components/Separator/Separator.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Separator/Separator.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 import { IStyle, ITheme } from '../../Styling';
 
 /**
@@ -31,6 +31,11 @@ export interface ISeparatorProps extends React.HTMLAttributes<HTMLElement> {
    * @defaultValue 'center'
    */
   alignContent?: 'start' | 'center' | 'end';
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -74,7 +74,8 @@ export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
       customElementsGroup,
       theme,
       ariaLabel,
-      shimmerColors
+      shimmerColors,
+      domRef
     } = this.props;
 
     const { contentLoaded } = this.state;
@@ -91,7 +92,7 @@ export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     return (
-      <div {...divProps} className={this._classNames.root}>
+      <div {...divProps} className={this._classNames.root} ref={domRef}>
         {!contentLoaded && (
           <div style={{ width: width ? width : '100%' }} className={this._classNames.shimmerWrapper}>
             <div className={this._classNames.shimmerGradient} />

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.types.ts
@@ -64,6 +64,11 @@ export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
    * Defines an object with possible colors to pass for Shimmer customization used on different backgrounds.
    */
   shimmerColors?: IShimmerColors;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -60,7 +60,8 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
       valueFormat,
       styles,
       theme,
-      originFromZero
+      originFromZero,
+      domRef
     } = this.props;
     const value = this.value;
     const renderedValue = this.renderedValue;
@@ -81,7 +82,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     const divButtonProps = buttonProps ? getNativeProps<React.HTMLAttributes<HTMLDivElement>>(buttonProps, divProperties) : undefined;
 
     return (
-      <div className={classNames.root}>
+      <div className={classNames.root} ref={domRef}>
         {label && (
           <Label className={classNames.titleLabel} {...(ariaLabel ? {} : { htmlFor: this._id })} disabled={disabled}>
             {label}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.types.ts
@@ -130,6 +130,11 @@ export interface ISliderProps extends React.ClassAttributes<SliderBase> {
    * @defaultvalue false
    */
   originFromZero?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -158,7 +158,8 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
       keytipProps,
       className,
       inputProps,
-      iconButtonProps
+      iconButtonProps,
+      domRef
     } = this.props as ISpinButtonInternalProps;
 
     const { isFocused, value, keyboardSpinDirection } = this.state;
@@ -170,7 +171,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onBlur', 'onFocus', 'className']);
 
     return (
-      <div className={classNames.root}>
+      <div className={classNames.root} ref={domRef}>
         {labelPosition !== Position.bottom && (iconProps || label) && (
           <div className={classNames.labelWrapper}>
             {iconProps && <Icon {...iconProps} className={classNames.icon} aria-hidden="true" />}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -245,6 +245,11 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional iconButton props on spin button
    */
   iconButtonProps?: IButtonProps;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
@@ -12,7 +12,7 @@ export class SpinnerBase extends React.Component<ISpinnerProps, any> {
   };
 
   public render() {
-    const { type, size, ariaLabel, ariaLive, styles, label, theme, className, labelPosition } = this.props;
+    const { type, size, ariaLabel, ariaLive, styles, label, theme, className, labelPosition, domRef } = this.props;
     const statusMessage = ariaLabel;
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['size']);
 
@@ -31,7 +31,7 @@ export class SpinnerBase extends React.Component<ISpinnerProps, any> {
     });
 
     return (
-      <div {...nativeProps} className={classNames.root}>
+      <div {...nativeProps} className={classNames.root} ref={domRef}>
         <div className={classNames.circle} />
         {label && <div className={classNames.label}>{label}</div>}
         {statusMessage && (

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.types.ts
@@ -67,6 +67,11 @@ export interface ISpinnerProps extends React.HTMLAttributes<HTMLElement> {
    * @defaultvalue SpinnerLabelPosition.bottom
    */
   labelPosition?: SpinnerLabelPosition;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.tsx
@@ -1,6 +1,6 @@
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { BaseComponent } from '../../Utilities';
+import { BaseComponent, mergeRefs } from '../../Utilities';
 import { hiddenContentStyle } from '../../Styling';
 import { IScrollablePaneContext, ScrollablePaneContext } from '../ScrollablePane/ScrollablePane.types';
 import { IStickyProps, StickyPositionType } from './Sticky.types';
@@ -143,14 +143,14 @@ export class Sticky extends BaseComponent<IStickyProps, IStickyState> {
 
   public render(): JSX.Element {
     const { isStickyTop, isStickyBottom } = this.state;
-    const { stickyClassName, children } = this.props;
+    const { stickyClassName, children, domRef } = this.props;
 
     if (!this.context.scrollablePane) {
-      return <div>{this.props.children}</div>;
+      return <div ref={domRef}>{this.props.children}</div>;
     }
 
     return (
-      <div ref={this._root}>
+      <div ref={mergeRefs(this._root, domRef)}>
         {this.canStickyTop && (
           <div ref={this._stickyContentTop} aria-hidden={!isStickyTop} style={{ pointerEvents: isStickyTop ? 'auto' : 'none' }}>
             <div style={this._getStickyPlaceholderHeight(isStickyTop)} />

--- a/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Sticky/Sticky.types.ts
@@ -29,6 +29,11 @@ export interface IStickyProps extends React.Props<Sticky> {
    * @defaultvalue true
    */
   isScrollSynced?: boolean;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 export enum StickyPositionType {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -89,7 +89,8 @@ export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGri
       onKeyDown,
       height,
       width,
-      borderWidth
+      borderWidth,
+      domRef
     } = this.props;
 
     this._classNames = getClassNames(styles!, {
@@ -124,6 +125,7 @@ export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGri
         onMouseLeave={onMouseLeave}
         onWheel={onWheel}
         onKeyDown={onKeyDown}
+        domRef={domRef}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 
 /**
  * {@docCategory SwatchColorPicker}
@@ -106,6 +106,11 @@ export interface IColorPickerGridCellProps {
   onWheel?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
 
   onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -103,7 +103,8 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       className,
       doNotContainWithinFocusZone,
       styles,
-      cellMargin
+      cellMargin,
+      domRef
     } = this.props;
 
     const classNames = getClassNames(styles!, {
@@ -133,6 +134,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
           tableCell: classNames.tableCell,
           focusedContainer: classNames.focusedContainer
         }}
+        domRef={domRef}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -1,5 +1,5 @@
 import { IStyle, ITheme } from '../../Styling';
-import { IStyleFunctionOrObject } from '../../Utilities';
+import { IStyleFunctionOrObject, IRefObject } from '../../Utilities';
 import { IColorCellProps, IColorPickerGridCellStyleProps, IColorPickerGridCellStyles } from './ColorPickerGridCell.types';
 
 /**
@@ -159,6 +159,11 @@ export interface ISwatchColorPickerProps {
    * Selector to focus on mouse leave. Should only be used in conjunction with `focusOnHover`.
    */
   mouseLeaveParentSelector?: string | undefined;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLTableElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
@@ -81,6 +81,8 @@ export class TeachingBubbleBase extends BaseComponent<ITeachingBubbleProps, ITea
       ? (classNames.subComponentStyles as ITeachingBubbleSubComponentStyles).callout
       : undefined;
 
+    const { domRef, ...contentProps } = this.props;
+
     return (
       <Callout
         target={target || targetElement}
@@ -89,9 +91,10 @@ export class TeachingBubbleBase extends BaseComponent<ITeachingBubbleProps, ITea
         className={classNames.root}
         styles={calloutStyles}
         hideOverflow
+        domRef={domRef}
       >
         <div ref={this.rootElement}>
-          <TeachingBubbleContent {...this.props} />
+          <TeachingBubbleContent {...contentProps} />
         </div>
       </Callout>
     );

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -119,6 +119,11 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
    * Defines the element id referencing the element containing the description for the TeachingBubble.
    */
   ariaDescribedBy?: string;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, KeyCodes } from '../../Utilities';
+import { BaseComponent, classNamesFunction, KeyCodes, mergeRefs } from '../../Utilities';
 import { ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles } from './TeachingBubble.types';
 import { ITeachingBubbleState } from './TeachingBubble.base';
 import { PrimaryButton, DefaultButton, IconButton } from '../../Button';
@@ -63,6 +63,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       theme,
       ariaDescribedBy,
       ariaLabelledBy,
+      domRef,
       footerContent: customFooterContent
     } = this.props;
 
@@ -142,7 +143,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
     return (
       <div
         className={classNames.content}
-        ref={this.rootElement}
+        ref={mergeRefs(this.rootElement, domRef)}
         role={'dialog'}
         tabIndex={-1}
         aria-labelledby={ariaLabelledBy}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -185,6 +185,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       theme,
       styles,
       autoAdjustHeight,
+      domRef,
       onRenderPrefix = this._onRenderPrefix,
       onRenderSuffix = this._onRenderSuffix,
       onRenderLabel = this._onRenderLabel,
@@ -211,7 +212,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     });
 
     return (
-      <div className={this._classNames.root}>
+      <div className={this._classNames.root} ref={domRef}>
         <div className={this._classNames.wrapper}>
           {onRenderLabel(this.props, this._onRenderLabel)}
           <div className={this._classNames.fieldGroup}>

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -281,6 +281,11 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * \}
    */
   maskFormat?: { [key: string]: RegExp };
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -34,7 +34,8 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
       maxWidth,
       onRenderContent = this._onRenderContent,
       targetElement,
-      theme
+      theme,
+      domRef
     } = this.props;
 
     this._classNames = getClassNames(styles!, {
@@ -50,6 +51,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
         target={targetElement}
         directionalHint={directionalHint}
         directionalHintForRTL={directionalHintForRTL}
+        domRef={domRef}
         {...calloutProps}
         {...getNativeProps(this.props, divProperties, ['id'])} // omitting ID due to it being used in the div below
         className={this._classNames.root}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -75,6 +75,11 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ITooltipStyleProps, ITooltipStyles>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -10,7 +10,8 @@ import {
   hasOverflow,
   portalContainsElement,
   classNamesFunction,
-  KeyCodes
+  KeyCodes,
+  mergeRefs
 } from '../../Utilities';
 import { ITooltipHostProps, TooltipOverflowMode, ITooltipHostStyles, ITooltipHostStyleProps, ITooltipHost } from './TooltipHost.types';
 import { Tooltip } from './Tooltip';
@@ -66,7 +67,8 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
       setAriaDescribedBy = true,
       tooltipProps,
       styles,
-      theme
+      theme,
+      domRef
     } = this.props;
 
     this._classNames = getClassNames(styles!, {
@@ -83,7 +85,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
     return (
       <div
         className={this._classNames.root}
-        ref={this._tooltipHost}
+        ref={mergeRefs(this._tooltipHost, domRef)}
         {...{ onFocusCapture: this._onTooltipMouseEnter }}
         {...{ onBlurCapture: this._hideTooltip }}
         onMouseEnter={this._onTooltipMouseEnter}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.types.ts
@@ -133,6 +133,11 @@ export interface ITooltipHostProps extends React.HTMLAttributes<HTMLDivElement |
   theme?: ITheme;
 
   /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
+
+  /**
    * Notifies when tooltip becomes visible or hidden, whatever the trigger was.
    */
   onTooltipToggle?(isTooltipVisible: boolean): void;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, elementContains, getId, classNamesFunction, styled } from '../../Utilities';
+import { BaseComponent, KeyCodes, css, elementContains, getId, classNamesFunction, styled, mergeRefs } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Callout, DirectionalHint } from '../../Callout';
@@ -214,7 +214,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
 
   public render(): JSX.Element {
     const { suggestedDisplayValue, isFocused, items } = this.state;
-    const { className, inputProps, disabled, theme, styles } = this.props;
+    const { className, inputProps, disabled, theme, styles, domRef } = this.props;
 
     const selectedSuggestionAlertId = this.props.enableSelectedSuggestionAlert ? this._ariaMap.selectedSuggestionAlert : '';
     const suggestionsAvailable = this.state.suggestionsVisible ? this._ariaMap.suggestionList : '';
@@ -245,7 +245,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
         };
 
     return (
-      <div ref={this.root} className={classNames.root} onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
+      <div ref={mergeRefs(this.root, domRef)} className={classNames.root} onKeyDown={this.onKeyDown} onBlur={this.onBlur}>
         <FocusZone
           componentRef={this.focusZone}
           direction={FocusZoneDirection.bidirectional}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -211,6 +211,11 @@ export interface IBasePickerProps<T> extends React.Props<any> {
    * Theme provided by styled() function.
    */
   theme?: ITheme;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLDivElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -22,7 +22,8 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
       ariaPosInSet = props.positionInSet,
       ariaSetSize = props.setSize,
       styles,
-      doNotContainWithinFocusZone
+      doNotContainWithinFocusZone,
+      domRef
     } = props;
 
     const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(
@@ -38,7 +39,15 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
     const rowsOfItems: any[][] = toMatrix(items, columnCount);
 
     const content = (
-      <table aria-posinset={ariaPosInSet} aria-setsize={ariaSetSize} id={this._id} role="grid" {...htmlProps} className={classNames.root}>
+      <table
+        aria-posinset={ariaPosInSet}
+        aria-setsize={ariaSetSize}
+        id={this._id}
+        role="grid"
+        {...htmlProps}
+        className={classNames.root}
+        ref={domRef}
+      >
         <tbody>
           {rowsOfItems.map((rows: any[], rowIndex: number) => {
             return (

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -78,6 +78,11 @@ export interface IGridProps extends React.TableHTMLAttributes<HTMLTableElement> 
    * Optional styles for the component.
    */
   styles?: IStyleFunctionOrObject<IGridStyleProps, IGridStyles>;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLTableElement>;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/utilities/grid/GridCell.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/GridCell.tsx
@@ -22,7 +22,8 @@ export class GridCell<T, P extends IGridCellProps<T>> extends React.Component<P,
       cellIsSelectedStyle,
       index,
       label,
-      getClassNames
+      getClassNames,
+      domRef
     } = this.props;
 
     return (
@@ -45,6 +46,7 @@ export class GridCell<T, P extends IGridCellProps<T>> extends React.Component<P,
         ariaLabel={label}
         title={label}
         getClassNames={getClassNames}
+        domRef={domRef}
       >
         {onRenderItem(item)}
       </CommandButton>

--- a/packages/office-ui-fabric-react/src/utilities/grid/GridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/GridCell.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IButtonClassNames } from '../../components/Button/BaseButton.classNames';
 import { ITheme } from '../../Styling';
+import { IRefObject } from '../../Utilities';
 
 export interface IGridCellProps<T> {
   /**
@@ -118,4 +119,9 @@ export interface IGridCellProps<T> {
    * Optional, onkeydown handler
    */
   onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
+
+  /**
+   * Provides a React reference to the underlying DOM element
+   */
+  domRef?: IRefObject<HTMLButtonElement | HTMLAnchorElement>;
 }

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -948,6 +948,9 @@ export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined 
 // @public
 export function mergeCustomizations(props: ICustomizerProps, parentContext: ICustomizerContext): ICustomizerContext;
 
+// @public
+export function mergeRefs<T>(...refs: (IRefObject<T> | undefined)[]): IRefObject<T>;
+
 // @public (undocumented)
 export function mergeScopedSettings(oldSettings?: ISettings, newSettings?: ISettings | ISettingsFunction): ISettings;
 

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -64,6 +64,7 @@ export * from './string';
 export * from './styled';
 export * from './warn';
 export * from './ie11Detector';
+export * from './mergeRefs';
 export { IStyleFunctionOrObject, Omit } from '@uifabric/merge-styles';
 export { setFocusVisibility } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';

--- a/packages/utilities/src/mergeRefs.ts
+++ b/packages/utilities/src/mergeRefs.ts
@@ -1,0 +1,18 @@
+import { IRefObject } from './createRef';
+
+/**
+ * Function merge multiple IRefObjects into one ref function. This allows one ref to
+ * be passed to React, which updates multiple refs.
+ */
+export function mergeRefs<T>(...refs: (IRefObject<T> | undefined)[]): IRefObject<T> {
+  return (value: T) => {
+    refs.forEach((ref: IRefObject<T>) => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref !== null && ref !== undefined) {
+        // work around the immutability of the React.RefObject type
+        ((ref as unknown) as { current: T }).current = value;
+      }
+    });
+  };
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7160
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Given that `ReactDOM.findDOMNode()` is [deprecated](https://reactjs.org/docs/strict-mode.html#warning-about-deprecated-finddomnode-usage) and [not compatible with React's Concurrent Mode](https://reactjs.org/docs/concurrent-mode-adoption.html#feature-comparison), developers need alternate ways to access the underlying DOMElements that make up Fabric controls.

This change adds a `domRef` to most components that exposes the top-level (or, in rare cases aroud popups, the primary) DOM Element from the control. The only components intentional skipped over for this change were those that provided the ability to custom render the top-level element; both because the typing would need to be for `IRefObject<any>`, and because a developer can use a custom rendering that provides its own ref.

As a necessary addition to the utilities package for this change, I added a function to merge multiple refs into one ref that can be passed to a JSX.Element.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11945)