### PR TITLE
Removing withInfo button from fabric storybook

### DIFF
--- a/change/office-ui-fabric-react-2020-04-11-16-07-24-fix-example8-update.json
+++ b/change/office-ui-fabric-react-2020-04-11-16-07-24-fix-example8-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "removing withInfo button from fabric storybook",
+  "packageName": "office-ui-fabric-react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none",
+  "date": "2020-04-11T23:07:24.503Z"
+}

--- a/packages/office-ui-fabric-react/.storybook/preview.js
+++ b/packages/office-ui-fabric-react/.storybook/preview.js
@@ -1,10 +1,8 @@
 import { initializeIcons } from '@uifabric/icons';
 import generateStoriesFromExamples from '@uifabric/build/storybook/generateStoriesFromExamples';
 import { configure, addParameters, addDecorator } from '@storybook/react';
-import { withInfo } from '@storybook/addon-info';
 import { withA11y } from '@storybook/addon-a11y';
 
-addDecorator(withInfo());
 addDecorator(withA11y());
 addParameters({
   a11y: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Removed withInfo button from fabric storybook as it doesn't seem to be used and throws an error when clicked.

Here is the button:

![image](https://user-images.githubusercontent.com/7192338/79056826-309a6580-7c0f-11ea-99ab-4881f6332fdc.png)

#### Focus areas to test

Run storybook


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12657)