### PR TITLE
chore: fix lerna-aliases for Northstar packages

### DIFF
--- a/packages/fluentui/accessibility/jest.config.js
+++ b/packages/fluentui/accessibility/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'accessibility',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/e2e/jest.config.js
+++ b/packages/fluentui/e2e/jest.config.js
@@ -2,9 +2,9 @@ const commonConfig = require('@uifabric/build/jest');
 
 module.exports = {
   ...commonConfig,
-  moduleNameMapper: {
-    ...require('lerna-alias').jest(),
-  },
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
   name: 'e2e',
   testRegex: '.*-test\\.tsx?$',
   setupFilesAfterEnv: ['./setup.test.ts'],

--- a/packages/fluentui/react-bindings/jest.config.js
+++ b/packages/fluentui/react-bindings/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-bindings',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/react-component-event-listener/jest.config.js
+++ b/packages/fluentui/react-component-event-listener/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-component-event-listener',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/react-component-nesting-registry/jest.config.js
+++ b/packages/fluentui/react-component-nesting-registry/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-component-nesting-registry',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/react-component-ref/jest.config.js
+++ b/packages/fluentui/react-component-ref/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-component-ref',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/react-context-selector/jest.config.js
+++ b/packages/fluentui/react-context-selector/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-context-selector',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/react-northstar/jest.config.js
+++ b/packages/fluentui/react-northstar/jest.config.js
@@ -4,7 +4,10 @@ module.exports = {
   ...commonConfig,
   name: 'react',
   moduleNameMapper: {
-    ...require('lerna-alias').jest(),
+    ...require('lerna-alias').jest({
+      directory: require('@uifabric/build/monorepo/findGitRoot')(),
+    }),
+
     'docs/(.*)$': `<rootDir>/../docs/$1`,
 
     // Legacy aliases, they should not be used in new tests

--- a/packages/fluentui/react-proptypes/jest.config.js
+++ b/packages/fluentui/react-proptypes/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'react-component-nesting-registry',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };

--- a/packages/fluentui/styles/jest.config.js
+++ b/packages/fluentui/styles/jest.config.js
@@ -1,5 +1,7 @@
 module.exports = {
   ...require('@uifabric/build/jest'),
   name: 'styles',
-  moduleNameMapper: require('lerna-alias').jest(),
+  moduleNameMapper: require('lerna-alias').jest({
+    directory: require('@uifabric/build/monorepo/findGitRoot')(),
+  }),
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

1. When we run Jest we don't have `dist` (i.e. compiled JS) for Northstar packages
1. We use [`lerna-aliases`](https://github.com/Andarist/lerna-alias) package to point to exact directory with TS instead (i.e. `@fluentui/react-compose/src/index.ts`)
1. To solve publishing issues I have created `lerna.json` (#12159) in `packages/fluentui` to not include Fabric's packages to our publishing pipeline
1. Now `lerna-aliases` uses that config instead of root's one (which contains all packages)
1. There is no `react-compose` and it's under these packages in `packages/fluentui/lerna.json`
1. 💣 

This PR adds proper `directory` setting to use root `lerna.json`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12436)