### PR TITLE
Support ability to add Grid accessibility semantics to TilesList

### DIFF
--- a/change/@uifabric-experiments-2020-04-02-15-03-59-tiles-list-grid.json
+++ b/change/@uifabric-experiments-2020-04-02-15-03-59-tiles-list-grid.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Support TilesList overrides for altering list semantics for grid accessibility",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "commit": "d8a2f14c09d6c8fe70b7308894f58b12ca2243fe",
+  "dependentChangeType": "patch",
+  "date": "2020-04-02T22:03:55.258Z"
+}

--- a/change/office-ui-fabric-react-2020-04-02-15-03-59-tiles-list-grid.json
+++ b/change/office-ui-fabric-react-2020-04-02-15-03-59-tiles-list-grid.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Support List overrides for rendering root and surface elements",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "d8a2f14c09d6c8fe70b7308894f58b12ca2243fe",
+  "dependentChangeType": "patch",
+  "date": "2020-04-02T22:03:59.462Z"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.scss
+++ b/packages/experiments/src/components/TilesList/TilesList.scss
@@ -42,6 +42,11 @@
   align-content: flex-start;
 }
 
+.row {
+  display: flex;
+  width: 100%;
+}
+
 .shimmeredList {
   &::after {
     content: '';

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -3,6 +3,30 @@ import { IRefObject, IBaseProps, ISize } from 'office-ui-fabric-react/lib/Utilit
 import { TilesList } from './TilesList';
 import { IFocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { IListProps } from 'office-ui-fabric-react/lib/List';
+import { IRenderFunction } from '@uifabric/utilities';
+
+export interface ITilesGridItemCellProps<TItem> {
+  item: TItem;
+  finalSize: {
+    width: number;
+    height: number;
+  };
+  position: {
+    column: number;
+  };
+}
+
+export interface ITilesListRowProps<TItem> {
+  cellElements: JSX.Element[];
+  divProps: React.HTMLAttributes<HTMLDivElement>;
+}
+
+export interface ITilesListRootProps<TItem> {
+  surfaceElement: JSX.Element | null;
+  divProps: React.HTMLAttributes<HTMLDivElement>;
+  rowCount: number;
+  columnCount: number;
+}
 
 export interface ITilesGridItem<TItem> {
   /**
@@ -26,8 +50,15 @@ export interface ITilesGridItem<TItem> {
   /**
    * Invoked to render the virtual DOM for the item.
    * This content will be rendered inside the cell allocated for the item.
+   * This is invoked if present, and only if `onRenderCell` is not provided.
    */
-  onRender: (content: TItem, finalSize?: ISize) => React.ReactNode;
+  onRender?: (content: TItem, finalSize?: ISize) => React.ReactNode;
+  /**
+   * Invoked to render the virtual DOM for the item in its positioned cell.
+   * Provided positioning and sizing information in addition to the item.
+   * Preferred over `onRender`.
+   */
+  onRenderCell?: (props: ITilesGridItemCellProps<TItem>) => JSX.Element | null;
 }
 
 export const enum TilesGridMode {
@@ -131,4 +162,14 @@ export interface ITilesListProps<TItem>
    * props to pass through to the underlying List
    */
   listProps?: Partial<IListProps>;
+  /**
+   * Override to render a 'row' of tiles in the list.
+   * Use this to append accessibility semantics based on the tiles in a row.
+   */
+  onRenderRow?: IRenderFunction<ITilesListRowProps<TItem>>;
+  /**
+   * Override to render the 'root' element of the list.
+   * Use this to append accessibility semantics based on the final layout of the list.
+   */
+  onRenderRoot?: IRenderFunction<ITilesListRootProps<TItem>>;
 }

--- a/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
+++ b/packages/experiments/src/components/TilesList/examples/ExampleHelpers.tsx
@@ -1,5 +1,13 @@
-import { TilesGridMode, ITilesGridItem, ITilesGridSegment, ITileSize } from '@uifabric/experiments/lib/TilesList';
+import {
+  TilesGridMode,
+  ITilesGridItem,
+  ITilesGridSegment,
+  ITilesGridItemCellProps,
+  ITilesListRootProps,
+  ITilesListRowProps,
+} from '@uifabric/experiments/lib/TilesList';
 import { lorem } from '@uifabric/example-data';
+import { IRenderFunction } from '@uifabric/utilities';
 
 type IAspectRatioByProbability = { [probability: string]: number };
 
@@ -76,7 +84,42 @@ export function createGroup(items: IExampleItem[], type: 'document' | 'media', i
   };
 }
 
-export function getTileCells(
+export function onRenderTilesListExampleRoot(
+  rootProps?: ITilesListRootProps<IExampleItem>,
+  defaultRender?: IRenderFunction<ITilesListRootProps<IExampleItem>>,
+): JSX.Element | null {
+  if (!rootProps || !defaultRender) {
+    return null;
+  }
+
+  return defaultRender({
+    ...rootProps,
+    divProps: {
+      ...rootProps.divProps,
+      'aria-colcount': rootProps.columnCount,
+      'aria-rowcount': rootProps.rowCount,
+    },
+  });
+}
+
+export function onRenderTilesListExampleRow(
+  rowProps?: ITilesListRowProps<IExampleItem>,
+  defaultRender?: IRenderFunction<ITilesListRowProps<IExampleItem>>,
+): JSX.Element | null {
+  if (!rowProps || !defaultRender) {
+    return null;
+  }
+
+  return defaultRender({
+    ...rowProps,
+    divProps: {
+      ...rowProps.divProps,
+      role: 'row',
+    },
+  });
+}
+
+export function getExampleTilesListCells(
   groups: IExampleGroup[],
   {
     onRenderCell,
@@ -84,8 +127,8 @@ export function getTileCells(
     size = 'large',
     shimmerMode = false,
   }: {
-    onRenderHeader: (item: IExampleItem) => JSX.Element;
-    onRenderCell: (item: IExampleItem, finalSize?: ITileSize) => JSX.Element;
+    onRenderHeader: (props: ITilesGridItemCellProps<IExampleItem>) => JSX.Element | null;
+    onRenderCell: (props: ITilesGridItemCellProps<IExampleItem>) => JSX.Element | null;
     size?: 'large' | 'small';
     shimmerMode?: boolean;
   },
@@ -102,7 +145,7 @@ export function getTileCells(
         name: group.name,
         index: group.index,
       },
-      onRender: onRenderHeader,
+      onRenderCell: onRenderHeader,
       isPlaceholder: shimmerMode,
     };
 
@@ -124,7 +167,7 @@ export function getTileCells(
                     width: isLargeSize ? 171 * item.aspectRatio : 135 * item.aspectRatio,
                     height: isLargeSize ? 171 : 135,
                   },
-            onRender: onRenderCell,
+            onRenderCell: onRenderCell,
             isPlaceholder: shimmerMode,
           };
         },

--- a/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
+++ b/packages/experiments/src/components/TilesList/examples/TilesList.Media.Example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { TilesList, ITileSize, ITilesGridItem, ITilesGridSegment } from '@uifabric/experiments/lib/TilesList';
+import {
+  TilesList,
+  ITilesGridItem,
+  ITilesGridSegment,
+  ITilesGridItemCellProps,
+} from '@uifabric/experiments/lib/TilesList';
 import { Tile, getTileLayout, renderTileWithLayout } from '@uifabric/experiments/lib/Tile';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { Selection, SelectionZone } from 'office-ui-fabric-react/lib/Selection';
@@ -10,7 +15,9 @@ import {
   IExampleItem,
   createGroup,
   createMediaItems,
-  getTileCells,
+  getExampleTilesListCells,
+  onRenderTilesListExampleRoot,
+  onRenderTilesListExampleRow,
 } from '@uifabric/experiments/lib/components/TilesList/examples/ExampleHelpers';
 import * as TilesListExampleStylesModule from './TilesList.Example.scss';
 import { lorem } from '@uifabric/example-data';
@@ -39,10 +46,6 @@ const GROUPS = createGroups();
 
 const ITEMS = ([] as IExampleItem[]).concat(...GROUPS.map((group: { items: IExampleItem[] }) => group.items));
 
-declare class TilesListClass extends TilesList<IExampleItem> {}
-
-const TilesListType: typeof TilesListClass = TilesList;
-
 export interface ITilesListMediaExampleState {
   isModalSelection: boolean;
   nameplateOnlyOnHover: boolean;
@@ -65,7 +68,7 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
     this.state = {
       isModalSelection: this._selection.isModal(),
       nameplateOnlyOnHover: false,
-      cells: getTileCells(GROUPS, {
+      cells: getExampleTilesListCells(GROUPS, {
         onRenderCell: this._onRenderMediaCell,
         onRenderHeader: this._onRenderHeader,
       }),
@@ -92,7 +95,12 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
         />
         <MarqueeSelection selection={this._selection}>
           <SelectionZone selection={this._selection} onItemInvoked={this._onItemInvoked} enterModalOnTouch={true}>
-            <TilesListType role="list" items={this.state.cells} />
+            <TilesList<IExampleItem>
+              onRenderRoot={onRenderTilesListExampleRoot}
+              onRenderRow={onRenderTilesListExampleRow}
+              items={this.state.cells}
+              role="grid"
+            />
           </SelectionZone>
         </MarqueeSelection>
       </div>
@@ -106,7 +114,7 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
   private _onToggleNameplateOnlyOnHover = (event: React.MouseEvent<HTMLElement>, checked: boolean): void => {
     this.setState({
       nameplateOnlyOnHover: checked,
-      cells: getTileCells(GROUPS, {
+      cells: getExampleTilesListCells(GROUPS, {
         onRenderCell: this._onRenderMediaCell,
         onRenderHeader: this._onRenderHeader,
       }),
@@ -126,15 +134,20 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
     alert(`Invoked item '${item.name}'`);
   };
 
-  private _onRenderMediaCell = (item: IExampleItem, finalSize: ITileSize): JSX.Element => {
+  private _onRenderMediaCell = (props: ITilesGridItemCellProps<IExampleItem>): JSX.Element => {
+    const {
+      finalSize,
+      item,
+      position: { column },
+    } = props;
+
     const pixelWidth = Math.round(finalSize.width);
     const pixelHeight = Math.round(finalSize.height);
 
     const tile = (
       <Tile
-        role="listitem"
-        aria-setsize={ITEMS.length}
-        aria-posinset={item.index}
+        role="gridcell"
+        aria-colindex={column + 1}
         contentSize={finalSize}
         className={AnimationClassNames.fadeIn400}
         selection={this._selection}
@@ -178,9 +191,14 @@ export class TilesListMediaExample extends React.Component<{}, ITilesListMediaEx
     });
   };
 
-  private _onRenderHeader = (item: IExampleItem): JSX.Element => {
+  private _onRenderHeader = (props: ITilesGridItemCellProps<IExampleItem>): JSX.Element => {
+    const {
+      item,
+      position: { column },
+    } = props;
+
     return (
-      <div role="presentation">
+      <div role="griditem" aria-colindex={column + 1}>
         <h3>{item.name}</h3>
       </div>
     );

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5400,6 +5400,22 @@ export interface IList {
     scrollToIndex: (index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode) => void;
 }
 
+// @public
+export interface IListOnRenderRootProps<T> {
+    divProps: React.HTMLAttributes<HTMLDivElement>;
+    pages: IPage<T>[];
+    rootRef: React.Ref<HTMLDivElement>;
+    surfaceElement: JSX.Element | null;
+}
+
+// @public
+export interface IListOnRenderSurfaceProps<T> {
+    divProps: React.HTMLAttributes<HTMLDivElement>;
+    pageElements: JSX.Element[];
+    pages: IPage<T>[];
+    surfaceRef: React.Ref<HTMLDivElement>;
+}
+
 // @public (undocumented)
 export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTMLDivElement> {
     className?: string;
@@ -5415,7 +5431,9 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
     onPageRemoved?: (page: IPage<T>) => void;
     onPagesUpdated?: (pages: IPage<T>[]) => void;
     onRenderCell?: (item?: T, index?: number, isScrolling?: boolean) => React.ReactNode;
-    onRenderPage?: (pageProps: IPageProps<T>, defaultRender?: IRenderFunction<IPageProps<T>>) => React.ReactNode;
+    onRenderPage?: IRenderFunction<IPageProps<T>>;
+    onRenderRoot?: IRenderFunction<IListOnRenderRootProps<T>>;
+    onRenderSurface?: IRenderFunction<IListOnRenderSurfaceProps<T>>;
     onShouldVirtualize?: (props: IListProps<T>) => boolean;
     renderCount?: number;
     renderedWindowsAhead?: number;
@@ -8105,7 +8123,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
         [key: string]: React.ReactInstance;
     };
     // (undocumented)
-    render(): JSX.Element;
+    render(): JSX.Element | null;
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean;

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -30,6 +30,57 @@ export const ScrollToMode = {
 export type ScrollToMode = typeof ScrollToMode[keyof typeof ScrollToMode];
 
 /**
+ * Props passed to the render override for the list root.
+ * {@docCategory List}
+ */
+export interface IListOnRenderRootProps<T> {
+  /**
+   * The ref to be applied to the list root.
+   * The `List` uses this element to track scroll position and sizing.
+   */
+  rootRef: React.Ref<HTMLDivElement>;
+  /**
+   * Props to apply to the list root element.
+   */
+  divProps: React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * The active pages to be rendered into the list.
+   * These will have been rendered using `onRenderPage`.
+   */
+  pages: IPage<T>[];
+  /**
+   * The content to be rendered as the list surface element.
+   * This will have been rendered using `onRenderSurface`.
+   */
+  surfaceElement: JSX.Element | null;
+}
+
+/**
+ * Props passed to the render override for the list surface.
+ * {@docCategory List}
+ */
+export interface IListOnRenderSurfaceProps<T> {
+  /**
+   * A ref to be applied to the surface element.
+   * The `List` uses this element to track content size and focus.
+   */
+  surfaceRef: React.Ref<HTMLDivElement>;
+  /**
+   * Props to apply to the list surface element.
+   */
+  divProps: React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * The active pages to be rendered into the list.
+   * These will have been rendered using `onRenderPage`.
+   */
+  pages: IPage<T>[];
+  /**
+   * The content to be rendered representing all active pages.
+   */
+  pageElements: JSX.Element[];
+}
+
+/**
  * {@docCategory List}
  */
 export interface IList {
@@ -180,7 +231,20 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * Called when the List will render a page.
    * Override this to control how cells are rendered within a page.
    */
-  onRenderPage?: (pageProps: IPageProps<T>, defaultRender?: IRenderFunction<IPageProps<T>>) => React.ReactNode;
+  onRenderPage?: IRenderFunction<IPageProps<T>>;
+
+  /**
+   * Render override for the element at the root of the `List`.
+   * Use this to apply some final attributes or structure to the content
+   * each time the list is updated with new active pages or items.
+   */
+  onRenderRoot?: IRenderFunction<IListOnRenderRootProps<T>>;
+
+  /**
+   * Render override for the element representing the surface of the `List`.
+   * Use this to alter the structure of the rendered content if necessary on each update.
+   */
+  onRenderSurface?: IRenderFunction<IListOnRenderSurfaceProps<T>>;
 
   /**
    * An object which can be passed in as a fresh instance to 'force update' the list.


### PR DESCRIPTION
#### Description of changes

The `TilesList` component renders using a flexbox layout, and declares its role as `list`. This works because the layout is fluid, and is the most flexible for various forms of content. However, for interactive content and selectable items, this is insufficient because `listitem` elements cannot support `aria-selected`.

This change provides a way for host consumers of `TilesList` to override the necessary pieces to use the `grid` role instead, with `row` elements inserted as-needed and `aria-colindex` supplied to the rendered content cells. Now, `TilesList` computes the row/column index of each cell, and supplies the total number of rows and maximum number of columns to an override for `onRenderRoot`. This, in turn overrides a new `onRenderRoot` hook of `List` itself, which is necessary because only `List` has the final set of 'page' specifications as it renders.

#### Focus areas to test

The existing `TilesList` examples have been updated to showcase the overrides to add 'grid' semantics. The 'generic' demo is left unchanged, showing that it preserves the 'list' semantic.

The best way to test is to use Narrator on Edge Chromium to listen for announcements of the 'selected' state of items in the "Document" and "Media" examples.

This replaces #12053 as it also fully-implements the 'grid' semantics.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12521)