### PR TITLE
Perf: avoid constant styles mutation in customizable which leads to constant style re-calculation on each render

### DIFF
--- a/apps/perf-test/src/scenarios/BaseButton.tsx
+++ b/apps/perf-test/src/scenarios/BaseButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { BaseButton } from 'office-ui-fabric-react';
 
-const scenario = <BaseButton text="I am a button" />;
+const scenario = <BaseButton text="I am a button" styles={{ root: { background: 'red' } }} />;
 
 export default scenario;

--- a/apps/perf-test/src/scenarios/Checkbox.tsx
+++ b/apps/perf-test/src/scenarios/Checkbox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Checkbox } from 'office-ui-fabric-react';
 
-const scenario = <Checkbox label="I am a checkbox" />;
+const scenario = <Checkbox label="I am a checkbox" styles={{ root: { background: 'red' } }} />;
 
 export default scenario;

--- a/apps/perf-test/src/scenarios/DefaultButton.tsx
+++ b/apps/perf-test/src/scenarios/DefaultButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react';
 
-const scenario = <DefaultButton text="I am a button" />;
+const scenario = <DefaultButton text="I am a button" styles={{ root: { background: 'red' } }} />;
 
 export default scenario;

--- a/apps/perf-test/src/scenarios/IconButton.tsx
+++ b/apps/perf-test/src/scenarios/IconButton.tsx
@@ -19,6 +19,14 @@ const menuProps: IContextualMenuProps = {
   directionalHintFixed: true,
 };
 
-const scenario = <IconButton menuProps={menuProps} iconProps={emojiIcon} title="Emoji" ariaLabel="Emoji" />;
+const scenario = (
+  <IconButton
+    menuProps={menuProps}
+    iconProps={emojiIcon}
+    title="Emoji"
+    ariaLabel="Emoji"
+    styles={{ root: { background: 'red' } }}
+  />
+);
 
 export default scenario;

--- a/apps/perf-test/src/scenarios/PrimaryButton.tsx
+++ b/apps/perf-test/src/scenarios/PrimaryButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PrimaryButton } from 'office-ui-fabric-react';
 
-const scenario = <PrimaryButton>I am a button</PrimaryButton>;
+const scenario = <PrimaryButton styles={{ root: { background: 'red' } }}>I am a button</PrimaryButton>;
 
 export default scenario;

--- a/change/@uifabric-utilities-2020-04-07-14-00-52-xgao-perf-improve.json
+++ b/change/@uifabric-utilities-2020-04-07-14-00-52-xgao-perf-improve.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Customizable: improve perf by avoid mutating styles when concatination is enabled",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "commit": "7236969c06c5d5e732da1087e229de9db9881309",
+  "dependentChangeType": "patch",
+  "date": "2020-04-07T21:00:52.058Z"
+}

