### PR TITLE
Vibraga/fix mdl2 focus button

### DIFF
--- a/change/@uifabric-mdl2-theme-2020-03-23-21-15-13-vibraga-fix-mdl2-focus-button.json
+++ b/change/@uifabric-mdl2-theme-2020-03-23-21-15-13-vibraga-fix-mdl2-focus-button.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix focus styles for buttons in MDL2 package",
+  "packageName": "@uifabric/mdl2-theme",
+  "email": "vibraga@microsoft.com",
+  "commit": "fe1633f3cd756c9314a13adb26b88df0f21cede4",
+  "dependentChangeType": "patch",
+  "date": "2020-03-24T04:15:12.967Z"
+}

--- a/packages/mdl2-theme/src/mdl2/styles/CompoundButton.styles.ts
+++ b/packages/mdl2-theme/src/mdl2/styles/CompoundButton.styles.ts
@@ -1,5 +1,6 @@
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;
@@ -21,6 +22,15 @@ export const CompoundButtonStyles = (props: IButtonProps): Partial<IButtonStyles
           backgroundColor: palette.themePrimary,
           borderColor: palette.themePrimary,
           ...getFocusStyle(theme, { inset: -1, borderColor: palette.white }),
+          selectors: {
+            [`.${IsFocusVisibleClassName} &:focus`]: {
+              selectors: {
+                ':after': {
+                  outlineColor: palette.neutralSecondary,
+                },
+              },
+            },
+          },
         },
         '&.ms-Button--compound': {
           ...getFocusStyle(theme, { inset: -1, borderColor: palette.white }),

--- a/packages/mdl2-theme/src/mdl2/styles/DefaultButton.styles.ts
+++ b/packages/mdl2-theme/src/mdl2/styles/DefaultButton.styles.ts
@@ -1,5 +1,6 @@
 import { getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;
@@ -12,7 +13,7 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
     root: {
       backgroundColor: palette.neutralLighter,
       border: '1px solid transparent',
-      ...getFocusStyle(theme, { inset: 0, borderColor: palette.white }),
+      ...getFocusStyle(theme, { inset: -1, borderColor: palette.white }),
     },
     rootHovered: {
       backgroundColor: palette.neutralLight,
@@ -63,6 +64,16 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
         '.ms-Button.is-disabled + .ms-Button.is-disabled': {
           backgroundColor: palette.neutralLighter,
           border: 'none',
+        },
+        [`.${IsFocusVisibleClassName} &:focus`]: {
+          selectors: {
+            ':after': {
+              left: 1,
+              right: 1,
+              bottom: 1,
+              top: 1,
+            },
+          },
         },
       },
     },

--- a/packages/mdl2-theme/src/mdl2/styles/PrimaryButton.styles.ts
+++ b/packages/mdl2-theme/src/mdl2/styles/PrimaryButton.styles.ts
@@ -1,4 +1,5 @@
 import { IButtonStyles, IButtonProps } from 'office-ui-fabric-react/lib/Button';
+import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles> => {
   const { theme } = props;
@@ -9,9 +10,17 @@ export const PrimaryButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
 
   return {
     root: {
-      border: 'none',
       backgroundColor: palette.themePrimary,
       color: palette.white,
+      selectors: {
+        [`.${IsFocusVisibleClassName} &:focus`]: {
+          selectors: {
+            ':after': {
+              outlineColor: palette.neutralSecondary,
+            },
+          },
+        },
+      },
     },
     rootHovered: {
       backgroundColor: palette.themeDarkAlt,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #12357 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Fixing several primary button focus styles in MDL2 package. Using the `getFocusStyles` function is not an option due to how complicated button styles are today so using the function's internal implementation to force the focus styles work properly.

# Before the fix
![beforeFocus](https://user-images.githubusercontent.com/29514833/77388613-d9128380-6d4d-11ea-8a3f-8ecb95b88ef0.gif)


#After the fix
![afterFocus](https://user-images.githubusercontent.com/29514833/77388623-e0399180-6d4d-11ea-9c08-4c7ee6aff33d.gif)





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12399)