### PR TITLE
chore(Image): replace `withSafeTypeForAs`

### DIFF
--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "~24.9.0",
     "@types/node": "^10.3.2",
     "@types/puppeteer": "1.12.3",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/sarif": "^2.1.1",
     "@uifabric/build": "^7.0.0",

--- a/apps/dom-tests/package.json
+++ b/apps/dom-tests/package.json
@@ -30,7 +30,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/puppeteer": "1.12.3",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "~24.9.0",
     "@types/prop-types": "15.7.1",
     "@types/puppeteer": "1.12.3",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/resemblejs": "~1.3.28",

--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
     "@types/node": "^10.3.2",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/resemblejs": "~1.3.28",
     "@types/webpack-env": "1.15.1",

--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@types/webpack-node-externals": "1.6.3",

--- a/apps/server-rendered-app/package.json
+++ b/apps/server-rendered-app/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -21,7 +21,7 @@
     "start": "just-scripts dev"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/apps/todo-app/package.json
+++ b/apps/todo-app/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -31,7 +31,7 @@
     "@storybook/addons": "^5.3.8",
     "@storybook/channels": "^5.3.8",
     "@storybook/react": "^5.3.8",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -31,7 +31,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/prop-types": "15.7.1",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-addons-test-utils": "0.14.18",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -32,7 +32,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/prop-types": "15.7.1",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -25,7 +25,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/markdown-to-jsx": "6.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-custom-scrollbars": "^4.0.5",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -15,7 +15,7 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -32,7 +32,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/prop-types": "15.7.1",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-addons-test-utils": "0.14.18",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -23,7 +23,7 @@
     "code-style": "just-scripts code-style"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -25,7 +25,7 @@
     "@types/faker": "^4.1.3",
     "@types/gulp": "^4.0.6",
     "@types/node": "^10.3.2",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-custom-scrollbars": "^4.0.5",
     "@types/react-router-dom": "^4.3.4",
     "@types/react-virtualized": "^9.21.8",

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@fluentui/react-northstar": "^0.47.0",
     "@types/puppeteer": "1.12.3",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-router-dom": "^4.3.4",
     "@uifabric/build": "^7.0.0",
     "puppeteer": "^1.13.0",

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@fluentui/digest": "^0.47.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "flamegrill": "0.1.3",

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@babel/polyfill": "^7.7.0",
     "@fluentui/react-northstar": "^0.47.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",
     "minimatch": "^3.0.4"

--- a/packages/fluentui/playground/package.json
+++ b/packages/fluentui/playground/package.json
@@ -42,7 +42,7 @@
     "@types/jest": "~24.9.0",
     "@types/jest-environment-puppeteer": "^4.3.1",
     "@types/node": "^10.3.2",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/storybook__addon-info": "^5.2.1",
     "@uifabric/build": "^7.0.0",
     "enzyme": "~3.10.0",

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -9,7 +9,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/simulant": "^0.2.0",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -9,7 +9,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -10,7 +10,7 @@
     "react-is": "^16.6.3"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-is": "^16.7.1",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"

