### PR TITLE
RFC(icon): update icon slots

### DIFF
--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -8,6 +8,7 @@
     "copy-to-clipboard": "^3.2.0",
     "faker": "^4.1.0",
     "flat": "^4.1.0",
+    "grommet-icons": "^4.4.0",
     "react-ace": "^5.1.2",
     "react-codesandboxer": "^3.1.3",
     "react-custom-scrollbars": "^4.2.1",
@@ -18,7 +19,8 @@
     "react-router-dom": "^5.0.1",
     "react-source-render": "4.0.0-1",
     "react-virtualized": "^9.21.1",
-    "react-vis": "^1.11.6"
+    "react-vis": "^1.11.6",
+    "styled-components": "^5.0.1"
   },
   "devDependencies": {
     "@types/color": "^3.0.0",

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -15,6 +15,7 @@
     "react-document-title": "^2.0.3",
     "react-element-to-jsx-string": "^14.0.2",
     "react-hot-loader": "^4.12.15",
+    "react-icons": "^3.9.0",
     "react-markdown": "^4.0.8",
     "react-router-dom": "^5.0.1",
     "react-source-render": "4.0.0-1",

--- a/packages/fluentui/docs/src/components/Playground/renderConfig.ts
+++ b/packages/fluentui/docs/src/components/Playground/renderConfig.ts
@@ -7,6 +7,7 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as Classnames from 'classnames';
+import * as GrommetIcons from 'grommet-icons';
 
 const accessibilityPackageJson = require('@fluentui/accessibility/package.json');
 const docsComponentsPackageJson = require('@fluentui/docs-components/package.json');
@@ -63,6 +64,10 @@ export const imports: Record<string, { version: string; module: any }> = {
   prettier: {
     version: docsComponentsPackageJson.peerDependencies['prettier'],
     module: null, // no need to use it in our examples
+  },
+  'grommet-icons': {
+    version: docsComponentsPackageJson.dependencies['grommet-icons'],
+    module: GrommetIcons,
   },
 };
 

--- a/packages/fluentui/docs/src/components/Playground/renderConfig.ts
+++ b/packages/fluentui/docs/src/components/Playground/renderConfig.ts
@@ -8,6 +8,7 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as Classnames from 'classnames';
 import * as GrommetIcons from 'grommet-icons';
+import * as ReactIconsFa from 'react-icons/fa';
 
 const accessibilityPackageJson = require('@fluentui/accessibility/package.json');
 const docsComponentsPackageJson = require('@fluentui/docs-components/package.json');
@@ -68,6 +69,10 @@ export const imports: Record<string, { version: string; module: any }> = {
   'grommet-icons': {
     version: docsComponentsPackageJson.dependencies['grommet-icons'],
     module: GrommetIcons,
+  },
+  'react-icons/fa': {
+    version: docsComponentsPackageJson.dependencies['react-icons'],
+    module: ReactIconsFa,
   },
 };
 

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Button, Flex, createSvgIcon } from '@fluentui/react-northstar';
 import cx from 'classnames';
 import { Volume } from 'grommet-icons';
+import { FaVolumeUp } from 'react-icons/fa';
 
 const SoundIcon = createSvgIcon({
   displayName: 'SoundIcon',
@@ -22,25 +23,28 @@ const SoundIcon = createSvgIcon({
 const ButtonExample = () => (
   <Flex column gap="gap.smaller">
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} content="Sound on" />
-      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" />
-      <Button iconAsJSX={<SoundIcon />} content="Sound on" />
-      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" />
-      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" />
+      <Button iconAsJSX={<SoundIcon />} content="Sound" />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound" />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" />
+      <Button iconAsJSX={<FaVolumeUp />} content="Sound" />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} content="Sound on" primary />
-      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" primary />
-      <Button iconAsJSX={<SoundIcon />} content="Sound on" primary />
-      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" primary />
-      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" primary />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" primary />
+      <Button iconAsJSX={<SoundIcon />} content="Sound" primary />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound" primary />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" primary />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" primary />
+      <Button iconAsJSX={<FaVolumeUp />} content="Sound" primary />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} iconOnly />
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly />
       <Button iconAsJSX={<SoundIcon />} iconOnly />
       <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly />
-      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" />
+      <Button iconAsJSX={<FaVolumeUp />} content="Sound" />
     </Flex>
     <Flex gap="gap.smaller">
       <Button icon={{ name: 'volume' }} iconOnly primary />
@@ -48,34 +52,40 @@ const ButtonExample = () => (
       <Button iconAsJSX={<SoundIcon />} iconOnly primary />
       <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly primary />
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly primary />
+      <Button iconAsJSX={<FaVolumeUp />} iconOnly primary />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} iconOnly circular />
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly circular />
       <Button iconAsJSX={<SoundIcon />} iconOnly circular />
       <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly circular />
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly circular />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly circular />
+      <Button iconAsJSX={<FaVolumeUp />} iconOnly circular />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} iconOnly primary circular />
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly primary circular />
       <Button iconAsJSX={<SoundIcon />} iconOnly primary circular />
       <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly primary circular />
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary circular />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly primary circular />
+      <Button iconAsJSX={<FaVolumeUp />} iconOnly primary circular />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} content="Sound on" text />
-      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" text />
-      <Button iconAsJSX={<SoundIcon />} content="Sound on" text />
-      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" text />
-      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" text />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" text />
+      <Button iconAsJSX={<SoundIcon />} content="Sound" text />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound" text />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" text />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" text />
+      <Button iconAsJSX={<FaVolumeUp />} content="Sound" text />
     </Flex>
     <Flex gap="gap.smaller">
