### PR TITLE
FocusZone: Adding check to see if element has editable content in Home and End keystroke scenarios

### DIFF
--- a/change/@fluentui-react-focus-2020-03-27-13-20-20-focusZoneContentEditableCheck.json
+++ b/change/@fluentui-react-focus-2020-03-27-13-20-20-focusZoneContentEditableCheck.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Adding check to see if element has editable content in Home and End keystroke scenarios.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "8acbb43e6e060829161cacb7ddbe5f06325a32ac",
+  "dependentChangeType": "patch",
+  "date": "2020-03-27T20:20:20.242Z"
+}

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -628,8 +628,9 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
         case KeyCodes.home:
           if (
-            this._isElementInput(ev.target as HTMLElement) &&
-            !this._shouldInputLoseFocus(ev.target as HTMLInputElement, false)
+            this._isContentEditableElement(ev.target as HTMLElement) ||
+            (this._isElementInput(ev.target as HTMLElement) &&
+              !this._shouldInputLoseFocus(ev.target as HTMLInputElement, false))
           ) {
             return false;
           }
@@ -645,8 +646,9 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
         case KeyCodes.end:
           if (
-            this._isElementInput(ev.target as HTMLElement) &&
-            !this._shouldInputLoseFocus(ev.target as HTMLInputElement, true)
+            this._isContentEditableElement(ev.target as HTMLElement) ||
+            (this._isElementInput(ev.target as HTMLElement) &&
+              !this._shouldInputLoseFocus(ev.target as HTMLInputElement, true))
           ) {
             return false;
           }
@@ -1207,6 +1209,10 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
       this._updateTabIndexes(child);
     }
+  }
+
+  private _isContentEditableElement(element: HTMLElement): boolean {
+    return element && element.getAttribute('contenteditable') === 'true';
   }
 
   private _isElementInput(element: HTMLElement): boolean {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds a check to see if the target element is content editable under the `Home` and `End` key cases when moving focus in the v7 version of the `FocusZone` component. This is done to bring the v0 and v7 versions closer together since the check already exists in the v0 version.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12456)