### PR TITLE
feat(ResponsiveTable): Adding responsive table prototype

### DIFF
--- a/packages/fluentui/docs/src/prototypes/table/ResponsiveTableContainer.tsx
+++ b/packages/fluentui/docs/src/prototypes/table/ResponsiveTableContainer.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { TableCell, TableProps, Table } from '@fluentui/react-northstar';
+import calculateBreakpoints, { Column, Breakpoint } from './calculateBreakpoints';
+import * as _ from 'lodash';
+
+interface ResponsiveTableProps extends TableProps {
+  columns: Column[];
+  children: React.ReactElement<typeof Table>;
+  breakpoints?: number[];
+  id?: string;
+}
+
+const ResponsiveTableContainer: React.FC<ResponsiveTableProps> = props => {
+  const { columns: config, children } = props;
+
+  const responsiveTableID = React.useMemo(() => props.id || _.uniqueId(`${Table.className}__responsive-wrapper`), [
+    props.id,
+  ]);
+
+  const [breakpoints, setBreakpoints] = React.useState<Breakpoint | undefined>();
+
+  /**
+   * Generate the stylesheet once and for all checking if
+   * the total size of the table ( based in th esum of the minWidth columns ) still fits in the current breakpoint
+   */
+  React.useLayoutEffect(() => {
+    setBreakpoints(calculateBreakpoints(config, props.breakpoints || [1200, 960, 600, 280]));
+  }, []);
+
+  return (
+    <div id={responsiveTableID}>
+      <style>
+        {_.map(
+          breakpoints,
+          (breakpoint, key) => `
+              @media (max-width: ${key}px) {
+                ${breakpoint
+                  .map(
+                    column =>
+                      `#${responsiveTableID} .${TableCell.className}:nth-child(${column.childIndex}) { display: none }`,
+                  )
+                  .join('\n  ')}
+              }`,
+        ).join('\n')}
+      </style>
+      {children}
+    </div>
+  );
+};
+
+export default ResponsiveTableContainer;

--- a/packages/fluentui/docs/src/prototypes/table/calculateBreakpoints.ts
+++ b/packages/fluentui/docs/src/prototypes/table/calculateBreakpoints.ts
@@ -1,0 +1,28 @@
+export type Breakpoints = Record<number, number> & { default?: number };
+
+export type Column = {
+  priority: number;
+  minWidth: number;
+  childIndex?: number;
+};
+
+export type Breakpoint = Record<string, Column[]>;
+
+export default function calculateBreakpoints(config: Column[], breakpoints: number[]): Breakpoint {
+  const minTableSize = config.reduce((acc, curr) => acc + curr.minWidth, 0);
+  const breaks = {};
+
+  const configsWithIndex: Column[] = config.map((column, i) => ({ ...column, childIndex: i + 1 }));
+  const tempConfig = configsWithIndex.sort((a, b) => a.priority - b.priority);
+
+  breakpoints.forEach(breakPoint => {
+    let tempMinTableSize = minTableSize;
+    for (let i = 0; tempMinTableSize > breakPoint; i++) {
+      const currColumn = configsWithIndex.find(column => tempConfig[i].priority === column.priority);
+      breaks[breakPoint] = breaks[breakPoint] ? [...breaks[breakPoint], currColumn] : [currColumn];
+      tempMinTableSize -= tempConfig[i].minWidth;
+    }
+  });
+
+  return breaks;
+}

--- a/packages/fluentui/docs/src/prototypes/table/index.tsx
+++ b/packages/fluentui/docs/src/prototypes/table/index.tsx
@@ -1,10 +1,22 @@
 import { gridCellMultipleFocusableBehavior, gridCellWithFocusableElementBehavior } from '@fluentui/accessibility';
-import { Avatar, Button, Checkbox, Dropdown, Flex, Icon, Menu, MenuButton, Text } from '@fluentui/react-northstar';
+import {
+  Avatar,
+  Button,
+  Checkbox,
+  Dropdown,
+  Flex,
+  Icon,
+  Menu,
+  MenuButton,
+  Text,
+  Table,
+} from '@fluentui/react-northstar';
 import * as React from 'react';
 import chatProtoStyle from '.././chatPane/chatProtoStyle';
 import { ComponentPrototype, PrototypeSection } from '../Prototypes';
 import AdvancedTable, { stringCellComparator } from './AdvancedTable';
 import InteractiveTable from './InteractiveTable';
+import ResponsiveTableContainer from './ResponsiveTableContainer';
 
 function handleRowClick(index) {
   alert(`OnClick on the row ${index} executed.`);
@@ -157,6 +169,30 @@ const rowsChannels = [
   },
 ];
 
+const columnsPerson = {
+  items: ['id', 'Name', 'Age', 'Picture'],
+};
+
+const rowsPerson = [
+  ['1', 'Roman van', '30 years', 'None'],
+  ['2', 'Alex', '1 year', 'None'],
+  ['3', 'Ali', '30000000000000 years', 'None'],
+];
+
+const responsiveColumnsConfig = [
+  { priority: 4, minWidth: 200 },
+  { priority: 3, minWidth: 360 },
+  { priority: 2, minWidth: 300 },
+  { priority: 1, minWidth: 200 },
+];
+
+const responsiveColumnsConfigPriorityOrder = [
+  { priority: 3, minWidth: 200 },
+  { priority: 2, minWidth: 360 },
+  { priority: 1, minWidth: 300 },
+  { priority: 4, minWidth: 200 },
+];
+
 export default () => (
   <PrototypeSection title="Advanced table">
     <ComponentPrototype title="Table example 1" description="Table with sorting, tags and dropdown menu in a cell">
@@ -168,6 +204,22 @@ export default () => (
     </ComponentPrototype>
     <ComponentPrototype title="Table example 3" description="Table with popover and context menu ">
       <InteractiveTable />
+    </ComponentPrototype>
+    <ComponentPrototype
+      title="Responsive Table"
+      description="Responsive table hiding columns based in the priority passed to the Resposive Container as columns configurarion. The container can also receive a Breakpoint input with an array of number representing the breakpoints"
+    >
+      <ResponsiveTableContainer columns={responsiveColumnsConfig}>
+        <Table rows={rowsPerson} header={columnsPerson} arial-label="Persons" />
+      </ResponsiveTableContainer>
+    </ComponentPrototype>
+    <ComponentPrototype
+      title="Responsive Table"
+      description="Responsive table hiding middle columns keeping the first and the last"
+    >
+      <ResponsiveTableContainer columns={responsiveColumnsConfigPriorityOrder}>
+        <Table rows={rowsPerson} header={columnsPerson} arial-label="Persons" />
+      </ResponsiveTableContainer>
     </ComponentPrototype>
   </PrototypeSection>
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adding a prototype of Responsive Table which responds to the viewport changes by hiding and showing columns based on whether they fit on the screen. The order in which they disappear an reappear is determined by each columns priority.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12360)