### PR TITLE
Panel: passing close button styles down using subComponentStyles

### DIFF
--- a/change/@uifabric-merge-styles-2020-04-08-22-07-06-xgao-fix-styles-panel-subcomp.json
+++ b/change/@uifabric-merge-styles-2020-04-08-22-07-06-xgao-fix-styles-panel-subcomp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix typing for subComponentStyles in StyleSet",
+  "packageName": "@uifabric/merge-styles",
+  "email": "xgao@microsoft.com",
+  "commit": "60647bcf49d8896f183df0a615c5e11cfb5bba3c",
+  "dependentChangeType": "patch",
+  "date": "2020-04-09T05:06:08.957Z"
+}

--- a/change/office-ui-fabric-react-2020-04-08-22-07-06-xgao-fix-styles-panel-subcomp.json
+++ b/change/office-ui-fabric-react-2020-04-08-22-07-06-xgao-fix-styles-panel-subcomp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Panel: passing close button styles down using subComponentStyles",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "60647bcf49d8896f183df0a615c5e11cfb5bba3c",
+  "dependentChangeType": "patch",
+  "date": "2020-04-09T05:07:06.045Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -39,7 +39,7 @@ export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
     [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
-        [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, IStyleSet<any>>;
+        [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any>;
     };
 };
 
@@ -401,7 +401,7 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
     [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
     subComponentStyles?: {
-        [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, IStyleSet<any>>;
+        [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any>;
     };
 };
 
@@ -421,7 +421,7 @@ export function keyframes(timeline: {
 }): string;
 
 // Warning: (ae-forgotten-export) The symbol "IStyleOptions" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public
 export function mergeCss(args: (IStyle | IStyleBaseArray | false | null | undefined) | (IStyle | IStyleBaseArray | false | null | undefined)[], options?: IStyleOptions): string;
 
@@ -459,7 +459,7 @@ export function mergeStyleSets<TStyleSet1 extends IStyleSet<TStyleSet1>, TStyleS
 export function mergeStyleSets(...styleSets: Array<IStyleSet<any> | undefined | false | null>): IProcessedStyleSet<any>;
 
 // Warning: (ae-forgotten-export) The symbol "Diff" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export type Omit<U, K extends keyof U> = Pick<U, Diff<keyof U, K>>;
 
@@ -486,7 +486,7 @@ export class Stylesheet {
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/IStyleSet.d.ts:48:5 - (ae-forgotten-export) The symbol "__MapToFunctionType" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/merge-styles/src/IStyleSet.ts
+++ b/packages/merge-styles/src/IStyleSet.ts
@@ -25,7 +25,7 @@ export type __MapToFunctionType<T> = Extract<T, Function> extends never
 export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
-  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, IStyleSet<any>> };
+  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunctionOrObject<any, any> };
 };
 
 /**
@@ -34,7 +34,7 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
 export type IConcatenatedStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
   [P in keyof Omit<TStyleSet, 'subComponentStyles'>]: IStyle;
 } & {
-  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, IStyleSet<any>> };
+  subComponentStyles?: { [P in keyof TStyleSet['subComponentStyles']]: IStyleFunction<any, any> };
 };
 
 /**

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4420,6 +4420,7 @@ export interface IDropdownStyles {
     dropdownOptionText: IStyle;
     errorMessage: IStyle;
     label: IStyle;
+    // @deprecated
     panel: IStyle;
     root: IStyle;
     subComponentStyles: IDropdownSubComponentStyles;
@@ -5989,7 +5990,8 @@ export interface IPanelStyleProps {
 
 // @public (undocumented)
 export interface IPanelStyles {
-    closeButton: IStyle;
+    // @deprecated
+    closeButton?: IStyle;
     commands: IStyle;
     content: IStyle;
     contentInner: IStyle;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6003,6 +6003,12 @@ export interface IPanelStyles {
     overlay: IStyle;
     root: IStyle;
     scrollableContent: IStyle;
+    subComponentStyles: IPanelSubComponentStyles;
+}
+
+// @public (undocumented)
+export interface IPanelSubComponentStyles {
+    closeButton: Partial<IButtonStyles>;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -257,7 +257,7 @@ export interface IDropdownStyles {
 
   /**
    * Refers to the panel that hosts the Dropdown options in small viewports.
-   * Note: This will be deprecated when Panel supports JS Styling.
+   * @deprecated Use `subComponentStyles.panel` instead.
    */
   panel: IStyle;
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -332,7 +332,9 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
   private _onRenderNavigationContent = (props: IPanelProps): JSX.Element | null => {
     const { closeButtonAriaLabel, hasCloseButton, onRenderHeader = this._onRenderHeader } = props;
     if (hasCloseButton) {
-      const iconButtonStyles = this._classNames.subComponentStyles.closeButton();
+      const iconButtonStyles = this._classNames.subComponentStyles
+        ? this._classNames.subComponentStyles.closeButton()
+        : undefined;
 
       return (
         <>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -332,9 +332,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
   private _onRenderNavigationContent = (props: IPanelProps): JSX.Element | null => {
     const { closeButtonAriaLabel, hasCloseButton, onRenderHeader = this._onRenderHeader } = props;
     if (hasCloseButton) {
-      const iconButtonStyles = this._classNames.subComponentStyles
-        ? this._classNames.subComponentStyles.closeButton()
-        : undefined;
+      const iconButtonStyles = this._classNames.subComponentStyles?.closeButton();
 
       return (
         <>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -341,6 +341,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
           {!this._hasCustomNavigation && onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
           <IconButton
             styles={iconButtonStyles}
+            // tslint:disable-next-line:deprecation
             className={this._classNames.closeButton}
             onClick={this._onPanelClick}
             ariaLabel={closeButtonAriaLabel}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IconButton, IButtonStyles } from '../../Button';
+import { IconButton } from '../../Button';
 import { Layer } from '../../Layer';
 import { Overlay } from '../../Overlay';
 import { Popup } from '../../Popup';

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { IconButton } from '../../Button';
+import { IconButton, IButtonStyles } from '../../Button';
 import { Layer } from '../../Layer';
 import { Overlay } from '../../Overlay';
 import { Popup } from '../../Popup';
-import { getTheme, IconFontSizes, IProcessedStyleSet } from '../../Styling';
+import { IProcessedStyleSet } from '../../Styling';
 import {
   allowScrollOnElement,
   allowOverscrollOnElement,
@@ -331,34 +331,14 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
 
   private _onRenderNavigationContent = (props: IPanelProps): JSX.Element | null => {
     const { closeButtonAriaLabel, hasCloseButton, onRenderHeader = this._onRenderHeader } = props;
-    const theme = getTheme();
     if (hasCloseButton) {
-      // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-      // const iconButtonStyles = this._classNames.subComponentStyles
-      // ? (this._classNames.subComponentStyles.iconButton as IStyleFunctionOrObject<IButtonStyleProps, IButtonStyles>)
-      // : undefined;
+      const iconButtonStyles = this._classNames.subComponentStyles.closeButton();
 
       return (
-        <React.Fragment>
+        <>
           {!this._hasCustomNavigation && onRenderHeader(this.props, this._onRenderHeader, this._headerTextId)}
           <IconButton
-            // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-            // className={iconButtonStyles}
-            styles={{
-              root: [
-                this._hasCustomNavigation && {
-                  height: 'auto',
-                  width: '44px',
-                },
-                {
-                  color: theme.palette.neutralSecondary,
-                  fontSize: IconFontSizes.large,
-                },
-              ],
-              rootHovered: {
-                color: theme.palette.neutralPrimary,
-              },
-            }}
+            styles={iconButtonStyles}
             className={this._classNames.closeButton}
             onClick={this._onPanelClick}
             ariaLabel={closeButtonAriaLabel}
@@ -366,7 +346,7 @@ export class PanelBase extends React.Component<IPanelProps, IPanelState> impleme
             data-is-visible={true}
             iconProps={{ iconName: 'Cancel' }}
           />
-        </React.Fragment>
+        </>
       );
     }
     return null;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -273,7 +273,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         height: commandBarHeight,
       },
     ],
-    closeButton: [],
     contentInner: [
       classNames.contentInner,
       {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -10,11 +10,8 @@ import {
   ScreenWidthMinXXLarge,
   ScreenWidthMinUhfMobile,
   IStyle,
+  IconFontSizes,
 } from '../../Styling';
-
-// TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-// import { IStyleFunctionOrObject } from '../../Utilities';
-// import { IButtonStyles, IButtonStyleProps } from '../../Button';
 
 const GlobalClassNames = {
   root: 'ms-Panel',
@@ -157,22 +154,6 @@ const sharedPaddingStyles = {
   paddingRight: '24px',
 };
 
-// // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-// function getIconButtonStyles(props: IPanelStyleProps): IStyleFunctionOrObject<IButtonStyleProps, IButtonStyles> {
-//   const { theme } = props;
-//   return () => ({
-//     root: {
-//       height: 'auto',
-//       width: '44px',
-//       color: theme.palette.neutralSecondary,
-//       fontSize: IconFontSizes.large
-//     },
-//     rootHovered: {
-//       color: theme.palette.neutralPrimary
-//     }
-//   });
-// }
-
 export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
   const {
     className,
@@ -292,15 +273,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         height: commandBarHeight,
       },
     ],
-    closeButton: [
-      classNames.closeButton,
-      {
-        marginRight: 14,
-      },
-      hasCustomNavigation && {
-        marginRight: 0,
-      },
-    ],
+    closeButton: [],
     contentInner: [
       classNames.contentInner,
       {
@@ -375,8 +348,25 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         paddingTop: 16,
       },
     ],
-    // subComponentStyles: {
-    //   iconButton: getIconButtonStyles(props)
-    // }
+    subComponentStyles: {
+      closeButton: {
+        root: [
+          classNames.closeButton,
+          {
+            marginRight: 14,
+            color: theme.palette.neutralSecondary,
+            fontSize: IconFontSizes.large,
+          },
+          hasCustomNavigation && {
+            marginRight: 0,
+            height: 'auto',
+            width: '44px',
+          },
+        ],
+        rootHovered: {
+          color: theme.palette.neutralPrimary,
+        },
+      },
+    },
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -5,6 +5,7 @@ import { IOverlayProps } from '../../Overlay';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { PanelBase } from './Panel.base';
+import { IButtonStyles } from '../Button';
 
 /**
  * {@docCategory Panel}
@@ -421,15 +422,12 @@ export interface IPanelStyleProps {
   hasCustomNavigation?: boolean;
 }
 
-// TODO -Issue #5689: Comment in once Button is converted to mergeStyles
-// export interface IPanelSubComponentStyles {
-//   /**
-//    * Styling for Icon child component.
-//    */
-//   // TODO: this should be the interface once we're on TS 2.9.2 but otherwise causes errors in 2.8.4
-//   // button: IStyleFunctionOrObject<IButtonStyleProps, IButtonStyles>;
-//   button: IStyleFunctionOrObject<any, any>;
-// }
+export interface IPanelSubComponentStyles {
+  /**
+   * Styling for close button child component.
+   */
+  closeButton: Partial<IButtonStyles>;
+}
 
 /**
  * {@docCategory Panel}
@@ -505,9 +503,8 @@ export interface IPanelStyles {
    */
   footerInner: IStyle;
 
-  // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
   /**
    * Styling for subcomponents.
    */
-  // subComponentStyles: IPanelSubComponentStyles;
+  subComponentStyles: IPanelSubComponentStyles;
 }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -4,8 +4,8 @@ import { ILayerProps } from '../../Layer';
 import { IOverlayProps } from '../../Overlay';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
+import { IButtonStyles } from '../Button/Button.types';
 import { PanelBase } from './Panel.base';
-import { IButtonStyles } from '../Button';
 
 /**
  * {@docCategory Panel}
@@ -475,8 +475,9 @@ export interface IPanelStyles {
 
   /**
    * Style for the close button IconButton element.
+   * @deprecated Use `subComponentStyles.closeButton` instead.
    */
-  closeButton: IStyle;
+  closeButton?: IStyle;
 
   /**
    * Style for the header container div element.

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -218,9 +218,9 @@ exports[`Panel renders Panel correctly 1`] = `
               <button
                 className=
                     ms-Button
-                    ms-Button--icon
                     ms-Panel-closeButton
                     ms-PanelAction-close
+                    ms-Button--icon
                     {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #5689
- [x] Include a change request file using `$ yarn change`

#### Description of changes

First and foremost, we are re-creating `styles` prop on every render (main reason why got me to make this PR).

This change fixes that by moving the close button styles to `subComponentStyles`. 

Also fixing typing bc i run into errors when `IStyleSet` contains more than one levels of `subComponentStyles` (e.g. Dropdown styles defined subComponentStyles.panel and panel defined subComponentStyles). 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12630)