### PR TITLE
RFC: do not use Box component

### DIFF
--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import Box, { BoxProps } from '../Box/Box';
 import {
   ShorthandValue,
   WithAsProp,
@@ -17,7 +16,13 @@ import {
   ProviderContextPrepared,
   FluentComponentStaticProps,
 } from '../../types';
-import { createShorthandFactory, UIComponentProps, commonPropTypes, ContentComponentProps } from '../../utils';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  commonPropTypes,
+  ContentComponentProps,
+  createPrimitiveShorthand,
+} from '../../utils';
 import { ListContext, ListContextSubscribedValue } from './listContext';
 
 export interface ListItemSlotClassNames {
@@ -32,19 +37,21 @@ export interface ListItemSlotClassNames {
   endMedia: string;
 }
 
-export interface ListItemProps extends UIComponentProps, ContentComponentProps<ShorthandValue<BoxProps>> {
+export interface ListItemProps
+  extends UIComponentProps,
+    ContentComponentProps<ShorthandValue<React.HTMLAttributes<HTMLDivElement>>> {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<ListItemBehaviorProps>;
-  contentMedia?: ShorthandValue<BoxProps>;
+  contentMedia?: ShorthandValue<React.HTMLAttributes<HTMLDivElement>>;
   /** Toggle debug mode. */
   debug?: boolean;
-  header?: ShorthandValue<BoxProps>;
-  endMedia?: ShorthandValue<BoxProps>;
-  headerMedia?: ShorthandValue<BoxProps>;
+  header?: ShorthandValue<React.HTMLAttributes<HTMLDivElement>>;
+  endMedia?: ShorthandValue<React.HTMLAttributes<HTMLDivElement>>;
+  headerMedia?: ShorthandValue<React.HTMLAttributes<HTMLDivElement>>;
 
   /** A list item can appear more important and draw the user's attention. */
   important?: boolean;
-  media?: ShorthandValue<BoxProps>;
+  media?: ShorthandValue<React.HTMLAttributes<HTMLDivElement>>;
 
   index?: number;
   /** A list item can indicate that it can be selected. */
@@ -134,7 +141,7 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
     }),
     rtl: context.rtl,
   });
-  const { classes, styles: resolvedStyles } = useStyles<ListItemStylesProps>(ListItem.displayName, {
+  const { classes } = useStyles<ListItemStylesProps>(ListItem.displayName, {
     className: ListItem.className,
     mapPropsToStyles: () => ({
       debug,
@@ -162,41 +169,41 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
     parentProps.onItemClick(e, props.index);
   };
 
-  const contentElement = Box.create(content, {
+  const contentElement = createPrimitiveShorthand('div', content, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.content,
-      styles: resolvedStyles.content,
+      className: cx(ListItem.slotClassNames.content, classes.content),
     }),
+    generateKey: false,
   });
-  const contentMediaElement = Box.create(contentMedia, {
+  const contentMediaElement = createPrimitiveShorthand('div', contentMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.contentMedia,
-      styles: resolvedStyles.contentMedia,
+      className: cx(ListItem.slotClassNames.contentMedia, classes.contentMedia),
     }),
+    generateKey: false,
   });
-  const headerElement = Box.create(header, {
+  const headerElement = createPrimitiveShorthand('div', header, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.header,
-      styles: resolvedStyles.header,
+      className: cx(ListItem.slotClassNames.header, classes.header),
     }),
+    generateKey: false,
   });
-  const headerMediaElement = Box.create(headerMedia, {
+  const headerMediaElement = createPrimitiveShorthand('div', headerMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.headerMedia,
-      styles: resolvedStyles.headerMedia,
+      className: cx(ListItem.slotClassNames.headerMedia, classes.headerMedia),
     }),
+    generateKey: false,
   });
-  const endMediaElement = Box.create(endMedia, {
+  const endMediaElement = createPrimitiveShorthand('div', endMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.endMedia,
-      styles: resolvedStyles.endMedia,
+      className: cx(ListItem.slotClassNames.endMedia, classes.endMedia),
     }),
+    generateKey: false,
   });
-  const mediaElement = Box.create(media, {
+  const mediaElement = createPrimitiveShorthand('div', media, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.media,
-      styles: resolvedStyles.media,
+      className: cx(ListItem.slotClassNames.media, classes.media),
     }),
+    generateKey: false,
   });
 
   const element = (

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -169,7 +169,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
       vertical,
     }),
   });
