### PR TITLE
chore: export consts for className and slotClassNames and replace static usages part 2

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,7 +27,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))
-- Export `componentNameClassName` and `componentNameSlotClassName` const inside `Accordion`, `Alert`, `Animation`, `Attachment`, `Avatar` @mnajdova ([#12706](https://github.com/microsoft/fluentui/pull/12706))
+- Export `componentNameClassName` and `componentNameSlotClassName` const inside `Accordion`*, `Alert`*, `Animation`, `Attachment`*, `Avatar` @mnajdova ([#12706](https://github.com/microsoft/fluentui/pull/12706))
+- Export `componentNameClassName` and `componentNameSlotClassName` const inside `Box`, `Button`*, `Card`* @mnajdova ([#12731](https://github.com/microsoft/fluentui/pull/12731))
 
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `offset` for components that use `Popper` (`Popup`, `Tooltip`, `MenuButton`, etc.) can be specified only as a tuple or function @layershifter ([#12530](https://github.com/microsoft/fluentui/pull/12530))
 - Support for deprecated `render` callback was removed @layershifter ([#12454](https://github.com/microsoft/fluentui/pull/12454))
 - renamed `ComponentName.className` to `ComponentName.deprecated_className` for all fluent components @mnajdova ([#12702](https://github.com/microsoft/fluentui/pull/12702))
+- removed `Card.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12731](https://github.com/microsoft/fluentui/pull/12731))
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))

--- a/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleWithTooltip.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleWithTooltip.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
   themes: ['teams', 'teamsDark', 'teamsHighContrast'],
-  steps: [builder => builder.hover(`.${Button.deprecated_className}`).snapshot('Shows tooltip')],
+  steps: [builder => builder.hover(`.${buttonClassName}`).snapshot('Shows tooltip')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Button/commonScreenerSteps.ts
+++ b/packages/fluentui/docs/src/examples/components/Button/commonScreenerSteps.ts
@@ -1,6 +1,6 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
-const button = `.${Button.deprecated_className}`;
+const button = `.${buttonClassName}`;
 
 const getScreenerSteps = (): ScreenerSteps => [
   builder => builder.hover(button).snapshot('Hovers the first button'),

--- a/packages/fluentui/docs/src/examples/components/Dialog/commonScreenerSteps.ts
+++ b/packages/fluentui/docs/src/examples/components/Dialog/commonScreenerSteps.ts
@@ -1,6 +1,6 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
-const button = `.${Button.deprecated_className}`;
+const button = `.${buttonClassName}`;
 
 const getScreenerSteps = (): ScreenerSteps => [builder => builder.click(button).snapshot('Clicks the trigger button')];
 

--- a/packages/fluentui/docs/src/examples/components/MenuButton/Rtl/MenuButtonExample.rtl.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/MenuButton/Rtl/MenuButtonExample.rtl.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.click(`.${Button.deprecated_className}`).snapshot('RTL: Shows menuButton')],
+  steps: [builder => builder.click(`.${buttonClassName}`).snapshot('RTL: Shows menuButton')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Popup/Rtl/PopupExample.rtl.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Rtl/PopupExample.rtl.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.click(`.${Button.deprecated_className}`).snapshot('RTL: Shows popup')],
+  steps: [builder => builder.click(`.${buttonClassName}`).snapshot('RTL: Shows popup')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Popup/Types/PopupControlledExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Types/PopupControlledExample.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const selectors = {
-  triggerButton: `.${Button.deprecated_className}[title*="Open popup"]`,
-  closeButton: `.${Button.deprecated_className}[title*="Close"]`,
+  triggerButton: `.${buttonClassName}[title*="Open popup"]`,
+  closeButton: `.${buttonClassName}[title*="Close"]`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Popup/Types/PopupCustomTargetExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Types/PopupCustomTargetExample.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.click(`.${Button.deprecated_className}`).snapshot('Shows popup')],
+  steps: [builder => builder.click(`.${buttonClassName}`).snapshot('Shows popup')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Popup/Types/PopupExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Types/PopupExample.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
   themes: ['teams', 'teamsDark', 'teamsHighContrast'],
-  steps: [builder => builder.click(`.${Button.deprecated_className}`).snapshot('Shows popup')],
+  steps: [builder => builder.click(`.${buttonClassName}`).snapshot('Shows popup')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.steps.ts
@@ -1,9 +1,9 @@
-import { Dropdown, Button } from '@fluentui/react-northstar';
+import { Dropdown, buttonClassName } from '@fluentui/react-northstar';
 
 const selectors = {
   toggleIndicator: `.${Dropdown.slotClassNames.toggleIndicator}`,
   item: (itemIndex: number) => `.${Dropdown.slotClassNames.itemsList} li:nth-child(${itemIndex})`,
-  popupTrigger: `.${Button.deprecated_className}`,
+  popupTrigger: `.${buttonClassName}`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Popup/Variations/PopupExampleOffset.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Variations/PopupExampleOffset.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const selectors = {
-  trigger: `.${Button.deprecated_className}`,
+  trigger: `.${buttonClassName}`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Rtl/TooltipExample.rtl.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Rtl/TooltipExample.rtl.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.hover(`.${Button.deprecated_className}`).snapshot('RTL: Shows tooltip')],
+  steps: [builder => builder.hover(`.${buttonClassName}`).snapshot('RTL: Shows tooltip')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExample.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
   themes: ['teams', 'teamsDark', 'teamsHighContrast'],
-  steps: [builder => builder.hover(`.${Button.deprecated_className}`).snapshot('Shows tooltip')],
+  steps: [builder => builder.hover(`.${buttonClassName}`).snapshot('Shows tooltip')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExamplePointing.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Types/TooltipExamplePointing.shorthand.steps.ts
@@ -1,13 +1,13 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
   steps: [
-    builder => builder.hover(`.${Button.deprecated_className}`).snapshot('Shows tooltip'),
+    builder => builder.hover(`.${buttonClassName}`).snapshot('Shows tooltip'),
     (builder, keys) =>
       builder
         .keys('body', keys.tab)
         .snapshot('Has outline on keyboard')
-        .click(`.${Button.deprecated_className}`)
+        .click(`.${buttonClassName}`)
         .snapshot('No outline after click'),
   ],
 };

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Usage/TooltipExampleDialogContent.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Usage/TooltipExampleDialogContent.shorthand.steps.ts
@@ -1,11 +1,11 @@
-import { Button, Dialog } from '@fluentui/react-northstar';
+import { buttonClassName, Dialog } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
   steps: [
     builder =>
       builder
-        .click(`.${Button.deprecated_className}`)
-        .hover(`.${Dialog.slotClassNames.content} .${Button.deprecated_className}`)
+        .click(`.${buttonClassName}`)
+        .hover(`.${Dialog.slotClassNames.content} .${buttonClassName}`)
         .snapshot('Shows tooltip in a dialog'),
   ],
 };

--- a/packages/fluentui/docs/src/examples/components/Tooltip/Usage/TooltipExampleTarget.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Tooltip/Usage/TooltipExampleTarget.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { Button } from '@fluentui/react-northstar';
+import { buttonClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.hover(`.${Button.deprecated_className}`).snapshot('Custom target: Shows tooltip')],
+  steps: [builder => builder.hover(`.${buttonClassName}`).snapshot('Custom target: Shows tooltip')],
 };
 
 export default config;

--- a/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/classNames.ts
+++ b/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/classNames.ts
@@ -1,4 +1,4 @@
-import { Button, ChatMessage, ChatItem } from '@fluentui/react-northstar';
+import { buttonClassName, ChatMessage, ChatItem } from '@fluentui/react-northstar';
 
 const classNames = {
   threadedMessage: {
@@ -9,7 +9,7 @@ const classNames = {
     timestamp: `${ChatMessage.slotClassNames.timestamp}-inner`,
   },
   threadReplies: {
-    trigger: `${Button.deprecated_className}__reply`,
+    trigger: `${buttonClassName}__reply`,
     message: `${ChatMessage.deprecated_className}__reply`,
     gutter: `${ChatItem.deprecated_className}__reply__gutter`,
     chatItem: `${ChatItem.deprecated_className}__reply`,

--- a/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/theme.tsx
+++ b/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/theme.tsx
@@ -1,4 +1,4 @@
-import { ThemeInput, ChatItem, Input, SvgIcon, Button, pxToRem } from '@fluentui/react-northstar';
+import { ThemeInput, ChatItem, Input, SvgIcon, buttonClassName, pxToRem } from '@fluentui/react-northstar';
 import classNames from './classNames';
 
 const customizedTheme: ThemeInput = {
@@ -112,7 +112,7 @@ const customizedTheme: ThemeInput = {
           backgroundColor: siteVariables.colorScheme.brand.foreground,
         },
 
-        [`& .${Button.deprecated_className} .${SvgIcon.deprecated_className}`]: {
+        [`& .${buttonClassName} .${SvgIcon.deprecated_className}`]: {
           color: siteVariables.colorScheme.default.background,
         },
       }),

--- a/packages/fluentui/e2e/tests/popupWithoutTrigger-example.tsx
+++ b/packages/fluentui/e2e/tests/popupWithoutTrigger-example.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Popup, Button } from '@fluentui/react-northstar';
+import { Popup, Button, buttonClassName } from '@fluentui/react-northstar';
 
 export const selectors = {
   popupContent: Popup.slotClassNames.content,
-  button: Button.deprecated_className,
+  button: buttonClassName,
 };
 
 const PopupWithoutTriggerExample = () => {

--- a/packages/fluentui/e2e/tests/tableNavigable-example.tsx
+++ b/packages/fluentui/e2e/tests/tableNavigable-example.tsx
@@ -1,4 +1,4 @@
-import { Table, Button, Flex, MenuButton, TableRow, TableCell, Ref } from '@fluentui/react-northstar';
+import { Table, Button, Flex, MenuButton, TableRow, TableCell, Ref, buttonClassName } from '@fluentui/react-northstar';
 import {
   gridNestedBehavior,
   gridCellWithFocusableElementBehavior,
@@ -7,10 +7,10 @@ import {
 import * as React from 'react';
 
 export const selectors = {
+  buttonClassName,
   tableHeaderClass: Table.slotClassNames.header,
   row: TableRow.deprecated_className,
   cell: TableCell.deprecated_className,
-  buttonClassName: Button.deprecated_className,
   beforeTableId: 'before-table',
   afterTableId: 'after-table',
   moreOptionsButtonId: 'more-options',

--- a/packages/fluentui/react-northstar/src/components/Box/Box.tsx
+++ b/packages/fluentui/react-northstar/src/components/Box/Box.tsx
@@ -21,6 +21,7 @@ export interface BoxProps extends UIComponentProps<BoxProps>, ContentComponentPr
 }
 
 export type BoxStylesProps = never;
+export const boxClassName = 'ui-box';
 
 const Box: React.FC<WithAsProp<BoxProps>> & FluentComponentStaticProps<BoxProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -35,7 +36,7 @@ const Box: React.FC<WithAsProp<BoxProps>> & FluentComponentStaticProps<BoxProps>
   });
 
   const { classes } = useStyles<BoxStylesProps>(Box.displayName, {
-    className: Box.deprecated_className,
+    className: boxClassName,
     mapPropsToInlineStyles: () => ({
       className,
       design,
@@ -65,7 +66,7 @@ const Box: React.FC<WithAsProp<BoxProps>> & FluentComponentStaticProps<BoxProps>
   return result;
 };
 
-Box.deprecated_className = 'ui-box';
+Box.deprecated_className = boxClassName;
 Box.displayName = 'Box';
 
 Box.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -97,6 +97,7 @@ export type ButtonStylesProps = Pick<
 > & {
   hasContent?: boolean;
 };
+export const buttonClassName = 'ui-button';
 
 const Button: React.FC<WithAsProp<ButtonProps>> &
   FluentComponentStaticProps<ButtonProps> & { Group: typeof ButtonGroup; Content: typeof ButtonContent } = props => {
@@ -148,7 +149,7 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
     rtl: context.rtl,
   });
   const { classes, styles: resolvedStyles } = useStyles<ButtonStylesProps>(Button.displayName, {
-    className: Button.deprecated_className,
+    className: buttonClassName,
     mapPropsToStyles: () => ({
       text,
       primary,
@@ -244,7 +245,7 @@ Button.defaultProps = {
 };
 
 Button.displayName = 'Button';
-Button.deprecated_className = 'ui-button';
+Button.deprecated_className = buttonClassName;
 
 Button.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -14,6 +14,7 @@ export interface ButtonContentProps extends BoxProps {
 }
 
 export type ButtonContentStylesProps = Pick<ButtonContentProps, 'size'>;
+export const buttonContentClassName = 'ui-button__content';
 
 const ButtonContent: React.FC<WithAsProp<ButtonContentProps>> &
   FluentComponentStaticProps<ButtonContentProps> = props => {
@@ -24,7 +25,7 @@ const ButtonContent: React.FC<WithAsProp<ButtonContentProps>> &
   const { size, content, children, className, styles, variables, design } = props;
 
   const { classes } = useStyles<ButtonContentStylesProps>(ButtonContent.displayName, {
-    className: ButtonContent.deprecated_className,
+    className: buttonContentClassName,
     mapPropsToStyles: () => ({ size }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -54,7 +55,7 @@ const ButtonContent: React.FC<WithAsProp<ButtonContentProps>> &
 };
 
 ButtonContent.displayName = 'ButtonContent';
-ButtonContent.deprecated_className = 'ui-button__content';
+ButtonContent.deprecated_className = buttonContentClassName;
 
 ButtonContent.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
@@ -31,12 +31,14 @@ export interface ButtonGroupProps extends UIComponentProps, ChildrenComponentPro
   circular?: boolean;
 }
 
+export const buttonGroupClassName = 'ui-buttons';
+
 class ButtonGroup extends UIComponent<WithAsProp<ButtonGroupProps>, any> {
   static create: ShorthandFactory<ButtonGroupProps>;
 
   static displayName = 'ButtonGroup';
 
-  static deprecated_className = 'ui-buttons';
+  static deprecated_className = buttonGroupClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/Card.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/Card.tsx
@@ -55,14 +55,7 @@ export interface CardProps extends UIComponentProps {
 }
 
 export type CardStylesProps = Pick<CardProps, 'compact' | 'horizontal' | 'centered' | 'size' | 'fluid'>;
-
-export interface CardSlotClassNames {
-  header: string;
-  body: string;
-  footer: string;
-  preview: string;
-  topControls: string;
-}
+export const cardClassName = 'ui-card';
 
 const Card: React.FC<WithAsProp<CardProps>> &
   FluentComponentStaticProps<CardProps> & {
@@ -72,7 +65,6 @@ const Card: React.FC<WithAsProp<CardProps>> &
     Preview: typeof CardPreview;
     TopControls: typeof CardPreview;
     Column: typeof CardColumn;
-    slotClassNames: CardSlotClassNames;
   } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Card.displayName, context.telemetry);
@@ -92,7 +84,7 @@ const Card: React.FC<WithAsProp<CardProps>> &
   });
 
   const { classes } = useStyles<CardStylesProps>(Card.displayName, {
-    className: Card.deprecated_className,
+    className: cardClassName,
     mapPropsToStyles: () => ({
       centered,
       horizontal,
@@ -129,15 +121,7 @@ const Card: React.FC<WithAsProp<CardProps>> &
 };
 
 Card.displayName = 'Card';
-Card.deprecated_className = 'ui-card';
-
-Card.slotClassNames = {
-  header: `${Card.deprecated_className}__header`,
-  body: `${Card.deprecated_className}__body`,
-  footer: `${Card.deprecated_className}__footer`,
-  preview: `${Card.deprecated_className}__preview`,
-  topControls: `${Card.deprecated_className}__top-controls`,
-};
+Card.deprecated_className = cardClassName;
 
 Card.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardBody.tsx
@@ -18,6 +18,7 @@ export interface CardBodyProps extends UIComponentProps, ChildrenComponentProps 
 }
 
 export type CardBodyStylesProps = Pick<CardBodyProps, 'fitted'>;
+export const cardBodyClassName = 'ui-card__body';
 
 const CardBody: React.FC<WithAsProp<CardBodyProps>> & FluentComponentStaticProps<CardBodyProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -33,7 +34,7 @@ const CardBody: React.FC<WithAsProp<CardBodyProps>> & FluentComponentStaticProps
   });
 
   const { classes } = useStyles<CardBodyStylesProps>(CardBody.displayName, {
-    className: CardBody.deprecated_className,
+    className: cardBodyClassName,
     mapPropsToStyles: () => ({ fitted }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -59,7 +60,7 @@ const CardBody: React.FC<WithAsProp<CardBodyProps>> & FluentComponentStaticProps
 };
 
 CardBody.displayName = 'CardBody';
-CardBody.deprecated_className = 'ui-card__body';
+CardBody.deprecated_className = cardBodyClassName;
 
 CardBody.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardColumn.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardColumn.tsx
@@ -14,6 +14,7 @@ export interface CardColumnProps extends UIComponentProps, ChildrenComponentProp
 }
 
 export type CardColumnStylesProps = never;
+export const cardColumnClassName = 'ui-card__column';
 
 const CardColumn: React.FC<WithAsProp<CardColumnProps>> & FluentComponentStaticProps<CardColumnProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -29,7 +30,7 @@ const CardColumn: React.FC<WithAsProp<CardColumnProps>> & FluentComponentStaticP
   });
 
   const { classes } = useStyles<CardColumnStylesProps>(CardColumn.displayName, {
-    className: CardColumn.deprecated_className,
+    className: cardColumnClassName,
     mapPropsToInlineStyles: () => ({
       className,
       design,
@@ -54,7 +55,7 @@ const CardColumn: React.FC<WithAsProp<CardColumnProps>> & FluentComponentStaticP
 };
 
 CardColumn.displayName = 'CardColumn';
-CardColumn.deprecated_className = 'ui-card__column';
+CardColumn.deprecated_className = cardColumnClassName;
 
 CardColumn.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardFooter.tsx
@@ -18,6 +18,7 @@ export interface CardFooterProps extends UIComponentProps, ChildrenComponentProp
 }
 
 export type CardFooterStylesProps = Pick<CardFooterProps, 'fitted'>;
+export const cardFooterClassName = 'ui-card__footer';
 
 const CardFooter: React.FC<WithAsProp<CardFooterProps>> & FluentComponentStaticProps<CardFooterProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -33,7 +34,7 @@ const CardFooter: React.FC<WithAsProp<CardFooterProps>> & FluentComponentStaticP
   });
 
   const { classes } = useStyles<CardFooterStylesProps>(CardFooter.displayName, {
-    className: CardFooter.deprecated_className,
+    className: cardFooterClassName,
     mapPropsToStyles: () => ({ fitted }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -59,7 +60,7 @@ const CardFooter: React.FC<WithAsProp<CardFooterProps>> & FluentComponentStaticP
 };
 
 CardFooter.displayName = 'CardFooter';
-CardFooter.deprecated_className = 'ui-card__footer';
+CardFooter.deprecated_className = cardFooterClassName;
 
 CardFooter.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardHeader.tsx
@@ -18,6 +18,7 @@ export interface CardHeaderProps extends UIComponentProps, ChildrenComponentProp
 }
 
 export type CardHeaderStylesProps = Pick<CardHeaderProps, 'fitted'>;
+export const cardHeaderClassName = 'ui-card__header';
 
 const CardHeader: React.FC<WithAsProp<CardHeaderProps>> & FluentComponentStaticProps<CardHeaderProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -33,7 +34,7 @@ const CardHeader: React.FC<WithAsProp<CardHeaderProps>> & FluentComponentStaticP
   });
 
   const { classes } = useStyles<CardHeaderStylesProps>(CardHeader.displayName, {
-    className: CardHeader.deprecated_className,
+    className: cardHeaderClassName,
     mapPropsToStyles: () => ({ fitted }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -59,7 +60,7 @@ const CardHeader: React.FC<WithAsProp<CardHeaderProps>> & FluentComponentStaticP
 };
 
 CardHeader.displayName = 'CardHeader';
-CardHeader.deprecated_className = 'ui-card__header';
+CardHeader.deprecated_className = cardHeaderClassName;
 
 CardHeader.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardPreview.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardPreview.tsx
@@ -21,6 +21,7 @@ export interface CardPreviewProps extends UIComponentProps, ChildrenComponentPro
 }
 
 export type CardPreviewStylesProps = Pick<CardPreviewProps, 'horizontal' | 'fitted'>;
+export const cardPreviewClassName = 'ui-card__preview';
 
 const CardPreview: React.FC<WithAsProp<CardPreviewProps>> & FluentComponentStaticProps<CardPreviewProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -36,7 +37,7 @@ const CardPreview: React.FC<WithAsProp<CardPreviewProps>> & FluentComponentStati
   });
 
   const { classes } = useStyles<CardPreviewStylesProps>(CardPreview.displayName, {
-    className: CardPreview.deprecated_className,
+    className: cardPreviewClassName,
     mapPropsToStyles: () => ({ horizontal, fitted }),
     mapPropsToInlineStyles: () => ({
       className,
@@ -62,7 +63,7 @@ const CardPreview: React.FC<WithAsProp<CardPreviewProps>> & FluentComponentStati
 };
 
 CardPreview.displayName = 'CardPreview';
-CardPreview.deprecated_className = 'ui-card__preview';
+CardPreview.deprecated_className = cardPreviewClassName;
 
 CardPreview.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Card/CardTopControls.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardTopControls.tsx
@@ -14,6 +14,7 @@ export interface CardTopControlsProps extends UIComponentProps, ChildrenComponen
 }
 
 export type CardTopControlsStylesProps = never;
+export const cardTopControlsClassName = 'ui-card__topcontrols';
 
 const CardTopControls: React.FC<WithAsProp<CardTopControlsProps>> &
   FluentComponentStaticProps<CardTopControlsProps> = props => {
@@ -30,7 +31,7 @@ const CardTopControls: React.FC<WithAsProp<CardTopControlsProps>> &
   });
 
   const { classes } = useStyles<CardTopControlsStylesProps>(CardTopControls.displayName, {
-    className: CardTopControls.deprecated_className,
+    className: cardTopControlsClassName,
     mapPropsToInlineStyles: () => ({
       className,
       design,
@@ -55,7 +56,7 @@ const CardTopControls: React.FC<WithAsProp<CardTopControlsProps>> &
 };
 
 CardTopControls.displayName = 'CardTopControls';
-CardTopControls.deprecated_className = 'ui-card__topcontrols';
+CardTopControls.deprecated_className = cardTopControlsClassName;
 
 CardTopControls.propTypes = {
   ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
@@ -8,7 +8,7 @@ import { ReactWrapper, CommonWrapper } from 'enzyme';
 import { mountWithProvider, findIntrinsicElement } from '../../../utils';
 import Menu from 'src/components/Menu/Menu';
 import MenuButton from 'src/components/MenuButton/MenuButton';
-import Button from 'src/components/Button/Button';
+import { buttonClassName } from 'src/components/Button/Button';
 import implementsPopperProps from 'test/specs/commonTests/implementsPopperProps';
 
 const mockMenu = { items: ['1', '2', '3'] };
@@ -16,7 +16,7 @@ const mockMenu = { items: ['1', '2', '3'] };
 const getToggleButton = (wrapper: ReactWrapper): CommonWrapper =>
   findIntrinsicElement(wrapper, `.${SplitButtonToggle.deprecated_className}`);
 const getMainButton = (wrapper: ReactWrapper): CommonWrapper =>
-  findIntrinsicElement(wrapper, `.${MenuButton.deprecated_className} .${Button.deprecated_className}`);
+  findIntrinsicElement(wrapper, `.${MenuButton.deprecated_className} .${buttonClassName}`);
 const getMenuItems = (wrapper: ReactWrapper): CommonWrapper =>
   findIntrinsicElement(wrapper, `.${Menu.slotClassNames.item}`);
 const getMenu = (wrapper: ReactWrapper): CommonWrapper =>

--- a/packages/fluentui/react-northstar/test/specs/components/Tooltip/Tooltip-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tooltip/Tooltip-test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import Tooltip from 'src/components/Tooltip/Tooltip';
-import Button from 'src/components/Button/Button';
+import Button, { buttonClassName } from 'src/components/Button/Button';
 
 import { mountWithProvider, findIntrinsicElement } from '../../../utils';
 import implementsPopperProps from 'test/specs/commonTests/implementsPopperProps';
@@ -14,7 +14,7 @@ describe('Tooltip', () => {
   test('aria-labelledby is not added on trigger if aria-label is passed to trigger shorthand', () => {
     const ariaLabelTestValue = 'test-aria-label';
     const wrapper = mountWithProvider(<Tooltip defaultOpen trigger={<Button aria-label={ariaLabelTestValue} />} />);
-    const trigger = findIntrinsicElement(wrapper, `.${Button.deprecated_className}`);
+    const trigger = findIntrinsicElement(wrapper, `.${buttonClassName}`);
 
     expect(trigger.getDOMNode()).toHaveAttribute('aria-label', ariaLabelTestValue);
     expect(trigger.getDOMNode()).not.toHaveAttribute('aria-labelledby');


### PR DESCRIPTION
Added const for className and slotClassNames inside `Box`, `Button`* and `Card`* components.

# BREAKING CHANGE
Removed `Card.slotClassNames` as there are already dedicated components for each different type of `Card`* component. Replace `Card.slotNames.componentName` usage with the accordin const `componentNameClassName`. For example

```tsx
// Before
import  { Card } from '@fluentui/react-northstar';
console.log(Card.slotClassNames.body)

// After
import  { cardBodyClassName } from '@fluentui/react-northstar';
console.log(cardBodyClassName);
```