### PR TITLE
SSR fix: generate keyframes during initial style calculation to avoid race condition

### DIFF
--- a/change/office-ui-fabric-react-2020-04-13-15-20-55-fix-keyframe-caching.json
+++ b/change/office-ui-fabric-react-2020-04-13-15-20-55-fix-keyframe-caching.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Keyframes are calculated on access. This helps with SSR generation, as namespace will be respected.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-13T22:20:55.160Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/ActivityItem.styles.ts
@@ -17,6 +17,20 @@ const ANIMATION_INNER_DIMENSION = '4px';
 const ANIMATION_OUTER_DIMENSION = '28px';
 const ANIMATION_BORDER_WIDTH = '4px';
 
+const fadeIn = memoizeFunction(() =>
+  keyframes({
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  }),
+);
+
+const slideIn = memoizeFunction(() =>
+  keyframes({
+    from: { transform: 'translateX(-10px)' },
+    to: { transform: 'translateX(0)' },
+  }),
+);
+
 export const getStyles = memoizeFunction(
   (
     theme: ITheme = getTheme(),
@@ -34,16 +48,6 @@ export const getStyles = memoizeFunction(
       ANIMATION_BORDER_WIDTH,
     );
 
-    const fadeIn: string = keyframes({
-      from: { opacity: 0 },
-      to: { opacity: 1 },
-    });
-
-    const slideIn: string = keyframes({
-      from: { transform: 'translateX(-10px)' },
-      to: { transform: 'translateX(0)' },
-    });
-
     const continuousPulseAnimation = {
       animationName: continuousPulse,
       animationIterationCount: '1',
@@ -52,13 +56,13 @@ export const getStyles = memoizeFunction(
     };
 
     const slideInAnimation = {
-      animationName: slideIn,
+      animationName: slideIn(),
       animationIterationCount: '1',
       animationDuration: '.5s',
     };
 
     const fadeInAnimation = {
-      animationName: fadeIn,
+      animationName: fadeIn(),
       animationIterationCount: '1',
       animationDuration: '.5s',
     };

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -1,123 +1,129 @@
 import { keyframes, PulsingBeaconAnimationStyles, HighContrastSelector } from '../../Styling';
 import { ICoachmarkStyleProps, ICoachmarkStyles } from './Coachmark.types';
-import { getRTL, IsFocusVisibleClassName } from '../../Utilities';
+import { getRTL, IsFocusVisibleClassName, memoizeFunction } from '../../Utilities';
 
 export const COACHMARK_WIDTH = 32;
 export const COACHMARK_HEIGHT = 32;
 
-export const translateOne: string = keyframes({
-  '0%': {
-    transform: 'translate(0, 0)', // orig 25
-    animationTimingFunction: 'linear',
-  },
-  '78.57%': {
-    transform: 'translate(0, 0)', // orig 25
-    animationTimingFunction: 'cubic-bezier(0.62, 0, 0.56, 1)',
-  },
-  '82.14%': {
-    transform: 'translate(0, -5px)', // orig 20
-    animationTimingFunction: 'cubic-bezier(0.58, 0, 0, 1)',
-  },
-  '84.88%': {
-    transform: 'translate(0, 9px)', // 34
-    animationTimingFunction: 'cubic-bezier(1, 0, 0.56, 1)',
-  },
-  '88.1%': {
-    transform: 'translate(0, -2px)', // orig 23
-    animationTimingFunction: 'cubic-bezier(0.58, 0, 0.67, 1)',
-  },
-  '90.12%': {
-    transform: 'translate(0, 0)',
-    animationTimingFunction: 'linear',
-  },
-  '100%': {
-    transform: 'translate(0, 0)',
-  },
-});
+export const translateOne = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      transform: 'translate(0, 0)', // orig 25
+      animationTimingFunction: 'linear',
+    },
+    '78.57%': {
+      transform: 'translate(0, 0)', // orig 25
+      animationTimingFunction: 'cubic-bezier(0.62, 0, 0.56, 1)',
+    },
+    '82.14%': {
+      transform: 'translate(0, -5px)', // orig 20
+      animationTimingFunction: 'cubic-bezier(0.58, 0, 0, 1)',
+    },
+    '84.88%': {
+      transform: 'translate(0, 9px)', // 34
+      animationTimingFunction: 'cubic-bezier(1, 0, 0.56, 1)',
+    },
+    '88.1%': {
+      transform: 'translate(0, -2px)', // orig 23
+      animationTimingFunction: 'cubic-bezier(0.58, 0, 0.67, 1)',
+    },
+    '90.12%': {
+      transform: 'translate(0, 0)',
+      animationTimingFunction: 'linear',
+    },
+    '100%': {
+      transform: 'translate(0, 0)',
+    },
+  }),
+);
 
