### PR TITLE
fix(doc): do not fetch Perf data in maximized examples

### DIFF
--- a/packages/fluentui/docs/src/app.tsx
+++ b/packages/fluentui/docs/src/app.tsx
@@ -5,7 +5,6 @@ import { Provider, Debug, themes } from '@fluentui/react-northstar';
 import { mergeThemes } from '@fluentui/styles';
 import { ThemeContext, ThemeContextData, themeContextDefaults } from './context/ThemeContext';
 import Routes from './routes';
-import { PerfDataProvider } from './components/ComponentDoc/PerfChart';
 
 // Experimental dev-time accessibility attributes integrity validation.
 import { setup } from '@fluentui/ability-attributes';
@@ -39,12 +38,8 @@ class App extends React.Component<any, ThemeContextData> {
             ],
           })}
         >
-          <PerfDataProvider>
-            <div>
-              <Debug />
-              <Routes />
-            </div>
-          </PerfDataProvider>
+          <Debug />
+          <Routes />
         </Provider>
       </ThemeContext.Provider>
     );

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -51,74 +51,77 @@ import EditorToolbarPrototype from './prototypes/EditorToolbar';
 import HexagonalAvatarPrototype from './prototypes/hexagonalAvatar';
 import TablePrototype from './prototypes/table';
 import VirtualizedTablePrototype from './prototypes/VirtualizedTable';