--- a/change/office-ui-fabric-react-2020-04-07-14-33-17-xgao-perf-improve.json
+++ b/change/office-ui-fabric-react-2020-04-07-14-33-17-xgao-perf-improve.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fabric: Refactor dir and theme creation (#11808)",
+  "comment": "CommandBar: prevent command button style mutation if possible",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "4212e45c58077f93f56f60a65d967e43f230e259",

--- a/change/office-ui-fabric-react-2020-04-07-14-33-17-xgao-perf-improve.json
+++ b/change/office-ui-fabric-react-2020-04-07-14-33-17-xgao-perf-improve.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fabric: Refactor dir and theme creation (#11808)",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "4212e45c58077f93f56f60a65d967e43f230e259",
+  "dependentChangeType": "patch",
+  "date": "2020-04-07T21:33:17.251Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { css, nullRender } from '../../Utilities';
+import {
+  classNamesFunction,
+  css,
+  nullRender,
+  IComponentAs,
+  getNativeProps,
+  divProperties,
+  composeComponentAs,
+  initializeComponentRef,
+} from '../../Utilities';
 import {
   ICommandBar,
   ICommandBarItemProps,
@@ -10,17 +19,9 @@ import {
 import { IOverflowSet, OverflowSet } from '../../OverflowSet';
 import { IResizeGroup, ResizeGroup } from '../../ResizeGroup';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { classNamesFunction } from '../../Utilities';
 import { CommandBarButton, IButtonProps } from '../../Button';
 import { TooltipHost } from '../../Tooltip';
-import {
-  IComponentAs,
-  getNativeProps,
-  divProperties,
-  composeComponentAs,
-  initializeComponentRef,
-} from '@uifabric/utilities';
-import { mergeStyles, IStyle } from '@uifabric/styling';
+import { getCommandButtonStyles } from './CommandBar.styles';
 
 const getClassNames = classNamesFunction<ICommandBarStyleProps, ICommandBarStyles>();
 
@@ -155,21 +156,11 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
 
     // tslint:disable-next-line:deprecation
     const itemText = item.text || item.name;
-    const rootStyles: IStyle = {
-      height: '100%',
-    };
-    const labelStyles: IStyle = {
-      whiteSpace: 'nowrap',
-    };
     const commandButtonProps: ICommandBarItemProps = {
       allowDisabledFocus: true,
       role: 'menuitem',
       ...item,
-      styles: {
-        ...item.buttonStyles,
-        root: item.buttonStyles ? mergeStyles(rootStyles, item.buttonStyles.root) : rootStyles,
-        label: item.buttonStyles ? mergeStyles(labelStyles, item.buttonStyles.label) : labelStyles,
-      },
+      styles: getCommandButtonStyles(item.buttonStyles),
       className: css('ms-CommandBarItem-link', item.className),
       text: !item.iconOnly ? itemText : undefined,
       menuProps: item.subMenuProps,

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.styles.ts
@@ -1,6 +1,6 @@
 import { ICommandBarStyleProps, ICommandBarStyles } from './CommandBar.types';
+import { IButtonStyles } from '../Button/Button.types';
 import { memoizeFunction } from '../../Utilities';
-import { IButtonStyles } from '../Button';
 import { IStyle } from '../../Styling';
 
 const COMMAND_BAR_HEIGHT = 44;
@@ -40,17 +40,21 @@ export const getStyles = (props: ICommandBarStyleProps): ICommandBarStyles => {
   };
 };
 
-export const getCommandButtonStyles = memoizeFunction((customStyles: IButtonStyles | undefined) => {
-  const rootStyles: IStyle = {
-    height: '100%',
-  };
-  const labelStyles: IStyle = {
-    whiteSpace: 'nowrap',
-  };
+export const getCommandButtonStyles = memoizeFunction(
+  (customStyles: IButtonStyles | undefined): IButtonStyles => {
+    const rootStyles: IStyle = {
+      height: '100%',
+    };
+    const labelStyles: IStyle = {
+      whiteSpace: 'nowrap',
+    };
 
-  return {
-    customStyles,
-    root: customStyles ? [rootStyles, customStyles.root] : rootStyles,
-    label: customStyles ? [labelStyles, customStyles.label] : labelStyles,
-  };
-});
+    const { root, label, ...restCustomStyles } = customStyles || {};
+
+    return {
+      ...restCustomStyles,
+      root: root ? [rootStyles, root] : rootStyles,
+      label: label ? [labelStyles, label] : labelStyles,
+    };
+  },
+);

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.styles.ts
@@ -1,4 +1,7 @@
 import { ICommandBarStyleProps, ICommandBarStyles } from './CommandBar.types';
+import { memoizeFunction } from '../../Utilities';
+import { IButtonStyles } from '../Button';
+import { IStyle } from '../../Styling';
 
 const COMMAND_BAR_HEIGHT = 44;
 
@@ -36,3 +39,18 @@ export const getStyles = (props: ICommandBarStyleProps): ICommandBarStyles => {
     ],
   };
 };
+
+export const getCommandButtonStyles = memoizeFunction((customStyles: IButtonStyles | undefined) => {
+  const rootStyles: IStyle = {
+    height: '100%',
+  };
+  const labelStyles: IStyle = {
+    whiteSpace: 'nowrap',
+  };
+
+  return {
+    customStyles,
+    root: customStyles ? [rootStyles, customStyles.root] : rootStyles,
+    label: customStyles ? [labelStyles, customStyles.label] : labelStyles,
+  };
+});

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -74,7 +74,7 @@ describe('customizable', () => {
       </Customizer>,
     );
     const component = wrapper.find('ConcatStyles');
-
+    wrapper.update();
     expect((component.props() as IComponentProps).styles).toEqual({ root: [globalStyles, componentStyles] });
   });
 
@@ -121,5 +121,76 @@ describe('customizable', () => {
     const component = wrapper.find('OverrideStyles');
 
     expect((component.props() as IComponentProps).styles).toEqual({ root: componentStyles });
+  });
+
+  it('should not mutate styles if no change to component and global styles', () => {
+    const globalRootStyles = { color: 'red', background: 'red' };
+    const componentRootStyles = { color: 'blue' };
+    const componentStyles = { root: componentRootStyles };
+
+    Customizations.applySettings({ styles: { root: globalRootStyles } });
+    const wrapper = mount(
+      <Customizer>
+        <ConcatStyles styles={componentStyles} />
+      </Customizer>,
+    );
+    const component = wrapper.find('ConcatStyles');
+    const finalStyles = (component.props() as IComponentProps).styles;
+    expect(finalStyles).toEqual({ root: [globalRootStyles, componentRootStyles] });
+
+    wrapper.setProps({});
+
+    const updatedComponent = wrapper.find('ConcatStyles');
+    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
+    expect(finalStylesAfterRerender).toBe(finalStyles);
+    expect(finalStylesAfterRerender).toEqual(finalStyles);
+  });
+
+  it('should not mutate styles if no change to component styles without global styles', () => {
+    const componentStyles = { root: { color: 'blue' } };
+
+    const wrapper = mount(
+      <Customizer>
+        <ConcatStyles styles={componentStyles} />
+      </Customizer>,
+    );
+    const component = wrapper.find('ConcatStyles');
+    const finalStyles = (component.props() as IComponentProps).styles;
+    expect(finalStyles).toEqual(componentStyles);
+
+    wrapper.setProps({});
+
+    const updatedComponent = wrapper.find('ConcatStyles');
+    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
+    expect(finalStylesAfterRerender).toBe(finalStyles);
+    expect(finalStylesAfterRerender).toEqual(finalStyles);
+  });
+
+  it('should update styles if component styles changed', () => {
+    const globalRootStyles = { color: 'red', background: 'red' };
+    const componentRootStyles = { color: 'blue' };
+    const componentStyles = { root: componentRootStyles };
+
+    Customizations.applySettings({ styles: { root: globalRootStyles } });
+    const wrapper = mount(
+      <Customizer>
+        <ConcatStyles styles={componentStyles} />
+      </Customizer>,
+    );
+    const component = wrapper.find('ConcatStyles');
+    const finalStyles = (component.props() as IComponentProps).styles;
+    expect(finalStyles).toEqual({ root: [globalRootStyles, componentRootStyles] });
+
+    const newComponentRootStyles = { color: 'red' };
+    const newComponentStyles = { root: newComponentRootStyles };
+
+    // re-render ConcatStyles with new styles
+    wrapper.setProps({
+      children: React.cloneElement(wrapper.props().children, { styles: newComponentStyles }),
+    });
+
+    const updatedComponent = wrapper.find('ConcatStyles');
+    const finalStylesAfterRerender = (updatedComponent.props() as IComponentProps).styles;
+    expect(finalStylesAfterRerender).toEqual({ root: [globalRootStyles, newComponentRootStyles] });
   });
 });

