### PR TITLE
fix(Dropdown): refactor event handlers for component and Downshift

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -860,10 +860,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
         newState.searchQuery = this.getSelectedItemAsString(changes.selectedItem);
         newState.value = multiple ? [...value, changes.selectedItem] : [changes.selectedItem];
         newState.open = false;
-
-        if (shouldAddHighlightedIndex) {
-          newState.highlightedIndex = items.indexOf(changes.selectedItem);
-        }
+        newState.highlightedIndex = shouldAddHighlightedIndex ? items.indexOf(changes.selectedItem) : null;
 
         if (getA11ySelectionMessage && getA11ySelectionMessage.onAdd) {
           this.setA11ySelectionMessage(getA11ySelectionMessage.onAdd(changes.selectedItem));
@@ -959,6 +956,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       newState.searchQuery !== undefined && 'onSearchQueryChange',
     ].filter(Boolean) as (keyof DropdownProps)[];
 
+    console.log(type, newState);
     this.setStateAndInvokeHandler(handlers, null, newState);
   };
 

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -884,11 +884,12 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
         break;
       case Downshift.stateChangeTypes.keyDownEscape:
-        if (!multiple) {
-          newState.value = [];
-        }
         if (search) {
           newState.searchQuery = '';
+
+          if (!multiple) {
+            newState.value = [];
+          }
         }
         newState.open = false;
         newState.highlightedIndex = highlightFirstItemOnOpen ? 0 : null;

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -883,8 +883,12 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
         break;
       case Downshift.stateChangeTypes.keyDownEscape:
-        newState.value = [];
-        newState.searchQuery = '';
+        if (!multiple) {
+          newState.value = [];
+        }
+        if (search) {
+          newState.searchQuery = '';
+        }
         newState.open = false;
         newState.highlightedIndex = highlightFirstItemOnOpen ? 0 : null;
         break;
