### PR TITLE
[6.0] Update repo name references (minimal)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@ packages/styling/src/interfaces/ @phkuo
 packages/styling/src/styles/ @phkuo
 # packages/utilities/
 packages/utilities/positioning/ @joschect
-packages/date-time @OfficeDev/uifabric-calendar @lorejoh @evlevy
+packages/date-time @lorejoh @evlevy
 packages/migration/ @ecraig12345 @kenotron
 
 ### Fabric
@@ -68,8 +68,8 @@ common/_themeOverrides.scss @phkuo
 common/_common.scss @phkuo
 
 ### Utilities
-dateMath/     @OfficeDev/uifabric-calendar @lorejoh
-dateValues/   @OfficeDev/uifabric-calendar @lorejoh
+dateMath/     @lorejoh
+dateValues/   @lorejoh
 
 ## Components
 Accordion/ @JasonGore
@@ -77,7 +77,7 @@ ActivityItem/ @jdhuntington
 Announced/ @natalieethell
 Breadcrumb/ @jdhuntington
 Button/ @khmakoto
-Calendar/ @OfficeDev/uifabric-calendar @lorejoh
+Calendar/ @lorejoh
 Callout/ @joschect
 react-cards/Card/  @khmakoto
 Check/ @KevinTCoughlin
@@ -89,7 +89,7 @@ ColorPicker/ @ecraig12345
 ComboBox/ @joschect
 CommandBar/ @micahgodbolt @joschect
 ContextualMenu/ @joschect
-DatePicker/ @OfficeDev/uifabric-calendar @lorejoh
+DatePicker/ @lorejoh
 DetailsList/ @KevinTCoughlin
 Dialog/ @kkjeer
 DocumentCard/ @yiminwu
@@ -148,7 +148,7 @@ Tooltip/ @micahgodbolt
 Announced/docs/ @natalieethell
 # Breadcrumb/docs/
 Button/docs/  @khmakoto
-Calendar/docs/   @OfficeDev/uifabric-calendar @lorejoh
+Calendar/docs/   @lorejoh
 Callout/docs/  @joschect
 react-cards/Card/docs/  @khmakoto
 # Check/docs/
@@ -158,7 +158,7 @@ ChoiceGroup/docs/   @srideshpande
 # ComboBox/docs/
 CommandBar/docs/   @micahgodbolt
 ContextualMenu/docs/  @joschect
-DatePicker/docs/   @OfficeDev/uifabric-calendar @lorejoh
+DatePicker/docs/   @lorejoh
 DetailsList/docs/ @KevinTCoughlin
 # Dialog/docs/
 DocumentCard/docs/ @yiminwu

--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -139,7 +139,7 @@
         const link = document.getElementsByClassName('prLink')[0];
         const number = pathParts[pullRequestIndex];
         link.innerHTML = `#${number}`;
-        link.href = `https://github.com/OfficeDev/office-ui-fabric-react/pull/${number}`;
+        link.href = `https://github.com/microsoft/fluentui/pull/${number}`;
       }
     </script>
   </body>

--- a/apps/vr-tests/screener.config.js
+++ b/apps/vr-tests/screener.config.js
@@ -27,7 +27,7 @@ const baseBranch = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
   : '6.0';
 
 module.exports = {
-  projectRepo: 'OfficeDev/office-ui-fabric-react',
+  projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
   apiKey: process.env.SCREENER_API_KEY,
   resolution: '1024x768',

--- a/apps/vr-tests/screener.local.config.js
+++ b/apps/vr-tests/screener.local.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  projectRepo: 'OfficeDev/office-ui-fabric-react',
+  projectRepo: 'microsoft/fluentui',
   storybookConfigDir: '.storybook',
   apiKey: 'ff2096ee-7c7d-4e80-824b-9114ff43549c',
   resolution: '1024x768',

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -28,8 +28,8 @@ steps:
 
   - script: |
       git config user.name "UI Fabric Build"
-      git config user.email "fabrictactical@service.microsoft.com"
-      git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/OfficeDev/office-ui-fabric-react.git
+      git config user.email "fluentui-internal@service.microsoft.com"
+      git remote set-url origin https://$(githubUser):$(githubPAT)@github.com/microsoft/fluentui.git
     displayName: Authenticate git for pushes
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,8 +51,8 @@ steps:
   # - task: GithubPRComment@0
   #   displayName: 'Post Perf Results to Github Pull Request'
   #   inputs:
-  #     githubOwner: OfficeDev
-  #     githubRepo: 'office-ui-fabric-react'
+  #     githubOwner: microsoft
+  #     githubRepo: 'fluentui'
   #     blobFilePath: '$(Build.SourcesDirectory)/$(PerfCommentFilePath)'
   #     status: '$(PerfCommentStatus)'
   #     uniqueId: 'perfComment9423'
@@ -60,8 +60,8 @@ steps:
   - task: GithubPRStatus@0
     displayName: 'Update Github Pull Request Status'
     inputs:
-      githubOwner: OfficeDev
-      githubRepo: 'office-ui-fabric-react'
+      githubOwner: microsoft
+      githubRepo: 'fluentui'
       githubContext: 'Pull Request Deployed Site'
       githubDescription: 'Click "Details" to go to the Deployed Site'
       githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
@@ -77,7 +77,7 @@ steps:
     displayName: publish sarif a11y reports
 
   - script: |
-      git config --global user.email "fabrictactical@microsoft.com"
+      git config --global user.email "fluentui-internal@microsoft.com"
       git config --global user.name "Fabric Tactical"
       npm run vrtest
     displayName: run VR Test

--- a/change/@uifabric-pr-deploy-site-2020-03-20-16-55-45-rename-6.json
+++ b/change/@uifabric-pr-deploy-site-2020-03-20-16-55-45-rename-6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update repo path",
+  "packageName": "@uifabric/pr-deploy-site",
+  "email": "elcraig@microsoft.com",
+  "commit": "e3e0e7ce2554a1ad7f605cf01ff348ac0d2c4310",
+  "date": "2020-03-20T23:55:45.240Z"
+}

--- a/rush.json
+++ b/rush.json
@@ -49,7 +49,7 @@
      * It specifies the remote url for the official Git repository.  If this URL is provided,
      * "rush change" will use it to find the right remote to compare against.
      */
-    "url": "https://github.com/OfficeDev/office-ui-fabric-react.git"
+    "url": "https://github.com/microsoft/fluentui.git"
   },
   /**
    * Event hooks are customized script actions that Rush executes when specific events occur

--- a/scripts/updateReleaseNotes.js
+++ b/scripts/updateReleaseNotes.js
@@ -15,8 +15,8 @@ let GitHubApi = require('github');
 const EOL = '\n';
 
 const REPO_DETAILS = {
-  owner: "OfficeDev",
-  repo: "office-ui-fabric-react"
+  owner: "microsoft",
+  repo: "fluentui"
 };
 
 const SHOULD_PATCH = argv.patch;


### PR DESCRIPTION
Update essential officedev/office-ui-fabric-react references to microsoft/fluentui.

Intentionally leaving references in docs etc as-is to avoid churn in an old branch.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12382)