-export const scaleOne: string = keyframes({
-  '0%': {
-    transform: ' scale(0)',
-    animationTimingFunction: 'linear',
-  },
-  '14.29%': {
-    transform: 'scale(0)',
-    animationTimingFunction: 'cubic-bezier(0.84, 0, 0.52, 0.99)',
-  },
-  '16.67%': {
-    transform: 'scale(1.15)',
-    animationTimingFunction: 'cubic-bezier(0.48, -0.01, 0.52, 1.01)',
-  },
-  '19.05%': {
-    transform: 'scale(0.95)',
-    animationTimingFunction: 'cubic-bezier(0.48, 0.02, 0.52, 0.98)',
-  },
-  '21.43%': {
-    transform: 'scale(1)',
-    animationTimingFunction: 'linear',
-  },
-  '42.86%': {
-    transform: 'scale(1)',
-    animationTimingFunction: 'cubic-bezier(0.48, -0.02, 0.52, 1.02)',
-  },
-  '45.71%': {
-    transform: 'scale(0.8)',
-    animationTimingFunction: 'cubic-bezier(0.48, 0.01, 0.52, 0.99)',
-  },
-  '50%': {
-    transform: 'scale(1)',
-    animationTimingFunction: 'linear',
-  },
-  '90.12%': {
-    transform: 'scale(1)',
-    animationTimingFunction: 'cubic-bezier(0.48, -0.02, 0.52, 1.02)',
-  },
-  '92.98%': {
-    transform: 'scale(0.8)',
-    animationTimingFunction: 'cubic-bezier(0.48, 0.01, 0.52, 0.99)',
-  },
-  '97.26%': {
-    transform: 'scale(1)',
-    animationTimingFunction: 'linear',
-  },
-  '100%': {
-    transform: 'scale(1)',
-  },
-});
+export const scaleOne = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      transform: ' scale(0)',
+      animationTimingFunction: 'linear',
+    },
+    '14.29%': {
+      transform: 'scale(0)',
+      animationTimingFunction: 'cubic-bezier(0.84, 0, 0.52, 0.99)',
+    },
+    '16.67%': {
+      transform: 'scale(1.15)',
+      animationTimingFunction: 'cubic-bezier(0.48, -0.01, 0.52, 1.01)',
+    },
+    '19.05%': {
+      transform: 'scale(0.95)',
+      animationTimingFunction: 'cubic-bezier(0.48, 0.02, 0.52, 0.98)',
+    },
+    '21.43%': {
+      transform: 'scale(1)',
+      animationTimingFunction: 'linear',
+    },
+    '42.86%': {
+      transform: 'scale(1)',
+      animationTimingFunction: 'cubic-bezier(0.48, -0.02, 0.52, 1.02)',
+    },
+    '45.71%': {
+      transform: 'scale(0.8)',
+      animationTimingFunction: 'cubic-bezier(0.48, 0.01, 0.52, 0.99)',
+    },
+    '50%': {
+      transform: 'scale(1)',
+      animationTimingFunction: 'linear',
+    },
+    '90.12%': {
+      transform: 'scale(1)',
+      animationTimingFunction: 'cubic-bezier(0.48, -0.02, 0.52, 1.02)',
+    },
+    '92.98%': {
+      transform: 'scale(0.8)',
+      animationTimingFunction: 'cubic-bezier(0.48, 0.01, 0.52, 0.99)',
+    },
+    '97.26%': {
+      transform: 'scale(1)',
+      animationTimingFunction: 'linear',
+    },
+    '100%': {
+      transform: 'scale(1)',
+    },
+  }),
+);
 
