### PR TITLE
FocusZone: Replacing use of 'on' helper with native eventing

### DIFF
--- a/change/@fluentui-react-focus-2020-04-15-12-40-10-focusZoneEventing.json
+++ b/change/@fluentui-react-focus-2020-04-15-12-40-10-focusZoneEventing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Replacing use of 'on' helper with native eventing.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T19:40:10.423Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR replaces the use of the `on` helper in `FocusZone` with the native `addEventListener` and `removeEventListener` to bring the v0 and v7 versions of `FocusZone` closer together.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12710)