--- a/packages/fluentui/react-context-selector/package.json
+++ b/packages/fluentui/react-context-selector/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.7.6"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-is": "^16.7.1",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-icons-northstar/package.json
+++ b/packages/fluentui/react-icons-northstar/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-is": "^16.7.1",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -35,7 +35,7 @@
     "@testing-library/jest-dom": "^5.1.1",
     "@types/classnames": "^2.2.9",
     "@types/faker": "^4.1.3",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/simulant": "^0.2.0",
     "@uifabric/build": "^7.0.0",
     "faker": "^4.1.0",

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -14,6 +14,11 @@ export type DebounceResultFn<T> = T & {
 // Utilities
 // ========================================================
 
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+export type PropsOfElement<
+  E extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+> = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithRef<E>>;
+
 export type ResultOf<T> = T extends (...arg: any[]) => infer TResult ? TResult : never;
 
 export type ObjectOf<T> = { [key: string]: T };

--- a/packages/fluentui/react-northstar/test/specs/components/Image/Image-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Image/Image-test.tsx
@@ -5,9 +5,7 @@ import Image from 'src/components/Image/Image';
 import { mountWithProviderAndGetComponent } from 'test/utils';
 
 describe('Image', () => {
-  isConformant(Image, {
-    constructorName: 'Image',
-  });
+  isConformant(Image);
 
   describe('accessibility', () => {
     handlesAccessibility(Image, {

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -10,7 +10,7 @@
     "prop-types": "^15.7.2"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/react-theming/package.json
+++ b/packages/fluentui/react-theming/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@types/jss": "^9.5.8",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "react": "16.8.6"
   },

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.7.6"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -10,7 +10,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0"
   },

--- a/packages/foundation-scenarios/package.json
+++ b/packages/foundation-scenarios/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@types/es6-promise": "0.0.32",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -30,7 +30,7 @@
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/sinon": "2.2.2",

--- a/packages/jest-serializer-merge-styles/package.json
+++ b/packages/jest-serializer-merge-styles/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/packages/lists/package.json
+++ b/packages/lists/package.json
@@ -32,7 +32,7 @@
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -40,7 +40,7 @@
     "@types/jest": "~24.9.0",
     "@types/node": "^10.3.2",
     "@types/prop-types": "15.7.1",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/resemblejs": "~1.3.28",

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -31,7 +31,7 @@
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/resemblejs": "~1.3.28",

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -25,7 +25,7 @@
     "just": "just-scripts"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",
     "@uifabric/tslint-rules": "^7.1.2",

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -31,7 +31,7 @@
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -28,7 +28,7 @@
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,7 @@
     "update-api": "just-scripts update-api"
   },
   "devDependencies": {
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -29,7 +29,7 @@
     "@types/enzyme-adapter-react-16": "1.0.3",
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",

--- a/packages/tsx-editor/package.json
+++ b/packages/tsx-editor/package.json
@@ -28,7 +28,7 @@
     "@types/es6-promise": "0.0.32",
     "@types/jest": "~24.9.0",
     "@types/node": "^10.3.2",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-syntax-highlighter": "^10.2.1",
     "@types/react-test-renderer": "^16.0.0",

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -31,7 +31,7 @@
     "@types/jest": "~24.9.0",
     "@types/node": "^10.3.2",
     "@types/prop-types": "15.7.1",
-    "@types/react": "16.8.11",
+    "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/sinon": "2.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4025,10 +4025,10 @@
     "@types/prop-types" "*"
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.8.11":
-  version "16.8.11"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.11.tgz#2b13a7ab797b7ed1309e3cbf69994405d2391623"
-  integrity sha512-xEqvjpe7L5xAMlbZYUxxrgo3+ZXBvdnbhDtLWE/Md5LRw/quMRebZBIbqyKCl/77i64rqVtC2/WVDuYmO/diJQ==
+"@types/react@*", "@types/react@16.8.25":
+  version "16.8.25"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.25.tgz#0247613ab58b1b11ba10fed662e1947c5f2bb89c"
+  integrity sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Currently we have `withSafeTypeForAs` utility which partially solves polymorphic typings for `as` prop but it's too complex and creates over-complicated [type definitions](https://cdn.jsdelivr.net/npm/@fluentui/react@0.44.0/dist/es/components/Image/Image.d.ts) in `dist`.

This PR removes usage of `withSafeTypeForAs` in `Image` component with simple typings. Approach is inspired by recent changes in emotion: emotion-js/emotion#1405 & [`react-polymorphic-box`](https://github.com/kripod/react-polymorphic-box). It's also compatible `React.forwardRef`.

#### Focus areas to test

I made a test snippet that allows to test all possible cases with broken props, feel free to add missing things 👍

```tsx
import * as React from "react";
import { Image, Button } from "@fluentui/react";

const ImageExample = () => (
  <>
    {/* Wrong default props */}
    <Image src="public/images/wireframe/square-image.png" to="Foo" />
    <Image src="public/images/wireframe/square-image.png" type="Foo" />

    {/* Wrong elements */}
    <Image as="aa" src="public/images/wireframe/square-image.png" />
    <Image as="blockq" src="public/images/wireframe/square-image.png" />

    {/* Wrong attrs on els */}
    <Image
      as="button"
      src="public/images/wireframe/square-image.png"
      type="Foo"
    />
    <Image as="a" src="public/images/wireframe/square-image.png" href1="Foo" />
    <Image
      as="button"
      src="public/images/wireframe/square-image.png"
      href="Foo"
    />

    {/* Wrong attr on components */}
    <Image
      as={Button}
      src="public/images/wireframe/square-image.png"
      type="Foo"
    />
    <Image
      as={Button}
      src="public/images/wireframe/square-image.png"
      typ="Foo"
    />
  </>
);

export default ImageExample;
```

Fixes https://github.com/microsoft/fluent-ui-react/issues/1527.

***

I also have to bump `@types/react` as `16.8.11` doesn't contain a needed change as cases like this will not work:
```tsx
<Image as="a" src="public/images/wireframe/square-image.png" href1="Foo" />
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12142)