### PR TITLE
doc: cache perf data

### DIFF
--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -8,6 +8,7 @@
     "copy-to-clipboard": "^3.2.0",
     "faker": "^4.1.0",
     "flat": "^4.1.0",
+    "idb": "^5.0.2",
     "react-ace": "^5.1.2",
     "react-codesandboxer": "^3.1.3",
     "react-custom-scrollbars": "^4.2.1",

--- a/packages/fluentui/docs/src/components/ComponentDoc/PerfChart/PerfDataContext.ts
+++ b/packages/fluentui/docs/src/components/ComponentDoc/PerfChart/PerfDataContext.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export type PerfSample = {
+  _id: number; // primary key, equals to build
   build: number;
   tag?: string;
   ts: string;

--- a/packages/fluentui/docs/src/components/ComponentDoc/PerfChart/PerfDataProvider.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/PerfChart/PerfDataProvider.tsx
@@ -1,34 +1,105 @@
 import * as React from 'react';
-import PerfDataContext from './PerfDataContext';
+import { openDB } from 'idb';
+import PerfDataContext, { PerfSample } from './PerfDataContext';
 import config from '../../../config';
 
-/**
- * Fetches data from network and stores them to context.
- * In production build, returns error instead of fetching the data.
- * TODO:
- * [ ] cache data in Local Storage
- * [ ] optionally fetch more data
- * [ ] refresh support
- * [ ] serve static data in public builds
- */
+const MAX_CACHE_SIZE = process.env.NODE_ENV !== 'production' ? 30 : 250;
+
+function log(...args) {
+  console.log('PerfDataProvider', ...args);
+}
+
+function openIndexedDb() {
+  return openDB('perfData', 1, {
+    upgrade(database, oldVersion, newVersion, transaction) {
+      database.createObjectStore('stats', { keyPath: '_id' });
+    },
+  });
+}
+
+async function loadPerfDataFromCache(): Promise<PerfSample[] | undefined> {
+  const db = await openIndexedDb();
+
+  const data = await db
+    .transaction('stats', 'readonly')
+    .objectStore('stats')
+    .getAll();
+
+  return data.sort((a, b) => b._id - a._id);
+}
+
+async function savePerfDataToCache(data: PerfSample[]) {
+  const db = await openIndexedDb();
+  const tx = db.transaction('stats', 'readwrite');
+  const store = tx.objectStore('stats');
+
+  log(`Adding ${data.length} item(s) to cache`);
+  data.forEach(value => {
+    store.put(value);
+  });
+
+  await tx.done;
+}
+
+async function deleteOldPerfDataFromCache(allData: PerfSample[]) {
+  const db = await openIndexedDb();
+  const tx = db.transaction('stats', 'readwrite');
+  const store = tx.objectStore('stats');
+
+  const dataToDelete = allData.slice(MAX_CACHE_SIZE);
+  log(`Deleting ${dataToDelete.length} old item(s) from cache`);
+  dataToDelete.forEach(value => {
+    store.delete(value._id);
+  });
+
+  await tx.done;
+}
+
+async function fetchDataFromServer(buildGt?: number): Promise<PerfSample[]> {
+  const params = [
+    process.env.NODE_ENV !== 'production' && 'withPrivateBuilds=true',
+    buildGt && `buildGt=${buildGt}`,
+  ].filter(Boolean);
+
+  const query = params.length > 0 ? `?${params.join('&')}` : '';
+
+  const response = await fetch(`${config.getStatsUri}${query}`);
+
+  return response.json();
+}
+
+function mergeData(dataFromCache: PerfSample[], dataFromServer: PerfSample[]): PerfSample[] {
+  // both sets are sorted in descending order
+  // dataFromServer are newer than dataFromCache
+  // the two sets do not overlap
+  return [...(dataFromServer || []), ...(dataFromCache || [])];
+}
+
 const PerfDataProvider: React.FC = ({ children }) => {
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState();
   const [data, setData] = React.useState();
 
   React.useEffect(() => {
-    const query = process.env.NODE_ENV === 'production' ? '' : '?withPrivateBuilds=true';
-
-    fetch(`${config.getStatsUri}${query}`)
-      .then(response => response.json())
-      .then(responseJson => {
-        setData(responseJson);
+    (async () => {
+      try {
+        const cachedData = await loadPerfDataFromCache();
+        const maxCachedBuild = cachedData?.[0]?._id;
+        log(`data from cache - ${cachedData.length} item(s), max build ${maxCachedBuild}`);
+        const dataFromServer = await fetchDataFromServer(maxCachedBuild);
+        const maxBuildFromServer = dataFromServer?.[0]?._id;
+        log(`data from server - ${dataFromServer.length} item(s), max build ${maxBuildFromServer}`);
+        savePerfDataToCache(dataFromServer);
+        const mergedData = mergeData(cachedData, dataFromServer);
+        log(`mergedData - ${mergedData.length} item(s)`);
+        deleteOldPerfDataFromCache(mergedData);
+        setData(mergedData);
         setLoading(false);
-      })
-      .catch(e => {
+      } catch (e) {
         setError(e);
         setLoading(false);
-      });
+      }
+    })();
   }, []);
 
   return <PerfDataContext.Provider value={{ loading, error, data }}>{children}</PerfDataContext.Provider>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11609,6 +11609,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+idb@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/idb/-/idb-5.0.2.tgz#294e5dd0f1930519dd07393a793cd4edfac93834"
+  integrity sha512-53yU1RbSPkSkQxufmNgcBkxxnbsTMGaYCv2NwQDmBP75muYj4Z75DsvCqhCCivYcC1XaXDi9tZSUOfDQFxuABA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`react-northstar` docsite fetches performance data on every load. This is a perf problem, especially on dev build which (1) fetches more data and (2) is refreshed often during development.

This PR stores fetched data to IndexedDB and then fetches only incremental changes from server.

First load:
![image](https://user-images.githubusercontent.com/9615899/78256232-8b89d980-74f8-11ea-90c4-52cc24d0bc2f.png)

Incremental fetch on reload:
![image](https://user-images.githubusercontent.com/9615899/78256281-9d6b7c80-74f8-11ea-8459-65377f1c2f7c.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12515)