### PR TITLE
Slider: use EventListener instead of EventGroup.

### DIFF
--- a/change/office-ui-fabric-react-2020-02-18-16-20-54-slider_eventing.json
+++ b/change/office-ui-fabric-react-2020-02-18-16-20-54-slider_eventing.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Slider: use EventListener, not _events",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "cb049b63dd93fdcf19e8dc7e04d6440b17d011bf",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T00:20:54.258Z"
+}

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -71,6 +71,7 @@
     "sinon": "^4.1.3"
   },
   "dependencies": {
+    "@fluentui/react-component-event-listener": "^0.44.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/foundation": "^7.5.10",
     "@uifabric/icons": "^7.3.9",

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode } from '../../Utilities';
+import { EventListener } from '@fluentui/react-component-event-listener';
 import { ISliderProps, ISlider, ISliderStyleProps, ISliderStyles } from './Slider.types';
 import { classNamesFunction, getNativeProps, divProperties } from '../../Utilities';
 import { Label } from '../../Label';
@@ -187,11 +188,11 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
   private _onMouseDownOrTouchStart = (event: MouseEvent | TouchEvent): void => {
     if (event.type === 'mousedown') {
-      this._events.on(window, 'mousemove', this._onMouseMoveOrTouchMove, true);
-      this._events.on(window, 'mouseup', this._onMouseUpOrTouchEnd, true);
+      <EventListener target={window} type="mousemove" listener={this._onMouseMoveOrTouchMove} capture />;
+      <EventListener target={window} type="mouseup" listener={this._onMouseUpOrTouchEnd} capture />;
     } else if (event.type === 'touchstart') {
-      this._events.on(window, 'touchmove', this._onMouseMoveOrTouchMove, true);
-      this._events.on(window, 'touchend', this._onMouseUpOrTouchEnd, true);
+      <EventListener target={window} type="touchmove" listener={this._onMouseMoveOrTouchMove} capture />;
+      <EventListener target={window} type="touchend" listener={this._onMouseUpOrTouchEnd} capture />;
     }
     this._onMouseMoveOrTouchMove(event, true);
   };
@@ -293,8 +294,6 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     if (this.props.onChanged) {
       this.props.onChanged(event, this.state.value as number);
     }
-
-    this._events.off();
   };
 
   private _onKeyDown = (event: KeyboardEvent): void => {

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -68,8 +68,8 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     const thumbOffsetPercent: number = min === max ? 0 : ((renderedValue! - min!) / (max! - min!)) * 100;
     const zeroOffsetPercent: number = min! >= 0 ? 0 : (-min! / (max! - min!)) * 100;
     const lengthString = vertical ? 'height' : 'width';
-    const onMouseDownProp: {} = disabled ? {} : { onMouseDown: this._onMouseDownOrTouchStart };
-    const onTouchStartProp: {} = disabled ? {} : { onTouchStart: this._onMouseDownOrTouchStart };
+    // const onMouseDownProp: {} = disabled ? {} : { onMouseDown: this._onMouseDownOrTouchStart };
+    // const onTouchStartProp: {} = disabled ? {} : { onTouchStart: this._onMouseDownOrTouchStart };
     const onKeyDownProp: {} = disabled ? {} : { onKeyDown: this._onKeyDown };
     const classNames = getClassNames(styles, {
       className,
@@ -96,8 +96,8 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
             aria-valuetext={this._getAriaValueText(value)}
             aria-label={ariaLabel || label}
             aria-disabled={disabled}
-            {...onMouseDownProp}
-            {...onTouchStartProp}
+            // {...onMouseDownProp}
+            // {...onTouchStartProp}
             {...onKeyDownProp}
             {...divButtonProps}
             className={css(classNames.slideBox, buttonProps!.className)}
@@ -146,6 +146,10 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
             </Label>
           )}
         </div>
+        <EventListener target={window} type="mousemove" listener={this._onMouseMoveOrTouchMove} capture />;
+        <EventListener target={window} type="mouseup" listener={this._onMouseUpOrTouchEnd} capture />;
+        <EventListener target={window} type="touchmove" listener={this._onMouseMoveOrTouchMove} capture />;
+        <EventListener target={window} type="touchend" listener={this._onMouseUpOrTouchEnd} capture />;
       </div>
     ) as React.ReactElement<{}>;
   }
@@ -186,16 +190,16 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     };
   }
 
-  private _onMouseDownOrTouchStart = (event: MouseEvent | TouchEvent): void => {
-    if (event.type === 'mousedown') {
-      <EventListener target={window} type="mousemove" listener={this._onMouseMoveOrTouchMove} capture />;
-      <EventListener target={window} type="mouseup" listener={this._onMouseUpOrTouchEnd} capture />;
-    } else if (event.type === 'touchstart') {
-      <EventListener target={window} type="touchmove" listener={this._onMouseMoveOrTouchMove} capture />;
-      <EventListener target={window} type="touchend" listener={this._onMouseUpOrTouchEnd} capture />;
-    }
-    this._onMouseMoveOrTouchMove(event, true);
-  };
+  // private _onMouseDownOrTouchStart = (event: MouseEvent | TouchEvent): void => {
+  //   if (event.type === 'mousedown') {
+  //     <EventListener target={window} type="mousemove" listener={this._onMouseMoveOrTouchMove} capture />;
+  //     <EventListener target={window} type="mouseup" listener={this._onMouseUpOrTouchEnd} capture />;
+  //   } else if (event.type === 'touchstart') {
+  //     <EventListener target={window} type="touchmove" listener={this._onMouseMoveOrTouchMove} capture />;
+  //     <EventListener target={window} type="touchend" listener={this._onMouseUpOrTouchEnd} capture />;
+  //   }
+  //   this._onMouseMoveOrTouchMove(event, true);
+  // };
 
   private _onMouseMoveOrTouchMove = (event: MouseEvent | TouchEvent, suppressEventCancelation?: boolean): void => {
     if (!this._sliderLine.current) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Changing Slider's eventing from the EventGroup dependent `_events` to the more performant `fluent-ui-react` EventListener. This is a draft because all of these eventing PRs can't really be published until the repo merge (per this [comment](https://github.com/OfficeDev/office-ui-fabric-react/pull/11960#issuecomment-587882721)) and I'm still ironing out some things I noticed while playing around with these event scenarios in Storybook after these changes and it's easier to ask for feedback on them with a PR deploy to show.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11987)