-  const { classes, styles: resolvedStyles } = useStyles<SliderStylesProps>(Slider.displayName, {
+  const { classes } = useStyles<SliderStylesProps>(Slider.displayName, {
     className: Slider.className,
     mapPropsToStyles: () => ({
       fluid,

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -24,6 +24,7 @@ import {
   UIComponentProps,
   setWhatInputSource,
   createShorthandFactory,
+  createPrimitiveShorthand,
 } from '../../utils';
 import {
   ComponentEventHandler,
@@ -35,7 +36,6 @@ import {
   ProviderContextPrepared,
 } from '../../types';
 import { SupportedIntrinsicInputProps } from '../../utils/htmlPropsUtils';
-import Box, { BoxProps } from '../Box/Box';
 
 const processInputValues = (
   p: Pick<SliderProps, 'min' | 'max'> & { value: string },
@@ -83,7 +83,7 @@ export interface SliderProps
   getA11yValueMessageOnChange?: (props: SliderProps) => string;
 
   /** Shorthand for the input component. */
-  input?: ShorthandValue<BoxProps>;
+  input?: ShorthandValue<React.InputHTMLAttributes<HTMLInputElement>>;
 
   /** Ref for input DOM node. */
   inputRef?: React.Ref<HTMLElement>;
@@ -204,21 +204,19 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
 
   // we need 2 wrappers around the slider rail, track, input and thumb slots to achieve correct component sizes
 
-  const inputElement = Box.create(input || type, {
+  const inputElement = createPrimitiveShorthand('input', input || type, {
     defaultProps: () =>
       getA11Props('input', {
         ...htmlInputProps,
-        as: 'input',
-        className: Slider.slotClassNames.input,
-        fluid,
+        className: cx(Slider.slotClassNames.input, classes.input),
         min: numericMin,
         max: numericMax,
         step,
-        styles: resolvedStyles.input,
         type,
         value: numericValue,
-        vertical,
       }),
+    generateKey: false,
+    mappedProp: 'type',
     overrideProps: handleInputOverrides,
   });
 

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -138,6 +138,19 @@ export function createShorthandFactory<P>({ Component, mappedProp, mappedArrayPr
     });
 }
 
+export function createPrimitiveShorthand<C extends keyof JSX.IntrinsicElements, P extends JSX.IntrinsicElements[C]>(
+  Component: C,
+  value: ShorthandValue<P>,
+  options?: CreateShorthandOptions<P> & { mappedProp?: string },
+) {
+  return createShorthandFromValue({
+    Component,
+    value,
+    mappedProp: options.mappedProp,
+    options,
+  });
+}
+
 // ============================================================
 // Private Utils
 // ============================================================
@@ -240,6 +253,13 @@ function createShorthandFromValue<P>({
   // Merge styles
   if (defaultProps.styles || overrideProps.styles || usersProps.styles) {
     (props as any).styles = mergeStyles(defaultProps.styles, usersProps.styles, overrideProps.styles);
+  }
+
+  //
+  // Handle `as` prop
+  //
+  if (typeof Component === 'string' && props.as) {
+    Component = props.as;
   }
 
   // ----------------------------------------


### PR DESCRIPTION
# RFC: do not use `Box` component

This RFC stars conversation to remove usages of `Box.create()` in our components?

## Why blame `Box`es?

Answer is simple: **Performance**.

![image](https://user-images.githubusercontent.com/14183168/77757590-c344dd00-7031-11ea-89d8-c6902d61d84d.png)

- `Box` is not cheap by itself (hooks, component itself)
- `Box` with `styles` doesn't cache styles (see opposite options)

## VS. additional components

## Still performance

To fix issue with `Box` & style caching we can also create additional components. I took `ButtonContent` as the simplest example:

_`ButtonMinimal.perf.tsx` was updated to render 100 `Button`s_

Conclusion: `div` are better, on bigger examples it will be more visible

#### `ButtonContent`

| Example                | min   | avg   | median | max   |
| ---------------------- | ----- | ----- | ------ | ----- |
| ButtonMinimal.perf.tsx | 15.85 | 23.67 | 24.15  | 50.49 |
| ButtonMinimal.perf.tsx | 15.62 | 22.46 | 23.74  | 40.98 |

#### `div`

| Example                | min   | avg   | median | max   |
| ---------------------- | ----- | ----- | ------ | ----- |
| ButtonMinimal.perf.tsx | 12.85 | 18.38 | 20.27  | 36.68 |
| ButtonMinimal.perf.tsx | 12.72 | 18.06 | 16.05  | 35.12 |

#### Styles/behavior structure

It becomes different as `content` was before just a slot on `Button`: now styles are moved to `ButtonContent`.

- Should we create a behavior for `ButtonContent`?
  - Yes = oops
  - No = Why? Now it's a separate unit

#### Bundle size

Still affects it. Especially in the case of `ListItem`. 5 components vs 5 `div`s.

## Proposal

Use plain elements instead of `Box`es:

```tsx
// Before
Box.create(media);

// After
createPrimitiveShorthand("div", media);
```

### What we will keep?

- support for `children` render props
- `as` prop will continue to work

### What we will loose?

- `design`, `styles` and `variables` will not longer work on shorthands

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12451)
