### PR TITLE
fix(Tooltip): make Tooltip appear on top of Dialogs

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -38,6 +38,7 @@ Removed types: `TeamsSvgIconSpec`, `ThemeIconSpec`, `SvgIconSpec`, `SvgIconSpecW
 - Fix `ButtonContent` className and added conformat test @mnajdova ([#12431](https://github.com/microsoft/fluentui/pull/12431))
 - Fix colors for keyboard navigation in vertical Menu component in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
 - Fix navigation into cell which has multiple actionable elements @kolaps33 ([#12533](https://github.com/microsoft/fluentui/pull/12533))
+- Give higher `zIndex` to `Tooltip` to make it appear on top of `Dialog` @silviuavram ([#12572](https://github.com/microsoft/fluentui/pull/12572))
 
 ### Features
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Tooltip/tooltipContentVariables.ts
@@ -36,5 +36,5 @@ export default (siteVars: any): TooltipContentVariables => ({
   color: siteVars.colorScheme.default.foreground3,
   backgroundColor: siteVars.colors.grey[500],
 
-  zIndex: siteVars.zIndexes.overlay,
+  zIndex: siteVars.zIndexes.overlayPriority,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/siteVariables.ts
@@ -63,6 +63,7 @@ export const zIndexes: Record<string, number> = {
   foreground: 1, // Put a component in front
   menuItem: 2, // Currently used only for menu item beak element
   overlay: 1000, // Dialog/popup/menu overlays
+  overlayPriority: 1001, // for nested overlays, like tooltip in dialog.
   debug: 999999999, // for debug purposes
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Both Dialog and Tooltip have the same zIndex from siteVariables. Created a new `overlayPriority` for the case when we need an overlay element on top of another (here Tooltip over Dialog).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12572)