### PR TITLE
More website fabric=>fluent updates

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -190,7 +190,7 @@
     })();
   }
 
-  function loadAppScripts(appPath) {
+  function loadAppScripts() {
     var scripts = [appPath + entryPointFilename + (isDev ? '.js' : '.min.js')];
 
     if (!window.React) {

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -53,7 +53,7 @@ const CURRENT_VERSION = '7';
 const VERSIONS = ['7', '6', '5'];
 const fabricVersionOptions: IContextualMenuItem[] = VERSIONS.map(version => ({
   key: version,
-  text: 'Fabric ' + version,
+  text: `${Number(version) >= 7 ? 'Fluent UI React' : 'Fabric React'} ${version}`,
   checked: version === CURRENT_VERSION,
 }));
 

--- a/change/@uifabric-fabric-website-2020-03-26-08-10-59-website-final.json
+++ b/change/@uifabric-fabric-website-2020-03-26-08-10-59-website-final.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "More Fabric=>Fluent fixes",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "682fe93832bc0cab071e8e29ceab1c97b6dc5585",
+  "dependentChangeType": "patch",
+  "date": "2020-03-26T15:10:59.618Z"
+}


### PR DESCRIPTION
Fix the version selector on the homepage to say "Fluent UI React" for 7 and "Fabric React" for 5-6.

Before:
![image](https://user-images.githubusercontent.com/5864305/77667631-b778ee00-6f3f-11ea-8dbd-2f974182bbbf.png)

After:
![image](https://user-images.githubusercontent.com/5864305/77667584-a62fe180-6f3f-11ea-9182-fa379bce5a9c.png)

Fix an error in the mirrored homepage.htm.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12437)