### PR TITLE
FocusZone: call native event methods directly instead of through on.

### DIFF
--- a/change/@fluentui-react-focus-2020-03-06-16-56-39-focuszone_native_eventing.json
+++ b/change/@fluentui-react-focus-2020-03-06-16-56-39-focuszone_native_eventing.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: directly call addEventListener & removeEventListener instead of on",
+  "packageName": "@fluentui/react-focus",
+  "email": "aneeshak@microsoft.com",
+  "commit": "0de6573cf885e8e4835e090e23d5a254af0e036b",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T22:56:39.786Z"
+}

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -18,7 +18,6 @@ import {
   isElementFocusSubZone,
   isElementFocusZone,
   isElementTabbable,
-  on,
   raiseClick,
   shouldWrapFocus,
   warnDeprecations,
@@ -63,9 +62,6 @@ const _allInstances: {
   [key: string]: FocusZone;
 } = {};
 const _outerZones: Set<FocusZone> = new Set();
-
-// Track the 1 global keydown listener we hook to window.
-let _disposeGlobalKeyDownListener: (() => void) | undefined;
 
 const ALLOWED_INPUT_TYPES = ['text', 'number', 'password', 'email', 'tel', 'url', 'search'];
 
@@ -155,11 +151,13 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         _outerZones.add(this);
 
         if (windowElement && _outerZones.size === 1) {
-          _disposeGlobalKeyDownListener = on(windowElement, 'keydown', this._onKeyDownCapture, true);
+          windowElement.addEventListener('keydown', this._onKeyDownCapture, true);
         }
       }
 
-      this._disposables.push(on(root, 'blur', this._onBlur, true));
+      if (windowElement) {
+        windowElement.addEventListener('blur', this._onBlur, true);
+      }
 
       // Assign initial tab indexes so that we can set initial focus as appropriate.
       this._updateTabIndexes();
@@ -193,16 +191,20 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   public componentWillUnmount(): void {
     delete _allInstances[this._id];
+    const { current: root } = this._root;
+    const windowElement = getWindow(root);
 
     if (!this._isInnerZone) {
       _outerZones.delete(this);
 
       // If this is the last outer zone, remove the keydown listener.
-      if (_outerZones.size === 0 && _disposeGlobalKeyDownListener) {
-        _disposeGlobalKeyDownListener();
-        // Clear reference so closure can be garbage-collected.
-        _disposeGlobalKeyDownListener = undefined;
+      if (_outerZones.size === 0 && windowElement) {
+        windowElement.removeEventListener('keydown', this._onKeyDownCapture, true);
       }
+    }
+
+    if (windowElement) {
+      windowElement.removeEventListener('blur', this._onBlur, true);
     }
 
     // Dispose all events.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

FocusZone currently using native eventing (through the on wrapper) - got rid of these calls to on and replaced them with addEventListener and removeEventListener.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12231)