-      <Button icon={{ name: 'volume' }} content="Sound on" primary />
-      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" primary text />
-      <Button iconAsJSX={<SoundIcon />} content="Sound on" primary text />
-      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" primary text />
-      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" primary text />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" primary text />
+      <Button iconAsJSX={<SoundIcon />} content="Sound" primary text />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound" primary text />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" primary text />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" primary text />
+      <Button iconAsJSX={<FaVolumeUp />} content="Sound" primary text />
     </Flex>
   </Flex>
 );

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -1,6 +1,83 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-northstar';
+import { Button, Flex, createSvgIcon } from '@fluentui/react-northstar';
+import cx from 'classnames';
+import { Volume } from 'grommet-icons';
 
-const ButtonExample = () => <Button content="Click here" />;
+const SoundIcon = createSvgIcon({
+  displayName: 'SoundIcon',
+  svg: ({ classes }) => (
+    <svg role="presentation" focusable="false" className={classes.svg} viewBox="8 8 16 16">
+      <g className={cx('ui-icon__outline', classes.outlinePart)}>
+        <path d="M19.0215,19.7998c-0.1279,0-0.2559-0.0488-0.3535-0.1465c-0.1953-0.1953-0.1953-0.5117,0-0.707 c0.7871-0.7871,1.2207-1.833,1.2207-2.9463c0-1.1128-0.4336-2.1592-1.2207-2.9463c-0.1953-0.1953-0.1953-0.5117,0-0.707 s0.5117-0.1953,0.707,0c0.9766,0.9756,1.5137,2.2729,1.5137,3.6533c0,1.3799-0.5371,2.6777-1.5137,3.6533 C19.2773,19.751,19.1494,19.7998,19.0215,19.7998z" />
+        <path d="M16.8516,10.1484C16.9502,10.2476,17,10.3647,17,10.5v11c0,0.1357-0.0498,0.2529-0.1484,0.3516 C16.752,21.9512,16.6348,22,16.5,22c-0.1094,0-0.209-0.0332-0.2969-0.1016L12.3438,19H9.1953c-0.3545,0-0.6328-0.1973-0.8359-0.5938 c-0.1616-0.3174-0.2656-0.7422-0.3125-1.2734C8.0156,16.7842,8,16.4062,8,16s0.0156-0.7861,0.0469-1.1406 c0.0469-0.5259,0.1509-0.9478,0.3125-1.2656C8.5625,13.1982,8.8408,13,9.1953,13h3.1484l3.8594-2.8984 C16.291,10.0342,16.3906,10,16.5,10C16.6348,10,16.752,10.0498,16.8516,10.1484z M12.8125,13.8984 c-0.0781,0.0576-0.2607,0.0967-0.5469,0.1172c-0.1562,0.0107-0.271,0.0156-0.3438,0.0156h-0.2578 c-0.2656,0-0.6641-0.0049-1.1953-0.0156C9.9375,14.0054,9.5391,14,9.2734,14C9.0908,14.6357,9,15.3022,9,16 c0,0.6934,0.0908,1.3594,0.2734,2c0.2603,0,0.6562-0.0049,1.1875-0.0156c0.5312-0.0098,0.9297-0.0156,1.1953-0.0156h0.2578 c0.25,0,0.4766,0.0156,0.6797,0.0469c0.104,0.0264,0.1768,0.0547,0.2188,0.0859L16,20.5v-9L12.8125,13.8984z" />
+      </g>
+      <g className={cx('ui-icon__filled', classes.filledPart)}>
+        <path d="M19.0215,19.7998c-0.1279,0-0.2559-0.0488-0.3535-0.1465c-0.1953-0.1953-0.1953-0.5117,0-0.707 c0.7871-0.7871,1.2207-1.833,1.2207-2.9463c0-1.1128-0.4336-2.1592-1.2207-2.9463c-0.1953-0.1953-0.1953-0.5117,0-0.707 s0.5117-0.1953,0.707,0c0.9766,0.9756,1.5137,2.2729,1.5137,3.6533c0,1.3799-0.5371,2.6777-1.5137,3.6533 C19.2773,19.751,19.1494,19.7998,19.0215,19.7998z" />
+        <path d="M16.8516,10.1484C16.9502,10.2476,17,10.3647,17,10.5v11c0,0.1357-0.0498,0.2529-0.1484,0.3516 C16.752,21.9512,16.6348,22,16.5,22c-0.1094,0-0.209-0.0332-0.2969-0.1016L12.3438,19H9.1953c-0.3545,0-0.6328-0.1973-0.8359-0.5938 c-0.1616-0.3174-0.2656-0.7422-0.3125-1.2734C8.0156,16.7842,8,16.4062,8,16s0.0156-0.7861,0.0469-1.1406 c0.0469-0.5259,0.1509-0.9478,0.3125-1.2656C8.5625,13.1982,8.8408,13,9.1953,13h3.1484l3.8594-2.8984 C16.291,10.0342,16.3906,10,16.5,10C16.6348,10,16.752,10.0498,16.8516,10.1484z" />
+      </g>
+    </svg>
+  ),
+});
+
+const ButtonExample = () => (
+  <Flex column gap="gap.smaller">
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} content="Sound on" />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" />
+      <Button iconAsJSX={<SoundIcon />} content="Sound on" />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} content="Sound on" primary />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" primary />
+      <Button iconAsJSX={<SoundIcon />} content="Sound on" primary />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" primary />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" primary />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} iconOnly />
+      <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly />
+      <Button iconAsJSX={<SoundIcon />} iconOnly />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly />
+      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} iconOnly primary />
+      <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly primary />
+      <Button iconAsJSX={<SoundIcon />} iconOnly primary />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly primary />
+      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} iconOnly circular />
+      <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly circular />
+      <Button iconAsJSX={<SoundIcon />} iconOnly circular />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly circular />
+      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly circular />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} iconOnly primary circular />
+      <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly primary circular />
+      <Button iconAsJSX={<SoundIcon />} iconOnly primary circular />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly primary circular />
+      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary circular />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} content="Sound on" text />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" text />
+      <Button iconAsJSX={<SoundIcon />} content="Sound on" text />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" text />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" text />
+    </Flex>
+    <Flex gap="gap.smaller">
+      <Button icon={{ name: 'volume' }} content="Sound on" primary />
+      <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound on" primary text />
+      <Button iconAsJSX={<SoundIcon />} content="Sound on" primary text />
+      <Button iconAsBox={{ content: <Volume color="currentColor" /> }} content="Sound on" primary text />
+      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound on" primary text />
+    </Flex>
+  </Flex>
+);
 
 export default ButtonExample;

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.shorthand.tsx
@@ -20,6 +20,30 @@ const SoundIcon = createSvgIcon({
   ),
 });
 
