### PR TITLE
fix(compose): add className as static and fix handling of handledProps

### DIFF
--- a/change/@fluentui-react-compose-2020-04-14-10-46-38-fix-compose-handle-parent-props.json
+++ b/change/@fluentui-react-compose-2020-04-14-10-46-38-fix-compose-handle-parent-props.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix(compose): add className as static and fix handling of handledProps",
+  "packageName": "@fluentui/react-compose",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-14T08:46:38.679Z"
+}

--- a/packages/fluentui/react-bindings/test/compose/compose-test.tsx
+++ b/packages/fluentui/react-bindings/test/compose/compose-test.tsx
@@ -92,6 +92,10 @@ describe('useCompose', () => {
     expect(wrapper.find('button').prop('className')).toContain('color-red');
   });
 
+  it('"className" is added as statics on composed component', () => {
+    expect(ComposedComponent).toHaveProperty('className', 'ui-composed');
+  });
+
   it('applies props on composed component', () => {
     const wrapper = mount(<ComposedComponent hidden color="red" visible />, { wrappingComponent: TestProvider });
 

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -9,6 +9,7 @@ import * as React from 'react';
 // @public (undocumented)
 export function compose<InputProps, InputStylesProps, ParentProps, ParentStylesProps>(InputComponent: React.FunctionComponent<ParentProps> & {
     fluentComposeConfig?: ComposePreparedOptions;
+    handledProps?: (keyof ParentProps)[];
 }, composeOptions?: ComposeOptions<InputProps, InputStylesProps, ParentStylesProps>): ComposedComponent<InputProps, InputStylesProps, ParentProps, ParentStylesProps>;
 
 // @public (undocumented)

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -13,6 +13,7 @@ export function compose<InputProps, InputStylesProps, ParentProps, ParentStylesP
 
 // @public (undocumented)
 export type ComposedComponent<InputProps = {}, InputStylesProps = {}, ParentProps = {}, ParentStylesProps = {}> = React.FunctionComponent<InputProps & ParentProps> & {
+    className: string;
     fluentComposeConfig: ComposePreparedOptions<InputProps, InputStylesProps, ParentProps, ParentStylesProps>;
 };
 

--- a/packages/react-compose/src/compose.ts
+++ b/packages/react-compose/src/compose.ts
@@ -26,7 +26,10 @@ function computeDisplayNames<InputProps, InputStylesProps, ParentProps, ParentSt
 }
 
 function compose<InputProps, InputStylesProps, ParentProps, ParentStylesProps>(
-  InputComponent: React.FunctionComponent<ParentProps> & { fluentComposeConfig?: ComposePreparedOptions },
+  InputComponent: React.FunctionComponent<ParentProps> & {
+    fluentComposeConfig?: ComposePreparedOptions;
+    handledProps?: (keyof ParentProps)[];
+  },
   composeOptions: ComposeOptions<InputProps, InputStylesProps, ParentStylesProps> = {},
 ): ComposedComponent<InputProps, InputStylesProps, ParentProps, ParentStylesProps> {
   const Component = (InputComponent.bind(null) as unknown) as ComposedComponent<
@@ -40,18 +43,23 @@ function compose<InputProps, InputStylesProps, ParentProps, ParentStylesProps>(
     ...defaultComposeOptions,
     ...(InputComponent.displayName && { displayNames: [InputComponent.displayName] }),
   };
-  const { handledProps = [], mapPropsToStylesProps } = composeOptions;
 
+  Component.className = composeOptions.className || inputOptions.className;
   Component.displayName = composeOptions.displayName || InputComponent.displayName;
+
   Component.fluentComposeConfig = {
-    className: composeOptions.className || inputOptions.className,
+    className: Component.className,
     displayNames: computeDisplayNames(inputOptions, composeOptions),
 
-    mapPropsToStylesPropsChain: (mapPropsToStylesProps
-      ? [...inputOptions.mapPropsToStylesPropsChain, mapPropsToStylesProps]
+    mapPropsToStylesPropsChain: (composeOptions.mapPropsToStylesProps
+      ? [...inputOptions.mapPropsToStylesPropsChain, composeOptions.mapPropsToStylesProps]
       : inputOptions.mapPropsToStylesPropsChain) as ((props: ParentStylesProps & InputProps) => InputStylesProps)[],
 
-    handledProps: [...inputOptions.handledProps, ...handledProps],
+    handledProps: [
+      ...(InputComponent.handledProps || []),
+      ...inputOptions.handledProps,
+      ...(composeOptions.handledProps || []),
+    ],
     overrideStyles: composeOptions.overrideStyles || false,
   };
 

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -6,6 +6,7 @@ export type ComposedComponent<
   ParentProps = {},
   ParentStylesProps = {}
 > = React.FunctionComponent<InputProps & ParentProps> & {
+  className: string;
   fluentComposeConfig: ComposePreparedOptions<InputProps, InputStylesProps, ParentProps, ParentStylesProps>;
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- exposes `className` as statics (was missing in the initial implementation)
- `handledProps` in config include props from parent component, too

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12677)