@@ -940,8 +944,8 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
         break;
       case Downshift.stateChangeTypes.unknown:
         if (newValue) {
-          newState.value = [newValue];
-          newState.searchQuery = newSearchQuery;
+          newState.value = multiple ? [...value, newValue] : [newValue];
+          newState.searchQuery = multiple ? '' : newSearchQuery;
           newState.open = false;
           newState.highlightedIndex = newHighlightedIndex;
         } else {
@@ -1110,14 +1114,14 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     selectItemAtIndex: (highlightedIndex: number) => void,
     toggleMenu: () => void,
   ): void => {
-    if (this.state.open) {
-      if (
-        !_.isNil(highlightedIndex) &&
-        this.state.filteredItems.length &&
-        !this.props.items[highlightedIndex]['disabled']
-      ) {
+    const { open, filteredItems } = this.state;
+    const { moveFocusOnTab, multiple, items } = this.props;
+
+    if (open) {
+      if (!_.isNil(highlightedIndex) && filteredItems.length && !items[highlightedIndex]['disabled']) {
         selectItemAtIndex(highlightedIndex);
-        if (!this.props.moveFocusOnTab && this.props.multiple) {
+
+        if (multiple && moveFocusOnTab !== undefined && !moveFocusOnTab) {
           e.preventDefault();
         }
       } else {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -860,8 +860,8 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
         break;
       }
-      case Downshift.stateChangeTypes.clickItem:
       case Downshift.stateChangeTypes.keyDownEnter:
+      case Downshift.stateChangeTypes.clickItem:
         const shouldAddHighlightedIndex = !multiple && !!items;
 
         newState.searchQuery = this.getSelectedItemAsString(newValue);
@@ -879,6 +879,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
         if (multiple) {
           setTimeout(() => (this.selectedItemsRef.current.scrollTop = this.selectedItemsRef.current.scrollHeight), 0);
         }
+
         this.tryFocusTriggerButton();
 
         break;
@@ -948,6 +949,8 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           newState.searchQuery = multiple ? '' : newSearchQuery;
           newState.open = false;
           newState.highlightedIndex = newHighlightedIndex;
+
+          this.tryFocusTriggerButton();
         } else {
           newState.open = newOpen;
         }
@@ -1121,7 +1124,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       if (!_.isNil(highlightedIndex) && filteredItems.length && !items[highlightedIndex]['disabled']) {
         selectItemAtIndex(highlightedIndex);
 
-        if (multiple && moveFocusOnTab !== undefined && !moveFocusOnTab) {
+        if (multiple && !moveFocusOnTab) {
           e.preventDefault();
         }
       } else {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -956,7 +956,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       newState.searchQuery !== undefined && 'onSearchQueryChange',
     ].filter(Boolean) as (keyof DropdownProps)[];
 
-    console.log(type, newState);
     this.setStateAndInvokeHandler(handlers, null, newState);
   };
 

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -219,7 +219,7 @@ describe('Dropdown', () => {
 
     it('is "true" when you start typing in the search input', () => {
       const { getItemNodes, changeSearchInput } = renderDropdown({
-        search: true
+        search: true,
       });
 
       changeSearchInput('item');
@@ -231,7 +231,7 @@ describe('Dropdown', () => {
       const { getItemNodes, changeSearchInput } = renderDropdown({
         search: true,
         defaultOpen: true,
-        defaultSearchQuery: 'item'
+        defaultSearchQuery: 'item',
       });
 
       changeSearchInput('');
@@ -739,7 +739,12 @@ describe('Dropdown', () => {
 
     it('has onChange called with null value by hitting Escape in search input', () => {
       const onChange = jest.fn();
-      const { keyDownOnSearchInput } = renderDropdown({ search: true, onChange, defaultValue: items[2], defaultSearchQuery: items[2] });
+      const { keyDownOnSearchInput } = renderDropdown({
+        search: true,
+        onChange,
+        defaultValue: items[2],
+        defaultSearchQuery: items[2],
+      });
 
       keyDownOnSearchInput('Escape');
 
@@ -748,8 +753,8 @@ describe('Dropdown', () => {
         null,
         expect.objectContaining({
           value: null,
-          searchQuery: ''
-        })
+          searchQuery: '',
+        }),
       );
     });
 
@@ -1088,7 +1093,7 @@ describe('Dropdown', () => {
       expect(getItemNodes()).toHaveLength(0);
     });
 
-    it('has onSearchQueryChange each time the input is changed', () => {
+    it('has onSearchQueryChange called each time the input is changed', () => {
       const onSearchQueryChange = jest.fn();
       const { changeSearchInput } = renderDropdown({ search: true, onSearchQueryChange });
 
@@ -1098,8 +1103,8 @@ describe('Dropdown', () => {
       expect(onSearchQueryChange).toHaveBeenLastCalledWith(
         null,
         expect.objectContaining({
-          searchQuery: 'ala'
-        })
+          searchQuery: 'ala',
+        }),
       );
 
       changeSearchInput('alladin');
@@ -1108,8 +1113,8 @@ describe('Dropdown', () => {
       expect(onSearchQueryChange).toHaveBeenLastCalledWith(
         null,
         expect.objectContaining({
-          searchQuery: 'alladin'
-        })
+          searchQuery: 'alladin',
+        }),
       );
     });
 
@@ -1125,8 +1130,8 @@ describe('Dropdown', () => {
         expect.objectContaining({
           searchQuery: '',
           value: null,
-          open: false
-        })
+          open: false,
+        }),
       );
     });
 
@@ -1138,7 +1143,7 @@ describe('Dropdown', () => {
         search: true,
         clearable: true,
         onChange,
-        defaultSearchQuery: items[0]
+        defaultSearchQuery: items[0],
       });
 
       changeSearchInput('');
@@ -1151,8 +1156,8 @@ describe('Dropdown', () => {
         expect.objectContaining({
           value: null,
           searchQuery: '',
-          open: false
-        })
+          open: false,
+        }),
       );
     });
 

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -873,6 +873,76 @@ describe('Dropdown', () => {
       expect(getItemNodes()).toHaveLength(0);
     });
 
+    it('is set correctly in multiple selection by using Tab on highlighted item', () => {
+      const itemSelectedIndex = 3;
+      const {
+        triggerButtonNode,
+        keyDownOnItemsList,
+        getSelectedItemNodeAtIndex,
+        getSelectedItemNodes,
+      } = renderDropdown({
+        defaultOpen: true,
+        defaultHighlightedIndex: itemSelectedIndex,
+        defaultValue: items[4],
+        multiple: true,
+      });
+
+      keyDownOnItemsList('Tab');
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getSelectedItemNodes()).toHaveLength(2);
+      expect(getSelectedItemNodeAtIndex(1)).toHaveTextContent(items[3]);
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[4]);
+    });
+
+    it('is set correctly in multiple selection by using Shift+Tab on highlighted item', () => {
+      const itemSelectedIndex = 2;
+      const {
+        triggerButtonNode,
+        keyDownOnItemsList,
+        getSelectedItemNodeAtIndex,
+        getSelectedItemNodes,
+      } = renderDropdown({
+        defaultOpen: true,
+        defaultHighlightedIndex: itemSelectedIndex,
+        defaultValue: items[4],
+        multiple: true,
+      });
+
+      keyDownOnItemsList('Tab', { shiftKey: true });
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getSelectedItemNodes()).toHaveLength(2);
+      expect(getSelectedItemNodeAtIndex(1)).toHaveTextContent(items[2]);
+      expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[4]);
+    });
+
+    it('is not cleared when hitting Escape if not search', () => {
+      const defaultValue = items[0];
+      const { triggerButtonNode, keyDownOnTriggerButton } = renderDropdown({
+        defaultValue,
+      });
+
+      keyDownOnTriggerButton('Escape');
+
+      expect(triggerButtonNode).toHaveTextContent(defaultValue);
+    });
+
+    it('is not cleared when hitting Escape if search but multiple', () => {
+      const defaultValue = [items[0], items[1]];
+      const { getSelectedItemNodes, keyDownOnSearchInput, searchInputNode } = renderDropdown({
+        defaultValue,
+        search: true,
+        multiple: true,
+        defaultSearchQuery: 'test',
+      });
+
+      keyDownOnSearchInput('Escape');
+
+      expect(searchInputNode).toHaveTextContent('');
+      expect(getSelectedItemNodes()).toHaveLength(2);
+    });
+
     it('is replaced when another item is selected', () => {
       const defaultValue = items[0];
       const itemSelectedIndex = 2;

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -658,6 +658,31 @@ describe('Dropdown', () => {
 
       expect(itemsListNode).toHaveAttribute('aria-activedescendant', expect.stringMatching(getItemIdRegexByIndex(2)));
     });
+
+    it('does not open with highlightedIndex after selecting item in multiple mode', () => {
+      const itemSelectedIndex = 2;
+      const { clickOnItemAtIndex, clickOnTriggerButton, itemsListNode } = renderDropdown({
+        defaultOpen: true,
+        multiple: true,
+      });
+
+      clickOnItemAtIndex(itemSelectedIndex);
+      clickOnTriggerButton();
+
+      expect(itemsListNode).not.toHaveAttribute('aria-activedescendant');
+    });
+
+    it('opens with highlightedIndex after selecting item in non-multiple mode', () => {
+      const itemSelectedIndex = 2;
+      const { clickOnItemAtIndex, clickOnTriggerButton, itemsListNode } = renderDropdown({
+        defaultOpen: true,
+      });
+
+      clickOnItemAtIndex(itemSelectedIndex);
+      clickOnTriggerButton();
+
+      expect(itemsListNode).toHaveAttribute('aria-activedescendant', expect.stringMatching(getItemIdRegexByIndex(2)));
+    });
   });
 
   describe('value', () => {

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -216,6 +216,52 @@ describe('Dropdown', () => {
 
       expect(getItemNodes()).toHaveLength(0);
     });
+
+    it('is "true" when you start typing in the search input', () => {
+      const { getItemNodes, changeSearchInput } = renderDropdown({
+        search: true
+      });
+
+      changeSearchInput('item');
+
+      expect(getItemNodes()).toHaveLength(items.length);
+    });
+
+    it('is "false" when you remove the query from the search input', () => {
+      const { getItemNodes, changeSearchInput } = renderDropdown({
+        search: true,
+        defaultOpen: true,
+        defaultSearchQuery: 'item'
+      });
+
+      changeSearchInput('');
+
+      expect(getItemNodes()).toHaveLength(0);
+    });
+
+    it('is "true" when opened by space bar on trigger button', () => {
+      const { getItemNodes, keyDownOnTriggerButton } = renderDropdown({});
+
+      keyDownOnTriggerButton(' ');
+
+      expect(getItemNodes()).toHaveLength(items.length);
+    });
+
+    it('is "true" when opened by arrow down on trigger button', () => {
+      const { getItemNodes, keyDownOnTriggerButton } = renderDropdown({});
+
+      keyDownOnTriggerButton('ArrowDown');
+
+      expect(getItemNodes()).toHaveLength(items.length);
+    });
+
+    it('is "true" when opened by arrow up on trigger button', () => {
+      const { getItemNodes, keyDownOnTriggerButton } = renderDropdown({});
+
+      keyDownOnTriggerButton('ArrowUp');
+
+      expect(getItemNodes()).toHaveLength(items.length);
+    });
   });
 
   describe('highlightedIndex', () => {
@@ -414,10 +460,10 @@ describe('Dropdown', () => {
     });
 
     it('is changed correctly on arrow down navigation', () => {
-      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown();
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({ defaultOpen: true });
 
       for (let index = 0; index < items.length; index++) {
-        keyDownOnTriggerButton('ArrowDown');
+        keyDownOnItemsList('ArrowDown');
 
         expect(itemsListNode).toHaveAttribute(
           'aria-activedescendant',
@@ -427,10 +473,10 @@ describe('Dropdown', () => {
     });
 
     it('is changed correctly on arrow up navigation', () => {
-      const { keyDownOnTriggerButton, itemsListNode } = renderDropdown();
+      const { keyDownOnItemsList, itemsListNode } = renderDropdown({ defaultOpen: true });
 
       for (let index = items.length - 1; index >= 0; index--) {
-        keyDownOnTriggerButton('ArrowUp');
+        keyDownOnItemsList('ArrowUp');
 
         expect(itemsListNode).toHaveAttribute(
           'aria-activedescendant',

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -691,6 +691,22 @@ describe('Dropdown', () => {
       );
     });
 
+    it('has onChange called with null value by hitting Escape in search input', () => {
+      const onChange = jest.fn();
+      const { keyDownOnSearchInput } = renderDropdown({ search: true, onChange, defaultValue: items[2], defaultSearchQuery: items[2] });
+
+      keyDownOnSearchInput('Escape');
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenLastCalledWith(
+        null,
+        expect.objectContaining({
+          value: null,
+          searchQuery: ''
+        })
+      );
+    });
+
     it('is set by clicking on item', () => {
       const itemSelectedIndex = 2;
       const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({ defaultOpen: true });
@@ -1024,6 +1040,73 @@ describe('Dropdown', () => {
       changeSearchInput('');
 
       expect(getItemNodes()).toHaveLength(0);
+    });
+
+    it('has onSearchQueryChange each time the input is changed', () => {
+      const onSearchQueryChange = jest.fn();
+      const { changeSearchInput } = renderDropdown({ search: true, onSearchQueryChange });
+
+      changeSearchInput('ala');
+
+      expect(onSearchQueryChange).toHaveBeenCalledTimes(1);
+      expect(onSearchQueryChange).toHaveBeenLastCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'ala'
+        })
+      );
+
+      changeSearchInput('alladin');
+
+      expect(onSearchQueryChange).toHaveBeenCalledTimes(2);
+      expect(onSearchQueryChange).toHaveBeenLastCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: 'alladin'
+        })
+      );
+    });
+
+    it('has onSearchQueryChange called with empty string by hitting Escape in search input', () => {
+      const onSearchQueryChange = jest.fn();
+      const { keyDownOnSearchInput } = renderDropdown({ search: true, onSearchQueryChange, defaultSearchQuery: 'foo' });
+
+      keyDownOnSearchInput('Escape');
+
+      expect(onSearchQueryChange).toHaveBeenCalledTimes(1);
+      expect(onSearchQueryChange).toHaveBeenLastCalledWith(
+        null,
+        expect.objectContaining({
+          searchQuery: '',
+          value: null,
+          open: false
+        })
+      );
+    });
+
+    it('has onChange called with null when changed to empty string and there was item selected', () => {
+      const onChange = jest.fn();
+      const { changeSearchInput, getClearIndicatorWrapper } = renderDropdown({
+        defaultValue: items[0],
+        search: true,
+        clearable: true,
+        onChange,
+        defaultSearchQuery: items[0]
+      });
+
+      changeSearchInput('');
+
+      expect(getClearIndicatorWrapper().length).toEqual(0);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          value: null,
+          searchQuery: '',
+          open: false
+        })
+      );
     });
 
     it('is the string equivalent of selected item in single search', () => {

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -1088,6 +1088,7 @@ describe('Dropdown', () => {
       const onChange = jest.fn();
       const { changeSearchInput, getClearIndicatorWrapper } = renderDropdown({
         defaultValue: items[0],
+        defaultOpen: true,
         search: true,
         clearable: true,
         onChange,

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/test-utils.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/test-utils.tsx
@@ -17,6 +17,7 @@ const renderDropdown = (props: DropdownProps = {}) => {
   const getSelectedItemsWrapper = () => findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.selectedItem}`);
   const getSelectedItemWrapperAtIndex = index => getSelectedItemsWrapper().at(index);
   const getItemWrapperAtIndex = index => getItemsWrapper().at(index);
+  const getClearIndicatorWrapper = () => findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.clearIndicator}`);
 
   return {
     wrapper,
@@ -28,6 +29,7 @@ const renderDropdown = (props: DropdownProps = {}) => {
     getItemNodes: () => getItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
     getSelectedItemNodes: () => getSelectedItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),
     getSelectedItemNodeAtIndex: index => getSelectedItemWrapperAtIndex(index).getDOMNode(),
+    getClearIndicatorWrapper,
     mouseOverItemAtIndex: index => getItemWrapperAtIndex(index).simulate('mousemove'),
     changeSearchInput: value => {
       searchInputWrapper.simulate('change', { target: { value } });
@@ -53,7 +55,7 @@ const renderDropdown = (props: DropdownProps = {}) => {
       );
     },
     clickOnClearIndicator: () => {
-      findIntrinsicElement(wrapper, `.${Dropdown.slotClassNames.clearIndicator}`).simulate('click');
+      getClearIndicatorWrapper().simulate('click');
     },
     clickOnSelectedItemAtIndex: (index: number, optional = {}) => {
       getSelectedItemWrapperAtIndex(index).simulate(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: 
Fixes https://github.com/OfficeDev/office-ui-fabric-react/issues/12225
Fixes https://github.com/OfficeDev/office-ui-fabric-react/issues/12314
Fixes https://github.com/OfficeDev/office-ui-fabric-react/issues/12304
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

- stop propagation of change event from reaching Dropdown, since onChange for Dropdown means something different than onChange for Input (value vs query).
- if we get empty search query and we had value set, we also set that to null, since we will consider that if user removed all the contents from the searchQuery, he intends the value to be removed.
- refactor the Downshift handlers. Merged all the changes from our end in `handleOnStateChange` and used types to make decisions. Removed the Downshift handlers of selectedItem and inputValue and only used the state handler.
- improve the unit tests.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12361)