### PR TITLE
chore(Dropdown): add e2e test for closing on outside click

### DIFF
--- a/packages/fluentui/e2e/tests/dropdownMoveFocusOnTab-example.tsx
+++ b/packages/fluentui/e2e/tests/dropdownMoveFocusOnTab-example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Dropdown } from '@fluentui/react-northstar';
+import { Dropdown, DropdownItem } from '@fluentui/react-northstar';
 
-const inputItems = [
+export const inputItems = [
   'Bruce Wayne',
   'Natasha Romanoff',
   'Steven Strange',
@@ -17,6 +17,7 @@ export const selectors = {
   previousFocusableSibling: 'previous-focusable-sibling',
   nextFocusableSibling: 'next-focusable-sibling',
   triggerButtonClass: Dropdown.slotClassNames.triggerButton,
+  listItem: DropdownItem.className,
 };
 
 const DropdownMoveFocusOnTabExample = () => (

--- a/packages/fluentui/e2e/tests/dropdownMoveFocusOnTab-test.ts
+++ b/packages/fluentui/e2e/tests/dropdownMoveFocusOnTab-test.ts
@@ -1,8 +1,9 @@
-import { selectors } from './dropdownMoveFocusOnTab-example';
+import { selectors, inputItems } from './dropdownMoveFocusOnTab-example';
 
 const triggerButton = `.${selectors.triggerButtonClass}`;
 const nextFocusableSibling = `#${selectors.nextFocusableSibling}`;
 const previousFocusableSibling = `#${selectors.previousFocusableSibling}`;
+const listItem = `.${selectors.listItem}`;
 
 describe('Dropdown', () => {
   describe('Focus behavior', () => {
@@ -28,6 +29,16 @@ describe('Dropdown', () => {
 
       expect(await e2e.isFocused(triggerButton)).toBe(false);
       expect(await e2e.isFocused(previousFocusableSibling)).toBe(true);
+    });
+
+    it('closes dropdown on outside click', async () => {
+      await e2e.clickOn(triggerButton);
+
+      expect(await e2e.count(listItem)).toBe(inputItems.length);
+
+      await e2e.clickOn(previousFocusableSibling);
+
+      expect(await e2e.count(listItem)).toBe(0);
     });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Follow-up from https://github.com/microsoft/fluentui/pull/12625 ,creating an e2e test for the outside close scenario.
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12683)