### PR TITLE
User/v sivsar/giving min and max

### DIFF
--- a/change/@uifabric-charting-2020-04-01-15-35-43-user-v-sivsar-givingMinAndMax.json
+++ b/change/@uifabric-charting-2020-04-01-15-35-43-user-v-sivsar-givingMinAndMax.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "providing Ymin and Ymax as props to the user",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "commit": "3c6820fba99b1ec60e4de4a4465015675c91552b",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T10:05:43.172Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.types.ts
+++ b/packages/charting/src/components/LineChart/LineChart.types.ts
@@ -52,6 +52,16 @@ export interface ILineChartProps {
   tickValues?: number[] | Date[];
 
   /**
+   * minimum  data value point in y-axis
+   */
+  yMinValue?: number;
+
+  /**
+   * maximum data value point in y-axis
+   */
+  yMaxValue?: number;
+
+  /**
    * the format in for the data on x-axis. For date object this can be specified to your requirement. Eg: '%m/%d', '%d'
    * Please look at https://www.npmjs.com/package/d3-time-format for all the formats supported
    */

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -94,7 +94,7 @@ export class LineChartBasicExample extends React.Component<{}, {}> {
     const rootStyle: IRootStyles = { width: '700px', height: '300px' };
     return (
       <div className={mergeStyles(rootStyle)}>
-        <LineChart data={data} legendsOverflowText={'Overflow Items'} />
+        <LineChart data={data} legendsOverflowText={'Overflow Items'} yMinValue={282} yMaxValue={301} />
       </div>
     );
   }

--- a/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
@@ -26,7 +26,7 @@ export class LineChartStyledExample extends React.Component<{}, {}> {
           { x: new Date('2018/01/20'), y: 24 },
           { x: new Date('2018/01/24'), y: 35 },
           { x: new Date('2018/01/26'), y: 35 },
-          { x: new Date('2018/01/29'), y: 38 },
+          { x: new Date('2018/01/29'), y: 90 },
         ],
         legend: 'Week',
         color: DefaultPalette.blue,
@@ -40,7 +40,7 @@ export class LineChartStyledExample extends React.Component<{}, {}> {
     const rootStyle: IRootStyles = { width: '700px', height: '300px' };
     return (
       <div className={mergeStyles(rootStyle)}>
-        <LineChart data={data} strokeWidth={4} />
+        <LineChart data={data} strokeWidth={4} yMaxValue={90} />
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12494
- [x] Include a change request file using `$ yarn change`

#### Description of changes

providing the flexibility to the user to specify Ymax and Ymin on the y-axis of the line chart with the help of the props `yMinValue`  and `yMaxValue`

**Explanation of `yMinValue` prop**
since from now onward we can provide `yMinValue` it could be possible that user may provide this value greater than any one of the  Y-dataPoint, in this case `yMinValue` will be ineffective and it set's to `0` which is the previous behavior. also there might be possible that user may not provide the  prop `yMinValue` in this case the minimum value is again `0` 

**Explanation of `yMaxValue` prop**
since from now onward we can provide `yMaxValue` it could be possible that user may provide this value lesser than any one of the Y-dataPoint, in this case `yMaxValue` will be ineffective and it's value be the greatest Y-dataPoint or greatest domain value(**case 4**) ,henceforth ignoring the value `yMaxValue`

**Explanation with Code**
as we know the line chart will give `4` intervals of y-axis so consider below `data`
```js
data: [
          { x: 12, y: 10 },
          { x: 43, y: 18 },
          { x: 53, y: 24 },
          { x: 23, y: 35 },
          { x: 42, y: 35 },
          { x: 35, y: 90 },
        ]
```
**Case 1**
let us assume the user has not specified  `yMinValue` in this case `yMinValue`  is set to `0`

**Case 2**
let us assume the user has provided   `yMinValue=13` , in this case , from ``data`` we can see that there is  `y=10` in `data[0].y` since user has provided `yMinValue`  greater than the min value present in array therefore we set the `yMinValue` to `0`  and `yMaxValue` set to the greatest Y-dataPoint or greatest domain value(**case 4**)

**Case 3**
let us assume the user has provided `yMaxValue=89`, in this case , from ``data`` we can see that there is  `y=90` in `data[5].y` since user has provided `yMaxValue` lesser than the max value present in array therefore we set `yMaxValue` to `90` or greatest domain value(**case 4**) and `yMinValue` to `0` since user has not provided.

**case 4 ( this is also one such scenario where `yMaxValue` prop can be ineffective.)**
let us assume the user has provided `yMaxValue=91` here you may get to conclusion that the provided value is greater that all the values present in array and therefore it is the rendered in chart, but this is not true, because as you know that we try to show `4` intervals of  **y-axis** therefore from the code we get the domain values `[0, 23, 46, 69, 92]` and as usual `yMinValue` will be `0` since it is not provided by the user and `yMaxValue` will be `92` instead of `91` because it is not possible to show in `4` intervals between `[0,91]` hence we take `92`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12495)