### PR TITLE
Allow forwarding of FocusTrapZone props in TeachingBubble

### DIFF
--- a/change/office-ui-fabric-react-2020-04-14-11-53-51-teaching-focus.json
+++ b/change/office-ui-fabric-react-2020-04-14-11-53-51-teaching-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Allow forwarding of FocusTrapZone props in TeachingBubble",
+  "packageName": "office-ui-fabric-react",
+  "email": "mhensler@microsoft.com",
+  "dependentChangeType": "minor",
+  "date": "2020-04-14T18:53:50.992Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7602,6 +7602,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     ariaLabelledBy?: string;
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITeachingBubble>;
+    focusTrapZoneProps?: IFocusTrapZoneProps;
     footerContent?: string | JSX.Element;
     hasCloseButton?: boolean;
     // @deprecated (undocumented)

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -8,6 +8,7 @@ import { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';
 import { ICalloutProps, ICalloutContentStyleProps, Target } from '../../Callout';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IFocusTrapZoneProps } from '../FocusTrapZone/index';
 
 /**
  * {@docCategory TeachingBubble}
@@ -44,6 +45,11 @@ export interface ITeachingBubbleProps
    * Properties to pass through for Callout, reference detail properties in ICalloutProps
    */
   calloutProps?: ICalloutProps;
+
+  /**
+   * Properties to pass through for FocusTrapZone, reference detail properties in IFocusTrapZoneProps
+   */
+  focusTrapZoneProps?: IFocusTrapZoneProps;
 
   /**
    * A headline for the Teaching Bubble.

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -66,6 +66,7 @@ export class TeachingBubbleContentBase extends React.Component<ITeachingBubblePr
       ariaDescribedBy,
       ariaLabelledBy,
       footerContent: customFooterContent,
+      focusTrapZoneProps,
     } = this.props;
 
     let imageContent;
@@ -152,7 +153,7 @@ export class TeachingBubbleContentBase extends React.Component<ITeachingBubblePr
         data-is-focusable={true}
       >
         {imageContent}
-        <FocusTrapZone isClickableOutsideFocusTrap={true}>
+        <FocusTrapZone isClickableOutsideFocusTrap={true} {...focusTrapZoneProps}>
           <div className={classNames.bodyContent}>
             {headerContent}
             {bodyContent}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #12692 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Enable callers to pass `FocusZoneProps` to `TeachingBubbleProps`

#### Focus areas to test

`TeachingBubble`, though this does not change any default behavior


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12693)