### PR TITLE
fix(Table):  fix navigation into cell which has multiple actionable elements

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix hover color for disabled `Dropdown` trigger button @silviuavram ([#12418](https://github.com/microsoft/fluentui/pull/12418))
 - Fix `ButtonContent` className and added conformat test @mnajdova ([#12431](https://github.com/microsoft/fluentui/pull/12431))
 - Fix colors for keyboard navigation in vertical Menu component in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
+- Fix navigation into cell which has multiple actionable elements @kolaps33 ([#12533](https://github.com/microsoft/fluentui/pull/12533))
 
 ### Features
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))

--- a/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
@@ -96,19 +96,21 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
 
   const element = (
     <Ref innerRef={cellRef}>
-      <ElementType
-        {...getA11yProps('root', {
-          className: classes.root,
-          onClick: handleClick,
-          ...unhandledProps,
-        })}
-      >
-        {hasChildren
-          ? children
-          : Box.create(content, {
-              defaultProps: () => ({ styles: resolvedStyles.content }),
-            })}
-      </ElementType>
+      {getA11yProps.unstable_wrapWithFocusZone(
+        <ElementType
+          {...getA11yProps('root', {
+            className: classes.root,
+            onClick: handleClick,
+            ...unhandledProps,
+          })}
+        >
+          {hasChildren
+            ? children
+            : Box.create(content, {
+                defaultProps: () => ({ styles: resolvedStyles.content }),
+              })}
+        </ElementType>,
+      )}
     </Ref>
   );
   setEnd();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix related to the bug:
https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/6664

#### Focus areas to test
test keyboard navigation

Fix:
root cause was that FocusZone was not added on the cell which has more actionable elements

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12533)