### PR TITLE
chore: refactor Attachment to be functional component

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -29,7 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed `Icon` component (`@fluentui/react-icons-northstar` icons should be used instead) @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
 - Removed `icons` from `theme` object (`@fluentui/react-icons-northstar` icons should be used instead) @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
 Removed types: `TeamsSvgIconSpec`, `ThemeIconSpec`, `SvgIconSpec`, `SvgIconSpecWithStyles` @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
-- Restricted prop sets in the `Attachment` component which are passed to styles functions @layershifter ([#12576](https://github.com/OfficeDev/office-ui-fabric-react/pull/12576))
+- Restricted prop sets in the `Attachment` component which are passed to styles functions @layershifter ([#12576](https://github.com/microsoft/fluentui/pull/12576))
 
 ### Fixes
 - Fix default focused input outline in Safari @sheff146 ([#12279](https://github.com/microsoft/fluentui/pull/12279))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed `Icon` component (`@fluentui/react-icons-northstar` icons should be used instead) @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
 - Removed `icons` from `theme` object (`@fluentui/react-icons-northstar` icons should be used instead) @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
 Removed types: `TeamsSvgIconSpec`, `ThemeIconSpec`, `SvgIconSpec`, `SvgIconSpecWithStyles` @mnajdova ([#12549](https://github.com/microsoft/fluentui/pull/12549))
+- Restricted prop sets in the `Attachment` component which are passed to styles functions @layershifter ([#12576](https://github.com/OfficeDev/office-ui-fabric-react/pull/12576))
 
 ### Fixes
 - Fix default focused input outline in Safari @sheff146 ([#12279](https://github.com/microsoft/fluentui/pull/12279))

--- a/packages/fluentui/accessibility/src/behaviors/Attachment/attachmentBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Attachment/attachmentBehavior.ts
@@ -8,7 +8,7 @@ import { Accessibility } from '../../types';
  * Adds attribute 'tabIndex=0' to 'root' slot.
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  */
-const attachmentBehavior: Accessibility = () => ({
+const attachmentBehavior: Accessibility<AttachmentBehaviorProps> = () => ({
   attributes: {
     root: {
       tabIndex: 0,
@@ -23,5 +23,7 @@ const attachmentBehavior: Accessibility = () => ({
     },
   },
 });
+
+export type AttachmentBehaviorProps = never;
 
 export default attachmentBehavior;

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -1,6 +1,7 @@
 export { default as alertBehavior } from './Alert/alertBehavior';
 export { default as alertWarningBehavior } from './Alert/alertWarningBehavior';
 export { default as alertBaseBehavior } from './Alert/alertBaseBehavior';
+export * from './Attachment/attachmentBehavior';
 export { default as attachmentBehavior } from './Attachment/attachmentBehavior';
 export { default as buttonBehavior } from './Button/buttonBehavior';
 export * from './Button/buttonBehavior';

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -1,24 +1,28 @@
-import { Accessibility, attachmentBehavior } from '@fluentui/accessibility';
+import { Accessibility, attachmentBehavior, AttachmentBehaviorProps } from '@fluentui/accessibility';
+import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
+import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import * as _ from 'lodash';
-import { WithAsProp, ShorthandValue, ComponentEventHandler, withSafeTypeForAs } from '../../types';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+
 import {
-  UIComponent,
-  createShorthandFactory,
-  commonPropTypes,
-  applyAccessibilityKeyHandlers,
-  ShorthandFactory,
-} from '../../utils';
+  WithAsProp,
+  ShorthandValue,
+  ComponentEventHandler,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
+import { createShorthandFactory, commonPropTypes, UIComponentProps, ChildrenComponentProps } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 import Button, { ButtonProps } from '../Button/Button';
 import Text, { TextProps } from '../Text/Text';
-import { UIComponentProps, ChildrenComponentProps } from '../../utils/commonPropInterfaces';
 
 export interface AttachmentProps extends UIComponentProps, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<AttachmentBehaviorProps>;
 
   /** Button shorthand for the action slot. */
   action?: ShorthandValue<ButtonProps>;
@@ -49,102 +53,129 @@ export interface AttachmentProps extends UIComponentProps, ChildrenComponentProp
   onClick?: ComponentEventHandler<AttachmentProps>;
 }
 
+export type AttachmentStylesProps = Required<Pick<AttachmentProps, 'actionable' | 'disabled'>>;
+
 export interface AttachmentSlotClassNames {
   action: string;
 }
 
-class Attachment extends UIComponent<WithAsProp<AttachmentProps>> {
-  static create: ShorthandFactory<AttachmentProps>;
+const Attachment: React.FC<WithAsProp<AttachmentProps>> &
+  FluentComponentStaticProps<AttachmentProps> & { slotClassNames: AttachmentSlotClassNames } = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(Attachment.displayName, context.telemetry);
+  setStart();
 
-  static className = 'ui-attachment';
+  const {
+    accessibility,
+    action,
+    actionable,
+    className,
+    description,
+    design,
+    disabled,
+    header,
+    icon,
+    onClick,
+    progress,
+    styles,
+    variables,
+  } = props;
 
-  static displayName = 'Attachment';
-
-  static slotClassNames: AttachmentSlotClassNames;
-
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false,
+  const getA11Props = useAccessibility(accessibility, {
+    debugName: Attachment.displayName,
+    actionHandlers: {
+      performClick: e => {
+        if (e.currentTarget === e.target) {
+          e.stopPropagation();
+          handleClick(e);
+        }
+      },
+    },
+    rtl: context.rtl,
+  });
+  const { classes, styles: resolvedStyles } = useStyles<AttachmentStylesProps>(Attachment.displayName, {
+    className: Attachment.className,
+    mapPropsToStyles: () => ({
+      actionable: actionable || !!onClick,
+      disabled,
     }),
-    action: customPropTypes.itemShorthand,
-    actionable: PropTypes.bool,
-    description: customPropTypes.itemShorthand,
-    header: customPropTypes.itemShorthand,
-    icon: customPropTypes.shorthandAllowingChildren,
-    progress: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  };
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  static defaultProps = {
-    accessibility: attachmentBehavior as Accessibility,
-  };
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(Attachment.handledProps, props);
 
-  renderComponent({ ElementType, classes, unhandledProps, styles, variables, accessibility }) {
-    const { header, description, icon, action, progress } = this.props;
-
-    return (
-      <ElementType
-        className={classes.root}
-        onClick={this.handleClick}
-        {...accessibility.attributes.root}
-        {...unhandledProps}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
-      >
-        {icon &&
-          Box.create(icon, {
-            defaultProps: () => ({ styles: styles.icon }),
-          })}
-        {(header || description) && (
-          <div className={classes.content}>
-            {Text.create(header, {
-              defaultProps: () => ({ styles: styles.header }),
-            })}
-
-            {Text.create(description, {
-              defaultProps: () => ({ styles: styles.description }),
-            })}
-          </div>
-        )}
-        {action &&
-          Button.create(action, {
-            defaultProps: () => ({
-              iconOnly: true,
-              text: true,
-              styles: styles.action,
-              className: Attachment.slotClassNames.action,
-            }),
-          })}
-        {!_.isNil(progress) && <div className={classes.progress} />}
-      </ElementType>
-    );
-  }
-
-  actionHandlers = {
-    performClick: event => this.performClick(event),
-  };
-
-  performClick = e => {
-    if (e.currentTarget === e.target) {
-      e.stopPropagation();
-      this.handleClick(e);
-    }
-  };
-
-  handleClick = (e: React.SyntheticEvent) => {
-    const { disabled } = this.props;
-
+  const handleClick = (e: React.KeyboardEvent | React.MouseEvent) => {
     if (disabled) {
       e.preventDefault();
       return;
     }
 
-    _.invoke(this.props, 'onClick', e, this.props);
+    _.invoke(props, 'onClick', e, props);
   };
-}
+
+  const element = (
+    <ElementType {...getA11Props('root', { className: classes.root, onClick: handleClick, ...unhandledProps })}>
+      {Box.create(icon, {
+        defaultProps: () => ({ styles: resolvedStyles.icon }),
+      })}
+      {(header || description) && (
+        <div className={classes.content}>
+          {Text.create(header, {
+            defaultProps: () => ({ styles: resolvedStyles.header }),
+          })}
+
+          {Text.create(description, {
+            defaultProps: () => ({ styles: resolvedStyles.description }),
+          })}
+        </div>
+      )}
+      {Button.create(action, {
+        defaultProps: () => ({
+          iconOnly: true,
+          text: true,
+          styles: resolvedStyles.action,
+          className: Attachment.slotClassNames.action,
+        }),
+      })}
+      {!_.isNil(progress) && <div className={classes.progress} style={{ width: `${progress}%` }} />}
+    </ElementType>
+  );
+  setEnd();
+
+  return element;
+};
 
 Attachment.create = createShorthandFactory({ Component: Attachment, mappedProp: 'header' });
 Attachment.slotClassNames = {
   action: `${Attachment.className}__action`,
 };
+
+Attachment.className = 'ui-attachment';
+Attachment.displayName = 'Attachment';
+
+Attachment.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false,
+  }),
+  action: customPropTypes.itemShorthand,
+  actionable: PropTypes.bool,
+  description: customPropTypes.itemShorthand,
+  header: customPropTypes.itemShorthand,
+  icon: customPropTypes.shorthandAllowingChildren,
+  progress: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+Attachment.defaultProps = {
+  accessibility: attachmentBehavior,
+};
+
+Attachment.handledProps = Object.keys(Attachment.propTypes) as any;
 
 /**
  * An Attachment represents a file or media attachment, which may contain some metadata or actions.

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentStyles.ts
@@ -1,5 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { AttachmentProps } from '../../../../components/Attachment/Attachment';
+
+import { AttachmentStylesProps } from '../../../../components/Attachment/Attachment';
 import { AttachmentVariables } from './attachmentVariables';
 import { pxToRem } from '../../../../utils';
 import SvgIcon from '../../../../components/SvgIcon/SvgIcon';
@@ -7,7 +8,7 @@ import getBorderFocusStyles from '../../getBorderFocusStyles';
 import getIconFillOrOutlineStyles from '../../getIconFillOrOutlineStyles';
 import Button from '../../../../components/Button/Button';
 
-const attachmentStyles: ComponentSlotStylesPrepared<AttachmentProps, AttachmentVariables> = {
+const attachmentStyles: ComponentSlotStylesPrepared<AttachmentStylesProps, AttachmentVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
@@ -32,7 +33,7 @@ const attachmentStyles: ComponentSlotStylesPrepared<AttachmentProps, AttachmentV
 
       ...borderFocusStyles,
 
-      ...((p.actionable || p.onClick) && {
+      ...(p.actionable && {
         cursor: 'pointer',
 
         ':focus-visible': {
@@ -130,7 +131,6 @@ const attachmentStyles: ComponentSlotStylesPrepared<AttachmentProps, AttachmentV
     display: 'block',
     bottom: 0,
     left: 0,
-    width: `${p.progress}%`,
     maxWidth: '100%',
     height: pxToRem(v.progressHeight),
     background: v.progressColor,

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -566,13 +566,7 @@ export default function isConformant(
       });
 
       wrapper.unmount();
-
-      expect(telemetry.performance).toHaveProperty(
-        Component.displayName,
-        expect.objectContaining({
-          count: 1,
-        }),
-      );
+      expect(telemetry.performance).toHaveProperty(Component.displayName);
     });
   });
 }

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -20,7 +20,6 @@ import helpers from './commonHelpers';
 
 import * as FluentUI from 'src/index';
 import { getEventTargetComponent, EVENT_TARGET_ATTRIBUTE } from './eventTarget';
-import { expectMissing } from 'office-ui-fabric-react/src/common/testUtilities';
 
 export interface Conformant {
   constructorName?: string;

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -1,5 +1,5 @@
 import { Accessibility, AriaRole, IS_FOCUSABLE_ATTRIBUTE } from '@fluentui/accessibility';
-import { FocusZone } from '@fluentui/react-bindings';
+import { FocusZone, Telemetry } from '@fluentui/react-bindings';
 import { Ref, RefFindNode } from '@fluentui/react-component-ref';
 import * as faker from 'faker';
 import * as _ from 'lodash';
@@ -20,6 +20,7 @@ import helpers from './commonHelpers';
 
 import * as FluentUI from 'src/index';
 import { getEventTargetComponent, EVENT_TARGET_ATTRIBUTE } from './eventTarget';
+import { expectMissing } from 'office-ui-fabric-react/src/common/testUtilities';
 
 export interface Conformant {
   constructorName?: string;
@@ -554,32 +555,25 @@ export default function isConformant(
     });
   });
 
-  const validListenerNames = _.reduce(syntheticEvent.types, (result, { listeners }) => [...result, ...listeners], []);
-
   // ---------------------------------------
-  // Opt-in tests
+  // Telemetry
   // ---------------------------------------
-  return {
-    // -------------------------------------
-    // Ensure that props are passed as a
-    // second argument to event handler
-    // -------------------------------------
-    hasExtendedHandlerFor(onEventName) {
-      describe(`has extended handler for '${onEventName}' event`, () => {
-        test(`'${onEventName}' is a valid event listener name`, () => {
-          expect(validListenerNames).toContain(onEventName);
-        });
 
-        test(`is declared in props`, () => {
-          expect(Component.propTypes[onEventName]).toBeTruthy();
-        });
+  describe('telemetry', () => {
+    test('reports telemetry to its Provider', () => {
+      const telemetry = new Telemetry();
+      const wrapper = mount(<Component {...requiredProps} />, {
+        wrappingComponentProps: { telemetry },
       });
 
-      // -----------------------------------
-      // Allows chained calls for optional
-      // test suites
-      // -----------------------------------
-      return this;
-    },
-  };
+      wrapper.unmount();
+
+      expect(telemetry.performance).toHaveProperty(
+        Component.displayName,
+        expect.objectContaining({
+          count: 1,
+        }),
+      );
+    });
+  });
 }

--- a/packages/fluentui/react-northstar/test/specs/components/Attachment/Attachment-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Attachment/Attachment-test.tsx
@@ -4,8 +4,9 @@ import { mountWithProvider, findIntrinsicElement } from 'test/utils';
 import * as keyboardKey from 'keyboard-key';
 
 import Attachment from 'src/components/Attachment/Attachment';
-import Text from 'src/components/Text/Text';
+import Box from 'src/components/Box/Box';
 import Button from 'src/components/Button/Button';
+import Text from 'src/components/Text/Text';
 import { ReactWrapper } from 'enzyme';
 
 const attachmentImplementsShorthandProp = implementsShorthandProp(Attachment);
@@ -24,10 +25,12 @@ const getAttachment = (onClickAttachment: jest.Mock, onClickButton: jest.Mock): 
 };
 
 describe('Attachment', () => {
-  isConformant(Attachment);
-  attachmentImplementsShorthandProp('header', Text);
-  attachmentImplementsShorthandProp('description', Text);
+  isConformant(Attachment, { constructorName: 'Attachment' });
+
   attachmentImplementsShorthandProp('action', Button);
+  attachmentImplementsShorthandProp('description', Text);
+  attachmentImplementsShorthandProp('icon', Box, { mapsValueToProp: 'children' });
+  attachmentImplementsShorthandProp('header', Text);
 
   describe('accessibility', () => {
     handlesAccessibility(Attachment, {

--- a/packages/fluentui/react-northstar/test/utils/withProvider.tsx
+++ b/packages/fluentui/react-northstar/test/utils/withProvider.tsx
@@ -1,5 +1,5 @@
 import { Telemetry } from '@fluentui/react-bindings';
-import { emptyTheme, ThemeInput } from '@fluentui/styles';
+import { emptyTheme } from '@fluentui/styles';
 import { mount, MountRendererProps, ComponentType } from 'enzyme';
 import * as React from 'react';
 import { ThemeProvider } from 'react-fela';
@@ -35,7 +35,6 @@ export const mountWithProviderAndGetComponent = <C extends React.Component, P = 
   Component: ComponentType<P>,
   elementToMount: React.ReactElement<P>,
   options?: MountRendererProps,
-  theme?: ThemeInput,
 ) => {
-  return mountWithProvider(elementToMount, options, theme).find(Component);
+  return mountWithProvider(elementToMount, options).find(Component);
 };

--- a/packages/fluentui/react-northstar/test/utils/withProvider.tsx
+++ b/packages/fluentui/react-northstar/test/utils/withProvider.tsx
@@ -1,19 +1,20 @@
+import { Telemetry } from '@fluentui/react-bindings';
 import { emptyTheme, ThemeInput } from '@fluentui/styles';
-import * as React from 'react';
 import { mount, MountRendererProps, ComponentType } from 'enzyme';
+import * as React from 'react';
 import { ThemeProvider } from 'react-fela';
 
 import { felaRenderer } from 'src/utils';
 import { ProviderContextPrepared } from 'src/types';
 
-export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => {
+export const EmptyThemeProvider: React.FunctionComponent<{ telemetry?: Telemetry }> = ({ children, telemetry }) => {
   const theme: ProviderContextPrepared = {
     renderer: felaRenderer,
     target: document,
     disableAnimations: false,
     rtl: false,
     theme: emptyTheme,
-    telemetry: undefined,
+    telemetry,
     performance: {} as any,
   };
 
@@ -23,7 +24,6 @@ export const EmptyThemeProvider: React.FunctionComponent = ({ children }) => {
 export const mountWithProvider = <C extends React.Component, P = C['props'], S = C['state']>(
   node: React.ReactElement<P>,
   options?: MountRendererProps,
-  theme?: ThemeInput,
 ) => {
   return mount(node, {
     wrappingComponent: EmptyThemeProvider,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `Attachment` component to be functional. As in all other cases it contains a breaking change with restricted props set that will be passed to styles functions.

## Prop sets

| `Attachment`    |
| --------- |
| `actionable` |
| `disabled` |

***

## Notable changes

- Adds a test for telemetry capturing
- `progress` was moved out from CSS styles as in `Slider` component

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12576)