### PR TITLE
[5.0] Update repo name references (minimal)

### DIFF
--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -30,7 +30,7 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
 
 // https://github.com/screener-io/screener-storybook#config-options
 const config = {
-  projectRepo: 'OfficeDev/office-ui-fabric-react',
+  projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
   apiKey: process.env.SCREENER_API_KEY,
   resolution: '1024x768',

--- a/apps/vr-tests/screener.local.config.js
+++ b/apps/vr-tests/screener.local.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  projectRepo: 'OfficeDev/office-ui-fabric-react',
+  projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
   apiKey: 'ff2096ee-7c7d-4e80-824b-9114ff43549c',
   resolution: '1024x768',

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -28,8 +28,8 @@ steps:
 
   - script: |
       git config user.name "UI Fabric Build"
-      git config user.email "fabrictactical@service.microsoft.com"
-      git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/OfficeDev/office-ui-fabric-react.git
+      git config user.email "fluentui-internal@service.microsoft.com"
+      git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
 
   - script: |

--- a/rush.json
+++ b/rush.json
@@ -2,7 +2,7 @@
   "npmVersion": "5.3.0",
   "rushVersion": "4.3.0",
   "repository": {
-    "url": "https://github.com/OfficeDev/office-ui-fabric-react.git"
+    "url": "https://github.com/microsoft/fluentui.git"
   },
   "nodeSupportedVersionRange": ">=6.9.0 <11.0.0",
   "projects": [
@@ -47,10 +47,7 @@
       "packageName": "@uifabric/styling",
       "projectFolder": "packages/styling",
       "versionPolicyName": "lockedMajor",
-      "cyclicDependencyProjects": [
-        "office-ui-fabric-react",
-        "@uifabric/example-app-base"
-      ],
+      "cyclicDependencyProjects": ["office-ui-fabric-react", "@uifabric/example-app-base"],
       "shouldPublish": true
     },
     {

--- a/scripts/deploy-github-status.js
+++ b/scripts/deploy-github-status.js
@@ -2,8 +2,8 @@ let argv = require('yargs').argv;
 let GitHubApi = require('github');
 
 const REPO_DETAILS = {
-  owner: "OfficeDev",
-  repo: "office-ui-fabric-react",
+  owner: "microsoft",
+  repo: "fluentui",
 };
 
 let statusConfig = Object.assign({},

--- a/scripts/updateReleaseNotes.js
+++ b/scripts/updateReleaseNotes.js
@@ -15,8 +15,8 @@ let GitHubApi = require('github');
 const EOL = '\n';
 
 const REPO_DETAILS = {
-  owner: "OfficeDev",
-  repo: "office-ui-fabric-react"
+  owner: "microsoft",
+  repo: "fluentui"
 };
 
 const SHOULD_PATCH = argv.patch;


### PR DESCRIPTION
Update essential officedev/office-ui-fabric-react references to microsoft/fluentui.

Intentionally leaving references in docs etc as-is to avoid churn in an old branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12380)