### PR TITLE
ContextualMenu: use EventListener instead of EventGroup.

### DIFF
--- a/change/office-ui-fabric-react-2020-02-18-16-21-08-contextualmenu_eventing.json
+++ b/change/office-ui-fabric-react-2020-02-18-16-21-08-contextualmenu_eventing.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ContextualMenu: use EventListener, not _events",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "2a8fcd5a8ea11af6b66433a0099e05db00c2a92b",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T00:21:08.707Z"
+}

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -71,6 +71,7 @@
     "sinon": "^4.1.3"
   },
   "dependencies": {
+    "@fluentui/react-component-event-listener": "^0.44.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/foundation": "^7.5.10",
     "@uifabric/icons": "^7.3.9",

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -11,6 +11,7 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
 import { IMenuItemClassNames, IContextualMenuClassNames } from './ContextualMenu.classNames';
 import { divProperties, getNativeProps, shallowCompare } from '../../Utilities';
+import { EventListener } from '@fluentui/react-component-event-listener';
 
 import {
   assign,
@@ -203,7 +204,6 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
       this.props.onMenuDismissed(this.props);
     }
 
-    this._events.dispose();
     this._async.dispose();
     this._mounted = false;
   }
@@ -357,6 +357,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
               </FocusZone>
             ) : null}
             {submenuProps && onRenderSubMenu(submenuProps, this._onRenderSubMenu)}
+            <EventListener target={this._targetWindow} type="resize" listener={this.dismiss} />
           </div>
         </Callout>
       );
@@ -375,14 +376,12 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   }
 
   private _onMenuOpened() {
-    this._events.on(this._targetWindow, 'resize', this.dismiss);
     this._shouldUpdateFocusOnMouseEvent = !this.props.delayUpdateFocusOnHover;
     this._gotMouseMove = false;
     this.props.onMenuOpened && this.props.onMenuOpened(this.props);
   }
 
   private _onMenuClosed() {
-    this._events.off(this._targetWindow, 'resize', this.dismiss);
     this._tryFocusPreviousActiveElement();
 
     if (this.props.onMenuDismissed) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Similar to #11987, making this a draft PR since we have to wait for the repo merge to be done for these to go in. There doesn't seem to be a resize scenario on ContextualMenu's Storybook so need to test this another way, through a custom example perhaps.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11988)