### PR TITLE
ComboBox: onResolveOptions and onPointerDown callbacks shouldn't hit when disabled.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-30-22-44-00-combobox_onresolveoptions.json
+++ b/change/office-ui-fabric-react-2020-03-30-22-44-00-combobox_onresolveoptions.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: onResolveOptions and onPointerDown callbacks should not hit when disabled.",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "bc8ee996913310eed2606c61ec663b76eae470bd",
+  "dependentChangeType": "patch",
+  "date": "2020-03-31T03:44:00.958Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -229,7 +229,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
   }
 
   public componentDidMount(): void {
-    if (this._comboBoxWrapper.current) {
+    if (this._comboBoxWrapper.current && !this.props.disabled) {
       // hook up resolving the options if needed on focus
       this._events.on(this._comboBoxWrapper.current, 'focus', this._onResolveOptions, true);
       if ('onpointerdown' in this._comboBoxWrapper.current) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12173 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Eventing calls needed a disabled check - that's all. I tested locally by adding `onResolveOptions={this._onResolveOptions}` to the disabled ComboBox example and having that local method do an alert if it got hit. It didn't get his with this added check - it did without the check.

#### Focus areas to test

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12485)