### PR TITLE
fix(styles): Add missing bold font-face declaration

### DIFF
--- a/change/@uifabric-styling-2020-03-23-21-47-20-swese44-boldFontFace.json
+++ b/change/@uifabric-styling-2020-03-23-21-47-20-swese44-boldFontFace.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "fix(styles): Add missing bold font-face declaration",
+  "packageName": "@uifabric/styling",
+  "email": "pjsw@microsoft.com",
+  "commit": "263db8d5a91c1d48134799cfaf90d0ee5e9f69a1",
+  "dependentChangeType": "patch",
+  "date": "2020-03-24T04:47:20.872Z"
+}

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -47,6 +47,7 @@ function _registerFontFaceSet(
     FontWeights.semibold,
     localFontName && localFontName + ' SemiBold',
   );
+  _registerFontFace(fontFamily, urlBase + '-bold', FontWeights.bold, localFontName && localFontName + ' Bold');
 }
 
 export function registerDefaultFontFaces(baseUrl: string): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12391
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adds the missing `bold` font-face declaration. Text at font-weight: 700 was incorrectly rendering at semibold/600 before this change. This was very apparent when installing or uninstalling the Segoe UI font locally, the website's bold text would become more bold when installed and less bold when uninstalled.

Before:
<img width="761" alt="Screen Shot 2020-03-23 at 9 29 28 PM" src="https://user-images.githubusercontent.com/471731/77389655-fac13a00-6d50-11ea-9138-378810383031.png">

After:
<img width="784" alt="Screen Shot 2020-03-23 at 9 28 43 PM" src="https://user-images.githubusercontent.com/471731/77389663-ff85ee00-6d50-11ea-99ec-ade3d53c0995.png">

#### Focus areas to test
Screener tests. We may also need to treat this like a breaking change since consumers may not expect bold text to become more bold.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12401)