### PR TITLE
feat(FocusZone): Bringing allowFocusRoot from v7 to v0

### DIFF
--- a/change/@fluentui-react-focus-2020-04-13-14-58-35-allowFocusRootV0.json
+++ b/change/@fluentui-react-focus-2020-04-13-14-58-35-allowFocusRootV0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Updating comment of allowFocusRoot to be more descriptive of its functionality.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T21:58:35.712Z"
+}

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -351,14 +351,18 @@ export default class FocusZone extends React.Component<FocusZoneProps> implement
       this._isParked = isParked;
 
       if (isParked) {
-        this._parkedTabIndex = this._root.current.getAttribute('tabindex');
-        this._root.current.setAttribute('tabindex', '-1');
+        if (!this.props.allowFocusRoot) {
+          this._parkedTabIndex = this._root.current.getAttribute('tabindex');
+          this._root.current.setAttribute('tabindex', '-1');
+        }
         this._root.current.focus();
-      } else if (this._parkedTabIndex) {
-        this._root.current.setAttribute('tabindex', this._parkedTabIndex);
-        this._parkedTabIndex = undefined;
-      } else {
-        this._root.current.removeAttribute('tabindex');
+      } else if (!this.props.allowFocusRoot) {
+        if (this._parkedTabIndex) {
+          this._root.current.setAttribute('tabindex', this._parkedTabIndex);
+          this._parkedTabIndex = undefined;
+        } else {
+          this._root.current.removeAttribute('tabindex');
+        }
       }
     }
   }

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -112,6 +112,9 @@ export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttribute
    */
   shouldReceiveFocus?: (childElement?: HTMLElement) => boolean;
 
+  /** Allow focus to move to root */
+  allowFocusRoot?: boolean;
+
   /**
    * Allows TAB key to be handled, thus alows tabbing through a focusable list of items in the
    * focus zone. A side effect is that users will not be able to TAB out of the focus zone and

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -112,7 +112,7 @@ export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttribute
    */
   shouldReceiveFocus?: (childElement?: HTMLElement) => boolean;
 
-  /** Allow focus to move to root */
+  /** Allows focus to park on root when focus is in the `FocusZone` at render time. */
   allowFocusRoot?: boolean;
 
   /**

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -432,14 +432,12 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
           root.setAttribute('tabindex', '-1');
         }
         root.focus();
-      } else {
-        if (!this.props.allowFocusRoot) {
-          if (this._parkedTabIndex) {
-            root.setAttribute('tabindex', this._parkedTabIndex);
-            this._parkedTabIndex = undefined;
-          } else {
-            root.removeAttribute('tabindex');
-          }
+      } else if (!this.props.allowFocusRoot) {
+        if (this._parkedTabIndex) {
+          root.setAttribute('tabindex', this._parkedTabIndex);
+          this._parkedTabIndex = undefined;
+        } else {
+          root.removeAttribute('tabindex');
         }
       }
     }

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -127,7 +127,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
    */
   onBeforeFocus?: (childElement?: HTMLElement) => boolean;
 
-  /** Allow focus to move to root */
+  /** Allows focus to park on root when focus is in the `FocusZone` at render time. */
   allowFocusRoot?: boolean;
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR brings the `allowFocusRoot` prop from the v7 version of `FocusZone` to the v0 version. This prop determines whether focus is allowed to park on the root when the focus is in the `FocusZone` at render time.

This PR also changes the comment documentation for the prop to make it more easily understandable.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12666)