### PR TITLE
Roster prototype

### DIFF
--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -419,7 +419,7 @@ class Sidebar extends React.Component<any, any> {
       {
         key: 'prototype-roster',
         title: { content: 'Roster', as: NavLink, to: '/prototype-roster' },
-        public: true
+        public: false
       }
     ];
 

--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -415,6 +415,11 @@ class Sidebar extends React.Component<any, any> {
         key: 'virtualized-table',
         title: { content: 'VirtualizedTable', as: NavLink, to: '/virtualized-table' },
         public: true
+      },
+      {
+        key: 'prototype-roster',
+        title: { content: 'Roster', as: NavLink, to: '/prototype-roster' },
+        public: true
       }
     ];
 

--- a/packages/fluentui/docs/src/prototypes/Roster/Roster.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/Roster.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { Tree, TreeItemProps, Flex } from '@fluentui/react';
+import { RosterItemData, RosterSectionType } from './interface/roster.interface';
+import { RosterItem } from './RosterItem';
+import { withTreeItemMemo } from './helpers/withTreeItemMemo';
+import { ActionsContext } from './actionsContext';
+import { initialRosterData } from './data/initialRosterData';
+import { lexCompareData } from './helpers/utils';
+import { RosterSectionTitle } from './RosterTitle';
+import { useRosterActions } from './hooks/useRosterActions';
+import { rosterStyles, rosterTreeStyles, rosterSectionStyles } from './styles/styles';
+
+export const Roster: React.FunctionComponent<{}> = () => {
+  return (
+    <Flex styles={rosterStyles}>
+      <RosterContent />
+    </Flex>
+  );
+};
+
+const RosterContent: React.FunctionComponent<{}> = () => {
+  const [rosterData, setRosterData] = React.useState(initialRosterData);
+
+  const { presenters: _presenters, attendees: _attendees, suggestions: _suggestions } = rosterData;
+
+  const presenters = getSection('presenters', Array.from(_presenters.values()).sort(lexCompareData));
+  const attendees = getSection('attendees', Array.from(_attendees.values()).sort(lexCompareData));
+  const suggestions = getSection('suggestions', Array.from(_suggestions.values()).sort(lexCompareData));
+
+  const actions = useRosterActions(rosterData, setRosterData);
+
+  return (
+    <ActionsContext.Provider value={actions}>
+      <Tree
+        as="div"
+        items={[presenters, attendees, suggestions]}
+        defaultActiveItemIds={['presenters', 'attendees', 'suggestions']}
+        styles={rosterTreeStyles}
+      />
+    </ActionsContext.Provider>
+  );
+};
+
+const customItemPropsArray: (keyof React.ComponentProps<typeof RosterItem>)[] = ['userId', 'visuals', 'displayName', 'type', 'isMuted'];
+const TreeItemMemo = withTreeItemMemo(RosterItem, customItemPropsArray);
+
+const getItem: (type: RosterSectionType, data: RosterItemData) => TreeItemProps = (type, data) => {
+  const { userId, displayName, visuals, isMuted } = data;
+  return {
+    id: userId,
+    children: (_, props) => (
+      <TreeItemMemo {...props} key={userId} userId={userId} displayName={displayName} visuals={visuals} type={type} isMuted={isMuted} />
+    )
+  };
+};
+
+const getSection: (type: RosterSectionType, data: RosterItemData[]) => TreeItemProps = (type, data) => {
+  return {
+    id: type,
+    title: <RosterSectionTitle type={type} />,
+    items: data.map(d => getItem(type, d)),
+    styles: rosterSectionStyles
+  };
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterAvatar.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterAvatar.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { useDelayedState } from './hooks/useDelayedState';
+import { RosterVisuals } from './interface/roster.interface';
+import { Avatar } from '@fluentui/react';
+import { rosterAvatarStyles } from './styles/styles';
+
+export const RosterAvatar: React.FunctionComponent<{ visuals: RosterVisuals; isActive: boolean }> = ({ visuals, isActive }) => {
+  const shouldRenderAvatar = useDelayedState({ delayMs: 500 + Math.floor(Math.random() * 2000) });
+  const shouldRenderPresence = useDelayedState({ delayMs: 500 + Math.floor(Math.random() * 2000) });
+  return (
+    <Avatar
+      image={shouldRenderAvatar ? getAvatar(visuals) : undefined}
+      status={shouldRenderPresence ? { state: 'success' } : { state: 'unknown' }}
+      styles={rosterAvatarStyles(isActive)}
+    />
+  );
+};
+
+const getAvatar = (v: RosterVisuals) => `public/images/avatar/small/${v}`;

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterItem.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterItem.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { List } from '@fluentui/react';
+import { IRosterItemInternalProps } from './interface/roster.interface';
+import { RosterAvatar } from './RosterAvatar';
+import { RosterUserName } from './RosterUsername';
+import { RosterState } from './RosterState';
+import { RosterMessage } from './RosterMessage';
+import { rosterListItemStyles } from './styles/styles';
+import { withRosterActions } from './helpers/withRosterActions';
+import { useJitterState } from './hooks/useJitterState';
+
+const RosterItemInternal: React.FunctionComponent<IRosterItemInternalProps> = ({ userId, visuals, displayName, action, isMuted, type }) => {
+  const isActive = useJitterState({ from: 500, to: 2000, enabled: (type === 'presenters' || type === 'attendees') && !isMuted });
+  return (
+    <List.Item
+      truncateHeader
+      key={userId}
+      media={<RosterAvatar isActive={isActive} visuals={visuals} />}
+      header={<RosterUserName isActive={isActive} displayName={displayName} />}
+      endMedia={<RosterState action={action} isMuted={isMuted} />}
+      content={<RosterMessage />}
+      styles={rosterListItemStyles}
+    />
+  );
+};
+
+export const RosterItem = withRosterActions(RosterItemInternal);

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterMessage.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterMessage.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Text } from '@fluentui/react';
+
+export const RosterMessage: React.FunctionComponent<{}> = () => {
+  return <Text content="message" />;
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterState.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterState.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { Icon, Flex } from '@fluentui/react';
+
+export const RosterState: React.FunctionComponent<{ action: React.ReactNode; isMuted: boolean }> = ({ action, isMuted }) => {
+  return (
+    <Flex vAlign="center">
+      <Flex>{isMuted ? <Icon outline name={'mic-off'} xSpacing="both" /> : null}</Flex>
+      {action}
+    </Flex>
+  );
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterTitle.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterTitle.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { RosterSectionType } from './interface/roster.interface';
+import { Flex, Icon } from '@fluentui/react';
+import { rosterTitleIconStyles } from './styles/styles';
+
+export const RosterSectionTitle: React.FunctionComponent<{ type: RosterSectionType }> = ({ type }) => {
+  const [isToggled, setToggled] = React.useState(true);
+  return (
+    <Flex onClick={() => setToggled(!isToggled)}>
+      <Icon name={isToggled ? 'icon-arrow-down' : 'icon-arrow-end'} styles={rosterTitleIconStyles} />
+      {(type as string).charAt(0).toUpperCase() + (type as string).slice(1)}
+    </Flex>
+  );
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/RosterUsername.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/RosterUsername.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Text } from '@fluentui/react';
+
+export const RosterUserName: React.FunctionComponent<{ displayName: string; isActive: boolean }> = ({ displayName, isActive }) => {
+  return <Text weight={isActive ? 'semibold' : 'regular'}>{displayName}</Text>;
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/actionsContext.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/actionsContext.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export interface IActionsContext {
+  promote: (id: string) => void;
+  demote: (id: string) => void;
+  mute: (id: string) => void;
+  unmute: (id: string) => void;
+}
+
+export const ActionsContext = React.createContext<IActionsContext>(undefined);
+
+export const useActions = () => React.useContext(ActionsContext);

--- a/packages/fluentui/docs/src/prototypes/Roster/data/initialRosterData.ts
+++ b/packages/fluentui/docs/src/prototypes/Roster/data/initialRosterData.ts
@@ -1,0 +1,33 @@
+import { RosterData, RosterItemData } from '../interface/roster.interface';
+
+export const initialRosterData: RosterData = {
+  presenters: new Map<string, RosterItemData>([
+    ['1', { userId: '1', displayName: 'Jenny from the Block', visuals: 'jenny.jpg', isMuted: false }],
+    ['2', { userId: '2', displayName: 'Lena Headey', visuals: 'lena.png', isMuted: false }],
+    ['3', { userId: '3', displayName: 'Lindsay Lohan', visuals: 'lindsay.png', isMuted: false }],
+    ['4', { userId: '4', displayName: 'Mark Ruffalo', visuals: 'mark.png', isMuted: false }],
+    ['5', { userId: '5', displayName: 'Matt Smith', visuals: 'matt.jpg', isMuted: false }],
+    ['6', { userId: '6', displayName: 'Matthew McConaughey', visuals: 'matthew.png', isMuted: false }],
+    ['7', { userId: '7', displayName: 'Molly Rankin', visuals: 'molly.png', isMuted: false }],
+    ['8', { userId: '8', displayName: 'Nan Nanny', visuals: 'nan.jpg', isMuted: false }],
+    ['9', { userId: '9', displayName: 'Nom Tasty', visuals: 'nom.jpg', isMuted: false }],
+    ['10', { userId: '10', displayName: 'Rachel McAdams', visuals: 'rachel.png', isMuted: false }],
+    ['11', { userId: '11', displayName: 'Stevie Griffin', visuals: 'stevie.jpg', isMuted: false }]
+  ]),
+  attendees: new Map<string, RosterItemData>([
+    ['12', { userId: '12', displayName: 'Joe Hill', visuals: 'joe.jpg', isMuted: false }],
+    ['13', { userId: '13', displayName: 'Laura Marling', visuals: 'laura.jpg', isMuted: false }],
+    ['14', { userId: '14', displayName: 'Tom Bombadil', visuals: 'tom.jpg', isMuted: false }],
+    ['15', { userId: '15', displayName: 'Veronica Rothe', visuals: 'veronika.jpg', isMuted: false }],
+    ['16', { userId: '16', displayName: 'Zoe Deschanel', visuals: 'zoe.jpg', isMuted: false }]
+  ]),
+  suggestions: new Map<string, RosterItemData>([
+    ['17', { userId: '17', displayName: 'Justin Bieber', visuals: 'justen.jpg', isMuted: false }],
+    ['18', { userId: '18', displayName: 'Christian Bale', visuals: 'christian.jpg', isMuted: false }],
+    ['19', { userId: '19', displayName: 'Daniel Radcliffe', visuals: 'daniel.jpg', isMuted: false }],
+    ['20', { userId: '20', displayName: 'Elliot Smith', visuals: 'elliot.jpg', isMuted: false }],
+    ['21', { userId: '21', displayName: 'Ada Lovelace', visuals: 'ade.jpg', isMuted: false }],
+    ['22', { userId: '22', displayName: 'Chris Pine', visuals: 'chris.jpg', isMuted: false }],
+    ['23', { userId: '23', displayName: 'Helen Mirren', visuals: 'helen.jpg', isMuted: false }]
+  ])
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/helpers/utils.ts
+++ b/packages/fluentui/docs/src/prototypes/Roster/helpers/utils.ts
@@ -1,0 +1,14 @@
+import { RosterItemData } from '../interface/roster.interface';
+
+export const lexCompareData = (a: RosterItemData, b: RosterItemData) => a.displayName.localeCompare(b.displayName);
+
+export const omit = <T>(object: T, keys: (keyof T)[]) => {
+  if (!object || typeof object !== 'object' || keys.length === 0) {
+    return object;
+  }
+  const ret = { ...object };
+  for (const key of keys) {
+    delete ret[key];
+  }
+  return ret;
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/helpers/withRosterActions.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/helpers/withRosterActions.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { IRosterItemInternalProps, IRosterItemProps } from '../interface/roster.interface';
+import { useActions } from '../actionsContext';
+import { ShorthandCollection, MenuItemProps, MenuShorthandKinds, Text, IconProps, Popup, Menu, Button } from '@fluentui/react';
+import { rosterMenuPopupStyles } from '../styles/styles';
+
+export const withRosterActions: (
+  C: React.ComponentType<IRosterItemInternalProps>
+) => React.ComponentType<IRosterItemProps> = Component => props => {
+  const { promote, demote, mute, unmute } = useActions();
+
+  const [isOpen, setOpen] = React.useState(false);
+  const [isContextOpen, setContextOpen] = React.useState(false);
+
+  const { userId, type, isMuted } = props;
+
+  const closeAll = () => {
+    setOpen(false);
+    setContextOpen(false);
+  };
+
+  const items: ShorthandCollection<MenuItemProps, MenuShorthandKinds> = [];
+
+  if (props.type === 'attendees') {
+    items.push({
+      key: 'promote',
+      content: <Text content="Promote" />,
+      icon: {
+        name: 'presenter',
+        outline: true,
+        xSpacing: 'after'
+      } as IconProps,
+      onClick: () => promote(userId)
+    });
+  } else if (type === 'presenters') {
+    items.push({
+      key: 'demote',
+      content: <Text content="Demote" />,
+      icon: {
+        name: 'no-presenter',
+        outline: true,
+        xSpacing: 'after'
+      } as IconProps,
+      onClick: () => demote(userId)
+    });
+  }
+
+  if (type !== 'suggestions') {
+    items.push({
+      key: 'mute',
+      content: <Text content={isMuted ? 'Unmute' : 'Mute'} />,
+      icon: {
+        name: isMuted ? 'mic' : 'mic-off',
+        outline: true,
+        xSpacing: 'after'
+      } as IconProps,
+      onClick: () => (isMuted ? unmute(userId) : mute(userId))
+    });
+  }
+
+  if (!items.length) {
+    return <Component {...props} action={null} />;
+  }
+
+  const menu = <Menu vertical items={items} onItemClick={closeAll} />;
+
+  const actionButton = (
+    <Popup
+      open={isOpen}
+      on="click"
+      onOpenChange={(_, { open }) => setOpen(open)}
+      position="below"
+      align="end"
+      trigger={
+        <Button
+          iconOnly
+          text
+          onClick={() => (isOpen ? setOpen(false) : setOpen(true))}
+          variables={{
+            isCallingSidePanelIconOnlyButton: true,
+            isCallingRosterPopupButton: true
+          }}
+          className="show-only-on-list-item-hover"
+          icon="more"
+          data-cid="ts-participant-action-button"
+        />
+      }
+      content={{ content: menu, variables: rosterMenuPopupStyles }}
+    />
+  );
+
+  return (
+    <Popup
+      open={isContextOpen}
+      on="context"
+      onOpenChange={(_, { open }) => setContextOpen(open)}
+      trigger={
+        <div>
+          <Component {...props} action={actionButton} />
+        </div>
+      }
+      content={{ content: menu, variables: rosterMenuPopupStyles }}
+    />
+  );
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/helpers/withTreeItemMemo.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/helpers/withTreeItemMemo.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { TreeItem, TreeItemProps } from '@fluentui/react';
+import { pick } from 'lodash';
+import { omit } from './utils';
+import { rosterTreeItemStyles } from '../styles/styles';
+
+export const withTreeItemMemo: <T extends React.JSXElementConstructor<React.ComponentProps<T>>>(
+  Constructor: T,
+  customItemPropsArray: (keyof React.ComponentProps<T>)[]
+) => React.FunctionComponent<React.ComponentProps<typeof TreeItem> & React.ComponentProps<T>> = (Constructor, customItemPropsArray) =>
+  React.memo<React.ComponentProps<typeof Constructor>>(props => {
+    const customItemProps = pick(props, customItemPropsArray) as React.ComponentProps<typeof Constructor>;
+    const treeItemProps = omit(props, customItemPropsArray) as TreeItemProps;
+
+    return <TreeItem styles={rosterTreeItemStyles} {...treeItemProps} title={<Constructor {...customItemProps} />} />;
+  });

--- a/packages/fluentui/docs/src/prototypes/Roster/hooks/useDelayedState.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/hooks/useDelayedState.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export const useDelayedState = ({ delayMs = 0 }: { delayMs?: number }) => {
+  const [shouldRender, setShouldRender] = React.useState(delayMs === 0);
+
+  React.useEffect(() => {
+    setTimeout(() => setShouldRender(true), delayMs);
+  }, []);
+
+  return shouldRender;
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/hooks/useJitterState.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/hooks/useJitterState.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+
+export const useJitterState = ({ from = 1000, to = 3000, enabled = true }: { from?: number; to?: number; enabled?: boolean }) => {
+  const [flag, setFlag] = React.useState(false);
+
+  const timeoutHandle = React.useRef<any>();
+
+  const jitter = () => {
+    setFlag(prev => !prev);
+    if (enabled) {
+      timeoutHandle.current = setTimeout(jitter, from + Math.floor(Math.random() * (to - from)));
+    }
+  };
+
+  React.useEffect(() => {
+    if (!enabled) {
+      if (timeoutHandle.current) {
+        clearTimeout(timeoutHandle.current);
+        setFlag(false);
+      }
+      return;
+    }
+    timeoutHandle.current = setTimeout(jitter, 0);
+  }, [enabled]);
+
+  return flag;
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/hooks/useRosterActions.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/hooks/useRosterActions.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { RosterData } from '../interface/roster.interface';
+import { IActionsContext } from '../actionsContext';
+
+export const useRosterActions = (rosterData: RosterData, setRosterData: React.Dispatch<React.SetStateAction<RosterData>>) => {
+  return React.useMemo<IActionsContext>(
+    () => ({
+      promote: id => {
+        setRosterData(_rosterData => {
+          const toBePromoted = _rosterData.attendees.get(id);
+          if (!toBePromoted) {
+            return _rosterData;
+          }
+          // An attempt at immer-like immutability.
+          const newData = { ..._rosterData };
+          newData.attendees = new Map(_rosterData.attendees);
+          newData.presenters = new Map(_rosterData.presenters);
+          newData.attendees.delete(id);
+          newData.presenters.set(id, { ...toBePromoted });
+          return newData;
+        });
+      },
+      demote: id => {
+        setRosterData(_rosterData => {
+          const toBeDemoted = _rosterData.presenters.get(id);
+          if (!toBeDemoted) {
+            return _rosterData;
+          }
+          const newData = { ..._rosterData };
+          newData.attendees = new Map(_rosterData.attendees);
+          newData.presenters = new Map(_rosterData.presenters);
+          newData.presenters.delete(id);
+          newData.attendees.set(id, { ...toBeDemoted });
+          return newData;
+        });
+      },
+      mute: id => {
+        setRosterData(_rosterData => {
+          const newData = { ...rosterData };
+          if (newData.presenters.has(id)) {
+            newData.presenters = new Map(rosterData.presenters);
+            const toBeMuted = newData.presenters.get(id);
+            newData.presenters.set(id, { ...toBeMuted, isMuted: true });
+          } else if (newData.attendees.has(id)) {
+            newData.attendees = new Map(rosterData.attendees);
+            const toBeMuted = newData.attendees.get(id);
+            newData.attendees.set(id, { ...toBeMuted, isMuted: true });
+          }
+          return newData;
+        });
+      },
+      unmute: id => {
+        setRosterData(_rosterData => {
+          const newData = { ...rosterData };
+          if (newData.presenters.has(id)) {
+            newData.presenters = new Map(rosterData.presenters);
+            const toBeMuted = newData.presenters.get(id);
+            newData.presenters.set(id, { ...toBeMuted, isMuted: false });
+          } else if (newData.attendees.has(id)) {
+            newData.attendees = new Map(rosterData.attendees);
+            const toBeMuted = newData.attendees.get(id);
+            newData.attendees.set(id, { ...toBeMuted, isMuted: false });
+          }
+          return newData;
+        });
+      }
+    }),
+    [rosterData, setRosterData]
+  );
+};

--- a/packages/fluentui/docs/src/prototypes/Roster/index.tsx
+++ b/packages/fluentui/docs/src/prototypes/Roster/index.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { PrototypeSection, ComponentPrototype } from '../Prototypes';
+import { Roster } from './Roster';
+
+export default () => (
+  <PrototypeSection title="Calling Roster">
+    <ComponentPrototype title="Calling Roster" description="Calling Roster is a calling roster.">
+      <Roster />
+    </ComponentPrototype>
+  </PrototypeSection>
+);

--- a/packages/fluentui/docs/src/prototypes/Roster/interface/roster.interface.ts
+++ b/packages/fluentui/docs/src/prototypes/Roster/interface/roster.interface.ts
@@ -1,0 +1,51 @@
+export type RosterVisuals =
+  | 'zoe.jpg'
+  | 'veronika.jpg'
+  | 'tom.jpg'
+  | 'stevie.jpg'
+  | 'rachel.png'
+  | 'nom.jpg'
+  | 'nan.jpg'
+  | 'molly.png'
+  | 'matthew.png'
+  | 'matt.jpg'
+  | 'mark.png'
+  | 'lindsay.png'
+  | 'lena.png'
+  | 'laura.jpg'
+  | 'justen.jpg'
+  | 'joe.jpg'
+  | 'jenny.jpg'
+  | 'helen.jpg'
+  | 'elliot.jpg'
+  | 'daniel.jpg'
+  | 'christian.jpg'
+  | 'chris.jpg'
+  | 'ade.jpg';
+
+export interface RosterData {
+  presenters: Map<string, RosterItemData>;
+  attendees: Map<string, RosterItemData>;
+  suggestions: Map<string, RosterItemData>;
+}
+
+export interface RosterItemData {
+  visuals: RosterVisuals;
+  userId: string;
+  displayName: string;
+  isMuted: boolean;
+}
+
+export type RosterSectionType = 'presenters' | 'attendees' | 'suggestions';
+
+export interface IRosterItemProps {
+  userId: string;
+  displayName: string;
+  visuals: RosterVisuals;
+  type: RosterSectionType;
+  isMuted: boolean;
+}
+
+export interface IRosterItemInternalProps extends IRosterItemProps {
+  action: React.ReactNode;
+}

--- a/packages/fluentui/docs/src/prototypes/Roster/styles/styles.ts
+++ b/packages/fluentui/docs/src/prototypes/Roster/styles/styles.ts
@@ -1,0 +1,87 @@
+import { colorScheme } from '@fluentui/react/src/themes/teams/colors';
+import { ComponentSlotStyle, Icon, List } from '@fluentui/react';
+
+export const rosterStyles: ComponentSlotStyle = {
+  background: colorScheme.default.background,
+  flex: '0 0 20rem',
+  maxWidth: '20rem',
+  width: '20rem',
+  height: '40rem',
+  border: `.2rem solid ${colorScheme.default!.background4}`,
+  '&::-webkit-scrollbar': {
+    width: '0.5rem'
+  },
+  '&::-webkit-scrollbar-thumb': {
+    backgroundColor: colorScheme.default!.border,
+    borderRadius: '0.8rem'
+  },
+  '&::-webkit-scrollbar-track': {
+    borderRadius: '0.8rem'
+  },
+  overflowY: 'auto',
+  overflowX: 'hidden',
+  willChange: 'scroll-position',
+  transform: 'translate3d(0, 0, 0)'
+};
+
+export const rosterTreeStyles: ComponentSlotStyle = {
+  paddingLeft: '0rem',
+  width: '100%'
+};
+
+export const rosterSectionStyles: ComponentSlotStyle = {
+  marginLeft: '1rem'
+};
+
+export const rosterListItemStyles: ComponentSlotStyle = {
+  '&:not(:hover):not(:focus)': {
+    '& .show-only-on-list-item-hover:not(:focus)': {
+      display: 'none'
+    }
+  },
+  borderRadius: '.3rem',
+  padding: '0 2rem',
+  ':hover': {
+    backgroundColor: colorScheme.default!.backgroundActive1,
+    color: colorScheme.default!.foregroundFocus1,
+    [`& .${Icon.className}`]: {
+      color: colorScheme.default!.foregroundFocus1
+    },
+    [`& .${List.Item.slotClassNames.contentWrapper}`]: {
+      color: colorScheme.default!.foregroundFocus1
+    }
+  },
+  [`& .${List.Item.slotClassNames.contentWrapper}`]: {
+    color: colorScheme.default!.foreground2
+  }
+};
+
+export const rosterAvatarStyles = (isSpeaking: boolean): ComponentSlotStyle => {
+  return {
+    ':before': {
+      content: `" "`,
+      position: 'absolute',
+      top: '-.4rem',
+      left: '-.4rem',
+      width: 'calc(100% + .8rem)',
+      height: 'calc(100% + .8rem)',
+      border: `.2rem solid ${colorScheme.brand!.borderFocus1}`,
+      borderRadius: '50%',
+      opacity: '0',
+      transition: 'opacity .25s cubic-bezier(.33,0,.67,1) .45s',
+      display: 'block',
+      ...(isSpeaking && {
+        opacity: '1'
+      })
+    }
+  };
+};
+
+export const rosterTreeItemStyles: ComponentSlotStyle = { marginLeft: '-1rem' };
+
+export const rosterMenuPopupStyles: ComponentSlotStyle = { padding: '0px' };
+
+export const rosterTitleIconStyles: ComponentSlotStyle = {
+  color: colorScheme.default!.foregroundActive,
+  marginRight: '0.4rem'
+};

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -52,6 +52,7 @@ import EditorToolbarPrototype from './prototypes/EditorToolbar';
 import HexagonalAvatarPrototype from './prototypes/hexagonalAvatar';
 import TablePrototype from './prototypes/table';
 import VirtualizedTablePrototype from './prototypes/VirtualizedTable';
+import RosterPrototype from './prototypes/Roster';
 
 const Routes = () => (
   <BrowserRouter basename={__BASENAME__}>
@@ -84,6 +85,7 @@ const Routes = () => (
           <Route exact path="/prototype-nested-popups-and-dialogs" component={NestedPopupsAndDialogsPrototype} />
           <Route exact path="/virtualized-tree" component={VirtualizedTreePrototype} />
           <Route exact path="/virtualized-table" component={VirtualizedTablePrototype} />
+          <Route exact path="/prototype-roster" component={RosterPrototype} />
           <Route exact path="/prototype-copy-to-clipboard" component={CopyToClipboardPrototype} />
           <Route exact path="/faq" component={FAQ} />
           <Route exact path="/accessibility" component={Accessibility} />


### PR DESCRIPTION
#### Description of changes

Introducing a calling roster prototype. The purpose of this prototype is to monitor potential performance regression (and confirm the effect of performance optimization) across Fluent versions.

![roster-model mov](https://user-images.githubusercontent.com/59018100/75881007-a47e6c80-5e1e-11ea-8b03-9e4aa73e860c.gif)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12180)