### PR TITLE
ChoiceGroup: fix bad cache key for getClassNames

### DIFF
--- a/apps/perf-test/src/scenarios/ChoiceGroup.tsx
+++ b/apps/perf-test/src/scenarios/ChoiceGroup.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+
+const options: IChoiceGroupOption[] = [
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C', disabled: true },
+  { key: 'D', text: 'Option D' },
+];
+
+const scenario = <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" required={true} />;
+
+export default scenario;

--- a/change/office-ui-fabric-react-2020-04-01-20-34-11-xgao-choice-group-style-perf.json
+++ b/change/office-ui-fabric-react-2020-04-01-20-34-11-xgao-choice-group-style-perf.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup: fix bad cache key for getClassNames",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "5a23152f3833f500d07e2a6c75080837ac76643e",
+  "dependentChangeType": "patch",
+  "date": "2020-04-02T03:34:11.680Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -12,10 +12,16 @@ import { composeRenderFunction } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>();
 
+const LARGE_IMAGE_SIZE = 71;
+
 /**
  * {@docCategory ChoiceGroup}
  */
-export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionProps, any> {
+export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionProps, {}> {
+  public static defaultProps: Partial<IChoiceGroupOptionProps> = {
+    imageSize: { width: 32, height: 32 },
+  };
+
   private _classNames: IProcessedStyleSet<IChoiceGroupOptionStyles>;
 
   constructor(props: IChoiceGroupOptionProps) {
@@ -31,7 +37,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       theme,
       iconProps,
       imageSrc,
-      imageSize = { width: 32, height: 32 },
+      imageSize,
       disabled,
       // tslint:disable-next-line:deprecation
       checked,
@@ -48,7 +54,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       hasImage: !!imageSrc,
       checked,
       disabled,
-      imageIsLarge: !!imageSrc && (imageSize.width > 71 || imageSize.height > 71),
+      imageIsLarge: !!imageSrc && (imageSize!.width > LARGE_IMAGE_SIZE || imageSize!.height > LARGE_IMAGE_SIZE),
       imageSize,
       focused,
     });

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -55,7 +55,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       checked,
       disabled,
       imageIsLarge: !!imageSrc && (imageSize!.width > LARGE_IMAGE_SIZE || imageSize!.height > LARGE_IMAGE_SIZE),
-      imageSize,
+      imageSize, // avoid unnecessary mutation for better style caching
       focused,
     });
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -19,6 +19,7 @@ const LARGE_IMAGE_SIZE = 71;
  */
 export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionProps, {}> {
   public static defaultProps: Partial<IChoiceGroupOptionProps> = {
+    // This ensures default imageSize value doesn't mutate. Mutation can cause style re-calcuation.
     imageSize: { width: 32, height: 32 },
   };
 
@@ -55,7 +56,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       checked,
       disabled,
       imageIsLarge: !!imageSrc && (imageSize!.width > LARGE_IMAGE_SIZE || imageSize!.height > LARGE_IMAGE_SIZE),
-      imageSize, // avoid unnecessary mutation for better style caching
+      imageSize,
       focused,
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
When `imageSize` is not defined, we create a new default prop object for it on every render.
That leads to we re-calculate styles on every render

#### Focus areas to test
Added a perf test for `ChoiceGroup`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12509)