### PR TITLE
fix: use composed displayName in telemetry

### DIFF
--- a/packages/fluentui/react-bindings/src/index.ts
+++ b/packages/fluentui/react-bindings/src/index.ts
@@ -25,7 +25,7 @@ export { default as unstable_calculateAnimationTimeout } from './styles/calculat
 export { default as unstable_getStyles } from './styles/getStyles';
 export * from './styles/types';
 
-export { default as useTelemetry } from './telemetry/useTelemetry';
+export { getTelemetry as deprecated_getTelemetry, default as useTelemetry } from './telemetry/useTelemetry';
 export * from './telemetry/types';
 
 export { default as getElementType } from './utils/getElementType';

--- a/packages/fluentui/react-bindings/src/telemetry/useTelemetry.ts
+++ b/packages/fluentui/react-bindings/src/telemetry/useTelemetry.ts
@@ -1,6 +1,7 @@
+import useComposeOptions from '../compose/useComposeOptions';
 import { Telemetry, UseTelemetryResult } from './types';
 
-const useTelemetry = (displayName: string, telemetry: Telemetry | undefined): UseTelemetryResult => {
+export const getTelemetry = (displayName: string, telemetry: Telemetry | undefined): UseTelemetryResult => {
   let start: number = -1;
   let end: number = -1;
 
@@ -29,6 +30,12 @@ const useTelemetry = (displayName: string, telemetry: Telemetry | undefined): Us
   };
 
   return { setStart, setEnd };
+};
+
+const useTelemetry = (displayName: string, telemetry: Telemetry | undefined): UseTelemetryResult => {
+  const composeOptions = useComposeOptions();
+
+  return getTelemetry(composeOptions?.displayNames[0] || displayName, telemetry);
 };
 
 export default useTelemetry;

--- a/packages/fluentui/react-northstar/src/utils/renderComponent.tsx
+++ b/packages/fluentui/react-northstar/src/utils/renderComponent.tsx
@@ -3,11 +3,11 @@ import {
   ComponentSlotClasses,
   FocusZone,
   getElementType,
+  deprecated_getTelemetry as getTelemetry,
   getUnhandledProps,
   ReactAccessibilityBehavior,
   unstable_getAccessibility as getAccessibility,
   unstable_getStyles as getStyles,
-  useTelemetry,
 } from '@fluentui/react-bindings';
 import {
   emptyTheme,
@@ -57,7 +57,7 @@ const renderComponent = <P extends {}>(
     logProviderMissingWarning();
   }
 
-  const { setStart, setEnd } = useTelemetry(displayName, context.telemetry);
+  const { setStart, setEnd } = getTelemetry(displayName, context.telemetry);
   const rtl = context.rtl || false;
 
   setStart();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Currently `useTelemetry` hook uses an original `displayName` always, it means that every component component will be reported as a parent (`Box`, for example). This PR fixes it.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12678)