### PR TITLE
chore: improve factories typings

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -250,22 +250,23 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
     }
   }
 
-  overrideItemProps = predefinedProps => ({
-    onFocus: (e, itemProps) => {
-      this.setState({
-        shouldFocusContainer: e.currentTarget === e.target,
-        isFromKeyboard: isFromKeyboard(),
-      });
-      _.invoke(predefinedProps, 'onFocus', e, itemProps);
-    },
-    onBlur: (e, itemProps) => {
-      this.setState({
-        shouldFocusContainer: e.currentTarget.contains(e.relatedTarget),
-        isFromKeyboard: false,
-      });
-      _.invoke(predefinedProps, 'onBlur', e, itemProps);
-    },
-  });
+  overrideItemProps = (predefinedProps: CarouselItemProps): CarouselItemProps =>
+    ({
+      onFocus: (e, itemProps: CarouselItemProps) => {
+        this.setState({
+          shouldFocusContainer: e.currentTarget === e.target,
+          isFromKeyboard: isFromKeyboard(),
+        });
+        _.invoke(predefinedProps, 'onFocus', e, itemProps);
+      },
+      onBlur: (e, itemProps: CarouselItemProps) => {
+        this.setState({
+          shouldFocusContainer: e.currentTarget.contains(e.relatedTarget),
+          isFromKeyboard: false,
+        });
+        _.invoke(predefinedProps, 'onBlur', e, itemProps);
+      },
+    } as unknown);
 
   renderContent = (accessibility, classes, unhandledProps) => {
     const { getItemPositionText, items, circular } = this.props;

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -500,12 +500,13 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                           styles: styles.clearIndicator,
                           accessibility: indicatorBehavior,
                         }),
-                        overrideProps: (predefinedProps: BoxProps) => ({
-                          onClick: (e: React.SyntheticEvent<HTMLElement>) => {
-                            _.invoke(predefinedProps, 'onClick', e);
-                            this.handleClear(e);
-                          },
-                        }),
+                        overrideProps: (predefinedProps: BoxProps): BoxProps =>
+                          ({
+                            onClick: (e: React.SyntheticEvent<HTMLElement>) => {
+                              _.invoke(predefinedProps, 'onClick', e);
+                              this.handleClear(e);
+                            },
+                          } as unknown),
                       })
                     : Box.create(toggleIndicator, {
                         defaultProps: () => ({
@@ -513,15 +514,16 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                           styles: styles.toggleIndicator,
                           accessibility: indicatorBehavior,
                         }),
-                        overrideProps: (predefinedProps: BoxProps) => ({
-                          onClick: e => {
-                            if (!disabled) {
-                              getToggleButtonProps({ disabled }).onClick(e);
-                            }
+                        overrideProps: (predefinedProps: BoxProps): BoxProps =>
+                          ({
+                            onClick: e => {
+                              if (!disabled) {
+                                getToggleButtonProps({ disabled }).onClick(e);
+                              }
 
-                            _.invoke(predefinedProps, 'onClick', e);
-                          },
-                        }),
+                              _.invoke(predefinedProps, 'onClick', e);
+                            },
+                          } as unknown),
                       })}
                   {this.renderItemsList(
                     styles,
@@ -707,16 +709,17 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
               'aria-hidden': !open,
             }),
 
-            overrideProps: (predefinedProps: ListProps) => ({
-              onFocus: (e: React.SyntheticEvent<HTMLElement>, listProps: ListProps) => {
-                this.handleTriggerButtonOrListFocus();
-                _.invoke(predefinedProps, 'onClick', e, listProps);
-              },
-              onBlur: (e: React.SyntheticEvent<HTMLElement>, listProps: ListProps) => {
-                this.handleListBlur(e);
-                _.invoke(predefinedProps, 'onBlur', e, listProps);
-              },
-            }),
+            overrideProps: (predefinedProps: ListProps): ListProps =>
+              ({
+                onFocus: (e: React.SyntheticEvent<HTMLElement>, listProps: ListProps) => {
+                  this.handleTriggerButtonOrListFocus();
+                  _.invoke(predefinedProps, 'onClick', e, listProps);
+                },
+                onBlur: (e: React.SyntheticEvent<HTMLElement>, listProps: ListProps) => {
+                  this.handleListBlur(e);
+                  _.invoke(predefinedProps, 'onBlur', e, listProps);
+                },
+              } as unknown),
           })}
         </Popper>
       </Ref>

