### PR TITLE
More fabric=>fluent wording updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.md
@@ -1,13 +1,13 @@
 ---
 name: Accessibility Issue
-about: Have you identified an accessibility issue regarding a Fabric control?
+about: Have you identified an accessibility issue regarding a Fluent UI React control?
 ---
 
 <!--
 Before submitting an accessibility issue please ensure the following are true:
 
 1. Search for dupes! Please make sure the issue is not already present in our issue tracker.
-2. This issue is caused by a Fabric control.
+2. This issue is caused by a Fluent UI React control.
 3. You can reproduce this bug in a CodePen.
 4. There is documentation or best practice that supports your expected behavior (review https://www.w3.org/TR/wai-aria-1.1/ for accessibility guidance.)
 
@@ -15,7 +15,7 @@ PLEASE NOTE:
 
 Do not link to, screenshot or reference a Microsoft product in this description.
 
-Our screen reader support is limited to Edge + Narrator. Please check ARIA component examples to ensure it is not a screen reader or browser issue. Issues that do not reproduce in Edge + Narrator, and aren't caused by obvious invalid aria values, should be filed with the respective screen reading software, not the Fabric repo.
+Our screen reader support is limited to Edge + Narrator. Please check ARIA component examples to ensure it is not a screen reader or browser issue. Issues that do not reproduce in Edge + Narrator, and aren't caused by obvious invalid aria values, should be filed with the respective screen reading software, not the Fluent UI repo.
 
 Issues that do not meet these guidelines will be closed.
 -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Found a bug in Fabric? Please let us know.
+about: Found a bug in Fluent UI React? Please let us know.
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Do you have Feature or improvement for Fabric? Let us know.
+about: Do you have Feature or improvement for Fluent UI React? Let us know.
 ---
 
 #### Describe the feature that you would like added

--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -1,6 +1,6 @@
 ---
 name: New Component
-about: Interested in contributing a new component to Fabric? This template includes necessary information to get started, and steps to completion
+about: Interested in contributing a new component to Fluent UI React? This template includes necessary information to get started, and steps to completion
 ---
 
 <!-- Use this template for new components or new component variants -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -5,4 +5,4 @@ about: 'Please use Stack Overflow for questions #office-ui-fabric'
 
 For _how-to_ questions and other non-bugs, please use StackOverflow instead of Github issues. You can tag your questions with [office-ui-fabric](https://stackoverflow.com/questions/tagged/office-ui-fabric).
 
-If you are a Microsoft employee you can also join the Microsoft UI Fabric teams channel.
+If you are a Microsoft employee you can also join the "Fluent UI Community" Teams channel.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ The `office-ui-fabric-react` repo has moved! This should not disrupt any current
 
 We have a lot in store for Fluent UI - [Read our announcement here.](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)
 
-# [Fluent UI React](https://dev.microsoft.com/fabric)
+# [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)
 
 **The React-based front-end framework for building experiences for Microsoft 365.**
 
-[![npm version](https://badge.fury.io/js/office-ui-fabric-react.svg)](https://badge.fury.io/js/office-ui-fabric-react) [![Build Status](https://uifabric.visualstudio.com/fabricpublic/_apis/build/status/office-ui-fabric-react%20-%20PR?branchName=master)](https://uifabric.visualstudio.com/fabricpublic/_build/latest?definitionId=84&branchName=master)
+[![npm version](https://badge.fury.io/js/%40fluentui%2Freact.svg)](https://badge.fury.io/js/%40fluentui%2Freact) [![Build Status](https://dev.azure.com/uifabric/fabricpublic/_apis/build/status/office-ui-fabric-react%20-%20PR?branchName=master)](https://dev.azure.com/uifabric/fabricpublic/_build/latest?definitionId=84&branchName=master)
 
 Fluent UI React is a collection of robust React-based components designed to make it simple for you to create consistent web experiences using the Fluent Design Language.
 

--- a/apps/a11y-tests/package.json
+++ b/apps/a11y-tests/package.json
@@ -2,7 +2,7 @@
   "name": "a11y-tests",
   "version": "7.0.0",
   "private": true,
-  "description": "A11y Tests for Office UI Fabric React",
+  "description": "A11y Tests for Fluent UI React",
   "scripts": {
     "build": "just-scripts build",
     "bundle": "just-scripts bundle",

--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/fabric-website-resources",
   "version": "7.6.34",
-  "description": "Office UI Fabric React local demo app",
+  "description": "Fluent UI React local demo app",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/apps/fabric-website-resources/src/AppDefinition.tsx
+++ b/apps/fabric-website-resources/src/AppDefinition.tsx
@@ -26,7 +26,7 @@ function loadReferences(): IAppLink[] {
 }
 
 export const AppDefinition: IAppDefinition = {
-  appTitle: 'UI Fabric - React',
+  appTitle: 'Fluent UI React',
   customizations: AppCustomizations,
   testPages: [
     {

--- a/apps/fabric-website-resources/src/AppDefinition.tsx
+++ b/apps/fabric-website-resources/src/AppDefinition.tsx
@@ -583,7 +583,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/fabric-website",
   "version": "7.10.21",
-  "description": "The official website for the UI Fabric project.",
+  "description": "The official website for the Fluent UI project.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": true,

--- a/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
+++ b/apps/fabric-website/src/pages/HomePage/HomePage.base.tsx
@@ -35,7 +35,7 @@ registerIcons({
 const fabricUsageIconBaseUrl = 'https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/svg/';
 
 /**
- * List of App/Brand icon names that use UI Fabric.
+ * List of App/Brand icon names that use Fluent UI.
  */
 const fabricUsageIcons = [
   { src: fabricUsageIconBaseUrl + 'outlook_48x1.svg', title: 'Outlook' },

--- a/apps/theming-designer/index.html
+++ b/apps/theming-designer/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>UI Fabric Theme Designer</title>
+    <title>Fluent UI Theme Designer</title>
     <script
       type="text/javascript"
       src="//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react.production.min.js"

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -103,7 +103,7 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
             aria-label="Microsoft Fabric Theme Designer page"
             styles={pipeFabricStyles}
           >
-            | UI Fabric Theme Designer
+            | Fluent UI Theme Designer
           </Link>
         </Stack>
         <PrimaryButton text="Export theme" onClick={this.showPanel} />

--- a/apps/theming-designer/src/components/Samples/index.tsx
+++ b/apps/theming-designer/src/components/Samples/index.tsx
@@ -81,7 +81,7 @@ const commandBarItems = [
     iconProps: {
       iconName: 'Upload',
     },
-    href: 'https://dev.office.com/fabric',
+    href: 'https://developer.microsoft.com/en-us/fluentui',
     ['data-automation-id']: 'uploadButton',
   },
   {

--- a/apps/vr-tests/package.json
+++ b/apps/vr-tests/package.json
@@ -2,7 +2,7 @@
   "name": "vr-tests",
   "version": "7.0.0",
   "private": true,
-  "description": "Visual Regression Tests for Office UI Fabric React",
+  "description": "Visual Regression Tests for Fluent UI React",
   "scripts": {
     "build": "just-scripts build",
     "clean": "",

--- a/change/@fluentui-examples-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@fluentui-examples-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@fluentui/examples",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:51.624Z"
+}

--- a/change/@fluentui-react-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@fluentui-react-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:24:09.775Z"
+}

--- a/change/@fluentui-react-compose-2020-04-10-13-17-09-more-fabric.json
+++ b/change/@fluentui-react-compose-2020-04-10-13-17-09-more-fabric.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update package description",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T20:17:09.034Z"
+}

--- a/change/@uifabric-api-docs-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-api-docs-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/api-docs",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:10.771Z"
+}

--- a/change/@uifabric-azure-themes-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-azure-themes-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:14.026Z"
+}

--- a/change/@uifabric-charting-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-charting-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:16.628Z"
+}

--- a/change/@uifabric-date-time-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-date-time-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:19.931Z"
+}

--- a/change/@uifabric-example-app-base-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-example-app-base-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Recommend Storybook instead; Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:44.174Z"
+}

--- a/change/@uifabric-example-data-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-example-data-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/example-data",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:47.734Z"
+}

--- a/change/@uifabric-experiments-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-experiments-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Remove graduation details; Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:59.183Z"
+}

--- a/change/@uifabric-fabric-website-2020-04-10-13-17-09-more-fabric.json
+++ b/change/@uifabric-fabric-website-2020-04-10-13-17-09-more-fabric.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update package description",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T20:17:01.245Z"
+}

--- a/change/@uifabric-fabric-website-resources-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-fabric-website-resources-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:21:06.237Z"
+}

--- a/change/@uifabric-file-type-icons-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-file-type-icons-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Remove section about fluent icons (should be default now); Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:22:13.783Z"
+}

--- a/change/@uifabric-fluent-theme-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-fluent-theme-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:22:37.303Z"
+}

--- a/change/@uifabric-foundation-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-foundation-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:22:42.977Z"
+}

