### PR TITLE
Have the version 5 website bundle React

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -45,8 +45,6 @@
     }
 
     var scripts = [
-      '//cdnjs.cloudflare.com/ajax/libs/react/16.3.1/umd/react.production.min.js',
-      '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.1/umd/react-dom.production.min.js',
       '/fabric-sitev5.js'
     ];
 

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -34,14 +34,8 @@ module.exports = function (argv) {
         chunkFilename: `${entryPointName}-${version}-[name]-${now}${minFileNamePart}.js`
       },
 
-      externals: [
-        {
-          'react': 'React'
-        },
-        {
-          'react-dom': 'ReactDOM'
-        },
-      ],
+      // The website config intentionally doesn't have React as an external because we bundle it
+      // to ensure we get a consistent version.
 
       resolve: {
         alias: {

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -17,10 +17,8 @@ module.exports = resources.createServeConfig({
 
   devServer: devServerConfig,
 
-  externals: {
-    'react': 'React',
-    'react-dom': 'ReactDOM'
-  },
+  // The website config intentionally doesn't have React as an external because we bundle it
+  // to ensure we get a consistent version.
 
   resolve: {
     alias: {

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -31,10 +31,8 @@ module.exports = resources.createServeConfig({
 
   devServer: devServer,
 
-  externals: {
-    'react': 'React',
-    'react-dom': 'ReactDOM'
-  },
+  // The website config intentionally doesn't have React as an external because we bundle it
+  // to ensure we get a consistent version.
 
   resolve: {
     alias: {

--- a/common/changes/@uifabric/fabric-website/2020-04-01-17-13.json
+++ b/common/changes/@uifabric/fabric-website/2020-04-01-17-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/fabric-website",
+      "comment": "Have the website bundle React",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com"
+}


### PR DESCRIPTION
Version 5 website should bundle React like 7 does so that the live site doesn't have to load React twice.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12500)