### PR TITLE
chore(Popup|Tooltip): refactor styles for pointers

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - removed `SplitButton.slotClassNames` and introduced new `SplitButtonToggle` component @mnajdova ([#12432](https://github.com/microsoft/fluentui/pull/12432))
 - replaced `paddleNext` and `paddlePrevious` to be `ShorthandValue<CarouselPaddleProps>` instead of `ShorthandValue<ButtonProps>` @mnajdova ([#12434](https://github.com/microsoft/fluentui/pull/12434))
 - Restricted prop set in the `PopupContent` component which is passed to styles functions @layershifter ([#12513](https://github.com/microsoft/fluentui/pull/12513))
+- `pointerSize` was replaced with `pointerHeight` & `pointerWidth` in `PopupContentVariables` @layershifter ([#12514](https://github.com/microsoft/fluentui/pull/12514))
+- Values of `pointerWidth` & `pointerHeight` were inverted in `TooltipContentVariables` @layershifter ([#12514](https://github.com/microsoft/fluentui/pull/12514))
+- `pointerHorizontalOffset` & `pointerVerticalOffset` are removed `TooltipContentVariables` @layershifter ([#12514](https://github.com/microsoft/fluentui/pull/12514))
 
 ### Fixes
 - Fix default focused input outline in Safari @sheff146 ([#12279](https://github.com/microsoft/fluentui/pull/12279))

--- a/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
@@ -35,7 +35,7 @@ import {
   commonPropTypes,
   rtlTextContainer,
 } from '../../utils';
-import { PopperChildrenProps } from '../../utils/positioner';
+import { getBasePlacement, PopperChildrenProps } from '../../utils/positioner';
 
 export interface PopupContentSlotClassNames {
   content: string;
@@ -75,7 +75,9 @@ export interface PopupContentProps extends UIComponentProps, ChildrenComponentPr
   autoFocus?: boolean | AutoFocusZoneProps;
 }
 
-export type PopupContentStylesProps = Required<Pick<PopupContentProps, 'placement' | 'pointing'>>;
+export type PopupContentStylesProps = Required<Pick<PopupContentProps, 'pointing'>> & {
+  basePlacement: Popper.Position;
+};
 
 const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
   FluentComponentStaticProps<PopupContentProps> & { slotClassNames: PopupContentSlotClassNames } = props => {
@@ -105,8 +107,8 @@ const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
   const { classes } = useStyles<PopupContentStylesProps>(PopupContent.displayName, {
     className: PopupContent.className,
     mapPropsToStyles: () => ({
+      basePlacement: getBasePlacement(placement, context.rtl),
       pointing,
-      placement,
     }),
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
     rtl: context.rtl,

--- a/packages/fluentui/react-northstar/src/components/Tooltip/TooltipContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tooltip/TooltipContent.tsx
@@ -17,7 +17,7 @@ import {
   rtlTextContainer,
 } from '../../utils';
 
-import { PopperChildrenProps } from '../../utils/positioner';
+import { getBasePlacement, PopperChildrenProps } from '../../utils/positioner';
 import { FluentComponentStaticProps, ProviderContextPrepared, WithAsProp, withSafeTypeForAs } from '../../types';
 
 export interface TooltipContentProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -38,6 +38,10 @@ export interface TooltipContentProps extends UIComponentProps, ChildrenComponent
   /** A ref to a pointer element. */
   pointerRef?: React.Ref<HTMLDivElement>;
 }
+
+export type TooltipContentStylesProps = Required<Pick<TooltipContentProps, 'pointing' | 'open'>> & {
+  basePlacement: Popper.Position;
+};
 
 const TooltipContent: React.FC<WithAsProp<TooltipContentProps>> &
   FluentComponentStaticProps<TooltipContentProps> = props => {
@@ -63,11 +67,11 @@ const TooltipContent: React.FC<WithAsProp<TooltipContentProps>> &
     debugName: TooltipContent.displayName,
     rtl: context.rtl,
   });
-  const { classes } = useStyles(TooltipContent.displayName, {
+  const { classes } = useStyles<TooltipContentStylesProps>(TooltipContent.displayName, {
     className: TooltipContent.className,
     mapPropsToStyles: () => ({
+      basePlacement: getBasePlacement(placement, context.rtl),
       open,
-      placement,
       pointing,
     }),
     mapPropsToInlineStyles: () => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/MenuButton/menuButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/MenuButton/menuButtonStyles.ts
@@ -9,9 +9,9 @@ const menuButtonStyles: ComponentSlotStylesPrepared<MenuButtonProps> = {
   }),
   popupContent: () => ({
     [`& .${PopupContent.slotClassNames.content}`]: {
+      borderWidth: '0px',
       padding: '0px',
     },
-    borderWidth: '0px',
   }),
 };
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentStyles.ts
@@ -1,44 +1,44 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+
 import { PopupContentStylesProps } from '../../../../components/Popup/PopupContent';
 import { PopupContentVariables } from './popupContentVariables';
-import getPointerStyles from '../../getPointerStyles';
-import initialPopperStyles from '../../../../utils/positioner/initialStyles';
+import { getContainerStyles, getPointerStyles } from '../../getPointerStyles';
 
 const popupContentStyles: ComponentSlotStylesPrepared<PopupContentStylesProps, PopupContentVariables> = {
-  root: ({ props: p, variables: v, rtl }): ICSSInJSStyle => ({
-    border: `${v.borderSize} solid ${v.borderColor}`,
-    borderRadius: v.borderRadius,
+  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    display: 'block',
+    zIndex: v.zIndex,
 
+    ...getContainerStyles({
+      placement: p.basePlacement,
+      margin: v.pointerMargin,
+    }),
+  }),
+
+  pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle =>
+    getPointerStyles({
+      backgroundColor: v.backgroundColor,
+      borderColor: v.borderColor,
+      borderSize: v.borderSize,
+      gap: v.pointerGap,
+      height: v.pointerHeight,
+      width: v.pointerWidth,
+
+      placement: p.basePlacement,
+      rtl,
+    }),
+
+  content: ({ variables: v }): ICSSInJSStyle => ({
+    display: 'block',
     background: v.backgroundColor,
     color: v.color,
     boxShadow: v.boxShadow,
 
-    display: 'block',
-    textAlign: 'left',
-    zIndex: v.zIndex,
+    border: `${v.borderSize} solid ${v.borderColor}`,
+    borderRadius: v.borderRadius,
 
-    ...(initialPopperStyles as ICSSInJSStyle),
-
-    ...(p.pointing && getPointerStyles(v.pointerOffset, v.pointerGap, v.pointerMargin, rtl, p.placement).root),
-  }),
-
-  pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle => ({
-    display: 'block',
-    position: 'absolute',
-
-    backgroundColor: 'inherit',
-    borderBottom: `${v.borderSize} solid ${v.borderColor}`,
-    borderRight: `${v.borderSize} solid ${v.borderColor}`,
-
-    height: v.pointerSize,
-    width: v.pointerSize,
-
-    ...getPointerStyles(v.pointerOffset, v.pointerGap, v.pointerMargin, rtl, p.placement).pointer,
-  }),
-
-  content: ({ variables: v }): ICSSInJSStyle => ({
-    display: 'block',
     padding: v.padding,
+    transform: 'rotate(360deg)',
   }),
 };
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentStyles.ts
@@ -9,10 +9,11 @@ const popupContentStyles: ComponentSlotStylesPrepared<PopupContentStylesProps, P
     display: 'block',
     zIndex: v.zIndex,
 
-    ...getContainerStyles({
-      placement: p.basePlacement,
-      margin: v.pointerMargin,
-    }),
+    ...(p.pointing &&
+      getContainerStyles({
+        placement: p.basePlacement,
+        margin: v.pointerMargin,
+      })),
   }),
 
   pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle =>

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Popup/popupContentVariables.ts
@@ -14,7 +14,8 @@ export interface PopupContentVariables {
   pointerMargin: string;
   pointerGap: string;
   pointerOffset: string;
-  pointerSize: string;
+  pointerHeight: string;
+  pointerWidth: string;
 
   zIndex: number;
 }
@@ -34,7 +35,8 @@ export default (siteVars: any): PopupContentVariables => {
     pointerOffset: pxToRem(5),
     pointerGap: pxToRem(5),
     pointerMargin: pxToRem(10),
-    pointerSize: pxToRem(10),
+    pointerHeight: pxToRem(5),
+    pointerWidth: pxToRem(10),
 
     zIndex: siteVars.zIndexes.overlay,
   };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentStyles.ts
@@ -1,76 +1,54 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { TooltipContentProps } from '../../../../components/Tooltip/TooltipContent';
+import { TooltipContentStylesProps } from '../../../../components/Tooltip/TooltipContent';
 import { TooltipContentVariables } from './tooltipContentVariables';
-import getPointerStyles from '../../getPointerStyles';
+import { getContainerStyles, getPointerStyles } from '../../getPointerStyles';
 import pointerSvg from '../../pointerSvgUrl';
-import { PopperChildrenProps } from '../../../../utils/positioner';
-
-type TooltipContentStylesProps = Pick<TooltipContentProps, 'placement' | 'pointing' | 'open'>;
-
-const getPointerOffset = (placement: PopperChildrenProps['placement'], v: TooltipContentVariables) =>
-  placement === 'top-start' ||
-  placement === 'top' ||
-  placement === 'top-end' ||
-  placement === 'bottom-end' ||
-  placement === 'bottom' ||
-  placement === 'bottom-start'
-    ? v.pointerVerticalOffset
-    : v.pointerHorizontalOffset;
 
 const tooltipContentStyles: ComponentSlotStylesPrepared<TooltipContentStylesProps, TooltipContentVariables> = {
-  root: ({ props: p, variables: v, rtl }): ICSSInJSStyle => {
-    const svgPointerStyles = getPointerStyles(
-      getPointerOffset(p.placement, v),
-      v.pointerGap,
-      v.pointerMargin,
-      rtl,
-      p.placement,
-      true,
-    );
+  root: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    display: 'block',
+    position: 'absolute',
 
-    return {
-      borderRadius: v.borderRadius,
-      display: 'block',
-      maxWidth: v.maxWidth,
-      color: v.color,
-      background: v.backgroundColor,
+    maxWidth: v.maxWidth,
+    zIndex: v.zIndex,
 
-      zIndex: v.zIndex,
-      position: 'absolute',
-      textAlign: 'left',
+    ...(p.pointing &&
+      getContainerStyles({
+        placement: p.basePlacement,
+        margin: v.pointerMargin,
+      })),
 
-      ...(p.pointing && svgPointerStyles.root),
+    ...(!p.open && {
+      opacity: 0,
+    }),
+  }),
+  pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle => ({
+    display: 'block',
+    position: 'absolute',
+    width: v.pointerWidth,
+    height: v.pointerHeight,
 
-      ...(!p.open && {
-        opacity: 0,
-      }),
-    };
-  },
-  pointer: ({ props: p, variables: v, rtl }): ICSSInJSStyle => {
-    const svgPointerStyles = getPointerStyles(
-      getPointerOffset(p.placement, v),
-      v.pointerGap,
-      v.pointerMargin,
-      rtl,
-      p.placement,
-      true,
-    );
-
-    return {
-      display: 'block',
-      position: 'absolute',
-      overflow: 'hidden',
-      width: v.pointerWidth,
+    ...getPointerStyles({
+      backgroundColor: v.backgroundColor,
+      borderSize: v.borderSize,
+      borderColor: 'transparent',
+      gap: v.pointerGap,
       height: v.pointerHeight,
-      backgroundImage: pointerSvg(v.backgroundColor),
-      ...svgPointerStyles.pointer,
-    };
-  },
+      width: v.pointerWidth,
+
+      placement: p.basePlacement,
+      rtl,
+      svg: pointerSvg(v.backgroundColor),
+    }),
+  }),
   content: ({ variables: v }): ICSSInJSStyle => ({
     display: 'block',
     padding: v.padding,
+    textAlign: 'left',
 
-    borderRadius: 'inherit',
+    color: v.color,
+    background: v.backgroundColor,
+    borderRadius: v.borderRadius,
     boxShadow: v.boxShadow,
   }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -11,8 +11,6 @@ export interface TooltipContentVariables {
 
   pointerMargin: string;
   pointerGap: string;
-  pointerHorizontalOffset: string;
-  pointerVerticalOffset: string;
   pointerWidth: string;
   pointerHeight: string;
 
@@ -31,12 +29,10 @@ export default (siteVars: any): TooltipContentVariables => ({
 
   maxWidth: pxToRem(246),
 
-  pointerVerticalOffset: pxToRem(10),
-  pointerHorizontalOffset: pxToRem(5),
   pointerMargin: pxToRem(6),
   pointerGap: pxToRem(5),
-  pointerWidth: pxToRem(6),
-  pointerHeight: pxToRem(16),
+  pointerWidth: pxToRem(16),
+  pointerHeight: pxToRem(6),
   color: siteVars.colorScheme.default.foreground3,
   backgroundColor: siteVars.colors.grey[500],
 

--- a/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
@@ -85,7 +85,7 @@ export const getPointerStyles = (options: GetPointerStylesOptions): ICSSInJSStyl
     '::before': {
       content: '" "',
       display: 'block',
-      height: height,
+      height,
       position: 'relative',
       transformOrigin: 'center top',
 

--- a/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
@@ -24,17 +24,18 @@ export const getContainerStyles = (options: GetContainerStylesOptions): ICSSInJS
   const { placement, margin } = options;
 
   return {
+    // TODO: Popper v2, replace margins with paddings
     ...(placement === 'bottom' && {
-      paddingTop: margin,
+      marginTop: margin,
     }),
     ...(placement === 'top' && {
-      paddingBottom: margin,
+      marginBottom: margin,
     }),
     ...(placement === 'left' && {
-      paddingRight: margin,
+      marginRight: margin,
     }),
     ...(placement === 'right' && {
-      paddingLeft: margin,
+      marginLeft: margin,
     }),
   };
 };
@@ -63,17 +64,22 @@ export const getPointerStyles = (options: GetPointerStylesOptions): ICSSInJSStyl
     }),
 
     ...(placement === 'bottom' && {
-      top: `calc(${height} + (${borderSize} * 2))`,
+      // TODO: use in Popper v2
+      // top: `calc(${height} + (${borderSize} * 2))`,
+      top: `calc((${height} * -1) + (${borderSize} * 2))`,
     }),
     ...(placement === 'top' && {
-      bottom: `calc(${height} + ${borderSize})`,
+      // bottom: `calc(${height} + ${borderSize})`,
+      bottom: `calc((${height} * -1) + ${borderSize})`,
     }),
 
     ...(placement === 'left' && {
-      right: `calc(${height} + ${borderSize})`,
+      // right: `calc(${height} + ${borderSize})`,
+      right: `calc((${height} * -1) + (${borderSize} * 2))`,
     }),
     ...(placement === 'right' && {
-      left: `calc(${height} + ${borderSize})`,
+      // left: `calc(${height} + ${borderSize})`,
+      left: `calc((${height} * -1) + (${borderSize} * 2))`,
     }),
 
     '::before': {
@@ -171,7 +177,9 @@ export const getPointerStyles = (options: GetPointerStylesOptions): ICSSInJSStyl
           width: height,
 
           left: gap,
-          bottom: `calc(${width} + ${borderSize})`,
+          // TODO: use in Popper v2
+          // bottom: `calc(${width} + ${borderSize})`,
+          bottom: `calc((${gap} * 2) + ${borderSize})`,
           transform: `rotate(${rtl ? -90 : 90}deg)`,
         }),
         ...(placement === 'top' && {
@@ -179,21 +187,24 @@ export const getPointerStyles = (options: GetPointerStylesOptions): ICSSInJSStyl
           width: height,
 
           left: gap,
-          bottom: `calc(${gap} - ${borderSize})`,
+          // bottom: `calc(${gap} - ${borderSize})`,
+          bottom: `calc(${gap} * 2)`,
           transform: `rotate(${rtl ? 90 : -90}deg)`,
         }),
         ...(placement === 'left' && {
           height: width,
           width: height,
 
-          left: height,
+          // left: height,
+          left: borderSize,
           transform: `rotate(${rtl ? 0 : 180}deg)`,
         }),
         ...(placement === 'right' && {
           height: width,
           width: height,
 
-          right: height,
+          // right: height,
+          right: borderSize,
           transform: `rotate(${rtl ? 180 : 0}deg)`,
         }),
       },

--- a/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/getPointerStyles.ts
@@ -1,69 +1,203 @@
 import { ICSSInJSStyle } from '@fluentui/styles';
 import Popper from 'popper.js';
 
-import { PopperChildrenProps } from '../../utils/positioner';
-
-const rtlMapping = {
-  left: 'right',
-  right: 'left',
+type GetContainerStylesOptions = {
+  placement: Popper.Position;
+  margin: string;
 };
 
-const getPointerStyles = (
-  pointerOffset: string,
-  pointerGap: string,
-  pointerMargin: string,
-  rtl: boolean,
-  popperPlacement?: PopperChildrenProps['placement'],
-  isSvg?: boolean,
-) => {
-  const placementValue = (popperPlacement || '').split('-', 1).pop();
-  const placement = (rtl && rtlMapping[placementValue]) || placementValue;
+type GetPointerStylesOptions = {
+  backgroundColor: string;
+  borderColor: string;
+  borderSize: string;
 
-  const rootStyles: Record<Popper.Position, ICSSInJSStyle> = {
-    top: {
-      marginBottom: pointerMargin,
-    },
-    right: {
-      marginLeft: pointerMargin,
-    },
-    bottom: {
-      marginTop: pointerMargin,
-    },
-    left: {
-      marginRight: pointerMargin,
-    },
-  };
-  const pointerStyles: Record<Popper.Position, ICSSInJSStyle> = {
-    top: {
-      bottom: `-${pointerOffset}`,
-      marginLeft: pointerGap,
-      marginRight: pointerGap,
-      transform: isSvg ? `rotate(${rtl ? 90 : -90}deg)` : 'rotate(45deg)',
-    },
-    right: {
-      left: `-${pointerOffset}`,
-      marginBottom: pointerGap,
-      marginTop: pointerGap,
-      transform: isSvg ? `rotate(${rtl ? 180 : 0}deg)` : 'rotate(135deg)',
-    },
-    bottom: {
-      top: `-${pointerOffset}`,
-      marginLeft: pointerGap,
-      marginRight: pointerGap,
-      transform: isSvg ? `rotate(${rtl ? -90 : 90}deg)` : 'rotate(-135deg)',
-    },
-    left: {
-      right: `-${pointerOffset}`,
-      marginBottom: pointerGap,
-      marginTop: pointerGap,
-      transform: isSvg ? `rotate(${rtl ? 0 : 180}deg)` : 'rotate(-45deg)',
-    },
-  };
+  gap: string;
+  height: string;
+  width: string;
+
+  placement: Popper.Position;
+  rtl: boolean;
+  svg?: string;
+};
+
+export const getContainerStyles = (options: GetContainerStylesOptions): ICSSInJSStyle => {
+  const { placement, margin } = options;
 
   return {
-    root: rootStyles[placement],
-    pointer: pointerStyles[placement],
+    ...(placement === 'bottom' && {
+      paddingTop: margin,
+    }),
+    ...(placement === 'top' && {
+      paddingBottom: margin,
+    }),
+    ...(placement === 'left' && {
+      paddingRight: margin,
+    }),
+    ...(placement === 'right' && {
+      paddingLeft: margin,
+    }),
   };
 };
 
-export default getPointerStyles;
+export const getPointerStyles = (options: GetPointerStylesOptions): ICSSInJSStyle => {
+  const { backgroundColor, borderColor, borderSize, gap, height, placement, rtl, svg, width } = options;
+
+  return {
+    display: 'block',
+    position: 'absolute',
+    zIndex: 1,
+
+    ...((placement === 'bottom' || placement === 'top') && {
+      paddingLeft: gap,
+      paddingRight: gap,
+
+      height,
+      width: `calc(${width} + (${gap} * 2))`,
+    }),
+    ...((placement === 'left' || placement === 'right') && {
+      paddingBottom: gap,
+      paddingTop: gap,
+
+      height: `calc(${width} + (${gap} * 2))`,
+      width: height,
+    }),
+
+    ...(placement === 'bottom' && {
+      top: `calc(${height} + (${borderSize} * 2))`,
+    }),
+    ...(placement === 'top' && {
+      bottom: `calc(${height} + ${borderSize})`,
+    }),
+
+    ...(placement === 'left' && {
+      right: `calc(${height} + ${borderSize})`,
+    }),
+    ...(placement === 'right' && {
+      left: `calc(${height} + ${borderSize})`,
+    }),
+
+    '::before': {
+      content: '" "',
+      display: 'block',
+      height: height,
+      position: 'relative',
+      transformOrigin: 'center top',
+
+      borderBottomColor: 'transparent',
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+      borderTopColor: 'transparent',
+      borderStyle: 'solid',
+
+      left: 0,
+      top: 0,
+
+      ...(placement === 'bottom' && {
+        borderBottomColor: backgroundColor,
+        borderWidth: `0 ${height} ${height}`,
+      }),
+      ...(placement === 'top' && {
+        borderTopColor: backgroundColor,
+        borderWidth: `${height} ${height} 0`,
+
+        top: `calc(${borderSize} * -1)`,
+      }),
+      ...(placement === 'left' && {
+        borderLeftColor: backgroundColor,
+        borderWidth: `${height} 0 ${height} ${height}`,
+      }),
+      ...(placement === 'right' && {
+        borderRightColor: backgroundColor,
+        borderWidth: `${height} ${height} ${height} 0`,
+      }),
+    },
+
+    '::after': {
+      content: '" "',
+      display: 'block',
+      height,
+      position: 'relative',
+      transformOrigin: 'center top',
+      zIndex: -1,
+
+      borderBottomColor: 'transparent',
+      borderLeftColor: 'transparent',
+      borderRightColor: 'transparent',
+      borderTopColor: 'transparent',
+      borderStyle: 'solid',
+
+      ...(placement === 'bottom' && {
+        borderBottomColor: borderColor,
+        borderWidth: `0 ${height} ${height}`,
+
+        left: 0,
+        bottom: `calc(${height} + 1px)`,
+      }),
+      ...(placement === 'top' && {
+        borderTopColor: borderColor,
+        borderWidth: `${height} ${height} 0`,
+
+        left: 0,
+        bottom: height,
+      }),
+      ...(placement === 'left' && {
+        borderLeftColor: borderColor,
+        borderWidth: `${height} 0 ${height} ${height}`,
+
+        left: borderSize,
+        bottom: width,
+      }),
+      ...(placement === 'right' && {
+        borderRightColor: borderColor,
+        borderWidth: `${height} ${height} ${height} 0`,
+
+        right: borderSize,
+        bottom: width,
+      }),
+    },
+
+    // :before & :after are used to draw CSS triangles, not valid for SVG
+    ...(svg && {
+      '::before': {
+        content: '" "',
+        backgroundImage: svg,
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center',
+        display: 'block',
+        position: 'relative',
+
+        ...(placement === 'bottom' && {
+          height: `calc(${width} + (${gap} * 2))`,
+          width: height,
+
+          left: gap,
+          bottom: `calc(${width} + ${borderSize})`,
+          transform: `rotate(${rtl ? -90 : 90}deg)`,
+        }),
+        ...(placement === 'top' && {
+          height: `calc(${width} + (${gap} * 2))`,
+          width: height,
+
+          left: gap,
+          bottom: `calc(${gap} - ${borderSize})`,
+          transform: `rotate(${rtl ? 90 : -90}deg)`,
+        }),
+        ...(placement === 'left' && {
+          height: width,
+          width: height,
+
+          left: height,
+          transform: `rotate(${rtl ? 0 : 180}deg)`,
+        }),
+        ...(placement === 'right' && {
+          height: width,
+          width: height,
+
+          right: height,
+          transform: `rotate(${rtl ? 180 : 0}deg)`,
+        }),
+      },
+      '::after': undefined,
+    }),
+  };
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -63,7 +63,7 @@ import { ToolbarMenuRadioGroupStylesProps } from '../../components/Toolbar/Toolb
 import { ToolbarMenuStylesProps } from '../../components/Toolbar/ToolbarMenu';
 import { ToolbarProps } from '../../components/Toolbar/Toolbar';
 import { ToolbarRadioGroupProps } from '../../components/Toolbar/ToolbarRadioGroup';
-import { TooltipContentProps } from '../../components/Tooltip/TooltipContent';
+import { TooltipContentStylesProps } from '../../components/Tooltip/TooltipContent';
 import { HierarchicalTreeItemProps } from '../../components/HierarchicalTree/HierarchicalTreeItem';
 import { HierarchicalTreeProps } from '../../components/HierarchicalTree/HierarchicalTree';
 import { HierarchicalTreeTitleProps } from '../../components/HierarchicalTree/HierarchicalTreeTitle';
@@ -136,7 +136,7 @@ export type TeamsThemeStylesProps = {
   ToolbarMenuItem: ToolbarMenuItemStylesProps;
   ToolbarMenuDivider: ToolbarMenuDividerStylesProps;
   ToolbarMenuRadioGroup: ToolbarMenuRadioGroupStylesProps;
-  TooltipContent: TooltipContentProps;
+  TooltipContent: TooltipContentStylesProps;
   Text: TextStylesProps;
   TreeItem: TreeItemStylesProps;
   TreeTitle: TreeTitleStylesProps;

--- a/packages/fluentui/react-northstar/src/utils/positioner/getBasePlacement.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/getBasePlacement.ts
@@ -1,0 +1,14 @@
+import Popper from 'popper.js';
+
+const rtlMapping: Partial<Record<Popper.Position, Popper.Position>> = {
+  left: 'right',
+  right: 'left',
+};
+
+function getBasePlacement(placement: Popper.Placement | undefined, rtl: boolean): Popper.Position {
+  const basePlacement = (placement || '').split('-', 1).pop() as Popper.Position;
+
+  return (rtl && rtlMapping[basePlacement]) || basePlacement;
+}
+
+export default getBasePlacement;

--- a/packages/fluentui/react-northstar/src/utils/positioner/index.ts
+++ b/packages/fluentui/react-northstar/src/utils/positioner/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './types.internal';
 
+export { default as getBasePlacement } from './getBasePlacement';
 export { default as getPopperPropsFromShorthand } from './getPopperPropsFromShorthand';
 export { default as Popper } from './Popper';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

### `PopupContentVariables`

`pointerSize` was replaced with `pointerHeight` & `pointerWidth`

#### Before
```tsx
{ pointerSize: pxToRem(10) }
```

#### After
```tsx
{
  pointerHeight: pxToRem(5), // half of size
  pointerWidth: pxToRem(10),
}
```

### `TooltipContentVariables`

`pointerHorizontalOffset` & `pointerVerticalOffset` are removed, offsets are calculated based on box models, so there is no need in them.

Values of `pointerWidth` & `pointerHeight` were inverted.

#### Before
```tsx
{
  pointerHeight: pxToRem(16),
  pointerWidth: pxToRem(6),
}
```

#### After
```tsx
{
  pointerHeight: pxToRem(6),
  pointerWidth: pxToRem(16),
}
```

#### Description of changes

These changes are part of preparation process for Popper v2 and should be done as in v2 we [can't use margins anymore](https://popper.js.org/docs/v2/migration-guide/#4-remove-all-css-margins).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12514)