--- a/change/@uifabric-icons-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-icons-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Clarify usage docs; Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/icons",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:22:56.886Z"
+}

--- a/change/@uifabric-mdl2-theme-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-mdl2-theme-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/mdl2-theme",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:01.072Z"
+}

--- a/change/@uifabric-merge-styles-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-merge-styles-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:03.933Z"
+}

--- a/change/@uifabric-migration-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-migration-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/migration",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:06.584Z"
+}

--- a/change/@uifabric-monaco-editor-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-monaco-editor-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:11.739Z"
+}

--- a/change/@uifabric-react-cards-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-react-cards-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Remove graduation details; Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/react-cards",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:42.189Z"
+}

--- a/change/@uifabric-react-hooks-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-react-hooks-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates; add note about reusability",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:55.998Z"
+}

--- a/change/@uifabric-styling-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-styling-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:24:21.467Z"
+}

--- a/change/@uifabric-test-utilities-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-test-utilities-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:24:27.156Z"
+}

--- a/change/@uifabric-theme-samples-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-theme-samples-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/theme-samples",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:24:30.714Z"
+}

--- a/change/@uifabric-tsx-editor-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-tsx-editor-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:24:58.346Z"
+}

--- a/change/@uifabric-utilities-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-utilities-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Remove irrelevant details; Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:25:00.736Z"
+}

--- a/change/@uifabric-variants-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-variants-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/variants",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:25:03.095Z"
+}

--- a/change/@uifabric-webpack-utils-2020-04-01-16-25-06-more-fabric.json
+++ b/change/@uifabric-webpack-utils-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Fabric=>Fluent wording updates",
+  "packageName": "@uifabric/webpack-utils",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:25:06.056Z"
+}

--- a/change/office-ui-fabric-react-2020-04-01-16-25-06-more-fabric.json
+++ b/change/office-ui-fabric-react-2020-04-01-16-25-06-more-fabric.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Readme: Add migration info",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "0aa8cea647b5c77acdc8858f9fb028d915ebea51",
+  "dependentChangeType": "patch",
+  "date": "2020-04-01T23:23:21.994Z"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "office-ui-fabric-react-repo",
+  "name": "fluent-ui-react-repo",
   "version": "7.0.0",
-  "description": "Reusable React components for building experiences for Office 365.",
+  "description": "Reusable React components for building experiences for Microsoft 365.",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/api-docs/README.md
+++ b/packages/api-docs/README.md
@@ -1,3 +1,3 @@
 # @uifabric/api-docs
 
