### PR TITLE
TilesList: Add role "row" around rows

### DIFF
--- a/change/@uifabric-experiments-2020-01-09-10-38-06-TilesList-row-wrapper.json
+++ b/change/@uifabric-experiments-2020-01-09-10-38-06-TilesList-row-wrapper.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TilesList: Wrap each row with role row",
+  "packageName": "@uifabric/experiments",
+  "email": "erabelle@microsoft.com",
+  "commit": "7aee96fe9241ac6461a9632195d7ed469712e5e5",
+  "date": "2020-01-09T18:38:05.938Z"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.scss
+++ b/packages/experiments/src/components/TilesList/TilesList.scss
@@ -42,6 +42,11 @@
   align-content: flex-start;
 }
 
+.row {
+  display: flex;
+  width: 100%;
+}
+
 .shimmeredList {
   &::after {
     content: '';

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -221,6 +221,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
     const endIndex = cells.length;
 
     let currentRow: IRowData | undefined;
+    let currentRowCells = [];
 
     let shimmerWrapperWidth = 0;
 
@@ -245,6 +246,11 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
         const cellAsFirstRow = data.rows[index];
 
         if (cellAsFirstRow) {
+          if (currentRowCells.length > 0) {
+            renderedCells.push(this._renderRow(currentRowCells, grid, isPlaceholder));
+            currentRowCells = [];
+          }
+
           if (cellAsFirstRow !== currentRow) {
             rowCount++;
           }
@@ -308,11 +314,11 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
           const totalPlaceholderItems = cellsPerRow * ROWS_OF_PLACEHOLDER_CELLS;
           shimmerWrapperWidth = cellsPerRow * finalSize.width + grid.spacing * (cellsPerRow - 1);
           for (let j = 0; j < totalPlaceholderItems; j++) {
-            renderedCells.push(renderedCell(j));
+            currentRowCells.push(renderedCell(j));
           }
         } else {
           shimmerWrapperWidth = finalSize.width / 3;
-          renderedCells.push(renderedCell());
+          currentRowCells.push(renderedCell());
         }
       }
 
@@ -326,6 +332,11 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
       const isOpenEnd = nextCell && nextCell.grid === grid;
 
       const margin = grid.spacing / 2;
+
+      if (currentRowCells.length > 0) {
+        renderedCells.push(this._renderRow(currentRowCells, grid, isPlaceholder));
+        currentRowCells = [];
+      }
 
       const finalGrid: JSX.Element = (
         <div
@@ -551,6 +562,14 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
     pageSpecificationCache.byIndex[startIndex] = pageSpecification;
 
     return pageSpecification;
+  };
+
+  private _renderRow = (row: JSX.Element[], grid: ITileGrid, isPlaceholder: boolean | undefined): JSX.Element => {
+    return (
+      <div role="row" className={TilesListStyles.row}>
+        {row}
+      </div>
+    );
   };
 
   private _onGetCellClassName = (): string => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a wrapper around TilesList rows to give them role="row". This is a portion of an accessibility fix to support aria-selected in TilesList.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12053)