+// very simple factory for creating img icons
+const createImgIcon = ({
+  name,
+  displayName,
+  baseUrl = 'https://spoprod-a.akamaihd.net/files/fabric/assets/item-types',
+  refreshUrl = '?v6',
+}: {
+  name: string;
+  displayName: string;
+  baseUrl?: string;
+  refreshUrl?: string;
+}) => {
+  const Component: React.FC<{ size?: number }> = props => {
+    const { size = 16, ...rest } = props;
+    const svgUrl = `${baseUrl}/${size}/${name}.svg?${refreshUrl}`;
+    return <img src={svgUrl} height="100%" width="100%" {...rest} />;
+  };
+
+  Component.displayName = displayName;
+  return Component;
+};
+
+const AccdbIcon = createImgIcon({ name: 'accdb', displayName: 'AccdbIcon' });
+
 const ButtonExample = () => (
   <Flex column gap="gap.smaller">
     <Flex gap="gap.smaller">
@@ -29,6 +53,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" />
       <Button iconAsJSX={<FaVolumeUp />} content="Sound" />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} content="Sound" />
+      <Button iconAsJSX={<AccdbIcon />} content="Sound" />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" primary />
@@ -37,14 +63,18 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" primary />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" primary />
       <Button iconAsJSX={<FaVolumeUp />} content="Sound" primary />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} content="Sound" primary />
+      <Button iconAsJSX={<AccdbIcon />} content="Sound" primary />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly />
       <Button iconAsJSX={<SoundIcon />} iconOnly />
       <Button iconAsBox={{ content: <Volume color="currentColor" /> }} iconOnly />
