### PR TITLE
chore(SplitButton): Replace useRangeKnob by useNumberKnob on split bu…

### DIFF
--- a/packages/fluentui/docs-components/src/knobs/defaultComponents.tsx
+++ b/packages/fluentui/docs-components/src/knobs/defaultComponents.tsx
@@ -47,7 +47,7 @@ const KnobNumber: React.FunctionComponent<KnobNumberKnobComponentProps> = props 
       const newValue = parseInt(e.target.value, 10);
       const min = parseInt(props.min, 10);
       const max = parseInt(props.max, 10);
-      props.setValue(newValue < min ? props.min : newValue > max ? props.max : newValue);
+      props.setValue(newValue < min ? props.min : newValue > max ? props.max : newValue || props.min);
     }}
     min={props.min}
     max={props.max}

--- a/packages/fluentui/docs/src/examples/components/SplitButton/Usage/SplitButtonMainOptionChangeExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/SplitButton/Usage/SplitButtonMainOptionChangeExample.shorthand.tsx
@@ -1,4 +1,4 @@
-import { useRangeKnob } from '@fluentui/docs-components';
+import { useNumberKnob } from '@fluentui/docs-components';
 import { SplitButton } from '@fluentui/react-northstar';
 import * as React from 'react';
 
@@ -9,7 +9,7 @@ const items = [
 ];
 
 const SplitButtonMainOptionChangeExample = () => {
-  const [activeIndex, setActiveIndex] = useRangeKnob<number>({ name: 'activeIndex', min: 0, max: 2, initialValue: 0 });
+  const [activeIndex, setActiveIndex] = useNumberKnob({ name: 'activeIndex', min: 0, max: 2, initialValue: 0 });
   const activeItem = items[activeIndex];
 
   return (


### PR DESCRIPTION
…tton example

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We were using range knob before because number knob didn't allowed min and max props. Now it's fixed so replacing it back.

#### Focus areas to test

(optional)