-export const rotateOne: string = keyframes({
-  '0%': {
-    transform: 'rotate(0deg)',
-    animationTimingFunction: 'linear',
-  },
-  '83.33%': {
-    transform: ' rotate(0deg)',
-    animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
-  },
-  '83.93%': {
-    transform: 'rotate(15deg)',
-    animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
-  },
-  '84.52%': {
-    transform: 'rotate(-15deg)',
-    animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
-  },
-  '85.12%': {
-    transform: 'rotate(15deg)',
-    animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
-  },
-  '85.71%': {
-    transform: 'rotate(-15deg)',
-    animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
-  },
-  '86.31%': {
-    transform: 'rotate(0deg)',
-    animationTimingFunction: 'linear',
-  },
-  '100%': {
-    transform: 'rotate(0deg)',
-  },
-});
+export const rotateOne = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      transform: 'rotate(0deg)',
+      animationTimingFunction: 'linear',
+    },
+    '83.33%': {
+      transform: ' rotate(0deg)',
+      animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+    },
+    '83.93%': {
+      transform: 'rotate(15deg)',
+      animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+    },
+    '84.52%': {
+      transform: 'rotate(-15deg)',
+      animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+    },
+    '85.12%': {
+      transform: 'rotate(15deg)',
+      animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+    },
+    '85.71%': {
+      transform: 'rotate(-15deg)',
+      animationTimingFunction: 'cubic-bezier(0.33, 0, 0.67, 1)',
+    },
+    '86.31%': {
+      transform: 'rotate(0deg)',
+      animationTimingFunction: 'linear',
+    },
+    '100%': {
+      transform: 'rotate(0deg)',
+    },
+  }),
+);
 
 export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
   const {
@@ -192,7 +198,7 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         animationIterationCount: '1',
         animationDelay: '0s',
         animationFillMode: 'forwards',
-        animationName: translateOne,
+        animationName: translateOne(),
         transition: 'opacity 0.5s ease-in-out',
       },
       !isCollapsed && {
@@ -212,7 +218,7 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         animationIterationCount: '1',
         animationDelay: '0s',
         animationFillMode: 'forwards',
-        animationName: scaleOne,
+        animationName: scaleOne(),
       },
     ],
     // Rotate Animation Layer
@@ -228,7 +234,7 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         animationIterationCount: '1',
         animationDelay: '0s',
         animationFillMode: 'forwards',
