### PR TITLE
ColorPicker: Add support for selecting transparency instead of alpha

### DIFF
--- a/change/office-ui-fabric-react-2020-04-06-09-05-28-transparency2.json
+++ b/change/office-ui-fabric-react-2020-04-06-09-05-28-transparency2.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ColorPicker: Add support for selecting transparency instead of alpha",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "8daab0296711d7edf6060e0f43d2794653db4387",
+  "dependentChangeType": "patch",
+  "date": "2020-04-06T16:05:28.690Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2455,6 +2455,7 @@ export type ICoachmarkTypes = ICoachmarkProps;
 export interface IColor extends IRGB, IHSV {
     hex: string;
     str: string;
+    t?: number;
 }
 
 // @public (undocumented)
@@ -2524,7 +2525,9 @@ export interface IColorPickerGridCellStyles {
 export interface IColorPickerProps {
     // @deprecated
     alphaLabel?: string;
+    // @deprecated
     alphaSliderHidden?: boolean;
+    alphaType?: 'alpha' | 'transparency' | 'none';
     // @deprecated
     blueLabel?: string;
     className?: string;
@@ -2545,11 +2548,9 @@ export interface IColorPickerProps {
 
 // @public (undocumented)
 export interface IColorPickerState {
-    // (undocumented)
     color: IColor;
-    // (undocumented)
     editingColor?: {
-        component: keyof IRGBHex;
+        component: ColorComponent;
         value: string;
     };
 }
@@ -2569,13 +2570,12 @@ export interface IColorPickerStrings {
     svAriaDescription?: string;
     svAriaLabel?: string;
     svAriaValueFormat?: string;
+    transparency?: string;
+    transparencyAriaLabel?: string;
 }
 
 // @public (undocumented)
-export interface IColorPickerStyleProps {
-    className?: string;
-    theme: ITheme;
-}
+export type IColorPickerStyleProps = Required<Pick<IColorPickerProps, 'theme'>> & Pick<IColorPickerProps, 'className' | 'alphaType'>;
 
 // @public (undocumented)
 export interface IColorPickerStyles {
@@ -2588,6 +2588,7 @@ export interface IColorPickerStyles {
     panel?: IStyle;
     root?: IStyle;
     table?: IStyle;
+    tableAlphaCell?: IStyle;
     tableHeader?: IStyle;
     tableHexCell?: IStyle;
 }
@@ -2637,8 +2638,11 @@ export interface IColorSliderProps {
     ariaLabel?: string;
     className?: string;
     componentRef?: IRefObject<IColorSlider>;
+    // @deprecated
     isAlpha?: boolean;
+    // @deprecated
     maxValue?: number;
+    // @deprecated
     minValue?: number;
     onChange?: (event: React.MouseEvent | React.KeyboardEvent, newValue?: number) => void;
     overlayColor?: string;
@@ -2648,11 +2652,14 @@ export interface IColorSliderProps {
     theme?: ITheme;
     // @deprecated
     thumbColor?: string;
+    type?: 'hue' | 'alpha' | 'transparency';
     value?: number;
 }
 
 // @public (undocumented)
-export type IColorSliderStyleProps = Required<Pick<IColorSliderProps, 'theme'>> & Pick<IColorSliderProps, 'className' | 'isAlpha'>;
+export type IColorSliderStyleProps = Required<Pick<IColorSliderProps, 'theme'>> & Pick<IColorSliderProps, 'className' | 'type'> & {
+    isAlpha?: boolean;
+};
 
 // @public (undocumented)
 export interface IColorSliderStyles {
@@ -9575,6 +9582,9 @@ export function updateRGB(color: IColor, component: keyof IRGB, value: number): 
 export function updateSV(color: IColor, s: number, v: number): IColor;
 
 // @public
+export function updateT(color: IColor, t: number): IColor;
+
+// @public
 export enum ValidationState {
     invalid = 2,
     valid = 0,
@@ -9608,7 +9618,7 @@ export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
 //
-// lib/components/ColorPicker/ColorPicker.base.d.ts:8:9 - (ae-forgotten-export) The symbol "IRGBHex" needs to be exported by the entry point index.d.ts
+// lib/components/ColorPicker/ColorPicker.base.d.ts:11:9 - (ae-forgotten-export) The symbol "ColorComponent" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, initializeComponentRef } from '../../Utilities';
+import { classNamesFunction, initializeComponentRef, warnDeprecations, warn } from '../../Utilities';
 import {
   IColorPickerProps,
   IColorPickerStyleProps,
@@ -10,10 +10,8 @@ import {
 import { TextField } from '../../TextField';
 import { ColorRectangle } from './ColorRectangle/ColorRectangle';
 import { ColorSlider } from './ColorSlider/ColorSlider';
-// These imports are separated to help with bundling
 import {
   MAX_COLOR_ALPHA,
-  MAX_COLOR_HUE,
   MAX_COLOR_RGB,
   MAX_HEX_LENGTH,
   MAX_RGBA_LENGTH,
@@ -22,34 +20,42 @@ import {
   HEX_REGEX,
   RGBA_REGEX,
 } from '../../utilities/color/consts';
+// These imports are separated to help with bundling
 import { IColor, IRGB } from '../../utilities/color/interfaces';
 import { getColorFromString } from '../../utilities/color/getColorFromString';
 import { getColorFromRGBA } from '../../utilities/color/getColorFromRGBA';
+import { clamp } from '../../utilities/color/clamp';
 import { updateA } from '../../utilities/color/updateA';
+import { updateT } from '../../utilities/color/updateT';
 import { updateH } from '../../utilities/color/updateH';
 import { correctRGB } from '../../utilities/color/correctRGB';
 import { correctHex } from '../../utilities/color/correctHex';
 import { ColorRectangleBase } from './ColorRectangle/ColorRectangle.base';
 
-type IRGBHex = Pick<IColor, 'r' | 'g' | 'b' | 'a' | 'hex'>;
+type ColorComponent = keyof Pick<IColor, 'r' | 'g' | 'b' | 'a' | 't' | 'hex'>;
 
 export interface IColorPickerState {
+  /** Most recently selected color */
   color: IColor;
+  /** Color component currently being edited via a text field (if intermediate value is invalid) */
   editingColor?: {
-    component: keyof IRGBHex;
+    /** Which color component is being edited */
+    component: ColorComponent;
+    /** Currently entered value, which is not valid */
     value: string;
   };
 }
 
 const getClassNames = classNamesFunction<IColorPickerStyleProps, IColorPickerStyles>();
 
-const colorComponents: Array<keyof IRGBHex> = ['hex', 'r', 'g', 'b', 'a'];
+const allColorComponents: ColorComponent[] = ['hex', 'r', 'g', 'b', 'a', 't'];
 
 /**
  * {@docCategory ColorPicker}
  */
 export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPickerState> implements IColorPicker {
   public static defaultProps: Partial<IColorPickerProps> = {
+    alphaType: 'alpha',
     strings: {
       rootAriaLabelFormat: 'Color picker, {0} selected.',
       hex: 'Hex',
@@ -57,6 +63,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       green: 'Green',
       blue: 'Blue',
       alpha: 'Alpha',
+      transparency: 'Transparency',
       hueAriaLabel: 'Hue',
       svAriaLabel: ColorRectangleBase.defaultProps.ariaLabel!,
       svAriaValueFormat: ColorRectangleBase.defaultProps.ariaValueFormat!,
@@ -65,31 +72,48 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
   };
 
   private _textChangeHandlers: {
-    [K in keyof IRGBHex]: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
+    [K in ColorComponent]: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
   };
   /**
    * Strings displayed in the UI as text field labels (these are in a separate object for convenient
    * indexing by short color component name).
    */
-  private _textLabels: { [K in keyof IRGBHex]: string };
-  /** Strings besides red/green/blue/alpha/hex */
-  private _strings: Required<IColorPickerStrings>;
+  private _textLabels: { [K in ColorComponent]: string };
+
+  /** Strings besides red/green/blue/alpha/hex, with defaults for all values except the deprecated `hue` */
+  private _strings: Required<Omit<IColorPickerStrings, ColorComponent | 'hue'>> & Pick<IColorPickerStrings, 'hue'>;
 
   constructor(props: IColorPickerProps) {
     super(props);
 
     initializeComponentRef(this);
 
+    const strings = props.strings!; // always defined since it's in defaultProps
+
+    warnDeprecations('ColorPicker', props, {
+      hexLabel: 'strings.hex',
+      redLabel: 'strings.red',
+      greenLabel: 'strings.green',
+      blueLabel: 'strings.blue',
+      alphaLabel: 'strings.alpha',
+      alphaSliderHidden: 'alphaType',
+    });
+
+    // tslint:disable-next-line:deprecation
+    if (strings.hue) {
+      // warnDeprecations can't handle nested deprecated props
+      warn("ColorPicker property 'strings.hue' was used but has been deprecated. Use 'strings.hueAriaLabel' instead.");
+    }
+
     this.state = {
       color: _getColorFromProps(props) || getColorFromString('#ffffff')!,
     };
 
     this._textChangeHandlers = {} as any;
-    for (const component of colorComponents) {
+    for (const component of allColorComponents) {
       this._textChangeHandlers[component] = this._onTextChange.bind(this, component);
     }
 
-    const strings = props.strings!; // always defined since it's in defaultProps
     const defaultStrings = ColorPickerBase.defaultProps.strings as Required<IColorPickerStrings>;
 
     this._textLabels = {
@@ -99,11 +123,15 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       b: props.blueLabel || strings.blue || defaultStrings.blue,
       a: props.alphaLabel || strings.alpha || defaultStrings.alpha,
       hex: props.hexLabel || strings.hex || defaultStrings.hex,
+      t: strings.transparency || defaultStrings.transparency,
       // tslint:enable:deprecation
     };
 
     this._strings = {
       ...defaultStrings,
+      // these aria labels default to the visible labels
+      alphaAriaLabel: this._textLabels.a,
+      transparencyAriaLabel: this._textLabels.t,
       ...strings,
     };
   }
@@ -126,23 +154,31 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     const props = this.props;
     const strings = this._strings;
     const textLabels = this._textLabels;
-    const { theme, className, styles, alphaSliderHidden } = props;
+    const {
+      theme,
+      className,
+      styles,
+      alphaType,
+      // tslint:disable-next-line:deprecation
+      alphaSliderHidden = alphaType === 'none',
+    } = props;
     const { color } = this.state;
+    const useTransparency = alphaType === 'transparency';
+    const colorComponents = ['hex', 'r', 'g', 'b', useTransparency ? 't' : 'a'];
+    const atValue = useTransparency ? color.t : color.a;
+    const atLabel = useTransparency ? textLabels.t : textLabels.a;
 
     const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
+      alphaType,
     });
 
-    const colorStr = color.str || '';
-    // Space out hex and RGBA colors for more helpful reading
-    const selectedColorAria =
-      colorStr[0] === '#'
-        ? colorStr.split('').join(' ')
-        : colorStr.indexOf('rgba(') === 0
-        ? `R G B A ${color.r} ${color.g} ${color.b} ${color.a!}%`
-        : colorStr;
-    const ariaLabel = strings.rootAriaLabelFormat.replace('{0}', selectedColorAria);
+    const selectedColorAriaParts = [textLabels.r, color.r, textLabels.g, color.g, textLabels.b, color.b];
+    if (!alphaSliderHidden && typeof atValue === 'number') {
+      selectedColorAriaParts.push(atLabel, `${atValue}%`);
+    }
+    const ariaLabel = strings.rootAriaLabelFormat.replace('{0}', selectedColorAriaParts.join(' '));
 
     return (
       <div className={classNames.root} role="group" aria-label={ariaLabel}>
@@ -159,23 +195,20 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
             <div className={classNames.flexSlider}>
               <ColorSlider
                 className="is-hue"
+                type="hue"
                 // tslint:disable-next-line:deprecation
                 ariaLabel={strings.hue || strings.hueAriaLabel}
-                minValue={0}
-                maxValue={MAX_COLOR_HUE}
                 value={color.h}
                 onChange={this._onHChanged}
               />
               {!alphaSliderHidden && (
                 <ColorSlider
                   className="is-alpha"
-                  isAlpha
-                  ariaLabel={strings.alphaAriaLabel || textLabels.a}
+                  type={alphaType as 'alpha' | 'transparency'}
+                  ariaLabel={useTransparency ? strings.transparencyAriaLabel : strings.alphaAriaLabel}
                   overlayColor={color.hex}
-                  minValue={0}
-                  maxValue={MAX_COLOR_ALPHA}
-                  value={color.a}
-                  onChange={this._onAChanged}
+                  value={atValue}
+                  onChange={this._onATChanged}
                 />
               )}
             </div>
@@ -200,17 +233,17 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
                 <td>{textLabels.r}</td>
                 <td>{textLabels.g}</td>
                 <td>{textLabels.b}</td>
-                {!alphaSliderHidden && <td>{textLabels.a}</td>}
+                {!alphaSliderHidden && <td className={classNames.tableAlphaCell}>{atLabel}</td>}
               </tr>
             </thead>
             <tbody>
               <tr>
-                {...colorComponents.map((comp: keyof IRGBHex) => {
-                  if (comp === 'a' && alphaSliderHidden) {
+                {...colorComponents.map((comp: ColorComponent) => {
+                  if ((comp === 'a' || comp === 't') && alphaSliderHidden) {
                     return null;
                   }
                   return (
-                    <td key={comp} style={comp === 'hex' ? undefined : { width: '18%' }}>
+                    <td key={comp}>
                       <TextField
                         className={classNames.input}
                         onChange={this._textChangeHandlers[comp]}
@@ -231,7 +264,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     );
   }
 
-  private _getDisplayValue(component: keyof IColor): string {
+  private _getDisplayValue(component: ColorComponent): string {
     const { color, editingColor } = this.state;
     if (editingColor && editingColor.component === component) {
       return editingColor.value;
@@ -252,14 +285,17 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     this._updateColor(ev, updateH(this.state.color, h));
   };
 
-  private _onAChanged = (ev: React.MouseEvent<HTMLElement>, a: number): void => {
-    this._updateColor(ev, updateA(this.state.color, Math.round(a)));
+  /** Callback for when the alpha/transparency slider changes */
+  private _onATChanged = (ev: React.MouseEvent<HTMLElement>, value: number): void => {
+    const updater = this.props.alphaType === 'transparency' ? updateT : updateA;
+    this._updateColor(ev, updater(this.state.color, Math.round(value)));
   };
 
-  private _onTextChange(component: keyof IRGBHex, event: React.FormEvent<HTMLInputElement>, newValue?: string): void {
+  private _onTextChange(component: ColorComponent, event: React.FormEvent<HTMLInputElement>, newValue?: string): void {
     const color = this.state.color;
     const isHex = component === 'hex';
     const isAlpha = component === 'a';
+    const isTransparency = component === 't';
     newValue = (newValue || '').substr(0, isHex ? MAX_HEX_LENGTH : MAX_RGBA_LENGTH);
 
     // Ignore what the user typed if it contains invalid characters
@@ -278,7 +314,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       // cause it to be automatically converted to a value of length 6, which may not be what the
       // user wanted if they're not finished typing. (Values of length 3 will be committed on blur.)
       isValid = newValue.length === MAX_HEX_LENGTH;
-    } else if (isAlpha) {
+    } else if (isAlpha || isTransparency) {
       isValid = Number(newValue) <= MAX_COLOR_ALPHA;
     } else {
       isValid = Number(newValue) <= MAX_COLOR_RGB;
@@ -299,6 +335,8 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       // Should be a valid color. Update the value.
       const newColor = isHex
         ? getColorFromString('#' + newValue)
+        : isTransparency
+        ? updateT(color, Number(newValue))
         : getColorFromRGBA({
             ...color,
             // Overwrite whichever key is being updated with the new value
@@ -317,12 +355,17 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     // If there was an intermediate incorrect value (such as too large or empty), correct it.
     const { value, component } = editingColor;
     const isHex = component === 'hex';
+    const isAlpha = component === 'a';
+    const isTransparency = component === 't';
     const minLength = isHex ? MIN_HEX_LENGTH : MIN_RGBA_LENGTH;
     if (value.length >= minLength && (isHex || !isNaN(Number(value)))) {
       // Real value. Clamp to appropriate length (hex) or range (rgba).
       let newColor: IColor | undefined;
       if (isHex) {
         newColor = getColorFromString('#' + correctHex(value));
+      } else if (isAlpha || isTransparency) {
+        const updater = isAlpha ? updateA : updateT;
+        newColor = updater(color, clamp(Number(value), MAX_COLOR_ALPHA));
       } else {
         newColor = getColorFromRGBA(
           correctRGB({
@@ -335,7 +378,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
       // Update state and call onChange
       this._updateColor(event, newColor);
     } else {
-      // Intermediate value was an empty string, too short (hex only), or just . (alpha only).
+      // Intermediate value was an empty string or too short (hex only).
       // Just clear the intermediate state and revert to the previous value.
       this.setState({ editingColor: undefined });
     }
@@ -352,6 +395,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     }
 
     const { color, editingColor } = this.state;
+    // For black or white, the hue can change without changing the string.
     const isDifferentColor = newColor.h !== color.h || newColor.str !== color.str;
 
     if (isDifferentColor || editingColor) {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.deprecated.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { ColorPicker } from './ColorPicker';
+import { ColorPickerBase, IColorPickerState } from './ColorPicker.base';
+import { IColorPickerProps, IColorPickerStrings } from './ColorPicker.types';
+import { ColorSliderBase } from './ColorSlider/ColorSlider.base';
+import { setWarningCallback } from '../../Utilities';
+
+// tslint:disable:deprecation
+
+describe('ColorPicker', () => {
+  let wrapper: ReactWrapper<IColorPickerProps, IColorPickerState, ColorPickerBase> | undefined;
+
+  beforeAll(() => {
+    // Prevent warn deprecations from failing test
+    setWarningCallback(() => {
+      /* no-op */
+    });
+  });
+
+  afterAll(() => {
+    setWarningCallback();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  it('hides alpha control slider', () => {
+    wrapper = mount(<ColorPicker color="#ffffff" alphaSliderHidden={true} />);
+
+    const alphaSlider = wrapper.find('.is-alpha');
+    const tableHeaders = wrapper.find('thead td');
+
+    // There should only be table headers and inputs for hex, red, green, and blue (no alpha)
+    expect(alphaSlider.exists()).toBe(false);
+    expect(tableHeaders).toHaveLength(4);
+
+    const inputs = wrapper.getDOMNode().querySelectorAll('input') as NodeListOf<HTMLInputElement>;
+    expect(inputs).toHaveLength(4);
+    expect(inputs[0].value).toBe('ffffff');
+    expect(inputs[1].value).toBe('255');
+    expect(inputs[2].value).toBe('255');
+    expect(inputs[3].value).toBe('255');
+  });
+
+  it('renders deprecated custom strings', () => {
+    const fields = ['Custom Hex', 'Custom Red', 'Custom Green', 'Custom Blue', 'Custom Alpha'];
+
+    wrapper = mount(
+      <ColorPicker
+        color="#FFFFFF"
+        hexLabel={fields[0]}
+        redLabel={fields[1]}
+        greenLabel={fields[2]}
+        blueLabel={fields[3]}
+        alphaLabel={fields[4]}
+      />,
+    );
+
+    const tableHeaders = wrapper.find('thead td');
+    tableHeaders.forEach((node, index) => {
+      expect(node.text()).toEqual(fields[index]);
+    });
+
+    const sliders = wrapper.find(ColorSliderBase);
+    expect(sliders.at(1).html()).toContain('Custom Alpha');
+  });
+
+  it('renders mix of new and deprecated custom strings', () => {
+    const customRed = 'Custom Red';
+    const customAlpha = 'Custom Alpha';
+    const customStrings: IColorPickerStrings = {
+      hex: 'Custom Hex',
+      blue: 'Custom Blue',
+    };
+
+    wrapper = mount(
+      <ColorPicker color="#FFFFFF" strings={customStrings} redLabel={customRed} alphaLabel={customAlpha} />,
+    );
+
+    const tableHeaders = wrapper.find('thead td');
+    expect(tableHeaders.at(0).text()).toEqual(customStrings.hex);
+    expect(tableHeaders.at(1).text()).toEqual(customRed);
+    expect(tableHeaders.at(2).text()).toEqual('Green'); // not customized
+    expect(tableHeaders.at(3).text()).toEqual(customStrings.blue);
+    expect(tableHeaders.at(4).text()).toEqual(customAlpha);
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.styles.ts
@@ -1,7 +1,7 @@
 import { IColorPickerStyleProps, IColorPickerStyles } from './ColorPicker.types';
 
 export const getStyles = (props: IColorPickerStyleProps): IColorPickerStyles => {
-  const { className, theme } = props;
+  const { className, theme, alphaType } = props;
 
   return {
     root: [
@@ -41,11 +41,13 @@ export const getStyles = (props: IColorPickerStyleProps): IColorPickerStyles => 
         },
       },
     ],
-    tableHexCell: [
-      {
-        width: '25%',
-      },
-    ],
+    tableHexCell: {
+      width: '25%',
+    },
+    // Account for "Transparency" being a longer word
+    tableAlphaCell: alphaType === 'transparency' && {
+      width: '22%',
+    },
     colorSquare: [
       'ms-ColorPicker-colorSquare',
       {
@@ -55,21 +57,15 @@ export const getStyles = (props: IColorPickerStyleProps): IColorPickerStyles => 
         border: '1px solid #c8c6c4',
       },
     ],
-    flexContainer: [
-      {
-        display: 'flex',
-      },
-    ],
-    flexSlider: [
-      {
-        flexGrow: '1',
-      },
-    ],
-    flexPreviewBox: [
-      {
-        flexGrow: '0',
-      },
-    ],
+    flexContainer: {
+      display: 'flex',
+    },
+    flexSlider: {
+      flexGrow: '1',
+    },
+    flexPreviewBox: {
+      flexGrow: '0',
+    },
     input: [
       'ms-ColorPicker-input',
       {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.test.tsx
@@ -13,6 +13,10 @@ import { ColorRectangleBase } from './ColorRectangle/ColorRectangle.base';
 import { ColorSliderBase } from './ColorSlider/ColorSlider.base';
 
 const noOp = () => undefined;
+const abcdef = getColorFromString('#abcdef')!;
+const black = getColorFromString('#000000')!;
+const white = getColorFromString('#ffffff')!;
+const AEAEAE = getColorFromString('#AEAEAE')!;
 
 describe('ColorPicker', () => {
   let wrapper: ReactWrapper<IColorPickerProps, IColorPickerState, ColorPickerBase> | undefined;
@@ -32,6 +36,20 @@ describe('ColorPicker', () => {
     value: string | number;
     input?: HTMLInputElement;
     inputValue?: string;
+  }
+
+  /** Verify that the text inputs have the correct values */
+  function verifyInputs(color: IColor, alphaType: IColorPickerProps['alphaType'] = 'alpha') {
+    const hasAlpha = alphaType !== 'none';
+    const inputs = wrapper!.getDOMNode().querySelectorAll('input') as NodeListOf<HTMLInputElement>;
+    expect(inputs).toHaveLength(hasAlpha ? 5 : 4);
+    expect(inputs[0].value).toBe(color.hex);
+    expect(inputs[1].value).toBe(String(color.r));
+    expect(inputs[2].value).toBe(String(color.g));
+    expect(inputs[3].value).toBe(String(color.b));
+    if (hasAlpha) {
+      expect(inputs[4].value).toBe(String(alphaType === 'transparency' ? color.t : color.a));
+    }
   }
 
   function validateChange(opts: IValidateChangeOptions) {
@@ -62,58 +80,70 @@ describe('ColorPicker', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('uses provided color string', () => {
-    wrapper = mount(<ColorPicker color="#abcdef" onChange={noOp} componentRef={colorPickerRef} />);
+  it('renders correctly with preview', () => {
+    const component = renderer.create(<ColorPicker color="#abcdef" showPreview />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 
-    expect(colorPicker!.color.hex).toEqual('abcdef');
+  it('renders correctly with transparency', () => {
+    const component = renderer.create(<ColorPicker color="#abcdef" alphaType="transparency" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('uses provided color string', () => {
+    wrapper = mount(<ColorPicker color={abcdef.str} onChange={noOp} componentRef={colorPickerRef} />);
+
+    expect(colorPicker!.color.hex).toEqual(abcdef.hex);
+    verifyInputs(abcdef);
   });
 
   it('uses provided color object', () => {
-    const color = getColorFromString('#abcdef')!;
-    wrapper = mount(<ColorPicker color={color} onChange={noOp} componentRef={colorPickerRef} />);
+    wrapper = mount(<ColorPicker color={abcdef} onChange={noOp} componentRef={colorPickerRef} />);
 
-    expect(colorPicker!.color).toEqual(color);
+    expect(colorPicker!.color).toEqual(abcdef);
+    verifyInputs(abcdef);
   });
 
   it('handles color object with 0 values correctly', () => {
-    const color = getColorFromString('#000000')!;
-    wrapper = mount(<ColorPicker color={color} onChange={noOp} componentRef={colorPickerRef} />);
-
-    const inputs = wrapper.getDOMNode().querySelectorAll('.ms-TextField input') as NodeListOf<HTMLInputElement>;
-    expect(inputs[1].value).toBe('0'); // not empty string
+    wrapper = mount(<ColorPicker color={black} onChange={noOp} componentRef={colorPickerRef} />);
+    // Inputs should not have empty strings
+    verifyInputs(black);
   });
 
   it('respects color prop change', () => {
     wrapper = mount(<ColorPicker color="#abcdef" onChange={onChange} componentRef={colorPickerRef} />);
 
-    wrapper.setProps({ color: '#AEAEAE' });
-    expect(colorPicker!.color.hex).toEqual('aeaeae');
+    wrapper.setProps({ color: AEAEAE.str });
+    expect(colorPicker!.color.hex).toEqual(AEAEAE.hex);
+    verifyInputs(AEAEAE);
     // shouldn't call onChange when the consumer updates the color prop
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('ignores invalid updates to color prop', () => {
-    wrapper = mount(<ColorPicker color="#abcdef" onChange={onChange} componentRef={colorPickerRef} />);
+    wrapper = mount(<ColorPicker color={abcdef} onChange={onChange} componentRef={colorPickerRef} />);
 
     wrapper.setProps({ color: 'foo' });
-    expect(colorPicker!.color.hex).toEqual('abcdef');
+    expect(colorPicker!.color.hex).toEqual(abcdef.hex);
+    verifyInputs(abcdef);
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
   it('hides alpha control slider', () => {
-    wrapper = mount(<ColorPicker color="#FFFFFF" alphaSliderHidden={true} />);
+    wrapper = mount(<ColorPicker color={white} alphaType="none" />);
 
     const alphaSlider = wrapper.find('.is-alpha');
     const tableHeaders = wrapper.find('thead td');
-    const inputs = wrapper.find('.ms-TextField');
 
     // There should only be table headers and inputs for hex, red, green, and blue (no alpha)
     expect(alphaSlider.exists()).toBe(false);
     expect(tableHeaders).toHaveLength(4);
-    expect(inputs).toHaveLength(4);
+    verifyInputs(white, 'none');
   });
 
-  it('show preview box', () => {
+  it('shows preview box', () => {
     wrapper = mount(<ColorPicker color="#FFFFFF" showPreview={true} />);
 
     const previewBox = wrapper.find('.is-preview');
@@ -122,7 +152,7 @@ describe('ColorPicker', () => {
     expect(previewBox.exists()).toBe(true);
   });
 
-  it('hide preview box', () => {
+  it('hides preview box', () => {
     wrapper = mount(<ColorPicker color="#FFFFFF" showPreview={false} />);
 
     const previewBox = wrapper.find('.is-preview');
@@ -151,21 +181,19 @@ describe('ColorPicker', () => {
 
   it('renders custom strings', () => {
     const fields = ['Custom Hex', 'Custom Red', 'Custom Green', 'Custom Blue', 'Custom Alpha'];
-    const customAria: Partial<IColorPickerStrings> = {
+    const customStrings: IColorPickerStrings = {
+      hex: fields[0],
+      red: fields[1],
+      green: fields[2],
+      blue: fields[3],
+      alpha: fields[4],
       svAriaLabel: 'custom rectangle',
       svAriaDescription: 'custom rectangle description',
       svAriaValueFormat: 'custom rectangle value', // missing placeholders but code doesn't check for that
       hueAriaLabel: 'custom hue',
     };
 
-    wrapper = mount(
-      <ColorPicker
-        color="#FFFFFF"
-        // even using a mix of deprecated and new props should work
-        hexLabel={fields[0]}
-        strings={{ red: fields[1], green: fields[2], blue: fields[3], alpha: fields[4], ...customAria }}
-      />,
-    );
+    wrapper = mount(<ColorPicker color="#FFFFFF" strings={customStrings} />);
 
     const tableHeaders = wrapper.find('thead td');
     tableHeaders.forEach((node, index) => {
@@ -175,26 +203,45 @@ describe('ColorPicker', () => {
     // Check for the aria strings in the HTML of the corresponding components (simplest way
     // to verify ColorPicker is passing custom values through correctly)
     const rectangleHtml = wrapper.find(ColorRectangleBase).html();
-    expect(rectangleHtml).toContain(customAria.svAriaLabel);
-    expect(rectangleHtml).toContain(customAria.svAriaDescription);
-    expect(rectangleHtml).toContain(customAria.svAriaValueFormat);
+    expect(rectangleHtml).toContain(customStrings.svAriaLabel);
+    expect(rectangleHtml).toContain(customStrings.svAriaDescription);
+    expect(rectangleHtml).toContain(customStrings.svAriaValueFormat);
 
     const sliders = wrapper.find(ColorSliderBase);
-    expect(sliders.at(0).html()).toContain(customAria.hueAriaLabel);
+    expect(sliders.at(0).html()).toContain(customStrings.hueAriaLabel);
     expect(sliders.at(1).html()).toContain('Custom Alpha');
   });
 
   it('uses default aria label', () => {
     wrapper = mount(<ColorPicker color="#abcdef" />);
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('Color picker, # a b c d e f selected.');
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+      'Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected.',
+    );
 
     wrapper.setProps({ color: 'rgba(255, 0, 0, 0.5)' });
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('Color picker, R G B A 255 0 0 50% selected.');
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+      'Color picker, Red 255 Green 0 Blue 0 Alpha 50% selected.',
+    );
   });
 
   it('can use custom aria label', () => {
     wrapper = mount(<ColorPicker color="#abcdef" strings={{ rootAriaLabelFormat: 'custom color picker {0}' }} />);
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('custom color picker # a b c d e f');
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe(
+      'custom color picker Red 171 Green 205 Blue 239 Alpha 100%',
+    );
+  });
+
+  it('handles transparency', () => {
+    const color = getColorFromString('rgba(20, 30, 40, 0.3)')!;
+    wrapper = mount(
+      <ColorPicker color={color} alphaType="transparency" onChange={noOp} componentRef={colorPickerRef} />,
+    );
+
+    expect(colorPicker!.color).toEqual(color);
+    verifyInputs(color, 'transparency');
+
+    const tableHeaders = wrapper.find('thead td');
+    expect(tableHeaders.at(4).text()).toBe('Transparency');
   });
 
   it('keeps color value when tabbing between Hex and RGBA text inputs', () => {
@@ -253,11 +300,25 @@ describe('ColorPicker', () => {
     validateChange({ calls: 3, prop: 'a', value: 50 });
   });
 
+  it('handles updating transparency text field', () => {
+    wrapper = mount(
+      <ColorPicker alphaType="transparency" onChange={onChange} color="#000000" componentRef={colorPickerRef} />,
+    );
+
+    const transparencyInput = wrapper.getDOMNode().querySelectorAll('input')[4];
+
+    ReactTestUtils.Simulate.input(transparencyInput, mockEvent('30'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(updatedColor!.t).toBe(30);
+    expect(colorPicker!.color.t).toBe(30);
+    expect(transparencyInput.value).toBe('30');
+    expect(updatedColor!.a).toBe(70);
+    expect(colorPicker!.color.a).toBe(70);
+  });
+
   // This has repeatedly broken in the past (really)
   it('allows updating text fields when alpha slider is hidden', () => {
-    wrapper = mount(
-      <ColorPicker onChange={onChange} color="#000000" alphaSliderHidden componentRef={colorPickerRef} />,
-    );
+    wrapper = mount(<ColorPicker onChange={onChange} color="#000000" alphaType="none" componentRef={colorPickerRef} />);
 
     const inputs = wrapper.getDOMNode().querySelectorAll('.ms-ColorPicker-input input') as NodeListOf<HTMLInputElement>;
 
@@ -517,5 +578,32 @@ describe('ColorPicker', () => {
     // original value is preserved on blur
     ReactTestUtils.Simulate.blur(hexInput);
     validateChange({ calls: 0, prop: 'hex', value: 'abcdef', input: hexInput });
+  });
+
+  it('handles intermediate invalid transparency values', () => {
+    const color = getColorFromString('rgba(20, 30, 40, 0.3)')!;
+
+    wrapper = mount(
+      <ColorPicker alphaType="transparency" onChange={onChange} color={color} componentRef={colorPickerRef} />,
+    );
+
+    const transparencyInput = wrapper.getDOMNode().querySelectorAll('input')[4];
+
+    // value too large => allowed in field but onChange not called
+    ReactTestUtils.Simulate.input(transparencyInput, mockEvent('123'));
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(colorPicker!.color.a).toBe(30); // original value
+    expect(colorPicker!.color.t).toBe(70);
+    expect(colorPicker!.state.editingColor).toEqual({ component: 't', value: '123' });
+    expect(transparencyInput.value).toBe('123');
+
+    // blur => value clamped (with correct alpha/transparency conversion)
+    ReactTestUtils.Simulate.blur(transparencyInput);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(colorPicker!.color.t).toBe(100);
+    expect(updatedColor!.t).toBe(100);
+    expect(transparencyInput.value).toBe('100');
+    expect(colorPicker!.color.a).toBe(0);
+    expect(updatedColor!.a).toBe(0);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.types.ts
@@ -37,7 +37,20 @@ export interface IColorPickerProps {
   onChange?: (ev: React.SyntheticEvent<HTMLElement>, color: IColor) => void;
 
   /**
-   * Whether to hide the alpha control slider.
+   * `alpha` (the default) means display a slider and text field for editing alpha values.
+   * `transparency` also displays a slider and text field but for editing transparency values.
+   * `none` hides these controls.
+   *
+   * Alpha represents the opacity of the color, whereas transparency represents the transparentness
+   * of the color: i.e. a 30% transparent color has 70% opaqueness.
+   *
+   * @defaultvalue 'alpha'
+   */
+  alphaType?: 'alpha' | 'transparency' | 'none';
+
+  /**
+   * Whether to hide the alpha (or transparency) slider and text field.
+   * @deprecated Use `alphaType: 'none'`
    */
   alphaSliderHidden?: boolean;
 
@@ -138,9 +151,20 @@ export interface IColorPickerStrings {
   alpha?: string;
 
   /**
+   * Label for the transparency text field.
+   * @defaultvalue Transparency
+   */
+  transparency?: string;
+
+  /**
    * Customized aria-label for the alpha slider.
    */
   alphaAriaLabel?: string;
+
+  /**
+   * Customized aria-label for the transparency slider.
+   */
+  transparencyAriaLabel?: string;
 
   /**
    * Aria label for the hue slider.
@@ -179,17 +203,8 @@ export interface IColorPickerStrings {
 /**
  * {@docCategory ColorPicker}
  */
-export interface IColorPickerStyleProps {
-  /**
-   * Theme (provided through customization).
-   */
-  theme: ITheme;
-
-  /**
-   * Additional CSS class(es) to apply to the ColorPicker.
-   */
-  className?: string;
-}
+export type IColorPickerStyleProps = Required<Pick<IColorPickerProps, 'theme'>> &
+  Pick<IColorPickerProps, 'className' | 'alphaType'>;
 
 /**
  * {@docCategory ColorPicker}
@@ -224,6 +239,11 @@ export interface IColorPickerStyles {
    * Style set for the table cell that contains the hex label.
    */
   tableHexCell?: IStyle;
+
+  /**
+   * Style set for the table cell that contains the alpha or transparency label.
+   */
+  tableAlphaCell?: IStyle;
 
   /**
    * Style set for each text field input.

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.deprecated.test.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import { ColorSlider } from './ColorSlider';
+import { MAX_COLOR_HUE, MAX_COLOR_ALPHA } from '../../../utilities/color/index';
+import { setWarningCallback } from '../../../Utilities';
+
+// tslint:disable:deprecation
+
+describe('ColorSlider', () => {
+  let component: renderer.ReactTestRenderer | undefined;
+
+  beforeAll(() => {
+    // Prevent warn deprecations from failing test
+    setWarningCallback(() => {
+      /* no-op */
+    });
+  });
+
+  afterAll(() => {
+    setWarningCallback();
+  });
+
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+      component = undefined;
+    }
+  });
+
+  it('renders hue slider correctly', () => {
+    component = renderer.create(<ColorSlider value={30} minValue={0} maxValue={MAX_COLOR_HUE} ariaLabel="Hue" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders alpha slider correctly', () => {
+    component = renderer.create(
+      <ColorSlider
+        isAlpha
+        value={30}
+        overlayColor="#ff0000"
+        minValue={0}
+        maxValue={MAX_COLOR_ALPHA}
+        ariaLabel="Alpha"
+      />,
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
@@ -14,7 +14,8 @@ const alphaStyle = {
 };
 
 export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
-  const { theme, className, isAlpha } = props;
+  // tslint:disable-next-line:deprecation
+  const { theme, className, type = 'hue', isAlpha: useAlphaBackground = type !== 'hue' } = props;
   const { palette, effects } = theme;
 
   return {
@@ -35,7 +36,7 @@ export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => 
           },
         },
       },
-      isAlpha ? alphaStyle : hueStyle,
+      useAlphaBackground ? alphaStyle : hueStyle,
       className,
     ],
     sliderOverlay: [

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.test.tsx
@@ -6,7 +6,7 @@ import { ColorSlider } from './ColorSlider';
 import { ColorSliderBase, IColorSliderState } from './ColorSlider.base';
 import { IColorSliderProps } from './ColorSlider.types';
 import { KeyCodes } from '../../../Utilities';
-import { MAX_COLOR_HUE, MAX_COLOR_ALPHA } from '../../../utilities/color/index';
+import { MAX_COLOR_HUE, MAX_COLOR_ALPHA } from 'office-ui-fabric-react/lib/utilities/color';
 
 describe('ColorSlider', () => {
   let wrapper: ReactWrapper<IColorSliderProps, IColorSliderState, ColorSliderBase> | undefined;
@@ -16,13 +16,15 @@ describe('ColorSlider', () => {
     colorSlider = ref;
   };
 
+  // Use a width of 100 in the fake bounding rect to simplify math
+  const width = 100;
   const getBoundingClientRect = () =>
     ({
       left: 0,
       top: 0,
-      right: 100,
+      right: width,
       bottom: 18,
-      width: 100,
+      width,
       height: 18,
     } as DOMRect);
 
@@ -37,57 +39,103 @@ describe('ColorSlider', () => {
     }
   });
 
+  /** Verify stored value and thumb position */
+  function verifyValue(type: IColorSliderProps['type'], value: number) {
+    expect(colorSlider!.value).toBeCloseTo(value);
+
+    const thumbStyle = wrapper!.find('.ms-ColorPicker-thumb').prop('style')!;
+    const max = type === 'hue' ? MAX_COLOR_HUE : MAX_COLOR_ALPHA;
+    expect(Number((thumbStyle.left as string).replace('%', ''))).toBeCloseTo((100 * value) / max);
+  }
+
   it('renders hue slider correctly', () => {
-    component = renderer.create(<ColorSlider value={30} minValue={0} maxValue={MAX_COLOR_HUE} ariaLabel="Hue" />);
+    component = renderer.create(<ColorSlider type="hue" value={30} ariaLabel="Hue" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
   it('renders alpha slider correctly', () => {
+    component = renderer.create(<ColorSlider type="alpha" value={30} overlayColor="ff0000" ariaLabel="Alpha" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders transparency slider correctly', () => {
     component = renderer.create(
-      <ColorSlider
-        isAlpha
-        value={30}
-        overlayColor="#ff0000"
-        minValue={0}
-        maxValue={MAX_COLOR_ALPHA}
-        ariaLabel="Alpha"
-      />,
+      <ColorSlider type="transparency" value={30} overlayColor="ff0000" ariaLabel="Transparency" />,
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
+  it('defaults to hue slider', () => {
+    wrapper = mount(<ColorSlider />);
+    // hue slider doesn't have an overlay
+    expect(wrapper.find('.ms-ColorPicker-sliderOverlay')).toHaveLength(0);
+  });
+
+  it('handles alpha slider overlay', () => {
+    wrapper = mount(<ColorSlider type="alpha" value={0} overlayColor="ff0000" />);
+
+    const overlay = wrapper.find('.ms-ColorPicker-sliderOverlay');
+    expect(overlay).toHaveLength(1);
+    const background = overlay.prop('style')!.background;
+    expect(background).toEqual('linear-gradient(to right, transparent, #ff0000)');
+  });
+
+  it('handles transparency slider overlay', () => {
+    wrapper = mount(<ColorSlider type="transparency" value={0} overlayColor="ff0000" />);
+
+    const overlay = wrapper.find('.ms-ColorPicker-sliderOverlay');
+    expect(overlay).toHaveLength(1);
+    const background = overlay.prop('style')!.background;
+    expect(background).toEqual('linear-gradient(to right, #ff0000, transparent)');
+  });
+
   it('defaults to 0', () => {
     wrapper = mount(<ColorSlider componentRef={colorSliderRef} />);
-    expect(colorSlider!.value).toBe(0);
+    verifyValue('hue', 0);
   });
 
   it('respects value prop', () => {
-    const onChange = jest.fn();
-    wrapper = mount(<ColorSlider value={15} isAlpha onChange={onChange} componentRef={colorSliderRef} />);
-    expect(colorSlider!.value).toBe(15);
+    wrapper = mount(<ColorSlider type="alpha" value={15} overlayColor="ff0000" componentRef={colorSliderRef} />);
+    verifyValue('alpha', 15);
+  });
 
-    wrapper.setProps({ value: 20 });
-    expect(colorSlider!.value).toBe(20);
+  it('respects updates to value prop', () => {
+    const onChange = jest.fn();
+    wrapper = mount(
+      <ColorSlider type="alpha" value={15} overlayColor="ff0000" onChange={onChange} componentRef={colorSliderRef} />,
+    );
+
+    wrapper.setProps({ value: 30 });
+    wrapper.update();
+
+    verifyValue('alpha', 30);
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it('uses appropriate aria label', () => {
-    wrapper = mount(<ColorSlider />);
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('Hue');
+  it('respects value prop for transparency', () => {
+    // The slider is meant to take in actual transparency values, rather than taking in alpha
+    // and displaying transparency.
+    wrapper = mount(<ColorSlider type="transparency" value={15} overlayColor="ff0000" componentRef={colorSliderRef} />);
+    verifyValue('transparency', 15);
+  });
 
-    wrapper.setProps({ isAlpha: true });
-    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('Alpha');
+  it('uses appropriate default aria label', () => {
+    wrapper = mount(<ColorSlider type="hue" />);
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('hue');
+
+    wrapper.setProps({ type: 'alpha' });
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('alpha');
 
     wrapper.setProps({ ariaLabel: 'custom' });
     expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('custom');
   });
 
-  it('respects updates to value prop', () => {
-    wrapper = mount(<ColorSlider value={15} isAlpha componentRef={colorSliderRef} />);
-    wrapper.setProps({ value: 30 });
-    expect(colorSlider!.value).toBe(30);
+  it('respects custom aria label', () => {
+    wrapper = mount(<ColorSlider type="hue" ariaLabel="custom" />);
+    expect(wrapper.getDOMNode().getAttribute('aria-label')).toBe('custom');
   });
 
   it('handles key events', () => {
@@ -95,29 +143,27 @@ describe('ColorSlider', () => {
     const onChange = jest.fn((ev: any, newValue?: number) => {
       value = newValue;
     });
-    wrapper = mount(
-      <ColorSlider value={100} maxValue={MAX_COLOR_HUE} onChange={onChange} componentRef={colorSliderRef} />,
-    );
+    wrapper = mount(<ColorSlider type="hue" value={100} onChange={onChange} componentRef={colorSliderRef} />);
 
     wrapper.simulate('keydown', { which: KeyCodes.left });
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(value).toBe(99);
-    expect(colorSlider!.value).toBe(99);
+    verifyValue('hue', 99);
 
     wrapper.simulate('keydown', { which: KeyCodes.right, shiftKey: true });
     expect(onChange).toHaveBeenCalledTimes(2);
-    expect(colorSlider!.value).toBe(109);
     expect(value).toBe(109);
+    verifyValue('hue', 109);
 
     wrapper.simulate('keydown', { which: KeyCodes.home });
     expect(onChange).toHaveBeenCalledTimes(3);
-    expect(colorSlider!.value).toBe(0);
     expect(value).toBe(0);
+    verifyValue('hue', 0);
 
     wrapper.simulate('keydown', { which: KeyCodes.end });
     expect(onChange).toHaveBeenCalledTimes(4);
-    expect(colorSlider!.value).toBe(359);
     expect(value).toBe(359);
+    verifyValue('hue', 359);
   });
 
   it('does not modify value if event default prevented', () => {
@@ -126,54 +172,53 @@ describe('ColorSlider', () => {
       value = newValue;
       ev.preventDefault();
     });
-    wrapper = mount(
-      <ColorSlider value={100} maxValue={MAX_COLOR_HUE} onChange={onChange} componentRef={colorSliderRef} />,
-    );
+    wrapper = mount(<ColorSlider type="hue" value={100} onChange={onChange} componentRef={colorSliderRef} />);
 
     wrapper.simulate('keydown', { which: KeyCodes.left });
+    wrapper.update();
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(value).toBe(99);
-    expect(colorSlider!.value).toBe(100);
+    verifyValue('hue', 100);
   });
 
   it('handles mouse events in range', () => {
     const onChange = jest.fn();
-    wrapper = mount(<ColorSlider value={0} isAlpha onChange={onChange} componentRef={colorSliderRef} />);
+    wrapper = mount(
+      <ColorSlider type="alpha" overlayColor="ff0000" value={0} onChange={onChange} componentRef={colorSliderRef} />,
+    );
     wrapper.getDOMNode().getBoundingClientRect = getBoundingClientRect;
 
     wrapper.simulate('mousedown', { type: 'mousedown', clientX: 5, clientY: 0 });
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(colorSlider!.value).toEqual(5);
+    verifyValue('alpha', 5);
 
     wrapper.simulate('mousedown', { type: 'mousedown', clientX: 10, clientY: 0 });
     expect(onChange).toHaveBeenCalledTimes(2);
-    expect(colorSlider!.value).toEqual(10);
+    verifyValue('alpha', 10);
 
     // mouse up => keep setting
     wrapper.simulate('mouseup');
     expect(onChange).toHaveBeenCalledTimes(2);
-    expect(colorSlider!.value).toEqual(10);
+    verifyValue('alpha', 10);
   });
 
   it('handles mouse events out of range', () => {
     const onChange = jest.fn();
-    wrapper = mount(
-      <ColorSlider value={0} maxValue={MAX_COLOR_HUE} onChange={onChange} componentRef={colorSliderRef} />,
-    );
+    wrapper = mount(<ColorSlider type="hue" value={0} onChange={onChange} componentRef={colorSliderRef} />);
     wrapper.getDOMNode().getBoundingClientRect = getBoundingClientRect;
 
     wrapper.simulate('mousedown', { type: 'mousedown', clientX: 100, clientY: 0 });
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(colorSlider!.value).toEqual(359);
+    verifyValue('hue', 359);
 
     // ignore movement out of range
     wrapper.simulate('mousemove', { type: 'mousemove', clientX: 200, clientY: 0 });
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(colorSlider!.value).toEqual(359);
+    verifyValue('hue', 359);
 
     // mouse up => keep setting
     wrapper.simulate('mouseup');
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(colorSlider!.value).toEqual(359);
+    verifyValue('hue', 359);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.types.ts
@@ -21,11 +21,13 @@ export interface IColorSliderProps {
 
   /**
    * Minimum value of the slider.
+   * @deprecated Will always be 0
    */
   minValue?: number;
 
   /**
    * Maximum value of the slider.
+   * @deprecated Will be 100 for alpha or transparency sliders, or 359 for hue sliders.
    */
   maxValue?: number;
 
@@ -40,14 +42,21 @@ export interface IColorSliderProps {
   ariaLabel?: string;
 
   /**
+   * Type of slider to display.
+   * @defaultvalue 'hue'
+   */
+  type?: 'hue' | 'alpha' | 'transparency';
+
+  /**
    * If true, the slider represents an alpha slider and will display a gray checkered pattern
    * in the background. Otherwise, the slider represents a hue slider.
    * @defaultvalue false
+   * @deprecated Use `type`
    */
   isAlpha?: boolean;
 
   /**
-   * Hex color to use when rendering an alpha slider's overlay.
+   * Hex color to use when rendering an alpha or transparency slider's overlay, *without* the `#`.
    */
   overlayColor?: string;
 
@@ -88,7 +97,12 @@ export interface IColorSliderProps {
  * {@docCategory ColorPicker}
  */
 export type IColorSliderStyleProps = Required<Pick<IColorSliderProps, 'theme'>> &
-  Pick<IColorSliderProps, 'className' | 'isAlpha'>;
+  Pick<IColorSliderProps, 'className' | 'type'> & {
+    /**
+     * @deprecated Use `type`
+     */
+    isAlpha?: boolean;
+  };
 
 /**
  * {@docCategory ColorPicker}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/__snapshots__/ColorSlider.deprecated.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`ColorSlider renders alpha slider correctly 1`] = `
         }
     style={
       Object {
-        "background": "linear-gradient(to right, transparent, #ff0000)",
+        "background": "linear-gradient(to right, transparent, ##ff0000)",
       }
     }
   />
@@ -116,76 +116,6 @@ exports[`ColorSlider renders hue slider correctly 1`] = `
     style={
       Object {
         "left": "8.356545961002785%",
-      }
-    }
-  />
-</div>
-`;
-
-exports[`ColorSlider renders transparency slider correctly 1`] = `
-<div
-  aria-label="Transparency"
-  aria-valuemax={100}
-  aria-valuemin={0}
-  aria-valuenow={30}
-  aria-valuetext="30"
-  className=
-      ms-ColorPicker-slider
-      {
-        background-image: url(data;
-        base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
-        border-radius: 2px;
-        border: 1px solid #edebe9;
-        box-sizing: border-box;
-        height: 20px;
-        margin-bottom: 8px;
-        outline: none;
-        position: relative;
-      }
-      .ms-Fabric--isFocusVisible &:focus {
-        outline: 1px solid #605e5c;
-      }
-  data-is-focusable={true}
-  onKeyDown={[Function]}
-  onMouseDown={[Function]}
-  role="slider"
-  tabIndex={0}
->
-  <div
-    className=
-        ms-ColorPicker-sliderOverlay
-        {
-          bottom: 0px;
-          content: ;
-          left: 0px;
-          position: absolute;
-          right: 0px;
-          top: 0px;
-        }
-    style={
-      Object {
-        "background": "linear-gradient(to right, #ff0000, transparent)",
-      }
-    }
-  />
-  <div
-    className=
-        ms-ColorPicker-thumb
-        is-slider
-        {
-          background: white;
-          border-radius: 50%;
-          border: 1px solid #8a8886;
-          box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-          height: 20px;
-          position: absolute;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          width: 20px;
-        }
-    style={
-      Object {
-        "left": "30%",
       }
     }
   />

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ColorPicker renders correctly 1`] = `
 <div
-  aria-label="Color picker, # a b c d e f selected."
+  aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
   className=
       ms-ColorPicker
       {
@@ -246,7 +246,7 @@ exports[`ColorPicker renders correctly 1`] = `
                 }
             style={
               Object {
-                "background": "linear-gradient(to right, transparent 0, #abcdef 100%)",
+                "background": "linear-gradient(to right, transparent, #abcdef)",
               }
             }
           />
@@ -321,7 +321,11 @@ exports[`ColorPicker renders correctly 1`] = `
           <td>
             Blue
           </td>
-          <td>
+          <td
+            className=
+
+
+          >
             Alpha
           </td>
         </tr>
@@ -486,13 +490,7 @@ exports[`ColorPicker renders correctly 1`] = `
               </div>
             </div>
           </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
-              }
-            }
-          >
+          <td>
             <div
               className=
                   ms-TextField
@@ -650,13 +648,7 @@ exports[`ColorPicker renders correctly 1`] = `
               </div>
             </div>
           </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
-              }
-            }
-          >
+          <td>
             <div
               className=
                   ms-TextField
@@ -814,13 +806,7 @@ exports[`ColorPicker renders correctly 1`] = `
               </div>
             </div>
           </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
-              }
-            }
-          >
+          <td>
             <div
               className=
                   ms-TextField
@@ -978,13 +964,7 @@ exports[`ColorPicker renders correctly 1`] = `
               </div>
             </div>
           </td>
-          <td
-            style={
-              Object {
-                "width": "18%",
-              }
-            }
-          >
+          <td>
             <div
               className=
                   ms-TextField
@@ -1137,6 +1117,2293 @@ exports[`ColorPicker renders correctly 1`] = `
                     spellCheck={false}
                     type="text"
                     value="100"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`ColorPicker renders correctly with preview 1`] = `
+<div
+  aria-label="Color picker, Red 171 Green 205 Blue 239 Alpha 100% selected."
+  className=
+      ms-ColorPicker
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        max-width: 300px;
+        position: relative;
+      }
+  role="group"
+>
+  <div
+    className=
+        ms-ColorPicker-panel
+        {
+          padding-bottom: 16px;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 16px;
+        }
+  >
+    <div
+      aria-describedby="ColorRectangle-description16"
+      aria-label="Saturation and brightness"
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={28}
+      aria-valuetext="Saturation 28 brightness 94"
+      className=
+          ms-ColorPicker-colorRect
+          {
+            border-radius: 2px;
+            border: 1px solid #f3f2f1;
+            margin-bottom: 8px;
+            min-height: 220px;
+            min-width: 220px;
+            outline: none;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-is-focusable={true}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      role="slider"
+      style={
+        Object {
+          "backgroundColor": "#0080ff",
+        }
+      }
+      tabIndex={0}
+    >
+      <div
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              width: 1px;
+            }
+        id="ColorRectangle-description16"
+      >
+        Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
+      </div>
+      <div
+        className=
+            ms-ColorPicker-light
+            {
+              background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+      />
+      <div
+        className=
+            ms-ColorPicker-dark
+            {
+              background: linear-gradient(to bottom, transparent 0, #000 100%);
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+      />
+      <div
+        className=
+            ms-ColorPicker-thumb
+            {
+              background: white;
+              border-radius: 50%;
+              border: 1px solid #8a8886;
+              box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+              height: 20px;
+              position: absolute;
+              transform: translate(-50%, -50%);
+              width: 20px;
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: 0px;
+              box-sizing: border-box;
+              content: "";
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+        style={
+          Object {
+            "backgroundColor": "#abcdef",
+            "left": "28%",
+            "top": "6%",
+          }
+        }
+      />
+    </div>
+    <div
+      className=
+
+          {
+            display: flex;
+          }
+    >
+      <div
+        className=
+
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          aria-label="Hue"
+          aria-valuemax={359}
+          aria-valuemin={0}
+          aria-valuenow={210}
+          aria-valuetext="210"
+          className=
+              ms-ColorPicker-slider
+              is-hue
+              {
+                background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
+                border-radius: 2px;
+                border: 1px solid #edebe9;
+                box-sizing: border-box;
+                height: 20px;
+                margin-bottom: 8px;
+                outline: none;
+                position: relative;
+              }
+              .ms-Fabric--isFocusVisible &:focus {
+                outline: 1px solid #605e5c;
+              }
+          data-is-focusable={true}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className=
+                ms-ColorPicker-thumb
+                is-slider
+                {
+                  background: white;
+                  border-radius: 50%;
+                  border: 1px solid #8a8886;
+                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  height: 20px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%, -50%);
+                  width: 20px;
+                }
+            style={
+              Object {
+                "left": "58.4958217270195%",
+              }
+            }
+          />
+        </div>
+        <div
+          aria-label="Alpha"
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={100}
+          aria-valuetext="100"
+          className=
+              ms-ColorPicker-slider
+              is-alpha
+              {
+                background-image: url(data;
+                base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
+                border-radius: 2px;
+                border: 1px solid #edebe9;
+                box-sizing: border-box;
+                height: 20px;
+                margin-bottom: 8px;
+                outline: none;
+                position: relative;
+              }
+              .ms-Fabric--isFocusVisible &:focus {
+                outline: 1px solid #605e5c;
+              }
+          data-is-focusable={true}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className=
+                ms-ColorPicker-sliderOverlay
+                {
+                  bottom: 0px;
+                  content: ;
+                  left: 0px;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                }
+            style={
+              Object {
+                "background": "linear-gradient(to right, transparent, #abcdef)",
+              }
+            }
+          />
+          <div
+            className=
+                ms-ColorPicker-thumb
+                is-slider
+                {
+                  background: white;
+                  border-radius: 50%;
+                  border: 1px solid #8a8886;
+                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  height: 20px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%, -50%);
+                  width: 20px;
+                }
+            style={
+              Object {
+                "left": "100%",
+              }
+            }
+          />
+        </div>
+      </div>
+      <div
+        className=
+
+            {
+              flex-grow: 0;
+            }
+      >
+        <div
+          className=
+              ms-ColorPicker-colorSquare
+              is-preview
+              {
+                border: 1px solid #c8c6c4;
+                height: 48px;
+                margin-bottom: 0;
+                margin-left: 8px;
+                margin-right: 0;
+                margin-top: 0;
+                width: 48px;
+              }
+          style={
+            Object {
+              "backgroundColor": "#abcdef",
+            }
+          }
+        />
+      </div>
+    </div>
+    <table
+      cellPadding="0"
+      cellSpacing="0"
+      className=
+          ms-ColorPicker-table
+          {
+            table-layout: fixed;
+            width: 100%;
+          }
+          & tbody td:last-of-type .ms-ColorPicker-input {
+            padding-right: 0px;
+          }
+      role="group"
+    >
+      <thead>
+        <tr
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+              }
+              & td {
+                padding-bottom: 4px;
+              }
+        >
+          <td
+            className=
+
+                {
+                  width: 25%;
+                }
+          >
+            Hex
+          </td>
+          <td>
+            Red
+          </td>
+          <td>
+            Green
+          </td>
+          <td>
+            Blue
+          </td>
+          <td
+            className=
+
+
+          >
+            Alpha
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Hex"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField17"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="abcdef"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Red"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField20"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="171"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Green"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField23"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="205"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Blue"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField26"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="239"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Alpha"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField29"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="100"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`ColorPicker renders correctly with transparency 1`] = `
+<div
+  aria-label="Color picker, Red 171 Green 205 Blue 239 Transparency 0% selected."
+  className=
+      ms-ColorPicker
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        max-width: 300px;
+        position: relative;
+      }
+  role="group"
+>
+  <div
+    className=
+        ms-ColorPicker-panel
+        {
+          padding-bottom: 16px;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 16px;
+        }
+  >
+    <div
+      aria-describedby="ColorRectangle-description32"
+      aria-label="Saturation and brightness"
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={28}
+      aria-valuetext="Saturation 28 brightness 94"
+      className=
+          ms-ColorPicker-colorRect
+          {
+            border-radius: 2px;
+            border: 1px solid #f3f2f1;
+            margin-bottom: 8px;
+            min-height: 220px;
+            min-width: 220px;
+            outline: none;
+            position: relative;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-is-focusable={true}
+      onKeyDown={[Function]}
+      onMouseDown={[Function]}
+      role="slider"
+      style={
+        Object {
+          "backgroundColor": "#0080ff",
+        }
+      }
+      tabIndex={0}
+    >
+      <div
+        className=
+
+            {
+              border: 0px;
+              height: 1px;
+              margin-bottom: -1px;
+              margin-left: -1px;
+              margin-right: -1px;
+              margin-top: -1px;
+              overflow: hidden;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: absolute;
+              width: 1px;
+            }
+        id="ColorRectangle-description32"
+      >
+        Use left and right arrow keys to set saturation. Use up and down arrow keys to set brightness.
+      </div>
+      <div
+        className=
+            ms-ColorPicker-light
+            {
+              background: linear-gradient(to right, white 0%, transparent 100%) /*@noflip*/;
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+      />
+      <div
+        className=
+            ms-ColorPicker-dark
+            {
+              background: linear-gradient(to bottom, transparent 0, #000 100%);
+              bottom: 0px;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+      />
+      <div
+        className=
+            ms-ColorPicker-thumb
+            {
+              background: white;
+              border-radius: 50%;
+              border: 1px solid #8a8886;
+              box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+              height: 20px;
+              position: absolute;
+              transform: translate(-50%, -50%);
+              width: 20px;
+            }
+            &:before {
+              border-radius: 50%;
+              border: 2px solid #ffffff;
+              bottom: 0px;
+              box-sizing: border-box;
+              content: "";
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+        style={
+          Object {
+            "backgroundColor": "#abcdef",
+            "left": "28%",
+            "top": "6%",
+          }
+        }
+      />
+    </div>
+    <div
+      className=
+
+          {
+            display: flex;
+          }
+    >
+      <div
+        className=
+
+            {
+              flex-grow: 1;
+            }
+      >
+        <div
+          aria-label="Hue"
+          aria-valuemax={359}
+          aria-valuemin={0}
+          aria-valuenow={210}
+          aria-valuetext="210"
+          className=
+              ms-ColorPicker-slider
+              is-hue
+              {
+                background: linear-gradient(to left,red 0,#f09 10%,#cd00ff 20%,#3200ff 30%,#06f 40%,#00fffd 50%,#0f6 60%,#35ff00 70%,#cdff00 80%,#f90 90%,red 100%);
+                border-radius: 2px;
+                border: 1px solid #edebe9;
+                box-sizing: border-box;
+                height: 20px;
+                margin-bottom: 8px;
+                outline: none;
+                position: relative;
+              }
+              .ms-Fabric--isFocusVisible &:focus {
+                outline: 1px solid #605e5c;
+              }
+          data-is-focusable={true}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className=
+                ms-ColorPicker-thumb
+                is-slider
+                {
+                  background: white;
+                  border-radius: 50%;
+                  border: 1px solid #8a8886;
+                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  height: 20px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%, -50%);
+                  width: 20px;
+                }
+            style={
+              Object {
+                "left": "58.4958217270195%",
+              }
+            }
+          />
+        </div>
+        <div
+          aria-label="Transparency"
+          aria-valuemax={100}
+          aria-valuemin={0}
+          aria-valuenow={0}
+          aria-valuetext="0"
+          className=
+              ms-ColorPicker-slider
+              is-alpha
+              {
+                background-image: url(data;
+                base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAJUlEQVQYV2N89erVfwY0ICYmxoguxjgUFKI7GsTH5m4M3w1ChQC1/Ca8i2n1WgAAAABJRU5ErkJggg==): ;
+                border-radius: 2px;
+                border: 1px solid #edebe9;
+                box-sizing: border-box;
+                height: 20px;
+                margin-bottom: 8px;
+                outline: none;
+                position: relative;
+              }
+              .ms-Fabric--isFocusVisible &:focus {
+                outline: 1px solid #605e5c;
+              }
+          data-is-focusable={true}
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          role="slider"
+          tabIndex={0}
+        >
+          <div
+            className=
+                ms-ColorPicker-sliderOverlay
+                {
+                  bottom: 0px;
+                  content: ;
+                  left: 0px;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                }
+            style={
+              Object {
+                "background": "linear-gradient(to right, #abcdef, transparent)",
+              }
+            }
+          />
+          <div
+            className=
+                ms-ColorPicker-thumb
+                is-slider
+                {
+                  background: white;
+                  border-radius: 50%;
+                  border: 1px solid #8a8886;
+                  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                  height: 20px;
+                  position: absolute;
+                  top: 50%;
+                  transform: translate(-50%, -50%);
+                  width: 20px;
+                }
+            style={
+              Object {
+                "left": "0%",
+              }
+            }
+          />
+        </div>
+      </div>
+    </div>
+    <table
+      cellPadding="0"
+      cellSpacing="0"
+      className=
+          ms-ColorPicker-table
+          {
+            table-layout: fixed;
+            width: 100%;
+          }
+          & tbody td:last-of-type .ms-ColorPicker-input {
+            padding-right: 0px;
+          }
+      role="group"
+    >
+      <thead>
+        <tr
+          className=
+
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 12px;
+                font-weight: 400;
+              }
+              & td {
+                padding-bottom: 4px;
+              }
+        >
+          <td
+            className=
+
+                {
+                  width: 25%;
+                }
+          >
+            Hex
+          </td>
+          <td>
+            Red
+          </td>
+          <td>
+            Green
+          </td>
+          <td>
+            Blue
+          </td>
+          <td
+            className=
+
+                {
+                  width: 22%;
+                }
+          >
+            Transparency
+          </td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Hex"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField33"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="abcdef"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Red"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField36"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="171"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Green"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField39"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="205"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Blue"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField42"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="239"
+                  />
+                </div>
+              </div>
+            </div>
+          </td>
+          <td>
+            <div
+              className=
+                  ms-TextField
+                  ms-ColorPicker-input
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    border: none;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 100%;
+                  }
+                  &.ms-TextField {
+                    padding-right: 4px;
+                  }
+                  & .ms-TextField-field {
+                    min-width: auto;
+                    padding-bottom: 5px;
+                    padding-left: 5px;
+                    padding-right: 5px;
+                    padding-top: 5px;
+                    text-overflow: clip;
+                  }
+            >
+              <div
+                className=
+                    ms-TextField-wrapper
+
+              >
+                <div
+                  className=
+                      ms-TextField-fieldGroup
+                      {
+                        align-items: stretch;
+                        background: #ffffff;
+                        border-radius: 2px;
+                        border: 1px solid #605e5c;
+                        box-shadow: none;
+                        box-sizing: border-box;
+                        cursor: text;
+                        display: flex;
+                        flex-direction: row;
+                        height: 32px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        padding-bottom: 0px;
+                        padding-left: 0px;
+                        padding-right: 0px;
+                        padding-top: 0px;
+                        position: relative;
+                      }
+                      &:hover {
+                        border-color: #323130;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                      }
+                >
+                  <input
+                    aria-invalid={false}
+                    aria-label="Transparency"
+                    autoComplete="off"
+                    className=
+                        ms-TextField-field
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          background-color: transparent;
+                          background: none;
+                          border-radius: 0px;
+                          border: none;
+                          box-shadow: none;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          margin-bottom: 0px;
+                          margin-left: 0px;
+                          margin-right: 0px;
+                          margin-top: 0px;
+                          min-width: 0px;
+                          outline: 0px;
+                          padding-bottom: 0;
+                          padding-left: 8px;
+                          padding-right: 8px;
+                          padding-top: 0;
+                          text-overflow: ellipsis;
+                          width: 100%;
+                        }
+                        &:active {
+                          outline: 0px;
+                        }
+                        &:focus {
+                          outline: 0px;
+                        }
+                        &:hover {
+                          outline: 0px;
+                        }
+                        &::-ms-clear {
+                          display: none;
+                        }
+                        &::placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &:-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                        &::-ms-input-placeholder {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          color: #605e5c;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          opacity: 1;
+                        }
+                    id="TextField45"
+                    onBlur={[Function]}
+                    onChange={[Function]}
+                    onFocus={[Function]}
+                    onInput={[Function]}
+                    spellCheck={false}
+                    type="text"
+                    value="0"
                   />
                 </div>
               </div>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -1,13 +1,76 @@
 import * as React from 'react';
 import {
   ColorPicker,
+  ChoiceGroup,
+  IChoiceGroupOption,
   Toggle,
   getColorFromString,
   IColor,
   IColorPickerStyles,
+  IColorPickerProps,
   updateA,
 } from 'office-ui-fabric-react/lib/index';
 import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { useConstCallback } from '@uifabric/react-hooks';
+
+const white = getColorFromString('#ffffff')!;
+
+export const ColorPickerBasicExample: React.FunctionComponent = () => {
+  const [color, setColor] = React.useState(white);
+  const [showPreview, setShowPreview] = React.useState(true);
+  const [alphaType, setAlphaType] = React.useState<IColorPickerProps['alphaType']>('alpha');
+
+  const updateColor = useConstCallback((ev: any, colorObj: IColor) => setColor(colorObj));
+  const onShowPreviewClick = useConstCallback((ev: any, checked?: boolean) => setShowPreview(!!checked));
+  const onAlphaTypeChange = React.useCallback(
+    (ev: any, option: IChoiceGroupOption = alphaOptions[0]) => {
+      if (option.key === 'none') {
+        // If hiding the alpha slider, remove transparency from the color
+        setColor(updateA(color, 100));
+      }
+      setAlphaType(option.key as IColorPickerProps['alphaType']);
+    },
+    [color],
+  );
+
+  return (
+    <div className={classNames.wrapper}>
+      <ColorPicker
+        color={color}
+        onChange={updateColor}
+        alphaType={alphaType}
+        showPreview={showPreview}
+        styles={colorPickerStyles}
+        // The ColorPicker provides default English strings for visible text.
+        // If your app is localized, you MUST provide the `strings` prop with localized strings.
+        strings={{
+          // By default, the sliders will use the text field labels as their aria labels.
+          // If you'd like to provide more detailed instructions, you can use these props.
+          alphaAriaLabel: 'Alpha slider: Use left and right arrow keys to change value, hold shift for a larger jump',
+          transparencyAriaLabel:
+            'Transparency slider: Use left and right arrow keys to change value, hold shift for a larger jump',
+          hueAriaLabel: 'Hue slider: Use left and right arrow keys to change value, hold shift for a larger jump',
+        }}
+      />
+
+      <div className={classNames.column2}>
+        <Toggle label="Show preview box" onChange={onShowPreviewClick} checked={showPreview} />
+        <ChoiceGroup
+          label="Alpha slider type"
+          options={alphaOptions}
+          defaultSelectedKey={alphaOptions[0].key}
+          onChange={onAlphaTypeChange}
+        />
+      </div>
+    </div>
+  );
+};
+
+const alphaOptions: IChoiceGroupOption[] = [
+  { key: 'alpha', text: 'Alpha' },
+  { key: 'transparency', text: 'Transparency' },
+  { key: 'none', text: 'None' },
+];
 
 const classNames = mergeStyleSets({
   wrapper: { display: 'flex' },
@@ -22,61 +85,3 @@ const colorPickerStyles: Partial<IColorPickerStyles> = {
   },
   colorRectangle: { height: 268 },
 };
-
-export interface IBasicColorPickerExampleState {
-  color: IColor;
-  alphaSliderHidden: boolean;
-  showPreview: boolean;
-}
-
-export class ColorPickerBasicExample extends React.Component<{}, IBasicColorPickerExampleState> {
-  public state: IBasicColorPickerExampleState = {
-    color: getColorFromString('#ffffff')!,
-    alphaSliderHidden: false,
-    showPreview: true,
-  };
-
-  public render(): JSX.Element {
-    const { color, alphaSliderHidden, showPreview: showPreview } = this.state;
-    return (
-      <div className={classNames.wrapper}>
-        <ColorPicker
-          color={color}
-          onChange={this._updateColor}
-          alphaSliderHidden={alphaSliderHidden}
-          showPreview={showPreview}
-          styles={colorPickerStyles}
-          // The ColorPicker provides default English strings for visible text.
-          // If your app is localized, you MUST provide the `strings` prop with localized strings.
-          // Below are the recommended aria labels for the hue and alpha slider
-          strings={{
-            alphaAriaLabel: 'Alpha Slider: Use left and right arrow keys to change value, hold shift for a larger jump',
-            hueAriaLabel: 'Hue Slider: Use left and right arrow keys to change value, hold shift for a larger jump',
-          }}
-        />
-
-        <div className={classNames.column2}>
-          <Toggle label="Hide alpha slider" onChange={this._onHideAlphaClick} checked={alphaSliderHidden} />
-          <Toggle label="Show Preview Box" onChange={this._onShowPreviewBoxClick} checked={showPreview} />
-        </div>
-      </div>
-    );
-  }
-
-  private _updateColor = (ev: React.SyntheticEvent<HTMLElement>, colorObj: IColor) => {
-    this.setState({ color: colorObj });
-  };
-
-  private _onHideAlphaClick = (ev: React.MouseEvent<HTMLElement>, checked?: boolean) => {
-    let color = this.state.color;
-    if (checked) {
-      // If hiding the alpha slider, remove transparency from the color
-      color = updateA(this.state.color, 100);
-    }
-    this.setState({ alphaSliderHidden: !!checked, color });
-  };
-
-  private _onShowPreviewBoxClick = (ev: React.MouseEvent<HTMLElement>, checked?: boolean) => {
-    this.setState({ showPreview: !!checked });
-  };
-}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -9,7 +9,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       }
 >
   <div
-    aria-label="Color picker, # f f f f f f selected."
+    aria-label="Color picker, Red 255 Green 255 Blue 255 Alpha 100% selected."
     className=
         ms-ColorPicker
         {
@@ -164,7 +164,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               }
         >
           <div
-            aria-label="Hue Slider: Use left and right arrow keys to change value, hold shift for a larger jump"
+            aria-label="Hue slider: Use left and right arrow keys to change value, hold shift for a larger jump"
             aria-valuemax={359}
             aria-valuemin={0}
             aria-valuenow={0}
@@ -214,7 +214,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             />
           </div>
           <div
-            aria-label="Alpha Slider: Use left and right arrow keys to change value, hold shift for a larger jump"
+            aria-label="Alpha slider: Use left and right arrow keys to change value, hold shift for a larger jump"
             aria-valuemax={100}
             aria-valuemin={0}
             aria-valuenow={100}
@@ -255,7 +255,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   }
               style={
                 Object {
-                  "background": "linear-gradient(to right, transparent 0, #ffffff 100%)",
+                  "background": "linear-gradient(to right, transparent, #ffffff)",
                 }
               }
             />
@@ -357,7 +357,11 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             <td>
               Blue
             </td>
-            <td>
+            <td
+              className=
+
+
+            >
               Alpha
             </td>
           </tr>
@@ -522,13 +526,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 </div>
               </div>
             </td>
-            <td
-              style={
-                Object {
-                  "width": "18%",
-                }
-              }
-            >
+            <td>
               <div
                 className=
                     ms-TextField
@@ -686,13 +684,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 </div>
               </div>
             </td>
-            <td
-              style={
-                Object {
-                  "width": "18%",
-                }
-              }
-            >
+            <td>
               <div
                 className=
                     ms-TextField
@@ -850,13 +842,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 </div>
               </div>
             </td>
-            <td
-              style={
-                Object {
-                  "width": "18%",
-                }
-              }
-            >
+            <td>
               <div
                 className=
                     ms-TextField
@@ -1014,13 +1000,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 </div>
               </div>
             </td>
-            <td
-              style={
-                Object {
-                  "width": "18%",
-                }
-              }
-            >
+            <td>
               <div
                 className=
                     ms-TextField
@@ -1193,6 +1173,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
     <div
       className=
           ms-Toggle
+          is-checked
           is-enabled
           {
             -moz-osx-font-smoothing: grayscale;
@@ -1231,136 +1212,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
         htmlFor="Toggle16"
         id="Toggle16-label"
       >
-        Hide alpha slider
-      </label>
-      <div
-        className=
-            ms-Toggle-innerContainer
-            {
-              display: inline-flex;
-              position: relative;
-            }
-      >
-        <button
-          aria-checked={false}
-          aria-labelledby="Toggle16-label"
-          checked={false}
-          className=
-              ms-Toggle-background
-              {
-                align-items: center;
-                background: #ffffff;
-                border-radius: 10px;
-                border: 1px solid #605e5c;
-                box-sizing: border-box;
-                cursor: pointer;
-                display: flex;
-                font-size: 20px;
-                height: 20px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 3px;
-                padding-right: 3px;
-                padding-top: 0;
-                position: relative;
-                transition: all 0.1s ease;
-                width: 40px;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid #ffffff;
-                bottom: -2px;
-                content: "";
-                left: -2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: -2px;
-                top: -2px;
-                z-index: 1;
-              }
-              &:hover {
-                border-color: #323130;
-              }
-              &:hover .ms-Toggle-thumb {
-                background-color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
-                border-color: Highlight;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-              }
-          data-is-focusable={true}
-          id="Toggle16"
-          onChange={[Function]}
-          onClick={[Function]}
-          role="switch"
-          type="button"
-        >
-          <span
-            className=
-                ms-Toggle-thumb
-                {
-                  background-color: #605e5c;
-                  border-color: transparent;
-                  border-radius: 50%;
-                  border-style: solid;
-                  border-width: .28em;
-                  box-sizing: border-box;
-                  display: block;
-                  height: 12px;
-                  transition: all 0.1s ease;
-                  width: 12px;
-                }
-          />
-        </button>
-      </div>
-    </div>
-    <div
-      className=
-          ms-Toggle
-          is-checked
-          is-enabled
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 8px;
-          }
-    >
-      <label
-        className=
-            ms-Label
-            ms-Toggle-label
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              display: block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow-wrap: break-word;
-              padding-bottom: 5px;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 5px;
-              word-wrap: break-word;
-            }
-        htmlFor="Toggle17"
-        id="Toggle17-label"
-      >
-        Show Preview Box
+        Show preview box
       </label>
       <div
         className=
@@ -1372,7 +1224,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle17-label"
+          aria-labelledby="Toggle16-label"
           checked={true}
           className=
               ms-Toggle-background
@@ -1423,7 +1275,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 background-color: WindowText;
               }
           data-is-focusable={true}
-          id="Toggle17"
+          id="Toggle16"
           onChange={[Function]}
           onClick={[Function]}
           role="switch"
@@ -1450,6 +1302,469 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           />
         </button>
+      </div>
+    </div>
+    <div
+      className=
+
+
+    >
+      <div
+        aria-labelledby="ChoiceGroup17-label"
+        className=
+            ms-ChoiceFieldGroup
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+        role="radiogroup"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          id="ChoiceGroup17-label"
+        >
+          Alpha slider type
+        </label>
+        <div
+          className=
+              ms-ChoiceFieldGroup-flexContainer
+
+        >
+          <div
+            className=
+                ms-ChoiceField
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-top: 8px;
+                  min-height: 26px;
+                  position: relative;
+                }
+                & .ms-ChoiceFieldLabel {
+                  display: inline-block;
+                  padding-left: 26px;
+                }
+          >
+            <div
+              className=
+                  ms-ChoiceField-wrapper
+
+            >
+              <input
+                checked={true}
+                className=
+                    ms-ChoiceField-input
+                    {
+                      height: 100%;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      width: 100%;
+                    }
+                id="ChoiceGroup17-alpha"
+                name="ChoiceGroup17"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className=
+                    ms-ChoiceField-field
+                    is-checked
+                    {
+                      border-color: #0078d4;
+                      cursor: pointer;
+                      display: inline-block;
+                      margin-top: 0px;
+                      min-height: 20px;
+                      position: relative;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &:hover .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:hover:before {
+                      border-color: #005a9e;
+                    }
+                    &:hover:after {
+                      border-color: #005a9e;
+                    }
+                    &:focus .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:focus:before {
+                      border-color: #005a9e;
+                    }
+                    &:focus:after {
+                      border-color: #005a9e;
+                    }
+                    &:before {
+                      background-color: #ffffff;
+                      border-color: #0078d4;
+                      border-radius: 50%;
+                      border-style: solid;
+                      border-width: 1px;
+                      box-sizing: border-box;
+                      content: "";
+                      display: inline-block;
+                      font-weight: normal;
+                      height: 20px;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-color;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 20px;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      border-color: Highlight;
+                    }
+                    &:after {
+                      border-color: #0078d4;
+                      border-radius: 50%;
+                      border-style: solid;
+                      border-width: 5px;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 10px;
+                      left: 5px;
+                      position: absolute;
+                      right: 0px;
+                      top: 5px;
+                      transition-duration: 200ms;
+                      transition-property: border-width;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 10px;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:after {
+                      border-color: Highlight;
+                    }
+                htmlFor="ChoiceGroup17-alpha"
+              >
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel18-alpha"
+                >
+                  Alpha
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            className=
+                ms-ChoiceField
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-top: 8px;
+                  min-height: 26px;
+                  position: relative;
+                }
+                & .ms-ChoiceFieldLabel {
+                  display: inline-block;
+                  padding-left: 26px;
+                }
+          >
+            <div
+              className=
+                  ms-ChoiceField-wrapper
+
+            >
+              <input
+                checked={false}
+                className=
+                    ms-ChoiceField-input
+                    {
+                      height: 100%;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      width: 100%;
+                    }
+                id="ChoiceGroup17-transparency"
+                name="ChoiceGroup17"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className=
+                    ms-ChoiceField-field
+                    {
+                      cursor: pointer;
+                      display: inline-block;
+                      margin-top: 0px;
+                      min-height: 20px;
+                      position: relative;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &:hover .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:hover:before {
+                      border-color: #323130;
+                    }
+                    &:hover:after {
+                      background-color: #605e5c;
+                      content: "";
+                      height: 10px;
+                      left: 5px;
+                      top: 5px;
+                      transition-property: background-color;
+                      width: 10px;
+                    }
+                    &:focus .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:focus:before {
+                      border-color: #323130;
+                    }
+                    &:focus:after {
+                      background-color: #605e5c;
+                      content: "";
+                      height: 10px;
+                      left: 5px;
+                      top: 5px;
+                      transition-property: background-color;
+                      width: 10px;
+                    }
+                    &:before {
+                      background-color: #ffffff;
+                      border-color: #323130;
+                      border-radius: 50%;
+                      border-style: solid;
+                      border-width: 1px;
+                      box-sizing: border-box;
+                      content: "";
+                      display: inline-block;
+                      font-weight: normal;
+                      height: 20px;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-color;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 20px;
+                    }
+                    &:after {
+                      border-radius: 50%;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 0px;
+                      left: 10px;
+                      position: absolute;
+                      right: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-width;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 0px;
+                    }
+                htmlFor="ChoiceGroup17-transparency"
+              >
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel18-transparency"
+                >
+                  Transparency
+                </span>
+              </label>
+            </div>
+          </div>
+          <div
+            className=
+                ms-ChoiceField
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: center;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-top: 8px;
+                  min-height: 26px;
+                  position: relative;
+                }
+                & .ms-ChoiceFieldLabel {
+                  display: inline-block;
+                  padding-left: 26px;
+                }
+          >
+            <div
+              className=
+                  ms-ChoiceField-wrapper
+
+            >
+              <input
+                checked={false}
+                className=
+                    ms-ChoiceField-input
+                    {
+                      height: 100%;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      opacity: 0;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      width: 100%;
+                    }
+                id="ChoiceGroup17-none"
+                name="ChoiceGroup17"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                type="radio"
+              />
+              <label
+                className=
+                    ms-ChoiceField-field
+                    {
+                      cursor: pointer;
+                      display: inline-block;
+                      margin-top: 0px;
+                      min-height: 20px;
+                      position: relative;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &:hover .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:hover:before {
+                      border-color: #323130;
+                    }
+                    &:hover:after {
+                      background-color: #605e5c;
+                      content: "";
+                      height: 10px;
+                      left: 5px;
+                      top: 5px;
+                      transition-property: background-color;
+                      width: 10px;
+                    }
+                    &:focus .ms-ChoiceFieldLabel {
+                      color: #201f1e;
+                    }
+                    &:focus:before {
+                      border-color: #323130;
+                    }
+                    &:focus:after {
+                      background-color: #605e5c;
+                      content: "";
+                      height: 10px;
+                      left: 5px;
+                      top: 5px;
+                      transition-property: background-color;
+                      width: 10px;
+                    }
+                    &:before {
+                      background-color: #ffffff;
+                      border-color: #323130;
+                      border-radius: 50%;
+                      border-style: solid;
+                      border-width: 1px;
+                      box-sizing: border-box;
+                      content: "";
+                      display: inline-block;
+                      font-weight: normal;
+                      height: 20px;
+                      left: 0px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-color;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 20px;
+                    }
+                    &:after {
+                      border-radius: 50%;
+                      box-sizing: border-box;
+                      content: "";
+                      height: 0px;
+                      left: 10px;
+                      position: absolute;
+                      right: 0px;
+                      transition-duration: 200ms;
+                      transition-property: border-width;
+                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                      width: 0px;
+                    }
+                htmlFor="ChoiceGroup17-none"
+              >
+                <span
+                  className="ms-ChoiceFieldLabel"
+                  id="ChoiceGroupLabel18-none"
+                >
+                  None
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/utilities/color/colors.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/colors.test.ts
@@ -21,6 +21,7 @@ import {
   clamp,
   IColor,
 } from './colors';
+import { updateT } from './updateT';
 
 describe('color utilities', () => {
   const testColor: IColor = {
@@ -31,11 +32,12 @@ describe('color utilities', () => {
     s: 100,
     v: 100,
     a: 100,
+    t: 0,
     hex: '0015ff',
     str: '#0015ff',
   };
-  const testColorAlpha: IColor = { ...testColor, a: 50, str: 'rgba(0, 21, 255, 0.5)' };
-  const testColorNoAlpha: IColor = { ...testColor, a: undefined };
+  const testColorAlpha: IColor = { ...testColor, a: 30, t: 70, str: 'rgba(0, 21, 255, 0.3)' };
+  const testColorNoAlpha: IColor = { ...testColor, a: undefined, t: undefined };
 
   describe('rgb2hex', () => {
     it('works', () => {
@@ -231,7 +233,7 @@ describe('color utilities', () => {
     it('works', () => {
       // despite the name, this function returns an HTML color string based on *only* the hue
       expect(getFullColorString({ h: 0, s: 50, v: 50 } as IColor)).toEqual('#ff0000');
-      expect(getFullColorString({ h: testColor.h, s: 50, v: 50, a: 50 } as IColor)).toEqual(testColor.str);
+      expect(getFullColorString({ h: testColor.h, s: 50, v: 50, a: 30 } as IColor)).toEqual(testColor.str);
     });
   });
 
@@ -239,7 +241,7 @@ describe('color utilities', () => {
     it('works', () => {
       expect(updateSV({ h: testColor.h, s: 50, v: 50 } as IColor, 100, 100)).toEqual(testColorNoAlpha);
 
-      expect(updateSV({ h: testColor.h, s: 50, v: 50, a: 50 } as IColor, 100, 100)).toEqual(testColorAlpha);
+      expect(updateSV({ h: testColor.h, s: 50, v: 50, a: 30, t: 70 } as IColor, 100, 100)).toEqual(testColorAlpha);
     });
   });
 
@@ -247,9 +249,12 @@ describe('color utilities', () => {
     it('works', () => {
       expect(updateH({ h: 15, s: testColor.s, v: testColor.v } as IColor, testColor.h)).toEqual(testColorNoAlpha);
 
-      expect(updateH({ h: 15, s: testColor.s, v: testColor.v, a: testColorAlpha.a } as IColor, testColor.h)).toEqual(
-        testColorAlpha,
-      );
+      expect(
+        updateH(
+          { h: 15, s: testColor.s, v: testColor.v, a: testColorAlpha.a, t: testColorAlpha.t } as IColor,
+          testColor.h,
+        ),
+      ).toEqual(testColorAlpha);
     });
   });
 
@@ -264,6 +269,7 @@ describe('color utilities', () => {
         s: 100,
         v: 100,
         a: 100,
+        t: 0,
         hex: '0015ff',
         str: '#0015ff',
       };
@@ -271,16 +277,23 @@ describe('color utilities', () => {
       expect(updateRGB({ r: 0, g: 255, b: 255 } as IColor, 'g', 21)).toEqual(expected);
       expect(updateRGB({ r: 0, g: 21, b: 0 } as IColor, 'b', 255)).toEqual(expected);
 
-      expected.a = 50;
-      expected.str = 'rgba(0, 21, 255, 0.5)';
-      expect(updateRGB({ r: 0, g: 21, b: 255 } as IColor, 'a', 50)).toEqual(expected);
-      expect(updateRGB({ r: 0, g: 21, b: 255, a: 25 } as IColor, 'a', 50)).toEqual(expected);
+      expected.a = 30;
+      expected.t = 70;
+      expected.str = 'rgba(0, 21, 255, 0.3)';
+      expect(updateRGB({ r: 0, g: 21, b: 255 } as IColor, 'a', 30)).toEqual(expected);
+      expect(updateRGB({ r: 0, g: 21, b: 255, a: 25 } as IColor, 'a', 30)).toEqual(expected);
     });
   });
 
   describe('updateA', () => {
     it('works', () => {
       expect(updateA(testColor, testColorAlpha.a!)).toEqual(testColorAlpha);
+    });
+  });
+
+  describe('updateT', () => {
+    it('works', () => {
+      expect(updateT(testColor, testColorAlpha.t!)).toEqual(testColorAlpha);
     });
   });
 

--- a/packages/office-ui-fabric-react/src/utilities/color/getColorFromHSV.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/getColorFromHSV.ts
@@ -18,6 +18,7 @@ export function getColorFromHSV(hsv: IHSV, a?: number): IColor {
   const { r, g, b } = hsv2rgb(h, s, v);
   const hex = hsv2hex(h, s, v);
   const str = _rgbaOrHexString(r, g, b, a, hex);
+  const t = MAX_COLOR_ALPHA - a;
 
-  return { a, b, g, h, hex, r, s, str, v };
+  return { a, b, g, h, hex, r, s, str, v, t };
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/getColorFromRGBA.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/getColorFromRGBA.ts
@@ -10,6 +10,7 @@ export function getColorFromRGBA(rgba: IRGB): IColor {
   const { h, s, v } = rgb2hsv(r, g, b);
   const hex = rgb2hex(r, g, b);
   const str = _rgbaOrHexString(r, g, b, a, hex);
+  const t = MAX_COLOR_ALPHA - a;
 
-  return { a, b, g, h, hex, r, s, str, v };
+  return { a, b, g, h, hex, r, s, str, v, t };
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/index.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/index.ts
@@ -20,5 +20,6 @@ export * from './updateH';
 export * from './updateRGB';
 export * from './getColorFromString';
 export * from './updateA';
+export * from './updateT';
 export * from './correctRGB';
 export * from './correctHSV';

--- a/packages/office-ui-fabric-react/src/utilities/color/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/interfaces.ts
@@ -34,4 +34,7 @@ export interface IColor extends IRGB, IHSV {
 
   /** CSS color string. If a hex value, it must be prefixed with #. */
   str: string;
+
+  /** Transparency value, range 0 (opaque) to 100 (transparent). Usually assumed to be 0 if not specified. */
+  t?: number;
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/updateA.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/updateA.ts
@@ -1,5 +1,6 @@
 import { IColor } from './interfaces';
 import { _rgbaOrHexString } from './_rgbaOrHexString';
+import { MAX_COLOR_ALPHA } from './consts';
 
 /**
  * Gets a color with the given alpha value and the same other components as `color`.
@@ -8,7 +9,8 @@ import { _rgbaOrHexString } from './_rgbaOrHexString';
 export function updateA(color: IColor, a: number): IColor {
   return {
     ...color,
-    a: a,
+    a,
+    t: MAX_COLOR_ALPHA - a,
     str: _rgbaOrHexString(color.r, color.g, color.b, a, color.hex),
   };
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/updateH.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/updateH.ts
@@ -14,14 +14,12 @@ export function updateH(color: IColor, h: number): IColor {
   const hex = rgb2hex(r, g, b);
 
   return {
-    a: color.a,
-    b: b,
-    g: g,
-    h: h,
-    hex: hex,
-    r: r,
-    s: color.s,
+    ...color,
+    h,
+    r,
+    g,
+    b,
+    hex,
     str: _rgbaOrHexString(r, g, b, color.a, hex),
-    v: color.v,
   };
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/updateSV.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/updateSV.ts
@@ -14,14 +14,13 @@ export function updateSV(color: IColor, s: number, v: number): IColor {
   const hex = rgb2hex(r, g, b);
 
   return {
-    a: color.a,
-    b: b,
-    g: g,
-    h: color.h,
-    hex: hex,
-    r: r,
-    s: s,
+    ...color,
+    s,
+    v,
+    r,
+    g,
+    b,
+    hex,
     str: _rgbaOrHexString(r, g, b, color.a, hex),
-    v: v,
   };
 }

--- a/packages/office-ui-fabric-react/src/utilities/color/updateT.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/updateT.ts
@@ -1,0 +1,17 @@
+import { IColor } from './interfaces';
+import { _rgbaOrHexString } from './_rgbaOrHexString';
+import { MAX_COLOR_ALPHA } from './consts';
+
+/**
+ * Gets a color with the given transparency value and the same other components as `color`.
+ * Does not modify the original color.
+ */
+export function updateT(color: IColor, t: number): IColor {
+  const a = MAX_COLOR_ALPHA - t;
+  return {
+    ...color,
+    t,
+    a,
+    str: _rgbaOrHexString(color.r, color.g, color.b, a, color.hex)
+  };
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add support for selecting transparency values instead of alpha values in the ColorPicker. This was started by @navkuma in #11836, but after thinking a good bit about what the best approach would be, I decided to make a separate PR implementing what I was thinking of.

The feature is enabled by setting a new prop `alphaType: 'alpha' | 'transparency' | 'none'`. This prop supersedes `alphaSliderHidden` and provides a single place to control if/how alpha/transparency controls are displayed. (Also considered `useTransparency` or `useTransparencySlider`, but `alphaType` has the advantage of putting all control in one place and mirroring the new `IColorSliderProps.type`. Of the other two options, I prefer `useTransparency` because the setting affects a text field, not just the slider.)

This is what it looks like in transparency mode:
![image](https://user-images.githubusercontent.com/5864305/75604281-d775d880-5a8b-11ea-856b-f96ab6c47359.png)

vs. alpha mode:
![image](https://user-images.githubusercontent.com/5864305/75604277-ce850700-5a8b-11ea-97a1-2b9a9d7ef23a.png)

Transparency values are stored in a new `IColor` property `t` (for clarity to the consumer). I updated the color utility functions ensure this mirrors the alpha value `IColor.a`.

For `ColorSlider`, to handle transparency sliders, I deprecated the `isAlpha` prop and added a new prop `type: 'hue' | 'alpha' | 'transparency'` (and deprecated `minValue` and `maxValue`, which are inferred from `type`). This is cleaner than having multiple boolean props for slider types.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12153)