### PR TITLE
docs(Tooltip): add a visual test for pointers

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Tooltip/Visual/TooltipExamplePointerMargin.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Visual/TooltipExamplePointerMargin.shorthand.tsx
@@ -1,0 +1,105 @@
+import * as React from 'react';
+import { Box, Grid, Tooltip } from '@fluentui/react-northstar';
+
+const TooltipExamplePointerMargin = () => (
+  <Grid columns={1} styles={{ margin: '200px', gridGap: '100px' }}>
+    <Tooltip
+      align="start"
+      content="Sample tooltip"
+      open
+      pointing
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="center"
+      content="Sample tooltip"
+      open
+      pointing
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="end"
+      content="Sample tooltip"
+      open
+      pointing
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+
+    <Tooltip
+      align="start"
+      content="Sample tooltip"
+      open
+      pointing
+      position="below"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="center"
+      content="Sample tooltip"
+      open
+      pointing
+      position="below"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="end"
+      content="Sample tooltip"
+      open
+      pointing
+      position="below"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+
+    <Tooltip
+      align="top"
+      content="Sample tooltip"
+      open
+      pointing
+      position="before"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="center"
+      content="Sample tooltip"
+      open
+      pointing
+      position="before"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="bottom"
+      content="Sample tooltip"
+      open
+      pointing
+      position="before"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+
+    <Tooltip
+      align="top"
+      content="Sample tooltip"
+      open
+      pointing
+      position="after"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="center"
+      content="Sample tooltip"
+      open
+      pointing
+      position="after"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+    <Tooltip
+      align="bottom"
+      content="Sample tooltip"
+      open
+      pointing
+      position="after"
+      trigger={<Box styles={{ border: '2px solid green' }}>X</Box>}
+    />
+  </Grid>
+);
+
+export default TooltipExamplePointerMargin;

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Visual/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Visual/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
+import NonPublicSection from 'docs/src/components/ComponentDoc/NonPublicSection';
+
+const Variations = () => (
+  <NonPublicSection title="Visual tests">
+    <ComponentExample examplePath="components/Tooltip/Visual/TooltipExamplePointerMargin" />
+  </NonPublicSection>
+);
+
+export default Variations;

--- a/packages/fluentui/docs/src/examples/components/Tooltip/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/index.tsx
@@ -5,6 +5,7 @@ import Types from './Types';
 import Variations from './Variations';
 import States from './States';
 import Usage from './Usage';
+import Visual from './Visual';
 
 const TooltipExamples = () => (
   <>
@@ -13,6 +14,7 @@ const TooltipExamples = () => (
     <States />
     <Rtl />
     <Usage />
+    <Visual />
   </>
 );
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds a similar visual test to that we have already for `Popup`. Is needed as `Tooltip` has an SVG pointer instead of CSS one.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12512)