### PR TITLE
fix(Tooltip): Prevent callout content from gaining mouse focus

### DIFF
--- a/change/office-ui-fabric-react-2020-03-17-19-45-29-tooltipFocus.json
+++ b/change/office-ui-fabric-react-2020-03-17-19-45-29-tooltipFocus.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "fix(Tooltip): Prevent callout content from gaining focus, which may cause the tooltip to close unexpectedly.",
+  "packageName": "office-ui-fabric-react",
+  "email": "joshjcarrier@gmail.com",
+  "commit": "a440ba759cf55005d08a051c4d7125d32a77cdba",
+  "dependentChangeType": "patch",
+  "date": "2020-03-18T02:45:29.706Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -45,6 +45,10 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
       maxWidth: maxWidth!
     });
 
+    const onMouseDown = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+      ev.preventDefault();
+    };
+
     return (
       <Callout
         target={targetElement}
@@ -58,6 +62,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
           className={this._classNames.content}
           id={id}
           role="tooltip"
+          onMouseDown={onMouseDown}
           onMouseEnter={this.props.onMouseEnter}
           onMouseLeave={this.props.onMouseLeave}
         >

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -118,6 +118,7 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
           }
         >
           <div
+            onMouseDown={[Function]}
             role="tooltip"
           >
             <p />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We've already concluded that [tooltips don't support focus](https://github.com/OfficeDev/office-ui-fabric-react/issues/10240#issuecomment-525906499) and in some scenarios allowing mouse down on tooltip content attempts to do so. This returns focus to the target element hosting the tooltip, and since the mouse is no longer hovering over it, the tooltip dismisses skipping any component being interacted with (like a link or button).

This adds a mouse down handler to the tooltip callout content to prevent focus from moving while still allowing elements under the cursor to receive the click.

#### Focus areas to test

* on the [Default Tooltip Usage](https://developer.microsoft.com/en-us/fabric#/controls/web/tooltip) example, click the [Hover over me] button and then click the tooltip. Expect that it no longer dismisses unexpectedly.

* on the [Default Tooltip Usage](https://developer.microsoft.com/en-us/fabric#/controls/web/tooltip) example, hover over the [Hover over me] button and double-click the text content `This is the tooltip content`. Expect that it no longer receives focus via text selection.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12344)