### PR TITLE
Update homepage.htm mirror to always use bundled React

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -191,19 +191,7 @@
   }
 
   function loadAppScripts() {
-    var scripts = [appPath + entryPointFilename + (isDev ? '.js' : '.min.js')];
-
-    if (!window.React) {
-      // Only needed for Fabric 5 and 6 (Fabric/Fluent UI 7 bundles React)
-      // DO NOT replace 16.3.2 with a newer version!
-      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react.production.min.js';
-      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom.production.min.js';
-
-      scripts.unshift(reactDomPath);
-      scripts.unshift(reactPath);
-    }
-
-    loadScripts(scripts);
+    loadScripts([appPath + entryPointFilename + (isDev ? '.js' : '.min.js')]);
 
     window.MonacoConfig = {
       baseUrl: appPath,

--- a/change/@uifabric-fabric-website-2020-04-01-15-23-08-bundle-react-all.json
+++ b/change/@uifabric-fabric-website-2020-04-01-15-23-08-bundle-react-all.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Update homepage.htm mirror to always use bundled React",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "b6b1b12b9430225883ec86c93258abb440da5b49",
+  "dependentChangeType": "none",
+  "date": "2020-04-01T22:23:08.560Z"
+}


### PR DESCRIPTION
We changed the Fabric 5 and 6 websites to bundle React too, so remove the code which loads React.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12506)