### PR TITLE
Have the version 6 website bundle React

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -184,11 +184,7 @@
       }
 
       function loadAppScripts(appPath) {
-        var version = isLocal ? '.development.js' : '.production.min.js';
-        var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.8.3/umd/react' + version;
-        var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.3/umd/react-dom' + version;
-
-        var scripts = [reactPath, reactDomPath, appPath + entryPointFilename + '.min.js'];
+        var scripts = [appPath + entryPointFilename + '.min.js'];
 
         // Load React and app scripts
         loadScripts(scripts);

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -31,14 +31,8 @@ module.exports = function(env) {
         chunkFilename: `${entryPointName}-${version}-[name]-${now}${minFileNamePart}.js`
       },
 
-      externals: [
-        {
-          react: 'React'
-        },
-        {
-          'react-dom': 'ReactDOM'
-        }
-      ],
+      // The website config intentionally doesn't have React as an external because we bundle it
+      // to ensure we get a consistent version.
 
       resolve: {
         alias: {

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -17,10 +17,8 @@ module.exports = resources.createServeConfig({
 
   devServer: devServerConfig,
 
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM'
-  },
+  // The website config intentionally doesn't have React as an external because we bundle it
+  // to ensure we get a consistent version.
 
   resolve: {
     alias: {

--- a/apps/fabric-website/webpack.uhf.serve.config.js
+++ b/apps/fabric-website/webpack.uhf.serve.config.js
@@ -30,10 +30,8 @@ module.exports = resources.createServeConfig({
 
   devServer: devServer,
 
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM'
-  },
+  // The website config intentionally doesn't have React as an external because we bundle it
+  // to ensure we get a consistent version.
 
   resolve: {
     alias: {

--- a/change/@uifabric-fabric-website-2020-04-01-10-16-13-bundle-react-6.json
+++ b/change/@uifabric-fabric-website-2020-04-01-10-16-13-bundle-react-6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Have the website bundle React",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "31a032677fa72960ed67420534554a7c395bfe74",
+  "date": "2020-04-01T17:16:13.600Z"
+}


### PR DESCRIPTION
Version 6 website should bundle React like 7 does so that the live site doesn't have to load React twice.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12501)