-Provides a set of page.json files to populate API references for the [UI Fabric website](https://dev.microsoft.com/fabric).
+Provides a set of page.json files to populate API references for the [Fluent UI website](https://developer.microsoft.com/en-us/fluentui).

--- a/packages/azure-themes/README.md
+++ b/packages/azure-themes/README.md
@@ -1,11 +1,12 @@
 # @uifabric/azure-themes
 
-**Azure theme for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Azure theme for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 The Azure themes require the following import statements:
 
 ```js
-import { Fabric, Customizer } from 'office-ui-fabric-react';
+import { Fabric, Customizer } from '@fluentui/react';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
 ```
 

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/azure-themes",
   "version": "7.0.57",
-  "description": "Azure themes for Office UI Components",
+  "description": "Azure themes for Fluent UI React",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/charting/README.md
+++ b/packages/charting/README.md
@@ -1,6 +1,7 @@
 # @uifabric/charting
 
-**Charting components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Charting components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 The charting components here are ready to be used in production environment. However there are might be API revisions before final release.
 

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/charting",
   "version": "1.1.4",
-  "description": "Experimental React charting components for building experiences for Office 365.",
+  "description": "Experimental React charting components for building experiences for Microsoft 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/charting/src/demo/AppDefinition.tsx
+++ b/packages/charting/src/demo/AppDefinition.tsx
@@ -60,7 +60,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/packages/charting/src/demo/AppDefinition.tsx
+++ b/packages/charting/src/demo/AppDefinition.tsx
@@ -2,7 +2,7 @@
 import { IAppDefinition } from '@uifabric/example-app-base';
 
 export const AppDefinition: IAppDefinition = {
-  appTitle: 'UI Fabric - Charting',
+  appTitle: 'Fluent UI React - Charting',
 
   testPages: [],
   examplePages: [

--- a/packages/date-time/README.md
+++ b/packages/date-time/README.md
@@ -1,6 +1,7 @@
 # @uifabric/date-time
 
-**Date and time-related components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Date and time-related components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 To import the components:
 

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/date-time",
   "version": "7.8.53",
-  "description": "Date and time related React components for building experiences for Office 365.",
+  "description": "Date and time related React components for building experiences for Microsoft 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/date-time/src/demo/AppDefinition.tsx
+++ b/packages/date-time/src/demo/AppDefinition.tsx
@@ -36,7 +36,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/packages/example-app-base/README.md
+++ b/packages/example-app-base/README.md
@@ -1,8 +1,8 @@
 # @uifabric/example-app-base
 
-**Deprecated** components and utilities used to build internal documentation sites and inner loops for various [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) packages.
+Components and utilities used to build internal documentation sites and inner loops for various [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) packages.
 
-**For new inner loops and documentation sites, please use [Storybook](https://storybook.js.org/) instead.** Storybook is a well-supported, well-documented platform for component development and documentation. `example-app-base` components have always been primarily intended for internal use and are now deprecated.
+**This package is in maintenance mode while we work on a replacement.** It should only be used in new projects if you must have a published documentation site that looks like the official Fluent UI React docs. If all you need is an inner loop for component development, **please use [Storybook](https://storybook.js.org/) instead.** Storybook is a well-supported, well-documented platform for component development and documentation.
 
 ## Live editor support
 

--- a/packages/example-app-base/README.md
+++ b/packages/example-app-base/README.md
@@ -1,12 +1,12 @@
 # @uifabric/example-app-base
 
-Components and utilities used to build documentation sites for various [Office UI Fabric React](https://dev.microsoft.com/fabric) packages.
+**Deprecated** components and utilities used to build internal documentation sites and inner loops for various [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) packages.
 
-These components are primarily intended for use within the office-ui-fabric-react repo. Therefore, the APIs may be unstable.
+**For new inner loops and documentation sites, please use [Storybook](https://storybook.js.org/) instead.** Storybook is a well-supported, well-documented platform for component development and documentation. `example-app-base` components have always been primarily intended for internal use and are now deprecated.
 
 ## Live editor support
 
-To set up the live code editor in the demo app for a package other than the `office-ui-fabric-react` package itself:
+To set up the live code editor in the demo app for a package other than the `@fluentui/react` package itself:
 
 1. Follow the setup steps from the [`@uifabric/monaco-editor` readme](https://github.com/microsoft/fluentui/blob/master/packages/monaco-editor/README.md) (the helpers mentioned are also re-exported from `@uifabric/tsx-editor` for convenience).
 
@@ -19,7 +19,7 @@ To set up the live code editor in the demo app for a package other than the `off
    - You're building off the default set of supported packages
    - The package you're demoing is `my-package`
    - `my-package` re-exports another package called `my-package-utilities` (it's not required that your package export anything else, but this is included to demonstrate setting it up)
-   - Each package's `.d.ts` rollup lives under `<package-name>/dist/<package-name>.d.ts`
+   - Each package's `.d.ts` rollup lives under `<package-folder>/dist/<unscoped-package-name>.d.ts`
 
 ```ts
 import { IPackageGroup } from '@uifabric/tsx-editor';

--- a/packages/example-app-base/index.html
+++ b/packages/example-app-base/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
-    <title>UI Fabric React Examples</title>
+    <title>Fluent UI React Examples</title>
   </head>
 
   <body>

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/example-app-base",
   "version": "7.12.32",
-  "description": "UI Fabric components for building documentation sites.",
+  "description": "Fluent UI React components for building documentation sites.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/example-app-base/src/components/ApiReferencesTable/tokenResolver.test.ts
+++ b/packages/example-app-base/src/components/ApiReferencesTable/tokenResolver.test.ts
@@ -6,7 +6,7 @@ describe('getTokenResolver', () => {
   });
 
   describe('in website', () => {
-    runTests('https://developer.microsoft.com/en-us/fabric', '#/controls/web');
+    runTests('https://developer.microsoft.com/en-us/fluentui', '#/controls/web');
   });
 
   function runTests(appUrl: string, areaPath: string) {

--- a/packages/example-app-base/src/components/TopNav/TopNav.tsx
+++ b/packages/example-app-base/src/components/TopNav/TopNav.tsx
@@ -121,7 +121,7 @@ export class TopNav extends React.Component<ITopNavProps, ITopNavState> {
     const home = pages.filter((page: INavPage) => page.isHomePage)[0];
     if (home) {
       return (
-        <a href={home.url} className={styles.appLogo} title="UI Fabric Home page">
+        <a href={home.url} className={styles.appLogo} title="Home page">
           {/* @todo: Set up baseImageUrl to easily swap image host. */}
           <img src={this.props.siteLogoSource} role="presentation" />
         </a>

--- a/packages/example-app-base/src/utilities/baseDefinition.tsx
+++ b/packages/example-app-base/src/utilities/baseDefinition.tsx
@@ -3,14 +3,14 @@ import { LoadingComponent } from '../components/LoadingComponent/index';
 import { ISiteDefinition } from './SiteDefinition.types';
 
 export const baseDefinition: ISiteDefinition = {
-  siteTitle: 'UI Fabric',
+  siteTitle: 'Fluent UI React',
   pages: [
     {
       title: 'Home',
       url: '#/',
       isContentFullBleed: true,
       isHomePage: true,
-      component: () => <LoadingComponent title="UI Fabric App Base" />,
+      component: () => <LoadingComponent title="Fluent UI React Example App Base" />,
       // tslint:disable-next-line:no-any
       // getComponent: cb => require.ensure([], require => cb(require<any>('../pages/HomePage/HomePage').HomePage))
     },

--- a/packages/example-app-base/src/utilities/createApp.tsx
+++ b/packages/example-app-base/src/utilities/createApp.tsx
@@ -107,7 +107,7 @@ function _getDefinition(groups: ExampleGroup[]): IAppDefinition {
       },
       {
         name: 'Fabric',
-        url: 'https://dev.microsoft.com/fabric',
+        url: 'https://developer.microsoft.com/en-us/fluentui',
       },
       {
         name: 'GitHub',

--- a/packages/example-data/README.md
+++ b/packages/example-data/README.md
@@ -1,5 +1,6 @@
 # @uifabric/example-data
 
-**Data generators for [Office UI Fabric React](https://dev.microsoft.com/fabric) examples**
+**Data generators for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui) examples**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-This package is intended for use within the office-ui-fabric-react repo. Therefore, the APIs may be unstable.
+This package is intended for use within the Fluent UI React repo. Therefore, the APIs may be unstable.

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/example-data",
   "version": "7.0.9",
-  "description": "Data generators for Office UI Fabric React examples.",
+  "description": "Data generators for Fluent UI React examples.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,3 +1,4 @@
 # @fluentui/examples
 
-**Examples and documentation for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Examples and documentation for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/examples",
   "version": "0.1.30",
-  "description": "Example code and docs for Fluent UI and UI Fabric packages.",
+  "description": "Example code and docs for Fluent UI packages.",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/experiments/README.md
+++ b/packages/experiments/README.md
@@ -1,6 +1,7 @@
 # @uifabric/experiments
 
-**Experimental components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Experimental components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 These are not production-ready components and **should never be used in product** unless you are the [CODEOWNER](https://github.com/microsoft/fluentui/blob/master/.github/CODEOWNERS) of the component and are responsible for reviewing all PRs involving this component. This experimental space is useful for testing new components whose APIs might change before final release.
 
@@ -8,12 +9,6 @@ To import experimental components:
 
 ```js
 import { ComponentName } from '@uifabric/experiments/lib/ComponentName';
-```
-
-Once the experimental component graduates to a production release, the component will be available at:
-
-```js
-import { ComponentName } from 'office-ui-fabric-react/lib/ComponentName';
 ```
 
 ### Testing locally

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/experiments",
   "version": "7.23.0",
-  "description": "Experimental React components for building experiences for Office 365.",
+  "description": "Experimental React components for building experiences for Microsoft 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/experiments/src/components/Pagination/PaginationPage.tsx
+++ b/packages/experiments/src/components/Pagination/PaginationPage.tsx
@@ -56,7 +56,7 @@ export class PaginationPage extends React.Component<IComponentDemoPageProps, {}>
               For cases when your application supports theming, Pagination component is equipped with everything you
               need to just load the custom theme to the application, and as long as the color palette you provide has an
               override for the{' '}
-              <Link href="https://developer.microsoft.com/en-us/fabric#/styles/colors">
+              <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/colors">
                 <code>Fabric colors</code>
               </Link>{' '}
               used in Pagination, everything should be ok. If no theming is supported, then follow the example showing

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -171,7 +171,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/packages/experiments/src/demo/AppDefinition.tsx
+++ b/packages/experiments/src/demo/AppDefinition.tsx
@@ -3,7 +3,7 @@ import { IAppDefinition } from '@uifabric/example-app-base';
 import { AppCustomizations } from './customizations';
 
 export const AppDefinition: IAppDefinition = {
-  appTitle: 'UI Fabric - Experiments',
+  appTitle: 'Fluent UI React - Experiments',
   customizations: AppCustomizations,
   testPages: [],
   examplePages: [

--- a/packages/experiments/src/slots/examples/Slots.Root.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Root.Example.tsx
@@ -11,7 +11,7 @@ export class SlotsRootExample extends React.Component<{}, {}> {
       <Stack {...stackProps}>
         <Button
           icon="share"
-          href="https://developer.microsoft.com/en-us/fabric"
+          href="https://developer.microsoft.com/en-us/fluentui"
           content="Root: Implicit 'a' via href prop"
         />
         <Button

--- a/packages/experiments/src/theming/examples/Theming.Schemes.Custom.Example.tsx
+++ b/packages/experiments/src/theming/examples/Theming.Schemes.Custom.Example.tsx
@@ -285,7 +285,7 @@ const items: ICommandBarItemProps[] = [
     key: 'upload',
     name: 'Upload',
     iconProps: { iconName: 'Upload' },
-    href: 'https://dev.office.com/fabric',
+    href: 'https://developer.microsoft.com/en-us/fluentui',
     target: '_blank',
   },
   { key: 'share', name: 'Share', iconProps: { iconName: 'Share' }, onClick: onCommandClick },

--- a/packages/experiments/src/theming/examples/Theming.Schemes.Variant.Example.tsx
+++ b/packages/experiments/src/theming/examples/Theming.Schemes.Variant.Example.tsx
@@ -164,7 +164,7 @@ const items: ICommandBarItemProps[] = [
     key: 'upload',
     name: 'Upload',
     iconProps: { iconName: 'Upload' },
-    href: 'https://dev.office.com/fabric',
+    href: 'https://developer.microsoft.com/en-us/fluentui',
     target: '_blank',
   },
   { key: 'share', name: 'Share', iconProps: { iconName: 'Share' }, onClick: onCommandClick },

--- a/packages/file-type-icons/README.md
+++ b/packages/file-type-icons/README.md
@@ -1,12 +1,13 @@
 # @uifabric/file-type-icons
 
-**File type icons for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**File type icons for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 This package includes a collection of icons to represent file types.
 
 ## Getting started
 
-If you are using Fabric React components, you can make all file type icons available by calling the `initializeFileTypeIcons` function from the `@uifabric/file-type-icons` package:
+If you are using Fluent UI React components, you can make all file type icons available by calling the `initializeFileTypeIcons` function from the `@uifabric/file-type-icons` package:
 
 ```tsx
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
@@ -22,17 +23,15 @@ initializeFileTypeIcons('https://my.cdn.com/path/to/icons/');
 
 ## Usage in code
 
-If you are using Fabric React, you can use the `Icon` component and pass in the corresponding icon properties to render a given icon.
+If you are using Fluent UI React, you can use the `Icon` component and pass in the corresponding icon properties to render a given icon.
 
 ```tsx
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from '@fluentui/react/lib/Icon';
 import { getFileTypeIconProps } from '@uifabric/file-type-icons';
 
 <Icon {...getFileTypeIconProps({extension: 'docx', size: 16}) />
 ```
 
-In Fabric 7, the new Fluent file type icons will be the default.
-
 ## Notes
 
-See [Office UI Fabric React](https://github.com/microsoft/fluentui) for more details on the UI Fabric project and packages within.
+See [GitHub](https://github.com/microsoft/fluentui) for more details on the Fluent UI React project and packages within.

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/file-type-icons",
   "version": "7.2.28",
-  "description": "Office UI Fabric file type icon set.",
+  "description": "Fluent UI React file type icon set.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/fluent-theme/README.md
+++ b/packages/fluent-theme/README.md
@@ -1,10 +1,11 @@
 # @uifabric/fluent-theme
 
-**Fluent theme for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Fluent theme for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-This package contains Fluent coloring, theming and styling for use with Fabric components.
+This package contains Fluent coloring, theming and styling constants for use with Fluent UI React components.
 
-Note that in `office-ui-fabric-react` version 7, components use the Fluent theme by default, so manually applying the Fluent theme is no longer necessary. However, this package still exports various constants which may be useful for manually styling components.
+Note that in `@fluentui/react` (or `office-ui-fabric-react`) version 7, components use the Fluent theme by default, so manually applying the Fluent theme is no longer necessary. However, this package still exports various constants which may be useful for manually styling components.
 
 To import the Fluent theme or some example constants:
 

--- a/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx
+++ b/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx
@@ -27,8 +27,8 @@ export default () => (
     <p>
       Fluent UI leverages Focus Trap Zone component which is based on the{' '}
       {link(
-        'Focus Trap Zone from Office UI Fabric.',
-        'https://developer.microsoft.com/en-us/fabric#/components/focustrapzone',
+        'Focus Trap Zone from Fluent UI React.',
+        'https://developer.microsoft.com/en-us/fluentui#/controls/web/focustrapzone',
       )}
     </p>
     <Header as="h2">Usage</Header>

--- a/packages/fluentui/docs/src/views/FocusZoneDoc.tsx
+++ b/packages/fluentui/docs/src/views/FocusZoneDoc.tsx
@@ -44,7 +44,10 @@ export default () => (
     </ul>
     <p>
       Fluent UI leverages {code('FocusZone')} component which is based on the{' '}
-      {link('Focus Zone from Office UI Fabric.', 'https://developer.microsoft.com/en-us/fabric#/components/focuszone')}{' '}
+      {link(
+        'Focus Zone from Fluent UI React.',
+        'https://developer.microsoft.com/en-us/fluentui#/controls/web/focuszone',
+      )}{' '}
       The Focus Zone can wrap any component / element and adds arrow key navigation functionality.
     </p>
     <Header as="h2">Usage</Header>

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -1,8 +1,9 @@
 # @uifabric/foundation
 
-**Foundation for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Foundation for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-This library provides the foundation for creating and using Fabric components.
+This library provides the foundation for creating and using Fluent UI React components.
 
 To import the foundation:
 

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -1,12 +1,13 @@
 # @uifabric/icons
 
-**Icons for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Icons for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-Fabric Icons includes a collection of 1100+ icons which you can use in your application.
+Fluent UI React Icons includes a collection of 1100+ icons which you can use in your application.
 
 ## Getting started
 
-If you are using Fabric React components, you can make all icons available by calling the `initializeIcons` function from the `@uifabric/icons` package:
+If you are using Fluent UI React components, you can make all icons available by calling the `initializeIcons` function from the `@uifabric/icons` package:
 
 ```tsx
 import { initializeIcons } from '@uifabric/icons';
@@ -22,17 +23,19 @@ This will make ALL icons in the collection available, but will download them on 
 
 ## Usage in code
 
-### getIcon API
+### Icon component
 
-If you are using Fabric React, you can use the `Icon` component and pass in the corresponding iconName property to render a given icon.
+If you are using Fluent UI React, you can use the `Icon` component and pass in the corresponding iconName property to render a given icon.
 
 ```tsx
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from '@fluentui/react/lib/Icon';
 
 <Icon iconName="Snow" />;
 ```
 
-The styling package includes a `getIconClassName` api which can provide a css class to use for rendering the icon manually using the `:before` pseudoselector:
+### `getIconClassName` API
+
+The styling package includes a `getIconClassName` API which can provide a css class to use for rendering the icon manually using the `:before` pseudoselector:
 
 ```ts
 import { getIconClassName } from '@uifabric/styling';
@@ -42,4 +45,4 @@ return `<i class="${getIconClassName('Snow')}" />`;
 
 ## Notes
 
-See [Office UI Fabric React](https://github.com/microsoft/fluentui) for more details on the UI Fabric project and packages within.
+See [GitHub](https://github.com/microsoft/fluentui) for more details on the Fluent UI React project and packages within.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/icons",
   "version": "7.3.24",
-  "description": "Office UI Fabric icon set.",
+  "description": "Fluent UI React icon set.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/lists/README.md
+++ b/packages/lists/README.md
@@ -1,6 +1,7 @@
 # @uifabric/lists
 
-**List components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**List components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 ## Overview
 
@@ -10,26 +11,20 @@ The intent of the `@uifabric/lists` package is to prototype approaches to lists 
 - **DynamicList** (in planning): Represents a component to display an arbitrary collection of items in a list, with view virtualization.
 - **FixedList** (in development): Inspired by Brian Vaughn's [react-window](https://github.com/bvaughn/react-window) (MIT license), this component is a special case of DynamicList which is specifically optimized for the case where all row heights are the same and known in advance.
 
-Eventually, this package will be a home for _all_ Fabric List controls, migrated in a backwards-compatible way. Until then, we recommend using `office-ui-fabric-react`'s more _stable_ List components:
+Since the components in this package are not yet production-ready, we recommend using `@fluentui/react`'s more _stable_ List components:
 
-- [List](https://developer.microsoft.com/en-us/fabric#/controls/web/list)
-- [DetailsList](https://developer.microsoft.com/en-us/fabric#/controls/web/detailslist)
-- [GroupedList](https://developer.microsoft.com/en-us/fabric#/controls/web/groupedlist)
+- [List](https://developer.microsoft.com/en-us/fluentui#/controls/web/list)
+- [DetailsList](https://developer.microsoft.com/en-us/fluentui#/controls/web/detailslist)
+- [GroupedList](https://developer.microsoft.com/en-us/fluentui#/controls/web/groupedlist)
 
 ## Usage
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 
-To import Lists components:
+To import list components:
 
 ```js
 import { ComponentName } from '@uifabric/lists';
-```
-
-Once the Lists component graduates to a production release, the component will be available at:
-
-```js
-import { ComponentName } from 'office-ui-fabric-react';
 ```
 
 ## Profiling

--- a/packages/lists/src/demo/AppDefinition.tsx
+++ b/packages/lists/src/demo/AppDefinition.tsx
@@ -23,7 +23,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/packages/lists/src/demo/AppDefinition.tsx
+++ b/packages/lists/src/demo/AppDefinition.tsx
@@ -2,7 +2,7 @@
 import { IAppDefinition } from '@uifabric/example-app-base';
 
 export const AppDefinition: IAppDefinition = {
-  appTitle: 'UI Fabric - Lists',
+  appTitle: 'Fluent UI React - Lists',
 
   testPages: [],
   examplePages: [

--- a/packages/mdl2-theme/README.md
+++ b/packages/mdl2-theme/README.md
@@ -1,8 +1,9 @@
 # @uifabric/mdl2-theme
 
-**MDL2 Theme package for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**MDL2 Theme package for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-This package contains MDL2 coloring, theming and styling for use with Fabric components.
+This package contains MDL2 coloring, theming and styling for use with Fluent UI React components.
 
 To import MDL2 theme:
 

--- a/packages/merge-styles/README.md
+++ b/packages/merge-styles/README.md
@@ -506,7 +506,7 @@ Stylesheet.getInstance().setConfig({
 });
 ```
 
-If you're working inside a Fabric app, this setting can also be applied using the global `window.FabricConfig.mergeStyles.cspSettings`. Note that this must be set before any Fabric code is loaded, or it may not be applied properly.
+If you're working inside a Fluent UI React app ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)), this setting can also be applied using the global `window.FabricConfig.mergeStyles.cspSettings`. Note that this must be set before any Fluent UI React code is loaded, or it may not be applied properly.
 
 ```ts
 window.FabricConfig = {

--- a/packages/migration/README.md
+++ b/packages/migration/README.md
@@ -1,8 +1,9 @@
 # @uifabric/migration
 
-**Migration scripts for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Migration scripts for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-These are a set of scripts to help migrating your code to be compatible with Fabric during an upgrade of Fabric.
+These are a set of scripts to help migrating your code to be compatible with the latest version during an upgrade.
 
 ## How to use this?
 

--- a/packages/monaco-editor/README.md
+++ b/packages/monaco-editor/README.md
@@ -51,7 +51,7 @@ This lightweight helper sets up the global `MonacoEnvironment` required for Mona
 
 #### Option B: Automatic using global
 
-Somewhere in a root file for your project (the Fabric projects do this in `index.html`), define a global variable `MonacoConfig` with the properties described above. Basic example:
+Somewhere in a root file for your project (the Fluent UI React projects do this in `index.html`), define a global variable `MonacoConfig` with the properties described above. Basic example:
 
 ```js
 window.MonacoConfig = {

--- a/packages/office-ui-fabric-react/README.md
+++ b/packages/office-ui-fabric-react/README.md
@@ -1,11 +1,42 @@
-# [Office UI Fabric React](https://dev.microsoft.com/fabric)
+> The **Office UI Fabric React** project has evolved into **Fluent UI React**! We have a lot in store for Fluent UI - [Read our announcement here](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/) and see more details about what this means for package consumers below.
 
-**The React-based front-end framework for building experiences for Office and Office 365.**
+# [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)
 
-**Fabric 7** Summary, breaking changes, and more details available in [the wiki](https://github.com/microsoft/fluentui/wiki/Fabric-7).
+**The React-based front-end framework for building experiences for Microsoft 365.**
 
-Fabric React is a collection of robust React-based components designed to make it simple for you to create consistent web experiences using the Office Design Language.
+Fluent UI React ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) is a collection of robust React-based components designed to make it simple for you to create consistent web experiences using the Fluent Design Language.
 
-For information about available controls, see the [Fabric website](https://dev.microsoft.com/fabric).
+For information about available controls, see the [Fluent UI website](https://developer.microsoft.com/en-us/fluentui).
 
-To get started using or contributing to Fabric, see the [full readme](https://github.com/microsoft/fluentui/blob/master/README.md).
+To get started using or contributing to Fluent UI React, see the [full readme](https://github.com/microsoft/fluentui/blob/master/README.md).
+
+## Moving to `@fluentui/react`
+
+Going forward, the `office-ui-fabric-package` will be renamed to `@fluentui/react`. The `@fluentui/react` package exists today as a mirror of `office-ui-fabric-react`'s public API surface. (Updates will still be published under both names for at least the duration of version 7.)
+
+If you'd like to start using `@fluentui/react` now, you can do so by changing your dependency and imports.
+
+Imports in either of these formats can be directly renamed:
+
+```ts
+// Old
+import { TextField } from 'office-ui-fabric-react';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+
+// New
+import { TextField } from '@fluentui/react';
+import { TextField } from '@fluentui/react/lib/TextField';
+```
+
+However, deeper imports from internal files **will not** work with `@fluentui/react`. (These types of imports are also unsupported today, as internal file paths are considered private APIs and therefore subject to change without notice.)
+
+```ts
+// Not supported currently; won't work with @fluentui/react
+import { TextField } from 'office-ui-fabric-react/lib/components/TextField/index';
+
+// Use instead
+import { TextField } from '@fluentui/react';
+import { TextField } from '@fluentui/react/lib/TextField';
+```
+
+If you're currently depending on an API which you think should be public but is not exported from the top level of the package, please [file an issue](https://github.com/microsoft/fluentui/issues) to discuss.

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "office-ui-fabric-react",
   "version": "7.106.0",
-  "description": "Reusable React components for building experiences for Office 365.",
+  "description": "Reusable React components for building experiences for Microsoft 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.Icon.Example.tsx
@@ -43,7 +43,7 @@ export const ButtonIconExample: React.FunctionComponent<IButtonExampleProps> = p
       </Stack>
       <p>
         For a list of Icons, visit our{' '}
-        <Link href="https://developer.microsoft.com/en-us/fabric#/styles/icons">Icon documentation</Link>.
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/styles/icons">Icon documentation</Link>.
       </p>
     </div>
   );

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -1,9 +1,5 @@
 @import '../../common/common';
 
-// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-//
-// Office UI Fabric
-// --------------------------------------------------
 // Calendar styles
 $Calendar-day: 28px;
 $Calendar-dayPicker-margin: 10px;

--- a/packages/office-ui-fabric-react/src/components/Check/Check.scss
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.scss
@@ -1,10 +1,5 @@
 @import '../../common/common';
 
-// Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE in the project root for license information.
-
-//
-// Office UI Fabric
-// --------------------------------------------------
 // Check styles
 
 $checkBoxHeight: 18px;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx
@@ -44,7 +44,7 @@ const _items: ICommandBarItemProps[] = [
     key: 'upload',
     text: 'Upload',
     iconProps: { iconName: 'Upload' },
-    href: 'https://dev.office.com/fabric',
+    href: 'https://developer.microsoft.com/en-us/fluentui',
   },
   {
     key: 'share',

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.ButtonAs.Example.tsx
@@ -93,7 +93,12 @@ const _items: ICommandBarItemProps[] = [
       ],
     },
   },
-  { key: 'upload', text: 'Upload', iconProps: { iconName: 'Upload' }, href: 'https://dev.office.com/fabric' },
+  {
+    key: 'upload',
+    text: 'Upload',
+    iconProps: { iconName: 'Upload' },
+    href: 'https://developer.microsoft.com/en-us/fluentui',
+  },
   { key: 'share', text: 'Share', iconProps: { iconName: 'Share' }, onClick: () => console.log('Share') },
   { key: 'download', text: 'Download', iconProps: { iconName: 'Download' }, onClick: () => console.log('Download') },
 ];

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.SplitDisabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.SplitDisabled.Example.tsx
@@ -36,7 +36,7 @@ const _items: ICommandBarItemProps[] = [
     iconProps: { iconName: 'Upload' },
     split: true,
     disabled: true,
-    href: 'https://dev.office.com/fabric',
+    href: 'https://developer.microsoft.com/en-us/fluentui',
     subMenuProps: {
       items: [
         { key: 'item1', text: 'Item One' },

--- a/packages/office-ui-fabric-react/src/components/Keytip/docs/KeytipOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Keytip/docs/KeytipOverview.md
@@ -1,23 +1,7 @@
-A Keytip is a small popup near a component that indicates a key sequence that
-will trigger that component. These are not to be confused with keyboard
-shortcuts; they are instead key sequences to traverse through levels of UI
-components. Technically, a Keytip is a wrapper around a Callout where the
-target element is discovered through a 'data-ktp-target' attribute on that
-element.
+A Keytip is a small popup near a component that indicates a key sequence that will trigger that component. These are not to be confused with keyboard shortcuts; they are instead key sequences to traverse through levels of UI components. Technically, a Keytip is a wrapper around a Callout where the target element is discovered through a 'data-ktp-target' attribute on that element.
 
-To enable Keytips on your page, a developer will add the KeytipLayer component
-somewhere in their document. It can be added anywhere in your document, but
-must only be added once. Use the registerKeytip utility helper to add a
-Keytip. A user will enter and exit keytip mode with a
-IKeytipTransitionSequence, which is a key with any amount of modifiers (Alt,
-Shift, etc).
+To enable Keytips on your page, a developer will add the KeytipLayer component somewhere in their document. It can be added anywhere in your document, but must only be added once. Use the registerKeytip utility helper to add a Keytip. A user will enter and exit keytip mode with a IKeytipTransitionSequence, which is a key with any amount of modifiers (Alt, Shift, etc).
 
-By default, the entry and exit sequence is 'Alt-Windows' (Meta) on Windows and
-'Option-Control' on macOS. There is also a sequence to 'return' up a level of
-keytips while traversing. This is by default 'Esc'.
+By default, the entry and exit sequence is 'Alt-Windows' (Meta) on Windows and 'Option-Control' on macOS. There is also a sequence to 'return' up a level of keytips while traversing. This is by default 'Esc'.
 
-Fabric components that have keytips enabled have an optional 'keytipProps' prop
-which handles registering, unregistering, and rendering of the keytip. The
-keySequences of the Keytip should be the full sequence to get to that keytip.
-There is a 'buildKeytipConfigMap' helper which will build a map of ID ->
-IKeytipProps to assist in defining your keytips.
+Fluent UI React components that have keytips enabled have an optional 'keytipProps' prop which handles registering, unregistering, and rendering of the keytip. The keySequences of the Keytip should be the full sequence to get to that keytip. There is a 'buildKeytipConfigMap' helper which will build a map of ID -> IKeytipProps to assist in defining your keytips.

--- a/packages/office-ui-fabric-react/src/components/Panel/docs/PanelDos.md
+++ b/packages/office-ui-fabric-react/src/components/Panel/docs/PanelDos.md
@@ -1,4 +1,4 @@
 - Use for self-contained experiences where the user does not need to interact with the app view to complete the task.
 - Use for complex creation, edit or management experiences.
-- Consider how the panel and its contained contents will scale across Fabric’s responsive web breakpoints.
+- Consider how the panel and its contained contents will scale across Fluent UI React’s responsive web breakpoints.
 - Make sure to have a minimum width of 340px for the `Panel` component

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
@@ -61,7 +61,7 @@ export const PanelSizesExample: React.FunctionComponent = () => {
     <div>
       <p style={firstPStyle}>
         See the{' '}
-        <Link href="https://developer.microsoft.com/en-us/fabric#/controls/web/panel#PanelType">
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/panel#PanelType">
           PanelType documentation
         </Link>{' '}
         for details on how each option affects panel sizing at different screen widths.

--- a/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
@@ -1,6 +1,6 @@
 A `Stack` is a container-type component that abstracts the implementation of a flexbox in order to define the layout of its children components.
 
-## Stack Properties
+### Stack Properties
 
 Although the `Stack` component has a number of different properties, there are three in particular that define the overall layout that the component has:
 
@@ -8,7 +8,7 @@ Although the `Stack` component has a number of different properties, there are t
 2. Alignment: Refers to how the children components are aligned inside the container. This is controlled via the `verticalAlign` and `horizontalAlign` properties. One thing to notice here is that while flexbox containers align always across the cross axis, `Stack` aims to remove the mental strain involved in this process by making the `verticalAlign` and `horizontalAlign` properties always follow the vertical and horizontal axes, respectively, regardless of the direction of the `Stack`.
 3. Spacing: Refers to the space that exists between children components inside the `Stack`. This is controlled via the `gap` and `verticalGap` properties.
 
-# Stack Items
+## Stack Items
 
 The `Stack` component provides an abstraction of a flexbox container but there are some flexbox related properties that are applied on specific children of the flexbox instead of being applied on the container. This is where `Stack Items` comes into play.
 
@@ -16,10 +16,10 @@ A `Stack Item` abstracts those properties that are or can be specifically applie
 
 To use a `Stack Item` in an application, the `Stack` component should be imported and `Stack.Item` should be used inside of a `Stack`. This is done so that the existence of the `Stack Item` is inherently linked to the `Stack` component.
 
-## Stack Wrapping
+### Stack Wrapping
 
 Aside from the previously mentioned properties, there is another property called `wrap` that determines if items overflow the `Stack` container or wrap around it. The wrap property only works in the direction of the `Stack`, which means that the children components can still overflow in the perpendicular direction (i.e. in a `Vertical Stack`, items might overflow horizontally and vice versa).
 
-## Stack Nesting
+### Stack Nesting
 
 `Stacks` can be nested inside one another in order to be able to configure the layout of the application as desired.

--- a/packages/office-ui-fabric-react/src/components/Text/docs/TextOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Text/docs/TextOverview.md
@@ -1,11 +1,5 @@
-Text is a component for displaying text.
-You can use Text to standardize text across your web app.
+Text is a component for displaying text. You can use Text to standardize text across your web app.
 
-You can specify the `variant` prop to apply font styles to Text.
-This variant pulls from the Fabric theme loaded on the page.
-If you do not specify the `variant` prop, by default, Text applies the styling from specifying the `variant` value to `medium`.
+You can specify the `variant` prop to apply font styles to Text. This variant pulls from the Fluent UI React theme loaded on the page. If you do not specify the `variant` prop, by default, Text applies the styling from specifying the `variant` value to `medium`.
 
-The Text control is inline wrap by default.
-You can specify `block` to enable block and `nowrap` to enable `nowrap`.
-In order for ellipsis on overflow to work properly, `block` should be set to true in addition to `nowrap`.
-Both of these props are false by default.
+The Text control is inline wrap by default. You can specify `block` to enable block and `nowrap` to enable `nowrap`. For ellipsis on overflow to work properly, `block` and `nowrap` should be manually set to `true`.

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -6,7 +6,7 @@ To use themes, an application must call `loadTheme()` immediately at app startup
 Here is an example:
 
 ```tsx
-import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
+import { loadTheme } from '@fluentui/react';
 
 loadTheme({
   palette: {
@@ -45,7 +45,7 @@ These can be used separately, or together, as shown in the example below.
 The overrides can include any property from [`IRawStyle`](#/controls/web/references/irawstyle).
 
 ```tsx
-import { loadTheme } from 'office-ui-fabric-react';
+import { loadTheme } from '@fluentui/react';
 
 loadTheme({
   defaultFontStyle: { fontFamily: 'Monaco, Menlo, Consolas', fontWeight: 'regular' },

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -366,7 +366,7 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
           &:focus {
             color: #0078d4;
           }
-      href="https://developer.microsoft.com/en-us/fabric#/styles/icons"
+      href="https://developer.microsoft.com/en-us/fluentui#/styles/icons"
       onClick={[Function]}
     >
       Icon documentation

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -374,7 +374,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       color: #323130;
                     }
                 data-is-focusable={true}
-                href="https://dev.office.com/fabric"
+                href="https://developer.microsoft.com/en-us/fluentui"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyPress={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -374,7 +374,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     color: #323130;
                   }
               data-is-focusable={true}
-              href="https://dev.office.com/fabric"
+              href="https://developer.microsoft.com/en-us/fluentui"
               onClick={[Function]}
               onKeyDown={[Function]}
               onKeyPress={[Function]}

--- a/packages/react-cards/README.md
+++ b/packages/react-cards/README.md
@@ -1,6 +1,7 @@
 # @uifabric/react-cards
 
-**Card components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Card components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 ## What are Card components?
 
@@ -15,18 +16,12 @@ A `Card` is a surface to display content and actions about a single topic. It ac
 - Borders
 - Colors
 
-This package is intended to contain different variants of `Card` components to be leveraged when building applications using UI Fabric.
+This package is intended to contain different variants of `Card` components to be leveraged when building applications using Fluent UI React.
 
 Please take note that, at the moment, these are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 
-To import ReactCards components:
+To import card components:
 
 ```js
 import { ComponentName } from '@uifabric/react-cards';
-```
-
-Once the ReactCards component graduates to a production release, the component will be available at:
-
-```js
-import { ComponentName } from 'office-ui-fabric-react';
 ```

--- a/packages/react-cards/src/components/Card/docs/CardDos.md
+++ b/packages/react-cards/src/components/Card/docs/CardDos.md
@@ -1,3 +1,3 @@
 - Make sure all the children of the Card component are of type CardItem or CardSection.
-- Take into account that CardItems are intended to hold only one child while making layout management easier (use it as you would use a [StackItem](https://developer.microsoft.com/en-us/fabric#/components/stack)).
-- Take into account that CardSections are intended to hold multiple children while making layout management easier (use it as you would use a [Stack](https://developer.microsoft.com/en-us/fabric#/components/stack)).
+- Take into account that CardItems are intended to hold only one child while making layout management easier (use it as you would use a [StackItem](https://developer.microsoft.com/en-us/fluentui#/components/stack)).
+- Take into account that CardSections are intended to hold multiple children while making layout management easier (use it as you would use a [Stack](https://developer.microsoft.com/en-us/fluentui#/components/stack)).

--- a/packages/react-cards/src/components/Card/docs/CardOverview.md
+++ b/packages/react-cards/src/components/Card/docs/CardOverview.md
@@ -2,4 +2,4 @@ A Card is a surface to display content and actions about a single topic. It acts
 
 A Card abstracts styling properties to utilize them in tandem with theme variables and provides some inherent styling in the way of a box-shadow on the container.
 
-**_Note:_** _This component is experimental and not yet importable from the `office-ui-fabric-react` package. Instead, import from the `@uifabric/react-cards` package._
+**_Note:_** _This component is experimental and not yet importable from the `@fluentui/react` package. Instead, import from the `@uifabric/react-cards` package._

--- a/packages/react-cards/src/demo/AppDefinition.tsx
+++ b/packages/react-cards/src/demo/AppDefinition.tsx
@@ -3,7 +3,7 @@ import { IAppDefinition } from '@uifabric/example-app-base';
 import { AppCustomizations } from './customizations';
 
 export const AppDefinition: IAppDefinition = {
-  appTitle: 'UI Fabric - Cards',
+  appTitle: 'Fluent UI React - Cards',
   customizations: AppCustomizations,
   testPages: [],
   examplePages: [

--- a/packages/react-cards/src/demo/AppDefinition.tsx
+++ b/packages/react-cards/src/demo/AppDefinition.tsx
@@ -25,7 +25,7 @@ export const AppDefinition: IAppDefinition = {
     },
     {
       name: 'Fabric',
-      url: 'https://dev.microsoft.com/fabric',
+      url: 'https://developer.microsoft.com/en-us/fluentui',
     },
     {
       name: 'GitHub',

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fluentui/react-compose",
   "version": "0.2.4",
-  "description": "UI Fabric React hooks.",
+  "description": "Fluent UI React component composition.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -1,8 +1,8 @@
 # @uifabric/react-hooks
 
-**UI Fabric React hooks**
+**[Fluent UI React](https://developer.microsoft.com/en-us/fluentui) hooks**
 
-Helpful hooks not provided by React itself.
+Helpful hooks not provided by React itself. These hooks were built for use in Fluent UI React ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) but can be used in React apps built with any UI library.
 
 - [useConst](#useconst) - Initialize and return a value that's always constant
 - [useConstCallback](#useconstcallback) - Like `useConst` but for functions

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/react-hooks",
   "version": "7.1.2",
-  "description": "UI Fabric React hooks.",
+  "description": "Fluent UI React hooks.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,4 @@
-# [Fluent UI React](https://dev.microsoft.com/fabric)
+# [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)
 
 **The React-based front-end framework for building experiences for Microsoft 365.**
 
@@ -6,6 +6,6 @@
 
 Fluent UI React is a collection of robust React-based components designed to make it simple for you to create consistent web experiences using the [Fluent Design System](https://www.microsoft.com/design/fluent/#/).
 
-For information about available controls, see the [Fluent UI website](https://dev.microsoft.com/fabric).
+For information about available controls, see the [Fluent UI website](https://developer.microsoft.com/en-us/fluentui).
 
 To get started using or contributing to Fluent UI, see the [full readme](https://github.com/microsoft/fluentui/blob/master/README.md).

--- a/packages/styling/README.md
+++ b/packages/styling/README.md
@@ -1,14 +1,15 @@
 # @uifabric/styling
 
-**Styling helpers for [Office UI Fabric](https://dev.microsoft.com/fabric)**
+**Styling helpers for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 ## Using the styling package
 
 Integrating components into your project depends heavily on your setup. The recommended setup is to use a bundler such as webpack which can resolve NPM package imports in your code and can bundle the specific things you import.
 
-If you're using `office-ui-fabric-react`, the `@uifabric/styling` package contents are re-exported under `office-ui-fabric-react/lib/Styling`. It's recommended to access styling this way rather than via a direct dependency.
+If you're using `@fluentui/react`, the `@uifabric/styling` package contents are re-exported under `@fluentui/react/lib/Styling` (for `office-ui-fabric-react`, use `office-ui-fabric-react/lib/Styling`). It's recommended to access styling this way rather than via a direct dependency.
 
-In a project which doesn't use `office-ui-fabric-react`, you can still install the styling package as a dependency:
+In a project which doesn't use `@fluentui/react` (or `office-ui-fabric-react`), you can still install the styling package as a dependency:
 
 ```bash
 npm install --save @uifabric/styling

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/styling",
   "version": "7.11.2",
-  "description": "Styling helpers for Office UI Fabric.",
+  "description": "Styling helpers for Fluent UI React.",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/packages/styling/src/interfaces/IFontStyles.ts
+++ b/packages/styling/src/interfaces/IFontStyles.ts
@@ -1,7 +1,7 @@
 import { IRawStyle } from '@uifabric/merge-styles';
 
 /**
- * UI Fabric font set.
+ * Fluent UI font set.
  * {@docCategory IFontStyles}
  */
 export interface IFontStyles {

--- a/packages/styling/src/interfaces/IPalette.ts
+++ b/packages/styling/src/interfaces/IPalette.ts
@@ -1,5 +1,5 @@
 /**
- * UI Fabric color palette.
+ * Fluent UI color palette.
  * {@docCategory IPalette}
  */
 export interface IPalette {

--- a/packages/test-utilities/README.md
+++ b/packages/test-utilities/README.md
@@ -1,6 +1,6 @@
 # @uifabric/test-utilities
 
-Provides a set of common test utilities for testing code within the UI Fabric repo.
+Provides a set of common test utilities for testing code within the Fluent UI React repo.
 
 ## API
 

--- a/packages/theme-samples/README.md
+++ b/packages/theme-samples/README.md
@@ -1,6 +1,7 @@
 # @uifabric/theme-samples
 
-**Theme samples package for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**Theme samples for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
 This is not a production-ready package and **should never be used in product**. This space is useful for serving as an example for theme definition and for testing new themes before finalizing them for use elsewhere.
 

--- a/packages/tsx-editor/README.md
+++ b/packages/tsx-editor/README.md
@@ -1,8 +1,8 @@
 # @uifabric/tsx-editor
 
-Monaco-based TypeScript+React live code editor with full typing support. It was primarily written for component examples on the [UI Fabric website](https://developer.microsoft.com/en-us/fabric#/controls/web), but it can be configured to work with other libraries too.
+Monaco-based TypeScript+React live code editor with full typing support. It was primarily written for component examples on the [Fluent UI React website](https://developer.microsoft.com/en-us/fluentui#/controls/web) ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)), but it can be configured to work with other libraries too.
 
-**WARNING:** The editor component's API is still **highly unstable**, so it **should not** be used outside the UI Fabric repo yet.
+**WARNING:** The editor component's API is still **highly unstable**, so it **should not** be used outside the Fluent UI React repo yet.
 
 ## Features
 
@@ -12,7 +12,7 @@ As the user edits TypeScript+React example code, it will be transpiled and rende
 
 ### Typings support
 
-By default, the editor will load types for React and UI Fabric. It can also be configured to load types for any package.
+By default, the editor will load types for React and Fluent UI React. It can also be configured to load types for any package.
 
 ### Delay loading
 

--- a/packages/tsx-editor/index.html
+++ b/packages/tsx-editor/index.html
@@ -4,7 +4,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
-    <title>UI Fabric React Examples</title>
+    <title>Fluent UI React Examples</title>
   </head>
 
   <body>

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -1,9 +1,8 @@
-# [Office UI Fabric React - utilities](https://dev.microsoft.com/fabric)
+# @uifabric/utilities
 
-**Utilities for Office UI Fabric React**
+**Utilities for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
 
-Fabric React is a responsive, mobile-first collection of robust components designed to make it quick and simple for you to create web experiences using the Office Design Language.
+This package includes a number of basic utility functions required by most Fluent UI React components.
 
-The `utilities` package includes a number of basic utility functions required by most Fabric components.
-
-See [Office UI Fabric React](https://github.com/microsoft/fluentui) for more details on the project and packages within.
+See [GitHub](https://github.com/microsoft/fluentui) for more details on the Fluent UI React project and packages within.

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/utilities",
   "version": "7.15.6",
-  "description": "Office UI Fabric utilities for building React components.",
+  "description": "Fluent UI React utilities for building components.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/variants/README.md
+++ b/packages/variants/README.md
@@ -1,6 +1,9 @@
-# [variants](https://dev.microsoft.com/fabric)
+# @uifabric/variants
 
-Variants are [themes](https://github.com/microsoft/fluentui/wiki/Theming) generated from an existing theme, as opposed to [from raw colors](https://developer.microsoft.com/en-us/fabric#/styles/themegenerator). A variant will share the same colors as the original theme it was generated from, but will use those colors differently. For example, the background color and text color might be swapped. Variants can be used to highlight or de-emphasize portions of the page.
+**Theme variant generator for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
+([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
+
+Variants are [themes](https://github.com/microsoft/fluentui/wiki/Theming) generated from an existing theme, as opposed to [from raw colors](https://developer.microsoft.com/en-us/fluentui#/styles/themegenerator). A variant will share the same colors as the original theme it was generated from, but will use those colors differently. For example, the background color and text color might be swapped. Variants can be used to highlight or de-emphasize portions of the page.
 
 Example of normal, soft, and strong variants:
 

--- a/packages/variants/package.json
+++ b/packages/variants/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/variants",
   "version": "7.1.41",
-  "description": "Office UI Fabric subtheme generator.",
+  "description": "Fluent UI React subtheme generator.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "sideEffects": [

--- a/packages/webpack-utils/README.md
+++ b/packages/webpack-utils/README.md
@@ -1,6 +1,6 @@
-# Office UI Fabric React - Webpack utilities
+# Fluent UI React - Webpack utilities
 
-This package contains different utilities for optimizing the use of Office UI Fabric React for the [Webpack](https://webpack.js.org) bundler.
+This package contains utilities for optimizing the use of Fluent UI React ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) for the [Webpack](https://webpack.js.org) bundler.
 
 ## Installation
 
@@ -14,7 +14,7 @@ or
 
 ## Fabric Async Loader
 
-This is a Webpack loader that will automatically perform code splitting with no code changes needed on the Fabric or the application side. It accomplishes this through the Webpack loader mechanism filtered through the `include` property. To use this, modify your `webpack.config.js` like so:
+This is a Webpack loader that will automatically perform code splitting with no code changes needed on the library or application side. It accomplishes this through the Webpack loader mechanism filtered through the `include` property. To use this, modify your `webpack.config.js` like so:
 
 ```js
 module.exports = {
@@ -34,7 +34,7 @@ module.exports = {
 };
 ```
 
-## Loader Options (Webpack 4 only)
+### Loader Options (Webpack 4 only)
 
 - `chunkName`: the generated file name will be based on this setting
 - `prefetch`: translates to the webpackPrefetch magic comment
@@ -45,4 +45,4 @@ module.exports = {
 Thanks to:
 
 - [react-loadable](https://github.com/jamiebuilds/react-loadable) by @jamiebuilds who created a delay loaded component
-- [react-loadable-loader](https://github.com/baflo/react-loadable-loader) by @baflo who inspired this project; Fabric modified that implementation to work with non-default exports
+- [react-loadable-loader](https://github.com/baflo/react-loadable-loader) by @baflo who inspired this project; we modified that implementation to work with non-default exports

--- a/packages/webpack-utils/package.json
+++ b/packages/webpack-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uifabric/webpack-utils",
   "version": "7.0.11",
-  "description": "Office UI Fabric utilities for Webpack bundler.",
+  "description": "Fluent UI React utilities for Webpack bundler.",
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/fluentui"

--- a/scripts/beachball/customRenderers.ts
+++ b/scripts/beachball/customRenderers.ts
@@ -4,7 +4,7 @@ import { PackageChangelogRenderInfo, ChangelogEntry } from 'beachball';
 import { getPullRequestForCommit, fluentRepoDetails } from '../github';
 
 const githubPAT = process.env.GITHUB_PAT;
-if (!githubPAT) {
+if (!githubPAT && (process.argv.includes('bump') || process.argv.includes('publish'))) {
   console.warn('\nGITHUB_PAT environment variable not found. GitHub requests may be rate-limited.\n');
 }
 

--- a/scripts/templates/create-package/EmptyReadme.mustache
+++ b/scripts/templates/create-package/EmptyReadme.mustache
@@ -1,6 +1,6 @@
 # {{{packageNpmName}}}
 
-**{{{friendlyPackageName}}} components for [Office UI Fabric React](https://dev.microsoft.com/fabric)**
+**{{{friendlyPackageName}}} components for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 
 These are not production-ready components and **should never be used in product**. This space is useful for testing new components whose APIs might change before final release.
 

--- a/scripts/typescript-compatibility-build.yml
+++ b/scripts/typescript-compatibility-build.yml
@@ -121,7 +121,7 @@ jobs:
         displayName: Install $(PackageName) in TypeScript $(TypeScriptVersion) test app
         workingDirectory: $(Build.StagingDirectory)/__tests__/tests/$(TypeScriptVersion)
 
-      # Build sample app consuming Office UI Fabric React to test TypeScript version compatibility
+      # Build sample app consuming Fluent UI React to test TypeScript version compatibility
       - script: |
           node common/scripts/install-run-rush.js test --to $(TypeScriptVersion)-office-ui-fabric-react-test
         displayName: Build TypeScript $(TypeScriptVersion) test app

--- a/scripts/use-yarn-please.js
+++ b/scripts/use-yarn-please.js
@@ -9,7 +9,7 @@ const Strings = {
 `,
   installYarn: `You currently do not have an installation of Yarn in your PATH. Please install the latest stable version of Yarn following the instructions at https://yarnpkg.com/en/docs/install or by running "npm install -g yarn".
 `,
-  gettingStartedWithYarn: `To install UI Fabric monorepo dependencies and establish links between projects, simply run:
+  gettingStartedWithYarn: `To install Fluent UI monorepo dependencies and establish links between projects, simply run:
 
   yarn
 
@@ -17,7 +17,7 @@ You can then build the packages:
 
   yarn build
 
-Or start a development inner loop against the UI Fabric demo:
+Or start a development inner loop against the Fluent UI React demo:
 
   yarn builddemo && yarn start
 

--- a/specs/Menu.md
+++ b/specs/Menu.md
@@ -429,7 +429,7 @@ Note: Class names removed
 </ul>
 ```
 
-### Office-ui-fabric-react DOM Structure
+### office-ui-fabric-react DOM Structure
 
 _Note:_ Some long class names removed
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Even more Fabric=>Fluent updates (outside the website):
- "Office UI Fabric React" and variants to "Fluent UI React" almost everywhere, with a note in each readme "(formerly Office UI Fabric React)" linking to the blog post
- "Office" and "Office 365" to "Microsoft 365"
- `developer.microsoft.com/fabric` (and variants) to `developer.microsoft.com/en-us/fluentui`
- Update example code in readmes to import from `@fluentui/react`

Extra updates in certain packages:
- `office-ui-fabric-react`: add note about the rename, link to blog post, and instructions for migrating
- `example-app-base`: add note that the components are deprecated and we recommend Storybook instead
- `experiments`, `react-cards`: remove details about experimental component graduation since the plan for that may change
- `file-type-icons`: remove section about how to use the fluent file type icons which is presumably irrelevant now

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12508)