-      <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" />
-      <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" />
-      <Button iconAsJSX={<FaVolumeUp />} content="Sound" />
+      <Button iconAsJSX={<Volume color="currentColor" />} iconOnly />
+      <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly />
+      <Button iconAsJSX={<FaVolumeUp />} iconOnly />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} iconOnly />
+      <Button iconAsJSX={<AccdbIcon />} iconOnly />
     </Flex>
     <Flex gap="gap.smaller">
       <Button icon={{ name: 'volume' }} iconOnly primary />
@@ -54,6 +84,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly primary />
       <Button iconAsJSX={<FaVolumeUp />} iconOnly primary />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} iconOnly primary />
+      <Button iconAsJSX={<AccdbIcon />} iconOnly primary />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly circular />
@@ -62,6 +94,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly circular />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly circular />
       <Button iconAsJSX={<FaVolumeUp />} iconOnly circular />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} iconOnly circular />
+      <Button iconAsJSX={<AccdbIcon />} iconOnly circular />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} iconOnly primary circular />
@@ -70,6 +104,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} iconOnly primary circular />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} iconOnly primary circular />
       <Button iconAsJSX={<FaVolumeUp />} iconOnly primary circular />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} iconOnly primary circular />
+      <Button iconAsJSX={<AccdbIcon />} iconOnly primary circular />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" text />
@@ -78,6 +114,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" text />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" text />
       <Button iconAsJSX={<FaVolumeUp />} content="Sound" text />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} content="Sound" text />
+      <Button iconAsJSX={<AccdbIcon />} content="Sound" text />
     </Flex>
     <Flex gap="gap.smaller">
       <Button iconAsBox={{ content: <SoundIcon /> }} content="Sound" primary text />
