### PR TITLE
merge: null values now preserve.

### DIFF
--- a/change/@uifabric-utilities-2020-04-10-08-53-35-fix-merge.json
+++ b/change/@uifabric-utilities-2020-04-10-08-53-35-fix-merge.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "merge: null values are now preserved.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T15:53:35.887Z"
+}

--- a/packages/utilities/src/merge.test.ts
+++ b/packages/utilities/src/merge.test.ts
@@ -17,6 +17,12 @@ describe('merge', () => {
     });
   });
 
+  it('can handle null values', () => {
+    expect(merge({}, { a: null })).toEqual({
+      a: null,
+    });
+  });
+
   it('can merge deeply', () => {
     expect(merge<{ a: { c: number }; b: number }>({}, { b: 0 }, { a: { c: 1 } }, { a: { c: 2 } })).toEqual({
       a: { c: 2 },

--- a/packages/utilities/src/merge.ts
+++ b/packages/utilities/src/merge.ts
@@ -24,7 +24,7 @@ function _merge<T extends Object>(target: T, source: T, circularReferences: any[
   for (let name in source) {
     if (source.hasOwnProperty(name)) {
       const value: T[Extract<keyof T, string>] = source[name];
-      if (typeof value === 'object') {
+      if (typeof value === 'object' && value !== null) {
         const isCircularReference = circularReferences.indexOf(value) > -1;
         target[name] = (isCircularReference
           ? value


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Before:
```tsx
merge({}, { a: null }) // results in { a: {} }
```

After:
```tsx
merge({}, { a: null }) // results in { a: null }
```



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12646)