+import { PerfDataProvider } from './components/ComponentDoc/PerfChart';
 
 const Routes = () => (
   <BrowserRouter basename={__BASENAME__}>
     <Switch>
       <Route exact path="/maximize/:exampleName/:rtl?" component={ExternalExampleLayout} />
       <DocsLayout>
-        <Switch>
-          <Route exact path="/" component={Introduction} />
-          <Route exact path="/components/:name/:tab" component={DocsRoot} sidebar />
-          <Route
-            exact
-            path="/components/:name"
-            render={routeProps => <Redirect to={`${routeProps.location.pathname}/definition`} />}
-          />
-          <Route exact path="/behaviors/:name" component={DocsBehaviorRoot} sidebar />
-          <Route exact path="/quick-start" component={QuickStart} />
-          <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
-          <Route exact path="/prototype-chat-messages" component={ChatMessagesPrototype} />
-          <Route exact path="/prototype-custom-scrollbar" component={CustomScrollbarPrototype} />
-          <Route exact path="/prototype-custom-toolbar" component={CustomToolbarPrototype} />
-          <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />
-          <Route exact path="/prototype-employee-card" component={EmployeeCardPrototype} />
-          <Route exact path="/prototype-meeting-options" component={MeetingOptionsPrototype} />
-          <Route exact path="/prototype-participants-list" component={ParticipantsListPrototype} />
-          <Route exact path="/prototype-search-page" component={SearchPagePrototype} />
-          <Route exact path="/prototype-mentions" component={MentionsPrototype} />
-          <Route exact path="/prototype-dropdowns" component={DropdownsPrototype} />
-          <Route exact path="/prototype-popups" component={PopupsPrototype} />
-          <Route exact path="/prototype-alerts" component={AlertsPrototype} />
-          <Route exact path="/prototype-editor-toolbar" component={EditorToolbarPrototype} />
-          <Route exact path="/prototype-hexagonal-avatar" component={HexagonalAvatarPrototype} />
-          <Route exact path="/prototype-table" component={TablePrototype} />
-          <Route exact path="/prototype-nested-popups-and-dialogs" component={NestedPopupsAndDialogsPrototype} />
-          <Route exact path="/virtualized-tree" component={VirtualizedTreePrototype} />
-          <Route exact path="/virtualized-table" component={VirtualizedTablePrototype} />
-          <Route exact path="/prototype-copy-to-clipboard" component={CopyToClipboardPrototype} />
-          <Route exact path="/faq" component={FAQ} />
-          <Route exact path="/accessibility" component={Accessibility} />
-          <Route exact path="/accessibility-behaviors" component={AccessibilityBehaviors} />
-          <Route exact path="/focus-zone" component={FocusZone} />
-          <Route exact path="/focus-trap-zone" component={FocusTrapZone} />
-          <Route exact path="/auto-focus-zone" component={AutoFocusZone} />
-          <Route exact path="/theming" component={Theming} />
-          <Route exact path="/theming-examples" component={ThemingExamples} />
-          <Route exact path="/layout">
-            <MarkdownPage page={Layout} />
-          </Route>
-          <Route exact path="/shorthand-props">
-            <MarkdownPage page={ShorthandProps} />
-          </Route>
-          <Route exact path="/component-architecture">
-            <MarkdownPage page={ComponentArchitecture} />
-          </Route>
-          <Route exact path="/theming-specification">
-            <MarkdownPage page={ThemingSpecification} />
-          </Route>
-          <Route exact path="/integrate-custom-components" component={IntegrateCustomComponents} />
-          <Route exact path="/performance" component={Performance} />
-          <Route exact path="/composition">
-            <MarkdownPage page={Composition} />
-          </Route>
-          <Route exact path="/colors" component={Colors} />
-          <Route exact path="/color-palette" component={ColorPalette} />
-          <Route exact path="/color-palette-category" component={CategoryColorPalette} />
-          <Route exact path="/color-schemes" component={ColorSchemes} />
-          <Route exact path="/color-schemes-category" component={CategoryColorSchemes} />
-          <Route exact path="/*" component={PageNotFound} />
-        </Switch>
+        <PerfDataProvider>
+          <Switch>
+            <Route exact path="/" component={Introduction} />
+            <Route exact path="/components/:name/:tab" component={DocsRoot} sidebar />
+            <Route
+              exact
+              path="/components/:name"
+              render={routeProps => <Redirect to={`${routeProps.location.pathname}/definition`} />}
+            />
+            <Route exact path="/behaviors/:name" component={DocsBehaviorRoot} sidebar />
+            <Route exact path="/quick-start" component={QuickStart} />
+            <Route exact path="/prototype-chat-pane" component={ChatPanePrototype} />
+            <Route exact path="/prototype-chat-messages" component={ChatMessagesPrototype} />
+            <Route exact path="/prototype-custom-scrollbar" component={CustomScrollbarPrototype} />
+            <Route exact path="/prototype-custom-toolbar" component={CustomToolbarPrototype} />
+            <Route exact path="/prototype-async-shorthand" component={AsyncShorthandPrototype} />
+            <Route exact path="/prototype-employee-card" component={EmployeeCardPrototype} />
+            <Route exact path="/prototype-meeting-options" component={MeetingOptionsPrototype} />
+            <Route exact path="/prototype-participants-list" component={ParticipantsListPrototype} />
+            <Route exact path="/prototype-search-page" component={SearchPagePrototype} />
+            <Route exact path="/prototype-mentions" component={MentionsPrototype} />
+            <Route exact path="/prototype-dropdowns" component={DropdownsPrototype} />
+            <Route exact path="/prototype-popups" component={PopupsPrototype} />
+            <Route exact path="/prototype-alerts" component={AlertsPrototype} />
+            <Route exact path="/prototype-editor-toolbar" component={EditorToolbarPrototype} />
+            <Route exact path="/prototype-hexagonal-avatar" component={HexagonalAvatarPrototype} />
+            <Route exact path="/prototype-table" component={TablePrototype} />
+            <Route exact path="/prototype-nested-popups-and-dialogs" component={NestedPopupsAndDialogsPrototype} />
+            <Route exact path="/virtualized-tree" component={VirtualizedTreePrototype} />
+            <Route exact path="/virtualized-table" component={VirtualizedTablePrototype} />
+            <Route exact path="/prototype-copy-to-clipboard" component={CopyToClipboardPrototype} />
+            <Route exact path="/faq" component={FAQ} />
+            <Route exact path="/accessibility" component={Accessibility} />
+            <Route exact path="/accessibility-behaviors" component={AccessibilityBehaviors} />
+            <Route exact path="/focus-zone" component={FocusZone} />
+            <Route exact path="/focus-trap-zone" component={FocusTrapZone} />
+            <Route exact path="/auto-focus-zone" component={AutoFocusZone} />
+            <Route exact path="/theming" component={Theming} />
+            <Route exact path="/theming-examples" component={ThemingExamples} />
+            <Route exact path="/layout">
+              <MarkdownPage page={Layout} />
+            </Route>
+            <Route exact path="/shorthand-props">
+              <MarkdownPage page={ShorthandProps} />
+            </Route>
+            <Route exact path="/component-architecture">
+              <MarkdownPage page={ComponentArchitecture} />
+            </Route>
+            <Route exact path="/theming-specification">
+              <MarkdownPage page={ThemingSpecification} />
+            </Route>
+            <Route exact path="/integrate-custom-components" component={IntegrateCustomComponents} />
+            <Route exact path="/performance" component={Performance} />
+            <Route exact path="/composition">
+              <MarkdownPage page={Composition} />
+            </Route>
+            <Route exact path="/colors" component={Colors} />
+            <Route exact path="/color-palette" component={ColorPalette} />
+            <Route exact path="/color-palette-category" component={CategoryColorPalette} />
+            <Route exact path="/color-schemes" component={ColorSchemes} />
+            <Route exact path="/color-schemes-category" component={CategoryColorSchemes} />
+            <Route exact path="/*" component={PageNotFound} />
+          </Switch>
+        </PerfDataProvider>
       </DocsLayout>
     </Switch>
   </BrowserRouter>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Do not fetch perf data in maximized example view.

react-northstar docsite fetches perf data from backend. Before this fix all maximized examples fetched the data as well. This caused unnecessary high load of backend especially when running screener.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12561)