@@ -86,6 +124,8 @@ const ButtonExample = () => (
       <Button iconAsJSX={<Volume color="currentColor" />} content="Sound" primary text />
       <Button iconAsBox={{ content: <FaVolumeUp /> }} content="Sound" primary text />
       <Button iconAsJSX={<FaVolumeUp />} content="Sound" primary text />
+      <Button iconAsBox={{ content: <AccdbIcon /> }} content="Sound" primary text />
+      <Button iconAsJSX={<AccdbIcon />} content="Sound" primary text />
     </Flex>
   </Flex>
 );

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -3,6 +3,7 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as _ from 'lodash';
+import cx from 'classnames';
 
 import {
   childrenExist,
@@ -29,6 +30,7 @@ import ButtonContent, { ButtonContentProps } from './ButtonContent';
 import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
+import Box, { BoxProps } from '../Box/Box';
 
 export interface ButtonProps
   extends UIComponentProps,
@@ -48,6 +50,12 @@ export interface ButtonProps
 
   /** A button can have an icon. */
   icon?: ShorthandValue<IconProps>;
+
+  /** A button can have an icon. */
+  iconAsBox?: ShorthandValue<BoxProps>;
+
+  /** A button can have an icon. */
+  iconAsJSX?: JSX.Element;
 
   /** A button can contain only an icon. */
   iconOnly?: boolean;
@@ -93,9 +101,11 @@ export interface ButtonProps
 
 export type ButtonStylesProps = Pick<
   ButtonProps,
-  'text' | 'primary' | 'disabled' | 'circular' | 'size' | 'loading' | 'inverted' | 'iconOnly' | 'fluid'
+  'text' | 'primary' | 'disabled' | 'circular' | 'size' | 'loading' | 'inverted' | 'iconOnly' | 'fluid' | 'iconPosition'
 > & {
   hasContent?: boolean;
+  hasIconAsJSX?: boolean;
+  hasIconAsBox?: boolean;
 };
 
 const Button: React.FC<WithAsProp<ButtonProps>> &
@@ -112,6 +122,8 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
     children,
     content,
     icon,
+    iconAsJSX,
+    iconAsBox,
     loader,
     disabled,
     iconPosition,
@@ -160,6 +172,8 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
       iconOnly,
       fluid,
       hasContent: !!content,
+      hasIconAsJSX: !!iconAsJSX,
+      hasIconAsBox: !!iconAsBox,
     }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -174,11 +188,23 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
   const ElementType = getElementType(props);
 
   const renderIcon = () => {
-    return Icon.create(icon, {
+    if (icon) {
+      return Icon.create(icon, {
+        defaultProps: () =>
+          getA11Props('icon', {
+            styles: resolvedStyles.icon,
+            xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
+          }),
+      });
+    }
+    if (iconAsJSX) {
+      return React.cloneElement(iconAsJSX, { className: cx(iconAsJSX.props.className || '', 'ui-button__icon') });
+    }
+
+    return Box.create(iconAsBox, {
       defaultProps: () =>
         getA11Props('icon', {
-          styles: resolvedStyles.icon,
-          xSpacing: !content ? 'none' : iconPosition === 'after' ? 'before' : 'after',
+          styles: resolvedStyles.iconAsBox,
         }),
     });
   };

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -24,7 +24,7 @@ const ButtonContent: React.FC<WithAsProp<ButtonContentProps>> &
   const { size, content, children, className, styles, variables, design } = props;
 
   const { classes } = useStyles<ButtonContentStylesProps>(ButtonContent.displayName, {
-    className,
+    className: ButtonContent.className,
     mapPropsToStyles: () => ({ size }),
     mapPropsToInlineStyles: () => ({
       className,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -36,6 +36,18 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
       verticalAlign: 'middle',
       cursor: 'pointer',
 
+      ...(p.hasIconAsJSX && {
+        '& .ui-button__icon': {
+          height: pxToRem(16),
+          ...(p.hasContent && {
+            margin: `0 ${pxToRem(10)} 0 0`,
+            ...(p.iconPosition === 'after' && {
+              margin: `0 0 0 ${pxToRem(10)} `,
+            }),
+          }),
+        },
+      }),
+
       ...(p.size === 'small' && {
         padding: v.sizeSmallPadding,
         height: v.sizeSmallHeight,
@@ -251,6 +263,22 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
 
     ...(p.hasContent && {
       marginRight: pxToRem(4),
+    }),
+  }),
+  iconAsBox: ({ props: p }) => ({
+    ...(p.hasIconAsBox && {
+      lineHeight: pxToRem(12),
+      height: pxToRem(16),
+      // grommet-icons required
+      '& svg': {
+        height: pxToRem(16),
+      },
+      ...(p.hasContent && {
+        margin: `0 ${pxToRem(10)} 0 0`,
+        ...(p.iconPosition === 'after' && {
+          margin: `0 0 0 ${pxToRem(10)} `,
+        }),
+      }),
     }),
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -39,6 +39,7 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
       ...(p.hasIconAsJSX && {
         '& .ui-button__icon': {
           height: pxToRem(16),
+          width: pxToRem(16),
           ...(p.hasContent && {
             margin: `0 ${pxToRem(10)} 0 0`,
             ...(p.iconPosition === 'after' && {
@@ -272,6 +273,10 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
       // grommet-icons required
       '& svg': {
         height: pxToRem(16),
+      },
+      '& img': {
+        height: pxToRem(16),
+        width: pxToRem(16),
       },
       ...(p.hasContent && {
         margin: `0 ${pxToRem(10)} 0 0`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -17926,6 +17926,13 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-icons@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.9.0.tgz#89a00f20a0e02e6bfd899977eaf46eb4624239d5"
+  integrity sha512-gKbYKR+4QsD3PmIHLAM9TDDpnaTsr3XZeK1NTAb6WQQ+gxEdJ0xuCgLq0pxXdS7Utg2AIpcVhM1ut/jlDhcyNg==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-input-autosize@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,7 +77,17 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.8.3":
+"@babel/generator@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.3.tgz#7c8b2956c6f68b3ab732bd16305916fbba521d94"
+  integrity sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==
+  dependencies:
+    "@babel/types" "^7.9.0"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
   integrity sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==
@@ -266,6 +276,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"
@@ -298,6 +313,11 @@
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.4.tgz#d1dbe64691d60358a974295fa53da074dd2ce8e8"
   integrity sha512-0fKu/QqildpXmPVaRBoXOlyBb3MC+J0A66x97qEfLOMkn3u6nfY5esWogQwi/K0BjASYy4DbnsEWnpNL6qT5Mw==
+
+"@babel/parser@^7.9.0":
+  version "7.9.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.3.tgz#043a5fc2ad8b7ea9facddc4e802a1f0f25da7255"
+  integrity sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==
 
 "@babel/plugin-proposal-async-generator-functions@^7.8.3":
   version "7.8.3"
@@ -936,12 +956,36 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.4.5":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.8.0", "@babel/types@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -1011,6 +1055,13 @@
   dependencies:
     "@emotion/memoize" "0.7.4"
 
+"@emotion/is-prop-valid@^0.8.3":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/memoize@0.7.4":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
@@ -1050,12 +1101,12 @@
     "@emotion/styled-base" "^10.0.27"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/stylis@0.8.5":
+"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -4502,6 +4553,11 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-dynamic-import@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz#482210140582a36b83c3e342e1cfebcaa9240948"
+  integrity sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==
+
 acorn-globals@^4.1.0:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.2.tgz#4e2c2313a597fd589720395f6354b41cd5ec8006"
@@ -4529,6 +4585,11 @@ acorn@^6.0.1, acorn@^6.0.7:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
+
+acorn@^6.0.5:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 acorn@^6.2.1:
   version "6.4.0"
@@ -5198,7 +5259,19 @@ atob@^2.1.1, atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autoprefixer@7.2.6, autoprefixer@^6.3.1, autoprefixer@^7.1.5, autoprefixer@^9.7.2:
+autoprefixer@^6.3.1:
+  version "6.7.7"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
+  integrity sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=
+  dependencies:
+    browserslist "^1.7.6"
+    caniuse-db "^1.0.30000634"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^5.2.16"
+    postcss-value-parser "^3.2.3"
+
+autoprefixer@^7.1.5:
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.6.tgz#256672f86f7c735da849c4f07d008abb056067dc"
   integrity sha512-Iq8TRIB+/9eQ8rbGhcP7ct5cYb/3qjNYAR2SnzLCEcwF6rvVOax8+9+fccgXk4bEhQGjOZd5TLhsksmAdsbGqQ==
@@ -5209,6 +5282,19 @@ autoprefixer@7.2.6, autoprefixer@^6.3.1, autoprefixer@^7.1.5, autoprefixer@^9.7.
     num2fraction "^1.2.2"
     postcss "^6.0.17"
     postcss-value-parser "^3.2.3"
+
+autoprefixer@^9.7.2:
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.7.4.tgz#f8bf3e06707d047f0641d87aee8cfb174b2a5378"
+  integrity sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==
+  dependencies:
+    browserslist "^4.8.3"
+    caniuse-lite "^1.0.30001020"
+    chalk "^2.4.2"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^7.0.26"
+    postcss-value-parser "^4.0.2"
 
 awesome-typescript-loader@^3.2.3:
   version "3.5.0"
@@ -5516,6 +5602,16 @@ babel-plugin-react-docgen@^4.0.0:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
     recast "^0.14.7"
+
+"babel-plugin-styled-components@>= 1":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -6035,7 +6131,7 @@ browserslist@4.7.0:
     electron-to-chromium "^1.3.247"
     node-releases "^1.1.29"
 
-browserslist@^1.3.6, browserslist@^1.5.2:
+browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
   version "1.7.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-1.7.7.tgz#0bd76704258be829b2398bb50e4b62d1a166b0b9"
   integrity sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=
@@ -6341,6 +6437,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+camelize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
+
 can-use-dom@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/can-use-dom/-/can-use-dom-0.1.0.tgz#22cc4a34a0abc43950f42c6411024a3f6366b45a"
@@ -6361,6 +6462,11 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000639:
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000978.tgz#6c71237ff5e2b759bc52496f560e2f6287e90a28"
   integrity sha512-UTzb0WomXxeqhAn3HgygItnkQeiLujN/O4D6hhB4ccSgktBysAbO/duUBJiNsPyxn/DsV8OnIn45jNeuvmUcPQ==
 
+caniuse-db@^1.0.30000634:
+  version "1.0.30001036"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30001036.tgz#8761fb6cd423ef2d3f8d96a21d898932252dc477"
+  integrity sha512-plRkihXQyiDaFUXC7x/jAIXXTKiiaWvfAagsruh/vmstnRQ+a2a95HyENxiTr5WrkPSvmFUIvsRUalVFyeh2/w==
+
 caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805:
   version "1.0.30000978"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz#1e3346c27fc46bce9ac1ccd77863153a263dde56"
@@ -6370,6 +6476,11 @@ caniuse-lite@^1.0.30000989, caniuse-lite@^1.0.30001022:
   version "1.0.30001022"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001022.tgz#9eeffe580c3a8f110b7b1742dcf06a395885e4c6"
   integrity sha512-FjwPPtt/I07KyLPkBQ0g7/XuZg6oUkYBVnPHNj3VHJbOjmmJ/GdSo/GUY6MwINEQvjhP6WZVbX8Tvms8xh0D5A==
+
+caniuse-lite@^1.0.30001020:
+  version "1.0.30001036"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001036.tgz#930ea5272010d8bf190d859159d757c0b398caf0"
+  integrity sha512-jU8CIFIj2oR7r4W+5AKcsvWNVIb6Q6OZE3UsrXrZBHFtreT4YgTeOJtTucp+zSedEpTi3L5wASSP0LYIE3if6w==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6526,7 +6637,7 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.1.tgz#54726b8b8fff4df053c42187e801fb4412df1494"
   integrity sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==
 
-chrome-trace-event@^1.0.2:
+chrome-trace-event@^1.0.0, chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
@@ -7244,7 +7355,7 @@ copy-props@^2.0.1:
     each-props "^1.3.0"
     is-plain-object "^2.0.1"
 
-copy-to-clipboard@3.2.0, copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.2.0:
+copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.2.0.tgz#d2724a3ccbfed89706fac8a894872c979ac74467"
   integrity sha512-eOZERzvCmxS8HWzugj4Uxl8OJxa7T2k1Gi0X5qavwydHIfuSHq2dTD09LOg/XyGq4Zpb5IsR/2OJ5lbOegz78w==
@@ -7457,6 +7568,11 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -7560,6 +7676,15 @@ css-selector-tokenizer@^0.7.0:
     cssesc "^0.1.0"
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
+
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -10833,6 +10958,18 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
   integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
+grommet-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/grommet-icons/-/grommet-icons-4.4.0.tgz#6503a33ca29e3c9d89ba56ef1b2bc786222e62a7"
+  integrity sha512-uOc3rsgIBVOm/iuN8dj2lKuBq0uhIPYxH84zDoY0jrJZLjcVH1bHUQLlv0R/e9oB/pCFYEBse1mnvps+f3ylmw==
+  dependencies:
+    grommet-styles "^0.2.0"
+
+grommet-styles@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/grommet-styles/-/grommet-styles-0.2.0.tgz#b2eac2b7e2747cb523434d21728ce5234f8ce4f4"
+  integrity sha512-0OMSYuGeyifYKpg4Gv2HzL8rUdd0ddnJ5LbCBKgDuloC71XIwr9g/Fxa6rs737MbPV7OZ4pEm4wvrjH4epzf1A==
+
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
@@ -11253,7 +11390,7 @@ hoek@6.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
   integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -13873,7 +14010,7 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-runner@^2.4.0:
+loader-runner@^2.3.0, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
@@ -14645,7 +14782,7 @@ memoizerific@^1.11.3:
   dependencies:
     map-or-similar "^1.5.0"
 
-memory-fs@^0.4.0, memory-fs@^0.4.1:
+memory-fs@^0.4.0, memory-fs@^0.4.1, memory-fs@~0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
   integrity sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=
@@ -15317,7 +15454,7 @@ node-ipc@^9.1.0:
     js-message "1.0.5"
     js-queue "2.0.0"
 
-node-libs-browser@^2.2.1:
+node-libs-browser@^2.0.0, node-libs-browser@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-2.2.1.tgz#b64f513d18338625f90346d27b0d235e631f6425"
   integrity sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==
@@ -17004,7 +17141,7 @@ postcss@6.0.1:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8:
+postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.2, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.2.16:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
   integrity sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==
@@ -17027,6 +17164,15 @@ postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.
   version "7.0.26"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.26.tgz#5ed615cfcab35ba9bbb82414a4fa88ea10429587"
   integrity sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
+postcss@^7.0.26:
+  version "7.0.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
+  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
   dependencies:
     chalk "^2.4.2"
     source-map "^0.6.1"
@@ -20249,6 +20395,22 @@ style-to-object@^0.2.1:
   dependencies:
     inline-style-parser "0.1.1"
 
+styled-components@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.0.1.tgz#57782a6471031abefb2db5820a1876ae853bc619"
+  integrity sha512-E0xKTRIjTs4DyvC1MHu/EcCXIj6+ENCP8hP01koyoADF++WdBUOrSGwU1scJRw7/YaYOhDvvoad6VlMG+0j53A==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.3"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
+
 supports-color@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
@@ -20275,7 +20437,7 @@ supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0:
+supports-color@^5.0.0, supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -20391,7 +20553,7 @@ tapable@^0.2.5:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.9.tgz#af2d8bbc9b04f74ee17af2b4d9048f807acd18a8"
   integrity sha512-2wsvQ+4GwBvLPLWsNfLCDYGsW6xb7aeC6utq2Qh0PFwgEy7K7dsma9Jsmb2zSQj7GvYAyUGSntLtsv++GmgL1A==
 
-tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.3:
+tapable@^1.0.0, tapable@^1.0.0-beta.5, tapable@^1.1.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
@@ -20461,7 +20623,7 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.1.1.tgz#f81ec25854af91a480d2f9d0c77ffcb26594ed1a"
   integrity sha512-UqvQSch04R+69g4RDhrslmGvGL3ucDRX/U+snYW0Mab4uCAyKSndUksaoqlJ81QKSpRnIsuOYQCbC2ZWx2896A==
 
-terser-webpack-plugin@^1.4.3:
+terser-webpack-plugin@^1.1.0, terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
   integrity sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==
@@ -21788,7 +21950,7 @@ warning@^4.0.2, warning@^4.0.3:
   dependencies:
     loose-envify "^1.0.0"
 
-watchpack@^1.6.0:
+watchpack@^1.5.0, watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
   integrity sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==
@@ -21940,7 +22102,7 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^1.2.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
+webpack-sources@^1.2.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -21955,7 +22117,37 @@ webpack-virtual-modules@^0.2.0:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.35.0, webpack@^4.33.0, webpack@^4.35.0, webpack@^4.38.0:
+webpack@4.35.0:
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.35.0.tgz#ad3f0f8190876328806ccb7a36f3ce6e764b8378"
+  integrity sha512-M5hL3qpVvtr8d4YaJANbAQBc4uT01G33eDpl/psRTBCfjxFTihdhin1NtAKB1ruDwzeVdcsHHV3NX+QsAgOosw==
+  dependencies:
+    "@webassemblyjs/ast" "1.8.5"
+    "@webassemblyjs/helper-module-context" "1.8.5"
+    "@webassemblyjs/wasm-edit" "1.8.5"
+    "@webassemblyjs/wasm-parser" "1.8.5"
+    acorn "^6.0.5"
+    acorn-dynamic-import "^4.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^1.0.0"
+    enhanced-resolve "^4.1.0"
+    eslint-scope "^4.0.0"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^1.0.0"
+    tapable "^1.1.0"
+    terser-webpack-plugin "^1.1.0"
+    watchpack "^1.5.0"
+    webpack-sources "^1.3.0"
+
+webpack@^4.33.0, webpack@^4.38.0:
   version "4.41.6"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.41.6.tgz#12f2f804bf6542ef166755050d4afbc8f66ba7e1"
   integrity sha512-yxXfV0Zv9WMGRD+QexkZzmGIh54bsvEs+9aRWxnN8erLWEOehAKUTeNBoUbA6HPEZPlRo7KDi2ZcNveoZgK9MA==


### PR DESCRIPTION
# Icon properties

## Problem description
Currently for `@fluentui/react-northstar` we use shorthands for `Icon` component to inject icons. 

The `Icon` component uses the `name` prop to lookup for SVGs in themes and requires to have all icons registered in a giant single object. As objects are not treeshakable and growing amount of icons this lead to bigger bundle size.

## Proposal
We introduced createSvgIcon factory (https://github.com/microsoft/fluentui/pull/12319) to move out SVG icons from a theme object to a dedicated component per icon. This opens a question how to handle existing Icon shorthands. 

It's impossible to use existing approach as there is no single component that handles icons, so there are two alternatives.

### Proposal 1 (icon as `Box` shorthand)
```jsx
<Button icon={{content: <SoundIcon/>}} content="Sound on"/>
```
Edited per @layershifter 's comment for clarifying confusion. The following code will result in the same as the above code
```jsx
<Button icon={<SoundIcon />} content="Sound on" />
```
This proposal defined for each icon slot a `Box` shorthand, where the users can specify the icon they want to use inside the content of the `Box`. The `Box` component is used here for simplification, we may even expend this by introducing `ButtonIcon` component where the slot may even support some additional props that make sense of the context where it is used, the `Button` in the example above.

If we go with this proposal, inside the button styles we will have dedicated slot for the icon's box, where we can add some additional styles for the icon. For example:

```jsx
const buttonStyles = {
  root: () => ({...}),
  icon: ({props: p}) => ({
    // styles for the icon box
    lineHeight: pxToRem(12),
    height: pxToRem(16),
    
    // we may target some icon's specific parts
    '& svg': {
      height: pxToRem(16),
    },
    
    // we may add some styles based on props
    ...(p.hasContent && {
      margin: `0 ${pxToRem(10)} 0 0`,
    })
  }),
}

```

Pros:
- keeping it consistent with the othar API that we have so far regarding slots
- reusing styles with potentional dedicated component (See `ButtonIcon proposal below`)

Cons:
- additional element in the DOM

This pattern is used in:
- Material UI - https://material-ui.com/components/buttons/#IconLabelButtons.js (the API looks like the Proposal 2, but the implementation is with element wrapping the icon)

### Proposal 2 (icon as JSX element)
```jsx
<Button icon={<SoundIcon/>} content="Sound on"/>
```
With this proposal, we will render the element specified in the icon slot, with adding additional custom className, for being able to target it consistently. 

Pros:
- no additional element in the DOM
- will work with whatever icons library we choose, as we will have one selector for the icons

Cons:
- if we absolutely need to style the icon, we will have to use selector (if we avoid style overrides for this - which is doable, this may not even be a problem)

This pattern is used in:
- Ant design - https://ant.design/components/button/
- Evergreen - https://evergreen.segment.com/components/button/
- Semantic UI react - https://react.semantic-ui.com/elements/button/#types-icon

### Othar notes
In addition to this any of the proposals above, we may even consider adding new components for the icons shorthands, like `ButtonIcon` component, which will allow the users to use children API too. 

## Final comment
This PR will not be merged as is, and the changes provided are just for showcase od the different proposals.
