### PR TITLE
feat(Card): Add size and fluid props

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -56,6 +56,7 @@ Removed types: `TeamsSvgIconSpec`, `ThemeIconSpec`, `SvgIconSpec`, `SvgIconSpecW
 - Add `borderRadius` variables to `Card` component @pompomon ([#12552](https://github.com/microsoft/fluentui/pull/12552))
 - Add `CustomerHubIcon`, `OcrOffIcon`, `OcrOnIcon` and `ContactGroupCallIcon` icons @mnajdova ([#12571](https://github.com/microsoft/fluentui/pull/12571))
 - Add `SwitchCameraIcon`, `PanoramaOffIcon`, `AttendeeIcon` and `GroupVideoCallGridIcon`. Updated `PanoramaIcon`. @TanelVari ([#12566](https://github.com/microsoft/fluentui/pull/12566))
+- Add `size` and `fluid` props to `Card` component @pompomon ([#12589](https://github.com/microsoft/fluentui/pull/12589))
 
 ### Documentation
 - Add per-component bundle size charts @miroslavstastny ([#12374](https://github.com/microsoft/fluentui/pull/12374))

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Button, Flex, Image, Text, Avatar, Card, Layout } from '@fluentui/react-northstar';
+import { StarIcon, DownloadIcon, MoreIcon } from '@fluentui/react-icons-northstar';
+
+const CardExample = () => (
+  <Card fluid>
+    <Card.Header>
+      <Flex gap="gap.small" column>
+        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Text content="Sample card" weight="bold" />
+        <Text content="Secondary line" size="small" />
+      </Flex>
+    </Card.Header>
+    <Card.Body>
+      <Flex column gap="gap.small">
+        <Image src="public/images/wireframe/square-image.png" fluid />
+        <Text content="Content text" />
+      </Flex>
+    </Card.Body>
+    <Card.Footer>
+      <Flex space="between">
+        <Button content="Action" />
+        <Flex>
+          <Button icon={<StarIcon />} iconOnly text title="Favourite" />
+          <Button icon={<DownloadIcon />} iconOnly text title="Download" />
+          <Button icon={<MoreIcon />} iconOnly text title="More" />
+        </Flex>
+      </Flex>
+    </Card.Footer>
+  </Card>
+);
+
+const ImageExampleFluent = () => (
+  <div>
+    <Layout styles={{ maxWidth: '200px' }} debug renderMainArea={() => <CardExample />} />
+    <Layout styles={{ maxWidth: '400px' }} debug renderMainArea={() => <CardExample />} />
+    <Layout styles={{ maxWidth: '600px' }} debug renderMainArea={() => <CardExample />} />
+  </div>
+);
+
+export default ImageExampleFluent;

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
@@ -5,10 +5,12 @@ import { StarIcon, DownloadIcon, MoreIcon } from '@fluentui/react-icons-northsta
 const CardExample = () => (
   <Card fluid>
     <Card.Header>
-      <Flex gap="gap.small" column>
+      <Flex gap="gap.small">
         <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
-        <Text content="Sample card" weight="bold" />
-        <Text content="Secondary line" size="small" />
+        <Flex column>
+          <Text content="Fluid card" weight="bold" />
+          <Text content="Secondary line" size="small" />
+        </Flex>
       </Flex>
     </Card.Header>
     <Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Button, Flex, Image, Text, Avatar, Card, Layout } from '@fluentui/react-northstar';
+import { Button, Flex, Text, Avatar, Card, Layout } from '@fluentui/react-northstar';
 import { StarIcon, DownloadIcon, MoreIcon } from '@fluentui/react-icons-northstar';
 
 const CardExample = () => (
@@ -13,12 +13,6 @@ const CardExample = () => (
         </Flex>
       </Flex>
     </Card.Header>
-    <Card.Body>
-      <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" fluid />
-        <Text content="Content text" />
-      </Flex>
-    </Card.Body>
     <Card.Footer>
       <Flex space="between">
         <Button content="Action" />

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
@@ -6,15 +6,17 @@ const CardExampleSize = () => (
   <Flex gap="gap.small">
     <Card size="small">
       <Card.Header>
-        <Flex gap="gap.small" column>
+        <Flex gap="gap.small">
           <Avatar
             image="public/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
           />
-          <Text content="Small card" weight="bold" />
-          <Text content="Secondary line" size="small" />
+          <Flex column>
+            <Text content="Small card" weight="bold" />
+            <Text content="Secondary line" size="small" />
+          </Flex>
         </Flex>
       </Card.Header>
       <Card.Body>
@@ -38,15 +40,17 @@ const CardExampleSize = () => (
 
     <Card>
       <Card.Header>
-        <Flex gap="gap.small" column>
+        <Flex gap="gap.small">
           <Avatar
             image="public/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
           />
-          <Text content="Medium(default) card" weight="bold" />
-          <Text content="Secondary line" size="small" />
+          <Flex column>
+            <Text content="Medium (default) card" weight="bold" />
+            <Text content="Secondary line" size="small" />
+          </Flex>
         </Flex>
       </Card.Header>
       <Card.Body>
@@ -71,15 +75,17 @@ const CardExampleSize = () => (
 
     <Card size="large">
       <Card.Header>
-        <Flex gap="gap.small" column>
+        <Flex gap="gap.small">
           <Avatar
             image="public/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
           />
-          <Text content="Large card" weight="bold" />
-          <Text content="Secondary line" size="small" />
+          <Flex column>
+            <Text content="Large card" weight="bold" />
+            <Text content="Secondary line" size="small" />
+          </Flex>
         </Flex>
       </Card.Header>
       <Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
@@ -1,6 +1,5 @@
-import { Button, Flex, Image, Text, Avatar, Card, Divider } from '@fluentui/react-northstar';
+import { Flex, Image, Text, Avatar, Card } from '@fluentui/react-northstar';
 import * as React from 'react';
-import { StarIcon, DownloadIcon, MoreIcon } from '@fluentui/react-icons-northstar';
 
 const CardExampleSize = () => (
   <Flex gap="gap.small">
@@ -25,17 +24,7 @@ const CardExampleSize = () => (
           <Text content="Content text" />
         </Flex>
       </Card.Body>
-      <Card.Footer>
-        <Flex space="between">
-          <Button content="Action" />
-          <Flex>
-            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
-            <Button icon={<MoreIcon />} iconOnly text title="More" />
-          </Flex>
-        </Flex>
-      </Card.Footer>
     </Card>
-
 
     <Card>
       <Card.Header>
@@ -58,18 +47,7 @@ const CardExampleSize = () => (
           <Text content="Content text" />
         </Flex>
       </Card.Body>
-      <Card.Footer>
-        <Flex space="between">
-          <Button content="Action" />
-          <Flex>
-            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
-            <Button icon={<DownloadIcon />} iconOnly text title="Download" />
-            <Button icon={<MoreIcon />} iconOnly text title="More" />
-          </Flex>
-        </Flex>
-      </Card.Footer>
     </Card>
-
 
     <Card size="large">
       <Card.Header>
@@ -92,16 +70,6 @@ const CardExampleSize = () => (
           <Text content="Content text" />
         </Flex>
       </Card.Body>
-      <Card.Footer>
-        <Flex space="between">
-          <Button content="Action" />
-          <Flex>
-            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
-            <Button icon={<DownloadIcon />} iconOnly text title="Download" />
-            <Button icon={<MoreIcon />} iconOnly text title="More" />
-          </Flex>
-        </Flex>
-      </Card.Footer>
     </Card>
   </Flex>
 );

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
@@ -1,0 +1,105 @@
+import { Button, Flex, Image, Text, Avatar, Card, Divider } from '@fluentui/react-northstar';
+import * as React from 'react';
+import { StarIcon, DownloadIcon, MoreIcon } from '@fluentui/react-icons-northstar';
+
+const CardExampleSize = () => (
+  <Flex gap="gap.small">
+    <Card size="small">
+      <Card.Header>
+        <Flex gap="gap.small" column>
+          <Avatar
+            image="public/images/avatar/small/matt.jpg"
+            label="Copy bandwidth"
+            name="Evie yundt"
+            status="unknown"
+          />
+          <Text content="Small card" weight="bold" />
+          <Text content="Secondary line" size="small" />
+        </Flex>
+      </Card.Header>
+      <Card.Body>
+        <Flex column gap="gap.small">
+          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Text content="Content text" />
+        </Flex>
+      </Card.Body>
+      <Card.Footer>
+        <Flex space="between">
+          <Button content="Action" />
+          <Flex>
+            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
+            <Button icon={<MoreIcon />} iconOnly text title="More" />
+          </Flex>
+        </Flex>
+      </Card.Footer>
+    </Card>
+
+    <Divider />
+
+    <Card>
+      <Card.Header>
+        <Flex gap="gap.small" column>
+          <Avatar
+            image="public/images/avatar/small/matt.jpg"
+            label="Copy bandwidth"
+            name="Evie yundt"
+            status="unknown"
+          />
+          <Text content="Medium(default) card" weight="bold" />
+          <Text content="Secondary line" size="small" />
+        </Flex>
+      </Card.Header>
+      <Card.Body>
+        <Flex column gap="gap.small">
+          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Text content="Content text" />
+        </Flex>
+      </Card.Body>
+      <Card.Footer>
+        <Flex space="between">
+          <Button content="Action" />
+          <Flex>
+            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
+            <Button icon={<DownloadIcon />} iconOnly text title="Download" />
+            <Button icon={<MoreIcon />} iconOnly text title="More" />
+          </Flex>
+        </Flex>
+      </Card.Footer>
+    </Card>
+
+    <Divider />
+
+    <Card size="large">
+      <Card.Header>
+        <Flex gap="gap.small" column>
+          <Avatar
+            image="public/images/avatar/small/matt.jpg"
+            label="Copy bandwidth"
+            name="Evie yundt"
+            status="unknown"
+          />
+          <Text content="Large card" weight="bold" />
+          <Text content="Secondary line" size="small" />
+        </Flex>
+      </Card.Header>
+      <Card.Body>
+        <Flex column gap="gap.small">
+          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Text content="Content text" />
+        </Flex>
+      </Card.Body>
+      <Card.Footer>
+        <Flex space="between">
+          <Button content="Action" />
+          <Flex>
+            <Button icon={<StarIcon />} iconOnly text title="Favourite" />
+            <Button icon={<DownloadIcon />} iconOnly text title="Download" />
+            <Button icon={<MoreIcon />} iconOnly text title="More" />
+          </Flex>
+        </Flex>
+      </Card.Footer>
+    </Card>
+  </Flex>
+);
+
+export default CardExampleSize;

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
@@ -36,7 +36,6 @@ const CardExampleSize = () => (
       </Card.Footer>
     </Card>
 
-    <Divider />
 
     <Card>
       <Card.Header>
@@ -71,7 +70,6 @@ const CardExampleSize = () => (
       </Card.Footer>
     </Card>
 
-    <Divider />
 
     <Card size="large">
       <Card.Header>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/index.tsx
@@ -15,6 +15,16 @@ const Variations = () => (
       description="Horizontal card"
       examplePath="components/Card/Variations/CardExampleHorizontal"
     />
+    <ComponentExample
+      title="Sizes"
+      description="A card can have assorted sizes"
+      examplePath="components/Card/Variations/CardExampleSize"
+    />
+    <ComponentExample
+      title="Fluid"
+      description="A card can take up the width and height of its container"
+      examplePath="components/Card/Variations/CardExampleFluid"
+    />
   </ExampleSection>
 );
 

--- a/packages/fluentui/react-northstar/src/components/Card/Card.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/Card.tsx
@@ -7,7 +7,8 @@ import {
   ProviderContextPrepared,
 } from '../../types';
 import { Accessibility, cardBehavior, CardBehaviorProps } from '@fluentui/accessibility';
-import { UIComponentProps, commonPropTypes, createShorthandFactory } from '../../utils';
+import * as CustomPropTypes from '@fluentui/react-proptypes';
+import { UIComponentProps, commonPropTypes, createShorthandFactory, SizeValue } from '../../utils';
 import { useTelemetry, useStyles, getElementType, useUnhandledProps, useAccessibility } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
@@ -45,9 +46,15 @@ export interface CardProps extends UIComponentProps {
 
   /** Centers content in a card. */
   centered?: boolean;
+
+  /** A card can be sized. */
+  size?: SizeValue;
+
+  /** A card can take up the width and height of its container. */
+  fluid?: boolean;
 }
 
-export type CardStylesProps = Pick<CardProps, 'compact' | 'horizontal' | 'centered'>;
+export type CardStylesProps = Pick<CardProps, 'compact' | 'horizontal' | 'centered' | 'size' | 'fluid'>;
 
 export interface CardSlotClassNames {
   header: string;
@@ -71,7 +78,7 @@ const Card: React.FC<WithAsProp<CardProps>> &
   const { setStart, setEnd } = useTelemetry(Card.displayName, context.telemetry);
   setStart();
 
-  const { className, design, styles, variables, children, compact, horizontal, centered } = props;
+  const { className, design, styles, variables, children, compact, horizontal, centered, size, fluid } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Card.handledProps, props);
   const getA11yProps = useAccessibility(props.accessibility, {
@@ -90,6 +97,8 @@ const Card: React.FC<WithAsProp<CardProps>> &
       centered,
       horizontal,
       compact,
+      size,
+      fluid,
     }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -136,10 +145,13 @@ Card.propTypes = {
   compact: PropTypes.bool,
   horizontal: PropTypes.bool,
   centered: PropTypes.bool,
+  size: CustomPropTypes.size,
+  fluid: PropTypes.bool,
 };
 
 Card.defaultProps = {
   accessibility: cardBehavior,
+  size: 'medium',
 };
 
 Card.handledProps = Object.keys(Card.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardStyles.ts
@@ -1,7 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { CardVariables } from './cardVariables';
 import { CardStylesProps } from '../../../../components/Card/Card';
-import { pxToRem } from '../../../../utils';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 
 const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariables> = {
@@ -20,12 +19,15 @@ const cardStyles: ComponentSlotStylesPrepared<CardStylesProps, CardVariables> = 
       position: 'relative',
       overflow: 'hidden',
       padding: v.padding,
+      width: v.width,
+      height: v.height,
+      ...(p.size === 'small' && { width: v.sizeSmallWidth, height: v.sizeSmallHeight, padding: v.sizeSmallPadding }),
+      ...(p.size === 'large' && { width: v.sizeLargeWidth, height: v.sizeLargeHeight, padding: v.sizeLargePadding }),
+      ...(p.fluid && { width: v.fluidWidth, height: v.fluidHeight }),
       ...(p.horizontal && { flexDirection: 'row' }),
       ...(p.compact && { padding: v.compactPadding }),
       ...(p.centered && { alignItems: 'center' }),
 
-      // TODO: update with latest design spec
-      width: pxToRem(300),
       borderWidth: v.borderWidth,
       borderStyle: v.borderStyle,
       borderColor: v.borderColor,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Card/cardVariables.ts
@@ -18,6 +18,16 @@ export interface CardVariables {
   previewMarginHorizontal: string;
   topControlsTop: string;
   topControlsRight: string;
+  width: string;
+  height: string;
+  sizeSmallWidth: string;
+  sizeSmallHeight: string;
+  sizeSmallPadding: string;
+  sizeLargeWidth: string;
+  sizeLargeHeight: string;
+  sizeLargePadding: string;
+  fluidHeight: string;
+  fluidWidth: string;
 }
 
 export default (siteVars): CardVariables => {
@@ -39,5 +49,16 @@ export default (siteVars): CardVariables => {
     previewMarginHorizontal: `0 ${pxToRem(10)} 0 0`,
     topControlsTop: pxToRem(10),
     topControlsRight: pxToRem(0),
+    // TODO: update with latest values from design
+    width: pxToRem(300),
+    height: '100%',
+    sizeSmallWidth: pxToRem(200),
+    sizeSmallHeight: '100%',
+    sizeSmallPadding: pxToRem(5),
+    sizeLargeWidth: pxToRem(500),
+    sizeLargeHeight: '100%',
+    sizeLargePadding: pxToRem(20),
+    fluidWidth: '100%',
+    fluidHeight: '100%',
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Add card `size` and `fluid` properties and default sizes

Sizes
![image](https://user-images.githubusercontent.com/2802155/78693244-47814500-78fb-11ea-9802-c657638995db.png)

Fluid
![image](https://user-images.githubusercontent.com/2802155/78693321-61228c80-78fb-11ea-9b2f-1201b1cb12c0.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12589)