--- a/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
+++ b/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
@@ -89,7 +89,7 @@ class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> 
 
   static defaultProps = {
     as: 'span',
-    accessibility: embedBehavior as Accessibility,
+    accessibility: embedBehavior,
     control: {},
   };
 
@@ -124,14 +124,16 @@ class Embed extends AutoControlledComponent<WithAsProp<EmbedProps>, EmbedState> 
     _.invoke(this.props, 'onClick', e, { ...this.props, active: newActive });
   };
 
-  handleFrameOverrides = predefinedProps => ({
-    onLoad: (e: React.SyntheticEvent) => {
-      _.invoke(predefinedProps, 'onLoad', e);
+  handleFrameOverrides = (predefinedProps: BoxProps): BoxProps =>
+    ({
+      onLoad: (e: React.SyntheticEvent<HTMLIFrameElement>) => {
+        _.invoke(predefinedProps, 'onLoad', e);
 
-      this.setState({ iframeLoaded: true });
-      this.frameRef.current.contentWindow.focus();
-    },
-  });
+        this.setState({ iframeLoaded: true });
+        this.frameRef.current.contentWindow.focus();
+      },
+      /* TODO fix me */
+    } as unknown);
 
   renderComponent({ ElementType, classes, accessibility, unhandledProps, styles, variables }) {
     const { control, iframe, placeholder, video } = this.props;

--- a/packages/fluentui/react-northstar/src/components/Input/Input.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/Input.tsx
@@ -184,7 +184,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
       }),
       overrideProps: {
         as: (wrapper && (wrapper as any).as) || ElementType,
-      },
+      } as unknown,
     });
   }
 

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -153,9 +153,10 @@ class RadioGroupItem extends AutoControlledComponent<WithAsProp<RadioGroupItemPr
             }),
           })}
           {Box.create(label, {
-            defaultProps: () => ({
-              as: 'span',
-            }),
+            defaultProps: () =>
+              ({
+                as: 'span',
+              } as BoxProps),
           })}
         </ElementType>
       </Ref>

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -185,17 +185,19 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
     rtl: context.rtl,
   });
 
-  const handleInputOverrides = () => ({
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = _.get(e, 'target.value');
-      _.invoke(props, 'onChange', e, { ...props, value });
-      actions.change(value);
-    },
-    onMouseDown: (e: React.MouseEvent<HTMLInputElement>) => {
-      setWhatInputSource(context.target, 'mouse');
-      _.invoke(props, 'onMouseDown', e, props);
-    },
-  });
+  const handleInputOverrides = (): BoxProps =>
+    ({
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+        const value = _.get(e, 'target.value');
+        _.invoke(props, 'onChange', e, { ...props, value });
+        actions.change(value);
+      },
+      onMouseDown: (e: React.MouseEvent<HTMLInputElement>) => {
+        setWhatInputSource(context.target, 'mouse');
+        _.invoke(props, 'onMouseDown', e, props);
+      },
+      /* TODO fix me */
+    } as unknown);
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Slider.handledProps, props);


### PR DESCRIPTION
#### Description of changes

This PR removes the usage of `Props` generic in factories as current typings allow you to pass `ComponentProps & any` which is obviously wrong.

I have to use `unknown` as in some cases as `BoxProps`/`AnyOtherProps` doesn't contain `HTMLAttribures`, should be solved with #12142.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12452)