### PR TITLE
Card: Removing unwanted outline when Cards are clicked

### DIFF
--- a/change/@uifabric-react-cards-2020-04-13-15-09-26-cardOutline.json
+++ b/change/@uifabric-react-cards-2020-04-13-15-09-26-cardOutline.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Card: Removing unwanted outline when Cards are clicked.",
+  "packageName": "@uifabric/react-cards",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T22:09:26.594Z"
+}

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -54,10 +54,11 @@ export const CardStyles: ICardComponent['styles'] = (props, theme, tokens): ICar
         boxShadow: tokens.boxShadow,
         cursor: tokens.cursor,
         height: tokens.height,
-        width: tokens.width,
-        minWidth: tokens.minWidth,
         maxWidth: tokens.maxWidth,
+        minWidth: tokens.minWidth,
+        outline: 'none',
         transition: 'box-shadow 0.5s ease',
+        width: tokens.width,
 
         selectors: {
           ':hover': {

--- a/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Card Item renders correctly 1`] = `
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -83,6 +84,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -173,6 +175,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -263,6 +266,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -353,6 +357,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -443,6 +448,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -558,6 +564,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -673,6 +680,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -738,6 +746,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -803,6 +812,7 @@ exports[`Card Item renders correctly when having tokens passed to it 1`] = `
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }

--- a/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Card Section renders correctly 1`] = `
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -95,6 +96,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -209,6 +211,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -323,6 +326,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -437,6 +441,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -551,6 +556,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -702,6 +708,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -853,6 +860,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -930,6 +938,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }
@@ -1007,6 +1016,7 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
         justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
+        outline: none;
         transition: box-shadow 0.5s ease;
         width: auto;
       }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12442
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Card` component was receiving an outline when clicked even when it wasn't interactable. This PR removes this outline in all scenarios given that even for clickable `Cards` we have different styling to identify that they are clickable.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12667)