### PR TITLE
Enable classnames caching for Label and Icon

### DIFF
--- a/change/@uifabric-utilities-2020-04-15-13-41-37-xgao-disableCache.json
+++ b/change/@uifabric-utilities-2020-04-15-13-41-37-xgao-disableCache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "classNamesFunction: add warning on cache full",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T20:41:37.017Z"
+}

--- a/change/office-ui-fabric-react-2020-04-15-13-41-37-xgao-disableCache.json
+++ b/change/office-ui-fabric-react-2020-04-15-13-41-37-xgao-disableCache.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Enable classnames caching for label and icon",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-15T20:40:57.189Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -37,8 +37,9 @@ const ANIMATIONS: { [key: number]: string | undefined } = {
 };
 
 const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>({
-  disableCaching: true,
+  disableCaching: true, // disabling caching becasue stylesProp.position mutates often
 });
+
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };
 // Microsoft Edge will overwrite inline styles if there is an animation pertaining to that style.
 // To help ensure that edge will respect the offscreen style opacity

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -37,7 +37,7 @@ const ANIMATIONS: { [key: number]: string | undefined } = {
 };
 
 const getClassNames = classNamesFunction<ICalloutContentStyleProps, ICalloutContentStyles>({
-  disableCaching: true, // disabling caching becasue stylesProp.position mutates often
+  disableCaching: true, // disabling caching because stylesProp.position mutates often
 });
 
 const BEAK_ORIGIN_POSITION = { top: 0, left: 0 };

--- a/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComponentExamples.test.tsx
@@ -87,6 +87,12 @@ const excludedExampleFileRegexes: RegExp[] = [
   /^Panel\./,
 ];
 
