### PR TITLE
FocusZone: Bringing shouldFocusOnMount prop from v0 to v7

### DIFF
--- a/change/@fluentui-react-focus-2020-04-15-12-10-56-focusZoneShouldFocusOnMount.json
+++ b/change/@fluentui-react-focus-2020-04-15-12-10-56-focusZoneShouldFocusOnMount.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T19:10:56.238Z"
+}

--- a/change/@fluentui-react-focus-2020-04-15-12-11-19-focusZoneShouldFocusOnMount.json
+++ b/change/@fluentui-react-focus-2020-04-15-12-11-19-focusZoneShouldFocusOnMount.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: Bringing shouldFocusOnMount prop from v0 to v7.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T19:11:19.189Z"
+}

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -56,7 +56,8 @@ export interface FocusZoneProps extends FocusZoneProperties, React.HTMLAttribute
   defaultTabbableElement?: (root: HTMLElement) => HTMLElement;
 
   /**
-   * If a default tabbable element should be force focused on FocusZone mount.
+   * Determines if a default tabbable element should be force focused on FocusZone mount.
+   * @default false
    */
   shouldFocusOnMount?: boolean;
 

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -81,6 +81,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
     onFocusNotification?: () => void;
     // @deprecated
     rootProps?: React.HTMLAttributes<HTMLDivElement>;
+    shouldFocusOnMount?: boolean;
     shouldInputLoseFocusOnArrowKey?: (inputElement: HTMLInputElement) => boolean;
 }
 

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -166,7 +166,9 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
       if (this.props.defaultActiveElement) {
         this._activeElement = this._getDocument().querySelector(this.props.defaultActiveElement) as HTMLElement;
-        this.focus();
+        if (this.props.shouldFocusOnMount) {
+          this.focus();
+        }
       }
     }
   }

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -66,6 +66,12 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
   defaultActiveElement?: string;
 
   /**
+   * Determines if a default tabbable element should be force focused on FocusZone mount.
+   * @default false
+   */
+  shouldFocusOnMount?: boolean;
+
+  /**
    * If set, the FocusZone will not be tabbable and keyboard navigation will be disabled.
    * This does not affect disabled attribute of any child.
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR brings the `shouldFocusOnMount` prop and functionality that exists in the v0 version of `FocusZone` to the v7 version. This prop determines if a default tabbable element should be force focused on `FocusZone` mount.

This PR also adjusts the comment for the prop slightly in both versions.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12709)