### PR TITLE
Explicit Website LTR and Fabric LTR

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="ltr" lang="en-us">
+<html lang="en-us">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -1,4 +1,4 @@
-import { registerIcons, on, KeyCodes } from 'office-ui-fabric-react';
+import { registerIcons, on, KeyCodes, setRTL } from 'office-ui-fabric-react';
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
 import { createSite } from './utilities/createSite';
 import * as platformPickerStyles from '@uifabric/example-app-base/lib/components/PlatformPicker/PlatformPicker.module.scss';
@@ -10,6 +10,8 @@ import { AndroidLogo, AppleLogo, WebLogo } from './utilities/index';
 // TODO: handle redirects
 
 initializeFileTypeIcons('https://static2.sharepointonline.com/files/fabric/assets/item-types-fluent/');
+
+setRTL(false);
 
 registerIcons({
   icons: {

--- a/change/@uifabric-fabric-website-2020-04-10-08-53-34-website-ltr.json
+++ b/change/@uifabric-fabric-website-2020-04-10-08-53-34-website-ltr.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "explicitly set RTL false on website",
+  "packageName": "@uifabric/fabric-website",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T15:53:34.257Z"
+}

--- a/change/office-ui-fabric-react-2020-04-10-09-22-36-website-ltr.json
+++ b/change/office-ui-fabric-react-2020-04-10-09-22-36-website-ltr.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "always return explicit Fabric dir",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-10T16:22:36.579Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
@@ -25,7 +25,7 @@ const getDir = (theme?: ITheme, dir?: IFabricProps['dir']) => {
     // If Fabric dir !== contextDir
     // Or If contextDir !== pageDir
     // Then we need to set dir of the Fabric root
-    rootDir: componentDir !== contextDir || componentDir !== pageDir ? componentDir : undefined,
+    rootDir: componentDir !== contextDir || componentDir !== pageDir ? componentDir : dir,
     // If dir !== contextDir || pageDir
     // then set contextual theme around content
     needsTheme: componentDir !== contextDir,

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -48,6 +48,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
         & textarea {
           font-family: inherit;
         }
+    dir="ltr"
   >
     <div
       className=
@@ -2037,6 +2038,7 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
         & textarea {
           font-family: inherit;
         }
+    dir="ltr"
   >
     <div
       className=


### PR DESCRIPTION
Somehow in the past our website explicitly set LTR on the <HTML>. Then we moved to <Fabric> always returning LTR and that HTML one disappeared (still can't see why).

So when we decided to remove the redundant LTR in Fabric, our website broke. 

So I'm adding an explicit LTR since we don't have direct access to the <HTML> element on the hosted page.  


Semi related. The Fabric control wasn't returning the 'dir' value unless it didn't match theme/page dir value. This could cause a bug where Fabric was the only element setting 'LTR'. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12647)