### PR TITLE
Customize rendering of CHANGELOG.md

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@uifabric/build/beachball/beachball.config');

--- a/package.json
+++ b/package.json
@@ -101,20 +101,6 @@
       "packages/fluentui/*"
     ]
   },
-  "beachball": {
-    "groups": [
-      {
-        "name": "fluent ui react",
-        "include": [
-          "packages/office-ui-fabric-react",
-          "packages/react"
-        ],
-        "disallowedChangeTypes": [
-          "major"
-        ]
-      }
-    ]
-  },
   "resolutions": {
     "webpack": "^4.35.0",
     "autoprefixer": "7.2.6",

--- a/scripts/beachball/beachball.config.js
+++ b/scripts/beachball/beachball.config.js
@@ -1,0 +1,14 @@
+const beachball = {
+  groups: [
+    {
+      name: 'fluent ui react',
+      include: ['packages/office-ui-fabric-react', 'packages/react'],
+      disallowedChangeTypes: ['major'],
+    },
+  ],
+  changelog: {
+    renderPackageChangelog: require('./renderPackageChangelog'),
+  },
+};
+
+module.exports = beachball;

--- a/scripts/beachball/renderPackageChangelog.js
+++ b/scripts/beachball/renderPackageChangelog.js
@@ -1,0 +1,57 @@
+const { groupBy } = require('lodash');
+const { owner, repo } = require('../githubInfo');
+
+function renderPackageChangelog({ packageChangelog, isGroupedChangelog, changelogJson }) {
+  const header = packageChangelog.tag
+    ? `[${packageChangelog.version}](https://github.com/${owner}/${repo}/tree/${packageChangelog.tag})`
+    : packageChangelog.version;
+
+  const previousChangelogEntry = changelogJson && changelogJson.entries ? changelogJson.entries[0] : undefined;
+  let subHeader = packageChangelog.date.toUTCString();
+  subHeader +=
+    packageChangelog.tag && previousChangelogEntry && previousChangelogEntry.tag
+      ? `\n[Compare changes](https://github.com/${owner}/${repo}/compare/${previousChangelogEntry.tag}..${packageChangelog.tag})`
+      : '';
+
+  return (
+    `\n## ${header}\n` +
+    `${subHeader}\n` +
+    (packageChangelog.comments.major
+      ? '\n### Major\n\n' + renderChangelogEntries(packageChangelog.comments.major, isGroupedChangelog)
+      : '') +
+    (packageChangelog.comments.minor
+      ? '\n### Minor changes\n\n' + renderChangelogEntries(packageChangelog.comments.minor, isGroupedChangelog)
+      : '') +
+    (packageChangelog.comments.patch
+      ? '\n### Patches\n\n' + renderChangelogEntries(packageChangelog.comments.patch, isGroupedChangelog)
+      : '') +
+    (packageChangelog.comments.prerelease
+      ? '\n### Changes\n\n' + renderChangelogEntries(packageChangelog.comments.prerelease, isGroupedChangelog)
+      : '')
+  );
+}
+
+function renderChangelogEntries(entries, includePackageInfo) {
+  if (includePackageInfo) {
+    const entriesMap = groupBy(entries, entry => entry.package);
+
+    let result = '';
+    Object.keys(entriesMap).forEach(pkgName => {
+      const entries = entriesMap[pkgName];
+      result += `- \`${pkgName}\`\n`;
+      entries.forEach(entry => {
+        result += `  - ${entry.comment} (${entry.author})\n`;
+      });
+    });
+
+    return result;
+  }
+
+  return entries
+    .map(entry => {
+      return `- ${entry.comment} (${entry.author})`;
+    })
+    .join('\n');
+}
+
+module.exports = renderPackageChangelog;

--- a/scripts/githubInfo.js
+++ b/scripts/githubInfo.js
@@ -1,0 +1,4 @@
+module.exports = {
+  owner: 'microsoft',
+  repo: 'fluentui',
+};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -110,6 +110,7 @@
     "just-scripts": "0.35.0",
     "lerna-alias": "^3.0.3-0",
     "license-webpack-plugin": "^2.1.1",
+    "lodash": "^4.17.15",
     "markdown-table": "^2.0.0",
     "mustache": "^2.3.0",
     "ngrok": "^3.0.1",

--- a/scripts/updateReleaseNotes/init.js
+++ b/scripts/updateReleaseNotes/init.js
@@ -1,5 +1,6 @@
 const GitHubApi = require('@octokit/rest');
 const yargs = require('yargs');
+const { owner, repo } = require('../githubInfo');
 
 const tokenMsg =
   '\nA GitHub personal access token is required even for dry runs due to the potential high rate of requests.\n' +
@@ -25,8 +26,8 @@ const argv = yargs
   .option('debug', { describe: 'Use debug mode for the GitHub API', type: 'boolean', default: false })
   // Default to checking the past 5 days in case there were any missed days or other issues
   .option('age', { describe: 'Get tags/releases up to this many days old', type: 'number', default: 5 })
-  .option('owner', { describe: 'Owner of the repo to work against', type: 'string', default: 'microsoft' })
-  .option('repo', { describe: 'Repo to work against', type: 'string', default: 'fluentui' })
+  .option('owner', { describe: 'Owner of the repo to work against', type: 'string', default: owner })
+  .option('repo', { describe: 'Repo to work against', type: 'string', default: owner })
   .version(false)
   .help().argv;
 

--- a/scripts/updateReleaseNotes/init.js
+++ b/scripts/updateReleaseNotes/init.js
@@ -27,7 +27,7 @@ const argv = yargs
   // Default to checking the past 5 days in case there were any missed days or other issues
   .option('age', { describe: 'Get tags/releases up to this many days old', type: 'number', default: 5 })
   .option('owner', { describe: 'Owner of the repo to work against', type: 'string', default: owner })
-  .option('repo', { describe: 'Repo to work against', type: 'string', default: owner })
+  .option('repo', { describe: 'Repo to work against', type: 'string', default: repo })
   .version(false)
   .help().argv;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Beachball change: https://github.com/microsoft/beachball/pull/289
Changes on CHANGELOG.md:
1. Made version header a link using tag
2. Added "Compare changes" link using tag
Note: we will later expand the custom render to include PR link as well.

**Before change:**
## 7.105.3
Wed, 25 Mar 2020 23:28:35 GMT

**After change:**
## [7.105.3](https://github.com/microsoft/fluentui/tree/office-ui-fabric-react_v7.105.3)
Wed, 25 Mar 2020 23:28:35 GMT
[Compare changes](https://github.com/microsoft/fluentui/compare/office-ui-fabric-react_v7.105.2..office-ui-fabric-react_v7.105.3)
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12443)