### PR TITLE
Fix high contrast focus state on vertical menu

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `inverted` prop to propTypes check in `Button` @silviuavram ([#12414](https://github.com/microsoft/fluentui/pull/12414))
 - Fix hover color for disabled `Dropdown` trigger button @silviuavram ([#12418](https://github.com/microsoft/fluentui/pull/12418))
 - Fix `ButtonContent` className and added conformat test @mnajdova ([#12431](https://github.com/microsoft/fluentui/pull/12431))
-- Fix keyboard navigation for vertical Menu components in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
+- Fix colors for keyboard navigation in vertical Menu component in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
 
 ### Features
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `inverted` prop to propTypes check in `Button` @silviuavram ([#12414](https://github.com/microsoft/fluentui/pull/12414))
 - Fix hover color for disabled `Dropdown` trigger button @silviuavram ([#12418](https://github.com/microsoft/fluentui/pull/12418))
 - Fix `ButtonContent` className and added conformat test @mnajdova ([#12431](https://github.com/microsoft/fluentui/pull/12431))
+- Fix keyboard navigation for vertical Menu components in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
 
 ### Features
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Menu/menuVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Menu/menuVariables.ts
@@ -18,7 +18,7 @@ export default (siteVars: any): Partial<MenuVariables> => ({
   ),
   color: siteVars.colors.white,
   colorActive: siteVars.colors.black,
-  colorFocus: siteVars.colors.black,
+  colorFocus: siteVars.colors.white,
   backgroundColorFocus: siteVars.accessibleCyan,
   backgroundColorActive: siteVars.accessibleCyan,
   primaryBorderColor: siteVars.colors.white,
@@ -28,7 +28,7 @@ export default (siteVars: any): Partial<MenuVariables> => ({
   pointingIndicatorBackgroundColor: 'transparent',
 
   verticalBackgroundColor: siteVars.colors.black,
-  verticalBackgroundColorFocus: siteVars.accessibleCyan,
+  verticalBackgroundColorFocus: undefined,
   iconOnlyColorActive: siteVars.colors.black,
   iconOnlyColorFocus: 'transparent',
   iconOnlyColorHover: siteVars.colors.black,
@@ -55,4 +55,7 @@ export default (siteVars: any): Partial<MenuVariables> => ({
   activePrimaryVerticalIndicatorColor: siteVars.colors.black,
   indicatorColorHover: siteVars.colors.black,
   primaryIndicatorColorHover: siteVars.colors.black,
+
+  borderColorFocus: siteVars.colors.black,
+  outlineColorFocus: siteVars.accessibleCyan,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -34,8 +34,13 @@ const getFocusedStyles = ({
 
   return {
     ...(!vertical && {
-      color: primary ? colors.foregroundFocus : v.colorActive || colors.foregroundActive,
-      background: primary ? colors.backgroundFocus : v.backgroundColorFocus || colors.backgroundFocus,
+      color: v.colorActive || colors.foregroundActive,
+      background: v.backgroundColorFocus || colors.backgroundFocus,
+      
+      ...(primary && {
+       color: colors.foregroundFocus,
+       background: colors.backgroundFocus,
+      }),
     }),
 
     ...(vertical && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -53,7 +53,8 @@ const getFocusedStyles = ({
       ...(primary && { color: v.color }),
 
       ...(active && {
-        color: primary ? colors.foregroundFocus : v.colorActive,
+        color: v.colorActive,
+        ...(primary && { color: colors.foregroundFocus }),
         background: v.backgroundColorActive || colors.backgroundActive,
       }),
     }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -33,14 +33,12 @@ const getFocusedStyles = ({
   if (active && !underlined && !vertical) return {};
 
   return {
-    ...(!vertical && {
-      color: v.colorActive || colors.foregroundActive,
-      background: v.backgroundColorFocus || colors.backgroundFocus,
-      
-      ...(primary && {
-       color: colors.foregroundFocus,
-       background: colors.backgroundFocus,
-      }),
+    color: v.colorActive || colors.foregroundActive,
+    background: v.backgroundColorFocus || colors.backgroundFocus,
+
+    ...(primary && {
+      color: colors.foregroundFocus,
+      background: colors.backgroundFocus,
     }),
 
     ...(vertical && {
@@ -54,8 +52,9 @@ const getFocusedStyles = ({
 
       ...(active && {
         color: v.colorActive,
-        ...(primary && { color: colors.foregroundFocus }),
         background: v.backgroundColorActive || colors.backgroundActive,
+
+        ...(primary && { color: colors.foregroundFocus }),
       }),
     }),
   };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -33,13 +33,9 @@ const getFocusedStyles = ({
   if (active && !underlined && !vertical) return {};
 
   return {
-    ...(primary && {
-      color: colors.foregroundFocus,
-    }),
-
     ...(!vertical && {
-      color: v.colorActive || colors.foregroundActive,
-      background: v.backgroundColorFocus || colors.backgroundFocus,
+      color: primary ? colors.foregroundFocus : v.colorActive || colors.foregroundActive,
+      background: primary ? colors.backgroundFocus : v.backgroundColorFocus || colors.backgroundFocus,
     }),
 
     ...(vertical && {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -29,21 +29,33 @@ const getFocusedStyles = ({
   colors: StrictColorScheme<ItemType<typeof menuColorAreas>>;
 }): ICSSInJSStyle => {
   const { primary, underlined, active, vertical } = props;
-  if (active && !underlined && !vertical) return {};
-  return {
-    color: v.colorActive,
-    background: v.backgroundColorFocus || colors.backgroundFocus,
 
+  if (active && !underlined && !vertical) return {};
+
+  return {
     ...(primary && {
       color: colors.foregroundFocus,
     }),
-    ...(vertical &&
-      !primary && {
-        border: `solid 1px ${v.borderColorFocus}`,
-        outline: `solid 1px ${v.outlineColorFocus}`,
-        margin: pxToRem(1),
-        background: v.verticalBackgroundColorFocus || colors.backgroundFocus,
+
+    ...(!vertical && {
+      color: v.colorActive || colors.foregroundActive,
+      background: v.backgroundColorFocus || colors.backgroundFocus,
+    }),
+
+    ...(vertical && {
+      border: `solid 1px ${v.borderColorFocus}`,
+      outline: `solid 1px ${v.outlineColorFocus}`,
+      margin: pxToRem(1),
+      background: v.verticalBackgroundColorFocus,
+      color: v.colorFocus || colors.foregroundFocus,
+
+      ...(primary && { color: v.color }),
+
+      ...(active && {
+        color: primary ? colors.foregroundFocus : v.colorActive,
+        background: v.backgroundColorActive || colors.backgroundActive,
       }),
+    }),
   };
 };
 
@@ -336,7 +348,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
 
       // focus styles
       ...(isFromKeyboard && {
-        color: v.colorFocus,
+        color: 'inherit',
 
         ...(iconOnly && {
           borderRadius: '50%',
@@ -347,17 +359,13 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         ...(primary
           ? {
               ...(iconOnly && {
-                color: 'inherit',
                 borderColor: v.borderColorActive || colors.borderActive,
               }),
-
-              ...(underlined && { color: 'inherit' }),
 
               ...(underlined && active && underlinedItem(colors.foregroundActive)),
             }
           : {
               ...(underlined && { fontWeight: 700 }),
-
               ...(underlined && active && underlinedItem(v.colorActive)),
             }),
       }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuVariables.ts
@@ -153,7 +153,7 @@ export default (siteVars: any): MenuVariables => {
     verticalItemBorderWidth: pxToRem(2),
     verticalItemBorderColor: 'transparent',
     verticalPointingBorderColor: siteVars.colorScheme.brand.borderActive,
-    verticalBackgroundColorFocus: siteVars.colors.grey[150],
+    verticalBackgroundColorFocus: undefined,
 
     activeUnderlinedColor: undefined,
     activeUnderlinedPrimaryColor: siteVars.colors.brand[600],


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

VSO issue #701692

#### Description of changes

Keyboard navigation now has bounding rectangle. Background doesn't change anymore.

#### Focus areas to test

Vertical menus for Menu component

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12462)