-        animationName: rotateOne,
+        animationName: rotateOne(),
       },
       !isCollapsed && {
         opacity: '1',

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -1,5 +1,5 @@
 import { HighContrastSelector, keyframes, noWrap, getGlobalClassNames, IRawStyle } from '../../Styling';
-import { getRTL } from '../../Utilities';
+import { getRTL, memoizeFunction } from '../../Utilities';
 import { IProgressIndicatorStyleProps, IProgressIndicatorStyles } from './ProgressIndicator.types';
 
 const GlobalClassNames = {
@@ -11,22 +11,27 @@ const GlobalClassNames = {
   progressBar: 'ms-ProgressIndicator-progressBar',
 };
 
-const IndeterminateProgress = keyframes({
-  '0%': {
-    left: '-30%',
-  },
-  '100%': {
-    left: '100%',
-  },
-});
-const IndeterminateProgressRTL = keyframes({
-  '100%': {
-    right: '-30%',
-  },
-  '0%': {
-    right: '100%',
-  },
-});
+const IndeterminateProgress = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      left: '-30%',
+    },
+    '100%': {
+      left: '100%',
+    },
+  }),
+);
+
+const IndeterminateProgressRTL = memoizeFunction(() =>
+  keyframes({
+    '100%': {
+      right: '-30%',
+    },
+    '0%': {
+      right: '100%',
+    },
+  }),
+);
 
 export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicatorStyles => {
   const isRTL = getRTL(props.theme);
@@ -109,7 +114,7 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
             background:
               `linear-gradient(to right, ${progressTrackColor} 0%, ` +
               `${palette.themePrimary} 50%, ${progressTrackColor} 100%)`,
-            animation: `${isRTL ? IndeterminateProgressRTL : IndeterminateProgress} 3s infinite`,
+            animation: `${isRTL ? IndeterminateProgressRTL() : IndeterminateProgress()} 3s infinite`,
             selectors: {
               [HighContrastSelector]: {
                 background: `highlight`,

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -1,6 +1,6 @@
 import { IShimmerStyleProps, IShimmerStyles } from './Shimmer.types';
 import { keyframes, getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
-import { getRTL } from '../../Utilities';
+import { getRTL, memoizeFunction } from '../../Utilities';
 
 const GlobalClassNames = {
   root: 'ms-Shimmer-container',
@@ -11,23 +11,27 @@ const GlobalClassNames = {
 
 const BACKGROUND_OFF_SCREEN_POSITION = '100%';
 
-const shimmerAnimation: string = keyframes({
-  '0%': {
-    transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,
-  },
-  '100%': {
-    transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`,
-  },
-});
+const shimmerAnimation = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,
+    },
+    '100%': {
+      transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`,
+    },
+  }),
+);
 
-const shimmerAnimationRTL: string = keyframes({
-  '100%': {
-    transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,
-  },
-  '0%': {
-    transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`,
-  },
-});
+const shimmerAnimationRTL = memoizeFunction(() =>
+  keyframes({
+    '100%': {
+      transform: `translateX(-${BACKGROUND_OFF_SCREEN_POSITION})`,
+    },
+    '0%': {
+      transform: `translateX(${BACKGROUND_OFF_SCREEN_POSITION})`,
+    },
+  }),
+);
 
 export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
   const { isDataLoaded, className, theme, transitionAnimationInterval, shimmerColor, shimmerWaveColor } = props;
@@ -101,7 +105,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
         animationTimingFunction: 'ease-in-out',
         animationDirection: 'normal',
         animationIterationCount: 'infinite',
-        animationName: isRTL ? shimmerAnimationRTL : shimmerAnimation,
+        animationName: isRTL ? shimmerAnimationRTL() : shimmerAnimation(),
       },
     ],
     dataWrapper: [

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
@@ -1,5 +1,6 @@
 import { ISpinnerStyleProps, ISpinnerStyles, SpinnerSize } from './Spinner.types';
 import { hiddenContentStyle, keyframes, HighContrastSelector, getGlobalClassNames } from '../../Styling';
+import { memoizeFunction } from '../../Utilities';
 
 const GlobalClassNames = {
   root: 'ms-Spinner',
@@ -7,14 +8,16 @@ const GlobalClassNames = {
   label: 'ms-Spinner-label',
 };
 
-const spinAnimation: string = keyframes({
-  '0%': {
-    transform: 'rotate(0deg)',
-  },
-  '100%': {
-    transform: 'rotate(360deg)',
-  },
-});
+const spinAnimation = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      transform: 'rotate(0deg)',
+    },
+    '100%': {
+      transform: 'rotate(360deg)',
+    },
+  }),
+);
 
 export const getStyles = (props: ISpinnerStyleProps): ISpinnerStyles => {
   const { theme, size, className, labelPosition } = props;
@@ -50,7 +53,7 @@ export const getStyles = (props: ISpinnerStyleProps): ISpinnerStyles => {
         borderRadius: '50%',
         border: '1.5px solid ' + palette.themeLight,
         borderTopColor: palette.themePrimary,
-        animationName: spinAnimation,
+        animationName: spinAnimation(),
         animationDuration: '1.3s',
         animationIterationCount: 'infinite',
         animationTimingFunction: 'cubic-bezier(.53,.21,.29,.67)',

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -8,6 +8,7 @@ import {
   IStyle,
   keyframes,
 } from '../../Styling';
+import { memoizeFunction } from '../../Utilities';
 
 const globalClassNames = {
   root: 'ms-TeachingBubble',
@@ -32,17 +33,19 @@ const globalClassNames = {
   buttonLabel: 'ms-Button-label',
 };
 
-const opacityFadeIn: string = keyframes({
-  '0%': {
-    opacity: 0,
-    animationTimingFunction: AnimationVariables.easeFunction1,
-    transform: 'scale3d(.90,.90,.90)',
-  },
-  '100%': {
-    opacity: 1,
-    transform: 'scale3d(1,1,1)',
-  },
-});
+const opacityFadeIn = memoizeFunction(() =>
+  keyframes({
+    '0%': {
+      opacity: 0,
+      animationTimingFunction: AnimationVariables.easeFunction1,
+      transform: 'scale3d(.90,.90,.90)',
+    },
+    '100%': {
+      opacity: 1,
+      transform: 'scale3d(1,1,1)',
+    },
+  }),
+);
 
 const rootStyle = (isWide?: boolean, calloutProps?: ICalloutContentStyleProps): IStyle[] => {
   const { calloutWidth, calloutMaxWidth } = calloutProps || {};
@@ -54,7 +57,7 @@ const rootStyle = (isWide?: boolean, calloutProps?: ICalloutContentStyleProps): 
       border: 0,
       outline: 'transparent',
       width: calloutWidth || 'calc(100% + 1px)',
-      animationName: `${opacityFadeIn}`,
+      animationName: `${opacityFadeIn()}`,
       animationDuration: '300ms',
       animationTimingFunction: 'linear',
       animationFillMode: 'both',


### PR DESCRIPTION
#### Description of changes

`keyframes()` calls generate a classname for a given animation. When this is done on file loading, the keyframe classnames are generated potentially before the user has an opportunity to configure SSR settings such as a namespace.

This change moves keyframe generation to be done at code access time, which is better in general.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12668)