### PR TITLE
fix(cache): classes cache miss on empty string

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -39,6 +39,7 @@ Removed types: `TeamsSvgIconSpec`, `ThemeIconSpec`, `SvgIconSpec`, `SvgIconSpecW
 - Fix `ButtonContent` className and added conformat test @mnajdova ([#12431](https://github.com/microsoft/fluentui/pull/12431))
 - Fix colors for keyboard navigation in vertical Menu component in Teams theme high contrast mode @TanelVari ([#12462](https://github.com/microsoft/fluentui/pull/12462))
 - Fix navigation into cell which has multiple actionable elements @kolaps33 ([#12533](https://github.com/microsoft/fluentui/pull/12533))
+- Fix classes cache miss on empty string result @mnajdova ([#12584](https://github.com/microsoft/fluentui/pull/12584))
 
 ### Features
 - Add `createSvgIcon` factory in `@fluentui/react-bindings` and `SvgIcon` component in `@fluentui/react-northstar` @mnajdova ([#12319](https://github.com/OfficeDev/office-ui-fabric-react/pull/12319))

--- a/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
@@ -211,7 +211,8 @@ const resolveStyles = (
       get(): string {
         if (cacheEnabled && theme) {
           const classesThemeCache = classesCache.get(theme) || {};
-          if (classesThemeCache[slotCacheKey]) {
+
+          if (classesThemeCache[slotCacheKey] || classesThemeCache[slotCacheKey] === '') {
             return slotName === 'root'
               ? cx(componentClassName, classesThemeCache[slotCacheKey], className)
               : classesThemeCache[slotCacheKey];


### PR DESCRIPTION
### Problem description

Sometimes some slots may resolved in no styles for some props combination, which means that basically the result from the cache is empty string. This however was resulting in a cache miss on our side and we were re-calculating the styles for that slot over and over again.

### Solution

We should not recalculate styles when the result is empty string, as it is a valid result.