### PR TITLE
Group publishing for @fluentui/react and office-ui-fabric-react packages

### DIFF
--- a/change/@fluentui-react-2020-03-20-12-24-02-remainder-pr-feedback.json
+++ b/change/@fluentui-react-2020-03-20-12-24-02-remainder-pr-feedback.json
@@ -4,6 +4,6 @@
   "packageName": "@fluentui/react",
   "email": "dzearing@microsoft.com",
   "commit": "b00a4fb9a29289adea7cb85463d5fd0b7923c226",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-03-20T19:24:02.050Z"
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "generate-version-files": "yarn workspace @uifabric/build just generate-version-files",
     "lint": "lerna run lint --parallel",
     "publish:beachball": "beachball publish --scope \"!packages/fluentui/*\"",
+    "bump": "beachball bump --scope \"!packages/fluentui/*\"",
     "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
     "perf": "cross-env PERF=true gulp perf --times=100",
     "perf:debug": "cross-env PERF=true gulp perf:debug --debug",

--- a/package.json
+++ b/package.json
@@ -103,8 +103,17 @@
     ]
   },
   "beachball": {
-    "disallowedChangeTypes": [
-      "major"
+    "groups": [
+      {
+        "name": "fluent ui react",
+        "include": [
+          "packages/office-ui-fabric-react",
+          "packages/react"
+        ],
+        "disallowedChangeTypes": [
+          "major"
+        ]
+      }
     ]
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "vrtest": "cd apps && cd vr-tests && npm run screener"
   },
   "devDependencies": {
-    "beachball": "^1.20.3",
+    "beachball": "^1.20.4",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5",
     "cross-env": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "generate-version-files": "yarn workspace @uifabric/build just generate-version-files",
     "lint": "lerna run lint --parallel",
     "publish:beachball": "beachball publish --scope \"!packages/fluentui/*\"",
-    "bump": "beachball bump --scope \"!packages/fluentui/*\"",
     "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
     "perf": "cross-env PERF=true gulp perf --times=100",
     "perf:debug": "cross-env PERF=true gulp perf:debug --debug",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vrtest": "cd apps && cd vr-tests && npm run screener"
   },
   "devDependencies": {
-    "beachball": "^1.20.2",
+    "beachball": "^1.20.3",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5",
     "cross-env": "^5.1.4",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -64,7 +64,7 @@
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
-    "beachball": "^1.20.3",
+    "beachball": "^1.20.4",
     "chalk": "^2.1.0",
     "circular-dependency-plugin": "^5.0.2",
     "clean-webpack-plugin": "^0.1.19",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -64,7 +64,7 @@
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
-    "beachball": "^1.20.2",
+    "beachball": "^1.20.3",
     "chalk": "^2.1.0",
     "circular-dependency-plugin": "^5.0.2",
     "clean-webpack-plugin": "^0.1.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5750,10 +5750,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.20.3:
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.3.tgz#d6d835d1d5889c985cce7aba009c9d79688cac88"
-  integrity sha512-a3BCVT6Felyw5dsainWyrhuSdLfaHZApr/OgZLS0McSpOD4m3zRkFJhWuJT8UWfbtnP5QjkBf4nMlPUrnSxVQA==
+beachball@^1.20.4:
+  version "1.20.4"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.4.tgz#f455d646bff4f08c2366fa0d75253f6b691d8a65"
+  integrity sha512-Sm8oamsV3EEUsz14l06He9DF+Da3zxa1wfdD7Yu2FeYxzGvFdcJKO4o7vIYRgFQaGIC2cWRI3uXO9Actund4pA==
   dependencies:
     cosmiconfig "^6.0.0"
     fs-extra "^8.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5750,10 +5750,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.20.2:
-  version "1.20.2"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.2.tgz#ad52dedae5d3582627de611c371e8a9252129fc6"
-  integrity sha512-YZ3SADQqxlerKcM7SvFeZ+1QYi08vSNlfQZ7lPfYtn2yKZv+vaBt6fRrn8VVhW590rRUCFinjBRzFr//XqdQGg==
+beachball@^1.20.3:
+  version "1.20.3"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.3.tgz#d6d835d1d5889c985cce7aba009c9d79688cac88"
+  integrity sha512-a3BCVT6Felyw5dsainWyrhuSdLfaHZApr/OgZLS0McSpOD4m3zRkFJhWuJT8UWfbtnP5QjkBf4nMlPUrnSxVQA==
   dependencies:
     cosmiconfig "^6.0.0"
     fs-extra "^8.0.1"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
- Use beachball [version groups](https://microsoft.github.io/beachball/version-groups) feature to bump `@fluentui/react` and `office-ui-fabric-react` packages with exact same pace
- Bumped beachball to latest which contains couple version groups fixes
- Fixed a change file which has incorrect `dependentChangeType`
- Changed to only disallow major change type for `@fluentui/react` and `office-ui-fabric-react` packages

**Note**: currently `@fluentui/react` and `office-ui-fabric-react` are published to different latest versions. they should have same version when next time one of the package does a `minor` bump

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12383)