### PR TITLE
Merge-styles: Expose key to class names

### DIFF
--- a/change/@uifabric-merge-styles-2020-04-10-22-14-04-exposeKeyToClassNames.json
+++ b/change/@uifabric-merge-styles-2020-04-10-22-14-04-exposeKeyToClassNames.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Expose keytoclassnames to app, so it can be cached by the app in places like indexed db.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-11T05:14:03.928Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -407,12 +407,12 @@ export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet>> = {
 
 // @public
 export interface IStyleSheetConfig {
+    classNameCache?: {
+        [key: string]: string;
+    };
     cspSettings?: ICSPSettings;
     defaultPrefix?: string;
     injectionMode?: InjectionMode;
-    keyToClassName?: {
-        [key: string]: string;
-    };
     namespace?: string;
     onInsertRule?: (rule: string) => void;
     rtl?: boolean;

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -410,6 +410,9 @@ export interface IStyleSheetConfig {
     cspSettings?: ICSPSettings;
     defaultPrefix?: string;
     injectionMode?: InjectionMode;
+    keyToClassName?: {
+        [key: string]: string;
+    };
     namespace?: string;
     onInsertRule?: (rule: string) => void;
     rtl?: boolean;
@@ -473,6 +476,9 @@ export class Stylesheet {
     cacheClassName(className: string, key: string, args: IStyle[], rules: string[]): void;
     classNameFromKey(key: string): string | undefined;
     getClassName(displayName?: string): string;
+    getClassNameCache(): {
+        [key: string]: string;
+    };
     static getInstance(): Stylesheet;
     getRules(includePreservedRules?: boolean): string;
     insertedRulesFromClassName(className: string): string[] | undefined;

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -68,6 +68,11 @@ export interface IStyleSheetConfig {
    * Callback executed when a rule is inserted.
    */
   onInsertRule?: (rule: string) => void;
+
+  /**
+   * Initial value for keyToClassName cache
+   */
+  keyToClassName?: { [key: string]: string };
 }
 
 const STYLESHEET_SETTING = '__stylesheet__';
@@ -114,7 +119,6 @@ export class Stylesheet {
    * Gets the singleton instance.
    */
   public static getInstance(): Stylesheet {
-    // tslint:disable-next-line:no-any
     _stylesheet = _global[STYLESHEET_SETTING] as Stylesheet;
 
     if (!_stylesheet || (_stylesheet._lastStyleElement && _stylesheet._lastStyleElement.ownerDocument !== document)) {
@@ -135,6 +139,8 @@ export class Stylesheet {
       cspSettings: undefined,
       ...config,
     };
+
+    this._keyToClassName = this._config.keyToClassName || {};
   }
 
   /**
@@ -186,6 +192,13 @@ export class Stylesheet {
    */
   public classNameFromKey(key: string): string | undefined {
     return this._keyToClassName[key];
+  }
+
+  /**
+   * Gets all classnames cache with the stylesheet
+   */
+  public getClassNameCache(): { [key: string]: string } {
+    return this._keyToClassName;
   }
 
   /**

--- a/packages/merge-styles/src/Stylesheet.ts
+++ b/packages/merge-styles/src/Stylesheet.ts
@@ -70,9 +70,9 @@ export interface IStyleSheetConfig {
   onInsertRule?: (rule: string) => void;
 
   /**
-   * Initial value for keyToClassName cache
+   * Initial value for classnames cache. Key is serialized css rules associated with a classname.
    */
-  keyToClassName?: { [key: string]: string };
+  classNameCache?: { [key: string]: string };
 }
 
 const STYLESHEET_SETTING = '__stylesheet__';
@@ -140,7 +140,7 @@ export class Stylesheet {
       ...config,
     };
 
-    this._keyToClassName = this._config.keyToClassName || {};
+    this._keyToClassName = this._config.classNameCache || {};
   }
 
   /**
@@ -195,7 +195,7 @@ export class Stylesheet {
   }
 
   /**
-   * Gets all classnames cache with the stylesheet
+   * Gets all classnames cache with the stylesheet.
    */
   public getClassNameCache(): { [key: string]: string } {
     return this._keyToClassName;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ X ] Include a change request file using `$ yarn change`

#### Description of changes

Expose keyToClassNames to app (i.e SharePoint pages) per discussion with @xugao  and @KevinTCoughlin , so app could cache it in places like indexed db. This avoid runtime style generation and significantly improve app EUPL. 

Data collected on dev env with the change
![image](https://user-images.githubusercontent.com/4000765/79036190-a9031700-7b7a-11ea-84b9-9619bd9f35c9.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12651)