--- a/packages/utilities/src/customizations/customizable.test.tsx
+++ b/packages/utilities/src/customizations/customizable.test.tsx
@@ -74,7 +74,6 @@ describe('customizable', () => {
       </Customizer>,
     );
     const component = wrapper.find('ConcatStyles');
-    wrapper.update();
     expect((component.props() as IComponentProps).styles).toEqual({ root: [globalStyles, componentStyles] });
   });
 

--- a/packages/utilities/src/customizations/customizable.tsx
+++ b/packages/utilities/src/customizations/customizable.tsx
@@ -20,6 +20,8 @@ export function customizable(
       public static displayName: string = 'Customized' + scope;
 
       // tslint:disable-next-line:no-any
+      private _styleCache: { default?: any; component?: any; merged?: any } = {};
+
       constructor(props: P) {
         super(props);
 
@@ -49,9 +51,18 @@ export function customizable(
               }
 
               // If concatStyles is true and custom styles have been defined compute those styles
-              if (concatStyles && (defaultProps.styles || componentProps.styles)) {
-                const mergedStyles = concatStyleSets(defaultProps.styles, componentProps.styles);
-                return <ComposedComponent {...defaultProps} {...componentProps} styles={mergedStyles} />;
+              if (concatStyles && defaultProps.styles) {
+                if (
+                  this._styleCache.default !== defaultProps.styles ||
+                  this._styleCache.component !== componentProps.styles
+                ) {
+                  const mergedStyles = concatStyleSets(defaultProps.styles, componentProps.styles);
+                  this._styleCache.default = defaultProps.styles;
+                  this._styleCache.component = componentProps.styles;
+                  this._styleCache.merged = mergedStyles;
+                }
+
+                return <ComposedComponent {...defaultProps} {...componentProps} styles={this._styleCache.merged} />;
               }
 
               return <ComposedComponent {...defaultProps} {...componentProps} />;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Currently there is a big flaw in `customizable`, that is:
if `concatStyles` is set to `true` and either global styles or component level styles are present, we always mutate the final `styles` that gets passed down to wrapped component. Every time `styles` prop changes, we will re-calculate all styles for the component.

This change simply adds a layer of caching similar to logic inside `styled`. The cache will invalidate as long as either global or component styles mutates by shallow comparison. 

The gain of this fix is quite significant:
All our button variations use `customizable`, and all of them hits this problem because `styles` prop is being passed. therefore with this fix, as long as `styles` props that passed to button doesn't mutate, we avoid a ton of style recalculation on each render. This also improves perf for components that use buttons (e.g. [`CommandBar`](https://github.com/microsoft/fluentui/blob/master/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx#L168), [`Nav`](https://github.com/microsoft/fluentui/blob/master/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx#L116))
(Gain can also be observed from flamegrill results once ready)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12596)