+function setCacheFullWarning(enabled: boolean) {
+  (window as any).FabricConfig = {
+    enableClassNameCacheFullWarning: enabled,
+  };
+}
+
 declare const global: any;
 
 /**
@@ -148,6 +154,10 @@ describe('Component Examples', () => {
     jest.spyOn(Math, 'random').mockImplementation(() => {
       return 0;
     });
+
+    // Enable cache full warning. If warning occurs, the test will fail.
+    // This helps us catch mutating styles which cause cache to always miss.
+    setCacheFullWarning(true);
   });
 
   afterAll(() => {
@@ -177,6 +187,8 @@ describe('Component Examples', () => {
         globalSnapshotState.added += snapshotState.added;
       }
     });
+
+    setCacheFullWarning(false);
   });
 
   for (const examplePath of examplePaths) {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
@@ -8,6 +8,7 @@ import {
   IDocumentCardStyles,
   IDocumentCardActivityPerson,
 } from 'office-ui-fabric-react/lib/DocumentCard';
+import { IIconProps } from 'office-ui-fabric-react/lib/Icon';
 import { ImageFit } from 'office-ui-fabric-react/lib/Image';
 import { TestImages } from '@uifabric/example-data';
 
@@ -18,7 +19,7 @@ const people: IDocumentCardActivityPerson[] = [
   { name: 'Christian Bergqvist', profileImageSrc: '', initials: 'CB' },
 ];
 
-const oneNoteIconProps = {
+const oneNoteIconProps: IIconProps = {
   iconName: 'OneNoteLogo',
   styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } },
 };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
@@ -18,6 +18,11 @@ const people: IDocumentCardActivityPerson[] = [
   { name: 'Christian Bergqvist', profileImageSrc: '', initials: 'CB' },
 ];
 
+const oneNoteIconProps = {
+  iconName: 'OneNoteLogo',
+  styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } },
+};
+
 export const DocumentCardImageExample: React.FunctionComponent = () => {
   const cardStyles: IDocumentCardStyles = {
     root: { display: 'inline-block', marginRight: 20, marginBottom: 20, width: 320 },
@@ -47,14 +52,7 @@ export const DocumentCardImageExample: React.FunctionComponent = () => {
         styles={cardStyles}
         onClickHref="http://bing.com"
       >
-        <DocumentCardImage
-          height={150}
-          imageFit={ImageFit.cover}
-          iconProps={{
-            iconName: 'OneNoteLogo',
-            styles: { root: { color: '#813a7c', fontSize: '120px', width: '120px', height: '120px' } },
-          }}
-        />
+        <DocumentCardImage height={150} imageFit={ImageFit.cover} iconProps={oneNoteIconProps} />
         <DocumentCardDetails>
           <DocumentCardTitle title="How to make a good design" shouldTruncate />
         </DocumentCardDetails>

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -10,9 +10,7 @@ export interface IIconState {
   imageLoadError: boolean;
 }
 
-const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>({
-  disableCaching: true,
-});
+const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>();
 
 export class IconBase extends React.Component<IIconProps, IIconState> {
   constructor(props: IIconProps) {

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -10,7 +10,12 @@ export interface IIconState {
   imageLoadError: boolean;
 }
 
-const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>();
+const getClassNames = classNamesFunction<IIconStyleProps, IIconStyles>({
+  // Icon is used a lot by other components.
+  // It's likely to see expected cases which pass different className to the Icon.
+  // Therefore setting a larger cache size.
+  cacheSize: 100,
+});
 
 export class IconBase extends React.Component<IIconProps, IIconState> {
   constructor(props: IIconProps) {

--- a/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
@@ -3,7 +3,12 @@ import { divProperties, getNativeProps } from '../../Utilities';
 import { classNamesFunction } from '../../Utilities';
 import { ILabelProps, ILabelStyleProps, ILabelStyles } from './Label.types';
 
-const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>();
+const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>({
+  // Label is used a lot by other components.
+  // It's likely to see expected cases which pass different className to the Label.
+  // Therefore setting a larger cache size.
+  cacheSize: 100,
+});
 
 export class LabelBase extends React.Component<ILabelProps, {}> {
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.base.tsx
@@ -3,9 +3,7 @@ import { divProperties, getNativeProps } from '../../Utilities';
 import { classNamesFunction } from '../../Utilities';
 import { ILabelProps, ILabelStyleProps, ILabelStyles } from './Label.types';
 
-const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>({
-  disableCaching: true,
-});
+const getClassNames = classNamesFunction<ILabelStyleProps, ILabelStyles>();
 
 export class LabelBase extends React.Component<ILabelProps, {}> {
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Nav, INavLink, INavStyles } from 'office-ui-fabric-react/lib/Nav';
+import { Nav, INavLink, INavStyles, INavLinkGroup } from 'office-ui-fabric-react/lib/Nav';
 
 const navStyles: Partial<INavStyles> = {
   root: {
@@ -11,6 +11,67 @@ const navStyles: Partial<INavStyles> = {
   },
 };
 
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    links: [
+      {
+        name: 'Home',
+        url: 'http://example.com',
+        expandAriaLabel: 'Expand Home section',
+        collapseAriaLabel: 'Collapse Home section',
+        links: [
+          {
+            name: 'Activity',
+            url: 'http://msn.com',
+            key: 'key1',
+            target: '_blank',
+          },
+          {
+            name: 'MSN',
+            url: 'http://msn.com',
+            disabled: true,
+            key: 'key2',
+            target: '_blank',
+          },
+        ],
+        isExpanded: true,
+      },
+      {
+        name: 'Documents',
+        url: 'http://example.com',
+        key: 'key3',
+        isExpanded: true,
+        target: '_blank',
+      },
+      {
+        name: 'Pages',
+        url: 'http://msn.com',
+        key: 'key4',
+        target: '_blank',
+      },
+      {
+        name: 'Notebook',
+        url: 'http://msn.com',
+        key: 'key5',
+        disabled: true,
+      },
+      {
+        name: 'Communication and Media',
+        url: 'http://msn.com',
+        key: 'key6',
+        target: '_blank',
+      },
+      {
+        name: 'News',
+        url: 'http://cnn.com',
+        icon: 'News',
+        key: 'key7',
+        target: '_blank',
+      },
+    ],
+  },
+];
+
 export const NavBasicExample: React.FunctionComponent = () => {
   return (
     <Nav
@@ -18,66 +79,7 @@ export const NavBasicExample: React.FunctionComponent = () => {
       selectedKey="key3"
       ariaLabel="Nav basic example"
       styles={navStyles}
-      groups={[
-        {
-          links: [
-            {
-              name: 'Home',
-              url: 'http://example.com',
-              expandAriaLabel: 'Expand Home section',
-              collapseAriaLabel: 'Collapse Home section',
-              links: [
-                {
-                  name: 'Activity',
-                  url: 'http://msn.com',
-                  key: 'key1',
-                  target: '_blank',
-                },
-                {
-                  name: 'MSN',
-                  url: 'http://msn.com',
-                  disabled: true,
-                  key: 'key2',
-                  target: '_blank',
-                },
-              ],
-              isExpanded: true,
-            },
-            {
-              name: 'Documents',
-              url: 'http://example.com',
-              key: 'key3',
-              isExpanded: true,
-              target: '_blank',
-            },
-            {
-              name: 'Pages',
-              url: 'http://msn.com',
-              key: 'key4',
-              target: '_blank',
-            },
-            {
-              name: 'Notebook',
-              url: 'http://msn.com',
-              key: 'key5',
-              disabled: true,
-            },
-            {
-              name: 'Communication and Media',
-              url: 'http://msn.com',
-              key: 'key6',
-              target: '_blank',
-            },
-            {
-              name: 'News',
-              url: 'http://cnn.com',
-              icon: 'News',
-              key: 'key7',
-              target: '_blank',
-            },
-          ],
-        },
-      ]}
+      groups={navLinkGroups}
     />
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.CustomGroupHeaders.Example.tsx
@@ -5,7 +5,6 @@ const navLinkGroups: INavLinkGroup[] = [
   {
     name: 'Pages',
     links: [
-      // prettier-ignore
       { name: 'Activity', url: 'http://msn.com', key: 'key1', target: '_blank' },
       { name: 'News', url: 'http://msn.com', key: 'key2', target: '_blank' },
     ],
@@ -13,7 +12,6 @@ const navLinkGroups: INavLinkGroup[] = [
   {
     name: 'More pages',
     links: [
-      // prettier-ignore
       { name: 'Settings', url: 'http://msn.com', key: 'key3', target: '_blank' },
       { name: 'Notes', url: 'http://msn.com', key: 'key4', target: '_blank' },
     ],

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.CustomGroupHeaders.Example.tsx
@@ -1,29 +1,31 @@
 import * as React from 'react';
 import { Nav, INavLinkGroup } from 'office-ui-fabric-react/lib/Nav';
 
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    name: 'Pages',
+    links: [
+      // prettier-ignore
+      { name: 'Activity', url: 'http://msn.com', key: 'key1', target: '_blank' },
+      { name: 'News', url: 'http://msn.com', key: 'key2', target: '_blank' },
+    ],
+  },
+  {
+    name: 'More pages',
+    links: [
+      // prettier-ignore
+      { name: 'Settings', url: 'http://msn.com', key: 'key3', target: '_blank' },
+      { name: 'Notes', url: 'http://msn.com', key: 'key4', target: '_blank' },
+    ],
+  },
+];
+
 export const NavCustomGroupHeadersExample: React.FunctionComponent = () => {
   return (
     <Nav
       onRenderGroupHeader={_onRenderGroupHeader}
       ariaLabel="Nav example with custom group headers"
-      groups={[
-        {
-          name: 'Pages',
-          links: [
-            // prettier-ignore
-            { name: 'Activity', url: 'http://msn.com', key: 'key1', target: '_blank' },
-            { name: 'News', url: 'http://msn.com', key: 'key2', target: '_blank' },
-          ],
-        },
-        {
-          name: 'More pages',
-          links: [
-            // prettier-ignore
-            { name: 'Settings', url: 'http://msn.com', key: 'key3', target: '_blank' },
-            { name: 'Notes', url: 'http://msn.com', key: 'key4', target: '_blank' },
-          ],
-        },
-      ]}
+      groups={navLinkGroups}
     />
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
@@ -1,81 +1,80 @@
 import * as React from 'react';
 import { Nav, INavStyles } from 'office-ui-fabric-react/lib/Nav';
+import { INavLinkGroup } from '../Nav.types';
 
 const navStyles: Partial<INavStyles> = { root: { width: 300 } };
 
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    name: 'Basic components',
+    expandAriaLabel: 'Expand Basic components section',
+    collapseAriaLabel: 'Collapse Basic components section',
+    links: [
+      {
+        key: 'ActivityItem',
+        name: 'ActivityItem',
+        url: '#/examples/activityitem',
+      },
+      {
+        key: 'Breadcrumb',
+        name: 'Breadcrumb',
+        url: '#/examples/breadcrumb',
+      },
+      {
+        key: 'Button',
+        name: 'Button',
+        url: '#/examples/button',
+      },
+    ],
+  },
+  {
+    name: 'Extended components',
+    expandAriaLabel: 'Expand Extended components section',
+    collapseAriaLabel: 'Collapse Extended components section',
+    links: [
+      {
+        key: 'ColorPicker',
+        name: 'ColorPicker',
+        url: '#/examples/colorpicker',
+      },
+      {
+        key: 'ExtendedPeoplePicker',
+        name: 'ExtendedPeoplePicker',
+        url: '#/examples/extendedpeoplepicker',
+      },
+      {
+        key: 'GroupedList',
+        name: 'GroupedList',
+        url: '#/examples/groupedlist',
+      },
+    ],
+  },
+  {
+    name: 'Utilities',
+    expandAriaLabel: 'Expand Utilities section',
+    collapseAriaLabel: 'Collapse Utilities section',
+    links: [
+      {
+        key: 'FocusTrapZone',
+        name: 'FocusTrapZone',
+        url: '#/examples/focustrapzone',
+      },
+      {
+        key: 'FocusZone',
+        name: 'FocusZone',
+        url: '#/examples/focuszone',
+      },
+      {
+        key: 'MarqueeSelection',
+        name: 'MarqueeSelection',
+        url: '#/examples/marqueeselection',
+      },
+    ],
+  },
+];
+
 export const NavFabricDemoAppExample: React.FunctionComponent = () => {
   return (
-    <Nav
-      styles={navStyles}
-      ariaLabel="Nav example similiar to one found in this demo page"
-      groups={[
-        {
-          name: 'Basic components',
-          expandAriaLabel: 'Expand Basic components section',
-          collapseAriaLabel: 'Collapse Basic components section',
-          links: [
-            {
-              key: 'ActivityItem',
-              name: 'ActivityItem',
-              url: '#/examples/activityitem',
-            },
-            {
-              key: 'Breadcrumb',
-              name: 'Breadcrumb',
-              url: '#/examples/breadcrumb',
-            },
-            {
-              key: 'Button',
-              name: 'Button',
-              url: '#/examples/button',
-            },
-          ],
-        },
-        {
-          name: 'Extended components',
-          expandAriaLabel: 'Expand Extended components section',
-          collapseAriaLabel: 'Collapse Extended components section',
-          links: [
-            {
-              key: 'ColorPicker',
-              name: 'ColorPicker',
-              url: '#/examples/colorpicker',
-            },
-            {
-              key: 'ExtendedPeoplePicker',
-              name: 'ExtendedPeoplePicker',
-              url: '#/examples/extendedpeoplepicker',
-            },
-            {
-              key: 'GroupedList',
-              name: 'GroupedList',
-              url: '#/examples/groupedlist',
-            },
-          ],
-        },
-        {
-          name: 'Utilities',
-          expandAriaLabel: 'Expand Utilities section',
-          collapseAriaLabel: 'Collapse Utilities section',
-          links: [
-            {
-              key: 'FocusTrapZone',
-              name: 'FocusTrapZone',
-              url: '#/examples/focustrapzone',
-            },
-            {
-              key: 'FocusZone',
-              name: 'FocusZone',
-              url: '#/examples/focuszone',
-            },
-            {
-              key: 'MarqueeSelection',
-              name: 'MarqueeSelection',
-              url: '#/examples/marqueeselection',
-            },
-          ],
-        },
-      ]}
-    />
+    <Nav styles={navStyles} ariaLabel="Nav example similiar to one found in this demo page" groups={navLinkGroups} />
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.FabricDemoApp.Example.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Nav, INavStyles } from 'office-ui-fabric-react/lib/Nav';
-import { INavLinkGroup } from '../Nav.types';
+import { Nav, INavStyles, INavLinkGroup } from 'office-ui-fabric-react/lib/Nav';
 
 const navStyles: Partial<INavStyles> = { root: { width: 300 } };
 

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Nested.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Nested.Example.tsx
@@ -1,68 +1,65 @@
 import * as React from 'react';
-import { Nav } from 'office-ui-fabric-react/lib/Nav';
+import { Nav, INavLinkGroup } from 'office-ui-fabric-react/lib/Nav';
+
+const navLinkGroups: INavLinkGroup[] = [
+  {
+    links: [
+      {
+        name: 'Parent link 1',
+        url: 'http://example.com',
+        target: '_blank',
+        expandAriaLabel: 'Expand Parent link 1',
+        collapseAriaLabel: 'Collapse Parent link 1',
+        links: [
+          {
+            name: 'Child link 1',
+            url: 'http://example.com',
+            target: '_blank',
+          },
+          {
+            name: 'Child link 2',
+            url: 'http://example.com',
+            target: '_blank',
+            expandAriaLabel: 'Expand Child link 2',
+            collapseAriaLabel: 'Collapse Child link 2',
+            links: [
+              {
+                name: '3rd level link 1',
+                url: 'http://example.com',
+                target: '_blank',
+              },
+              {
+                name: '3rd level link 2',
+                url: 'http://example.com',
+                target: '_blank',
+              },
+            ],
+          },
+          {
+            name: 'Child link 3',
+            url: 'http://example.com',
+            target: '_blank',
+          },
+        ],
+      },
+      {
+        name: 'Parent link 2',
+        url: 'http://example.com',
+        target: '_blank',
+        expandAriaLabel: 'Expand Parent link 2',
+        collapseAriaLabel: 'Collapse Parent link 2',
+        links: [
+          {
+            name: 'Child link 4',
+            url: 'http://example.com',
+            target: '_blank',
+          },
+        ],
+      },
+    ],
+  },
+];
 
 export const NavNestedExample: React.FunctionComponent = () => {
-  return (
-    <Nav
-      ariaLabel="Nav example with nested links"
-      groups={[
-        {
-          links: [
-            {
-              name: 'Parent link 1',
-              url: 'http://example.com',
-              target: '_blank',
-              expandAriaLabel: 'Expand Parent link 1',
-              collapseAriaLabel: 'Collapse Parent link 1',
-              links: [
-                {
-                  name: 'Child link 1',
-                  url: 'http://example.com',
-                  target: '_blank',
-                },
-                {
-                  name: 'Child link 2',
-                  url: 'http://example.com',
-                  target: '_blank',
-                  expandAriaLabel: 'Expand Child link 2',
-                  collapseAriaLabel: 'Collapse Child link 2',
-                  links: [
-                    {
-                      name: '3rd level link 1',
-                      url: 'http://example.com',
-                      target: '_blank',
-                    },
-                    {
-                      name: '3rd level link 2',
-                      url: 'http://example.com',
-                      target: '_blank',
-                    },
-                  ],
-                },
-                {
-                  name: 'Child link 3',
-                  url: 'http://example.com',
-                  target: '_blank',
-                },
-              ],
-            },
-            {
-              name: 'Parent link 2',
-              url: 'http://example.com',
-              target: '_blank',
-              expandAriaLabel: 'Expand Parent link 2',
-              collapseAriaLabel: 'Collapse Parent link 2',
-              links: [
-                {
-                  name: 'Child link 4',
-                  url: 'http://example.com',
-                  target: '_blank',
-                },
-              ],
-            },
-          ],
-        },
-      ]}
-    />
-  );
+  return <Nav ariaLabel="Nav example with nested links" groups={navLinkGroups} />;
 };

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -22,7 +22,11 @@ import {
 import { getPersonaInitialsColor } from '../PersonaInitialsColor';
 import { sizeToPixels } from '../PersonaConsts';
 
-const getClassNames = classNamesFunction<IPersonaCoinStyleProps, IPersonaCoinStyles>();
+const getClassNames = classNamesFunction<IPersonaCoinStyleProps, IPersonaCoinStyles>({
+  // There can be many PersonaCoin rendered with different sizes.
+  // Therefore setting a larger cache size.
+  cacheSize: 100,
+});
 
 export interface IPersonaState {
   isImageLoaded?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -15,7 +15,11 @@ const coinSizePresenceScaleFactor = 3;
 const presenceMaxSize = 40;
 const presenceFontMaxSize = 20;
 
-const getClassNames = classNamesFunction<IPersonaPresenceStyleProps, IPersonaPresenceStyles>();
+const getClassNames = classNamesFunction<IPersonaPresenceStyleProps, IPersonaPresenceStyles>({
+  // There can be many PersonaPresence rendered with different sizes.
+  // Therefore setting a larger cache size.
+  cacheSize: 100,
+});
 
 /**
  * PersonaPresence with no default styles.

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction } from '../../../Utilities';
+import { classNamesFunction, memoizeFunction } from '../../../Utilities';
 import { IRawStyle } from '../../../Styling';
 import {
   IShimmerElementsGroupProps,
@@ -51,31 +51,16 @@ function getRenderedElements(
     shimmerElements.map(
       (element: IShimmerElement, index: number): JSX.Element => {
         const { type, ...filteredElem } = element;
+        const { verticalAlign, height } = filteredElem;
+        const styles = getElementStyles(verticalAlign, type, height, backgroundColor, rowHeight);
+
         switch (element.type) {
           case ShimmerElementType.circle:
-            return (
-              <ShimmerCircle
-                key={index}
-                {...filteredElem}
-                styles={getElementStyles(element, backgroundColor, rowHeight)}
-              />
-            );
+            return <ShimmerCircle key={index} {...filteredElem} styles={styles} />;
           case ShimmerElementType.gap:
-            return (
-              <ShimmerGap
-                key={index}
-                {...filteredElem}
-                styles={getElementStyles(element, backgroundColor, rowHeight)}
-              />
-            );
+            return <ShimmerGap key={index} {...filteredElem} styles={styles} />;
           case ShimmerElementType.line:
-            return (
-              <ShimmerLine
-                key={index}
-                {...filteredElem}
-                styles={getElementStyles(element, backgroundColor, rowHeight)}
-              />
-            );
+            return <ShimmerLine key={index} {...filteredElem} styles={styles} />;
         }
       },
     )
@@ -86,59 +71,62 @@ function getRenderedElements(
   return renderedElements;
 }
 
-function getElementStyles(
-  element: IShimmerElement,
-  backgroundColor?: string,
-  rowHeight?: number,
-): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles {
-  const { verticalAlign, type, height: elementHeight } = element;
-  const dif: number = rowHeight && elementHeight ? rowHeight - elementHeight : 0;
+const getElementStyles = memoizeFunction(
+  (
+    verticalAlign: 'center' | 'bottom' | 'top' | undefined,
+    elementType: ShimmerElementType,
+    elementHeight: number | undefined,
+    backgroundColor?: string,
+    rowHeight?: number,
+  ): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
+    const dif: number = rowHeight && elementHeight ? rowHeight - elementHeight : 0;
 
-  let borderStyle: IRawStyle | undefined;
+    let borderStyle: IRawStyle | undefined;
 
-  if (!verticalAlign || verticalAlign === 'center') {
-    borderStyle = {
-      borderBottomWidth: `${dif ? Math.floor(dif / 2) : 0}px`,
-      borderTopWidth: `${dif ? Math.ceil(dif / 2) : 0}px`,
-    };
-  } else if (verticalAlign && verticalAlign === 'top') {
-    borderStyle = {
-      borderBottomWidth: `${dif}px`,
-      borderTopWidth: `0px`,
-    };
-  } else if (verticalAlign && verticalAlign === 'bottom') {
-    borderStyle = {
-      borderBottomWidth: `0px`,
-      borderTopWidth: `${dif}px`,
-    };
-  }
-
-  if (backgroundColor) {
-    switch (type) {
-      case ShimmerElementType.circle:
-        return {
-          root: { ...borderStyle, borderColor: backgroundColor },
-          svg: { fill: backgroundColor },
-        };
-      case ShimmerElementType.gap:
-        return {
-          root: { ...borderStyle, borderColor: backgroundColor, backgroundColor: backgroundColor },
-        };
-      case ShimmerElementType.line:
-        return {
-          root: { ...borderStyle, borderColor: backgroundColor },
-          topLeftCorner: { fill: backgroundColor },
-          topRightCorner: { fill: backgroundColor },
-          bottomLeftCorner: { fill: backgroundColor },
-          bottomRightCorner: { fill: backgroundColor },
-        };
+    if (!verticalAlign || verticalAlign === 'center') {
+      borderStyle = {
+        borderBottomWidth: `${dif ? Math.floor(dif / 2) : 0}px`,
+        borderTopWidth: `${dif ? Math.ceil(dif / 2) : 0}px`,
+      };
+    } else if (verticalAlign && verticalAlign === 'top') {
+      borderStyle = {
+        borderBottomWidth: `${dif}px`,
+        borderTopWidth: `0px`,
+      };
+    } else if (verticalAlign && verticalAlign === 'bottom') {
+      borderStyle = {
+        borderBottomWidth: `0px`,
+        borderTopWidth: `${dif}px`,
+      };
     }
-  }
 
-  return {
-    root: borderStyle,
-  };
-}
+    if (backgroundColor) {
+      switch (elementType) {
+        case ShimmerElementType.circle:
+          return {
+            root: { ...borderStyle, borderColor: backgroundColor },
+            svg: { fill: backgroundColor },
+          };
+        case ShimmerElementType.gap:
+          return {
+            root: { ...borderStyle, borderColor: backgroundColor, backgroundColor: backgroundColor },
+          };
+        case ShimmerElementType.line:
+          return {
+            root: { ...borderStyle, borderColor: backgroundColor },
+            topLeftCorner: { fill: backgroundColor },
+            topRightCorner: { fill: backgroundColor },
+            bottomLeftCorner: { fill: backgroundColor },
+            bottomRightCorner: { fill: backgroundColor },
+          };
+      }
+    }
+
+    return {
+      root: borderStyle,
+    };
+  },
+);
 
 /**
  * User should not worry to provide which of the elements is the highest so we do the calculation for him.

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -445,6 +445,7 @@ export type IClassNames<T> = {
 
 // @public (undocumented)
 export interface IClassNamesFunctionOptions {
+    cacheSize?: number;
     disableCaching?: boolean;
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
1. Re-enable caching for Label & Icon and increased cache size for both.
I don't see a reason to disable them. David told me they were previously disabled bc classname passed to them kept mutating and causing cache miss. But I went through all use cases in our repo and don't find a case for them to keep on mutating (for the caching not being helpful). I increased their cache size from 50 to 100 bc they are 2 components that are commonly used by other components so a larger set of cache key variations can be considered expected. Note, the new cache size is enough for rendering all our examples (we know because `ComponentExamples.test` is passing). I think that is a good threshold to set given it's very unlikely a real app scenario can match the same usages of our components.

2. Added ability to show cache full warning from `classNamesFunction` by setting a flag in `FabricConfig`
    - Users can use this for debugging perf issue. 
    - We can enable the warning which can fail `ComponentExamples.test` if cache is unexpectedly full. This can help us catch bad cache busting code. 

3. Found and fixed a few constantly mutating styles prop in our code

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12712)