### PR TITLE
feat(Dropdown): support disabled items

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))
 - Add `useUnhandledProps()` hook @layershifter ([#12371](https://github.com/OfficeDev/office-ui-fabric-react/pull/12371))
 - Adding base layout and API for `Card` component @pompomon ([#12349](https://github.com/OfficeDev/office-ui-fabric-react/pull/12349))
+- Add `disabled` support form `DropdownItem` @silviuavram ([#12407](https://github.com/microsoft/fluentui/pull/12407))
 
 <!--------------------------------[ v0.47.0 ]------------------------------- -->
 ## [v0.47.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.47.0) (2020-03-19)

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -743,7 +743,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                 key: (item as any).header,
               }),
           }),
-          overrideProps: this.handleItemOverrides(item, index, getItemProps, selected),
+          overrideProps: this.handleItemOverrides(item, index, getItemProps, selected, !!item['disabled']),
           render: renderItem,
         });
       },
@@ -862,11 +862,13 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     index: number,
     getItemProps: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any,
     selected: boolean,
+    disabled: boolean,
   ) => (predefinedProps: DropdownItemProps) => ({
     accessibilityItemProps: {
       ...getItemProps({
         item,
         index,
+        disabled,
         onClick: e => {
           e.stopPropagation();
           e.nativeEvent.stopImmediatePropagation();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -993,7 +993,11 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     toggleMenu: () => void,
   ): void => {
     if (this.state.open) {
-      if (!_.isNil(highlightedIndex) && this.state.filteredItems.length) {
+      if (
+        !_.isNil(highlightedIndex) &&
+        this.state.filteredItems.length &&
+        !this.props.items[highlightedIndex]['disabled']
+      ) {
         selectItemAtIndex(highlightedIndex);
         if (!this.props.moveFocusOnTab && this.props.multiple) {
           e.preventDefault();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -867,7 +867,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       ...getItemProps({
         item,
         index,
-        disabled: !!item['disabled'],
+        disabled: item['disabled'],
         onClick: e => {
           e.stopPropagation();
           e.nativeEvent.stopImmediatePropagation();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -743,7 +743,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                 key: (item as any).header,
               }),
           }),
-          overrideProps: this.handleItemOverrides(item, index, getItemProps, selected, !!item['disabled']),
+          overrideProps: this.handleItemOverrides(item, index, getItemProps, selected),
           render: renderItem,
         });
       },
@@ -862,13 +862,12 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     index: number,
     getItemProps: (options: GetItemPropsOptions<ShorthandValue<DropdownItemProps>>) => any,
     selected: boolean,
-    disabled: boolean,
   ) => (predefinedProps: DropdownItemProps) => ({
     accessibilityItemProps: {
       ...getItemProps({
         item,
         index,
-        disabled,
+        disabled: !!item['disabled'],
         onClick: e => {
           e.stopPropagation();
           e.nativeEvent.stopImmediatePropagation();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
@@ -45,6 +45,9 @@ export interface DropdownItemProps extends UIComponentProps<DropdownItemProps> {
   /** A slot for a checkable indicator. */
   checkableIndicator?: ShorthandValue<BoxProps>;
 
+  /** A dropdown item can show that it cannot be interacted with. */
+  disabled?: boolean;
+
   /** Item's header. */
   header?: ShorthandValue<BoxProps>;
 
@@ -186,6 +189,7 @@ DropdownItem.propTypes = {
   content: customPropTypes.itemShorthand,
   checkable: PropTypes.bool,
   checkableIndicator: customPropTypes.shorthandAllowingChildren,
+  disabled: PropTypes.bool,
   header: customPropTypes.itemShorthand,
   image: customPropTypes.itemShorthandWithoutJSX,
   onClick: PropTypes.func,

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -731,6 +731,76 @@ describe('Dropdown', () => {
       expect(triggerButtonNode).toHaveTextContent(items[itemSelectedIndex]);
     });
 
+    it('is not set by clicking on disabled item', () => {
+      const inputItems = [{ header: 'item1' }, { header: 'item2', disabled: true }];
+      const { triggerButtonNode, clickOnItemAtIndex, getItemNodes } = renderDropdown({
+        items: inputItems,
+        defaultOpen: true,
+      });
+
+      clickOnItemAtIndex(1);
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getItemNodes()).toHaveLength(2);
+    });
+
+    // ToDo: investigate why 'Enter' still selects disabled item, manually it does not.
+    it.skip('is not set by using Enter on highlighted disabled item', () => {
+      const inputItems = [{ header: 'item1' }, { header: 'item2', disabled: true }];
+      const { triggerButtonNode, keyDownOnItemsList, getItemNodes } = renderDropdown({
+        items: inputItems,
+        defaultOpen: true,
+        defaultHighlightedIndex: 1,
+      });
+
+      keyDownOnItemsList('Enter');
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getItemNodes()).toHaveLength(2);
+    });
+
+    it('is not set by using Spacebar on highlighted disabled item', () => {
+      const inputItems = [{ header: 'item1' }, { header: 'item2', disabled: true }];
+      const { triggerButtonNode, keyDownOnItemsList, getItemNodes } = renderDropdown({
+        defaultOpen: true,
+        items: inputItems,
+        defaultHighlightedIndex: 1,
+      });
+
+      keyDownOnItemsList(' ');
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getItemNodes()).toHaveLength(2);
+    });
+
+    it('is not set by using Tab on highlighted selected item', () => {
+      const inputItems = [{ header: 'item1' }, { header: 'item2', disabled: true }];
+      const { triggerButtonNode, keyDownOnItemsList, getItemNodes } = renderDropdown({
+        defaultOpen: true,
+        items: inputItems,
+        defaultHighlightedIndex: 1,
+      });
+
+      keyDownOnItemsList('Tab');
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getItemNodes()).toHaveLength(0);
+    });
+
+    it('is not set by using Shift+Tab on highlighted disabled item', () => {
+      const inputItems = [{ header: 'item1' }, { header: 'item2', disabled: true }];
+      const { triggerButtonNode, keyDownOnItemsList, getItemNodes } = renderDropdown({
+        defaultOpen: true,
+        items: inputItems,
+        defaultHighlightedIndex: 1,
+      });
+
+      keyDownOnItemsList('Tab', { shiftKey: true });
+
+      expect(triggerButtonNode).toHaveTextContent('');
+      expect(getItemNodes()).toHaveLength(0);
+    });
+
     it('is replaced when another item is selected', () => {
       const defaultValue = items[0];
       const itemSelectedIndex = 2;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Downshift already supports handling `disabled` as a key in the item object. We need to pass that from our `Dropdown` to `getItemProps` in order to make it work.

Fully functional disabled item navigation should be achievable by updating to Downshift https://github.com/downshift-js/downshift/releases/tag/v4.0.1 or above. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12407)