### PR TITLE
chore: export consts for className and slotClassNames and remove internal static usages part 5

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,12 +25,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for deprecated `render` callback was removed @layershifter ([#12454](https://github.com/microsoft/fluentui/pull/12454))
 - renamed `ComponentName.className` to `ComponentName.deprecated_className` for all fluent components @mnajdova ([#12702](https://github.com/microsoft/fluentui/pull/12702))
 - removed `Card.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12731](https://github.com/microsoft/fluentui/pull/12731))
+- removed `Header.slotClassNames`, `Form.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
+- removed `HierarchicalTreeItemSlotClassNames`'s `title` slot, `HierarchicalTreeTitle`'s className should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Accordion`*, `Alert`*, `Animation`, `Attachment`*, `Avatar` @mnajdova ([#12706](https://github.com/microsoft/fluentui/pull/12706))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Box`, `Button`*, `Card`* @mnajdova ([#12731](https://github.com/microsoft/fluentui/pull/12731))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Carousel`*, `Chat`*, `Checkbox` @mnajdova ([#12733](https://github.com/microsoft/fluentui/pull/12733))
+- Export `componentNameClassName` and `componentNameSlotClassName` const inside `Flex`*, `Form`*, `Grid`, `Header`*, `HierarchicalTree`*, `Image`, `Input` @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))

--- a/packages/fluentui/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Input/Types/InputExample.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { Input } from '@fluentui/react-northstar';
+import { inputClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [builder => builder.focus(`.${Input.deprecated_className} input`).snapshot('Can be focused')],
+  steps: [builder => builder.focus(`.${inputClassName} input`).snapshot('Can be focused')],
   themes: ['teams', 'teamsDark', 'teamsHighContrast'],
 };
 

--- a/packages/fluentui/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Input/Variations/InputExampleClearable.shorthand.steps.ts
@@ -1,9 +1,7 @@
-import { Input } from '@fluentui/react-northstar';
+import { inputClassName } from '@fluentui/react-northstar';
 
 const config: ScreenerTestsConfig = {
-  steps: [
-    builder => builder.setValue(`.${Input.deprecated_className} input`, 'Some text...').snapshot('Can be clearable'),
-  ],
+  steps: [builder => builder.setValue(`.${inputClassName} input`, 'Some text...').snapshot('Can be clearable')],
   themes: ['teams', 'teamsDark', 'teamsHighContrast'],
 };
 

--- a/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/theme.tsx
+++ b/packages/fluentui/docs/src/prototypes/chatMessages/ThreadedMessages/theme.tsx
@@ -1,7 +1,7 @@
 import {
   ThemeInput,
   chatItemSlotClassNames,
-  Input,
+  inputSlotClassNames,
   SvgIcon,
   buttonClassName,
   pxToRem,
@@ -95,7 +95,7 @@ const customizedTheme: ThemeInput = {
     },
     Input: {
       root: ({ props: p, theme: { siteVariables } }) => ({
-        [`& .${Input.slotClassNames.input}`]: {
+        [`& .${inputSlotClassNames.input}`]: {
           height: pxToRem(50),
           backgroundColor: siteVariables.colorScheme.default.background,
         },

--- a/packages/fluentui/e2e/tests/hierarchicalTree-example.tsx
+++ b/packages/fluentui/e2e/tests/hierarchicalTree-example.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { HierarchicalTree, HierarchicalTreeItem, HierarchicalTreeTitle } from '@fluentui/react-northstar';
+import {
+  HierarchicalTree,
+  hierarchicalTreeClassName,
+  hierarchicalTreeItemClassName,
+  hierarchicalTreeTitleClassName,
+} from '@fluentui/react-northstar';
 
 const items = [
   {
@@ -71,9 +76,9 @@ const items = [
 ];
 
 export const selectors = {
-  treeClass: HierarchicalTree.deprecated_className,
-  treeItemClass: HierarchicalTreeItem.deprecated_className,
-  treeTitleClass: HierarchicalTreeTitle.deprecated_className,
+  treeClass: hierarchicalTreeClassName,
+  treeItemClass: hierarchicalTreeItemClassName,
+  treeTitleClass: hierarchicalTreeTitleClassName,
 };
 
 const TreeExample = () => <HierarchicalTree items={items} />;

--- a/packages/fluentui/react-northstar/src/components/Flex/Flex.tsx
+++ b/packages/fluentui/react-northstar/src/components/Flex/Flex.tsx
@@ -45,6 +45,7 @@ export type FlexStylesProps = Pick<
   FlexProps,
   'column' | 'debug' | 'fill' | 'gap' | 'hAlign' | 'inline' | 'padding' | 'space' | 'vAlign' | 'wrap'
 >;
+export const flexClassName = 'ui-flex';
 
 const Flex: React.FC<WithAsProp<FlexProps>> & {
   deprecated_className: string;
@@ -74,7 +75,7 @@ const Flex: React.FC<WithAsProp<FlexProps>> & {
   } = props;
 
   const { classes } = useStyles<FlexStylesProps>(Flex.displayName, {
-    className: Flex.deprecated_className,
+    className: flexClassName,
     mapPropsToStyles: () => ({
       column,
       debug,
@@ -118,7 +119,7 @@ const Flex: React.FC<WithAsProp<FlexProps>> & {
   return element;
 };
 
-Flex.deprecated_className = 'ui-flex';
+Flex.deprecated_className = flexClassName;
 Flex.displayName = 'Flex';
 
 Flex.propTypes = {

--- a/packages/fluentui/react-northstar/src/components/Flex/FlexItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Flex/FlexItem.tsx
@@ -68,6 +68,8 @@ const applyStyles = (
   });
 };
 
+export const flexItemClassName = 'ui-flex__item';
+
 /**
  * A FlexItem is a layout component that customizes alignment of Flex child.
  */
@@ -79,7 +81,7 @@ const FlexItem: React.FC<FlexItemProps> & { deprecated_className: string; __isFl
   const { align, children, className, design, grow, flexDirection, push, shrink, size, styles, variables } = props;
 
   const { classes, styles: resolvedStyles } = useStyles<FlexItemStylesProps>(FlexItem.displayName, {
-    className: FlexItem.deprecated_className,
+    className: flexItemClassName,
     mapPropsToStyles: () => ({
       align,
       grow,
@@ -116,7 +118,7 @@ const FlexItem: React.FC<FlexItemProps> & { deprecated_className: string; __isFl
   return element;
 };
 
-FlexItem.deprecated_className = 'ui-flex__item';
+FlexItem.deprecated_className = flexItemClassName;
 FlexItem.displayName = 'FlexItem';
 
 FlexItem.propTypes = {

--- a/packages/fluentui/react-northstar/src/components/Form/Form.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/Form.tsx
@@ -16,10 +16,6 @@ import {
 import { ComponentEventHandler, WithAsProp, ShorthandCollection, withSafeTypeForAs } from '../../types';
 import FormField, { FormFieldProps } from './FormField';
 
-export interface FormSlotClassNames {
-  field: string;
-}
-
 export interface FormProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -40,16 +36,14 @@ export interface FormProps extends UIComponentProps, ChildrenComponentProps {
   onSubmit?: ComponentEventHandler<FormProps>;
 }
 
+export const formClassName = 'ui-form';
+
 class Form extends UIComponent<WithAsProp<FormProps>, any> {
   static create: ShorthandFactory<FormProps>;
 
   static displayName = 'Form';
 
-  static deprecated_className = 'ui-form';
-
-  static slotClassNames: FormSlotClassNames = {
-    field: `${Form.deprecated_className}__field`,
-  };
+  static deprecated_className = formClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -93,9 +87,7 @@ class Form extends UIComponent<WithAsProp<FormProps>, any> {
 
   renderFields = () => {
     const { fields } = this.props;
-    return _.map(fields, field =>
-      FormField.create(field, { defaultProps: () => ({ className: Form.slotClassNames.field }) }),
-    );
+    return _.map(fields, field => FormField.create(field));
   };
 }
 

--- a/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
@@ -49,10 +49,12 @@ export interface FormFieldProps extends UIComponentProps, ChildrenComponentProps
   type?: string;
 }
 
+export const formFieldClassName = 'ui-form__field';
+
 class FormField extends UIComponent<WithAsProp<FormFieldProps>, any> {
   static displayName = 'FormField';
 
-  static deprecated_className = 'ui-form__field';
+  static deprecated_className = formFieldClassName;
 
   static create: ShorthandFactory<FormFieldProps>;
 

--- a/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
+++ b/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
@@ -28,10 +28,12 @@ export interface GridProps extends UIComponentProps, ChildrenComponentProps, Con
   rows?: string | number;
 }
 
+export const gridClassName = 'ui-grid';
+
 class Grid extends UIComponent<WithAsProp<GridProps>> {
   static displayName = 'Grid';
 
-  static deprecated_className = 'ui-grid';
+  static deprecated_className = gridClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Header/Header.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/Header.tsx
@@ -20,10 +20,6 @@ import HeaderDescription, { HeaderDescriptionProps } from './HeaderDescription';
 
 import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types';
 
-export interface HeaderSlotClassNames {
-  description: string;
-}
-
 export interface HeaderProps
   extends UIComponentProps,
     ChildrenComponentProps,
@@ -41,14 +37,12 @@ export interface HeaderProps
   align?: AlignValue;
 }
 
+export const headerClassName = 'ui-header';
+
 class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
   static displayName = 'Header';
 
-  static deprecated_className = 'ui-header';
-
-  static slotClassNames: HeaderSlotClassNames = {
-    description: `${Header.deprecated_className}__description`,
-  };
+  static deprecated_className = headerClassName;
 
   static create: ShorthandFactory<HeaderProps>;
 
@@ -85,7 +79,6 @@ class Header extends UIComponent<WithAsProp<HeaderProps>, any> {
         {!hasChildren &&
           HeaderDescription.create(description, {
             defaultProps: () => ({
-              className: Header.slotClassNames.description,
               variables: {
                 ...(v.descriptionColor && { color: v.descriptionColor }),
               },

--- a/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
@@ -27,10 +27,12 @@ export interface HeaderDescriptionProps
   accessibility?: Accessibility;
 }
 
+export const headerDescriptionClassName = 'ui-header__description';
+
 class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, any> {
   static create: ShorthandFactory<HeaderDescriptionProps>;
 
-  static deprecated_className = 'ui-header__description';
+  static deprecated_className = headerDescriptionClassName;
 
   static displayName = 'HeaderDescription';
 

--- a/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTree.tsx
+++ b/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTree.tsx
@@ -26,10 +26,6 @@ import {
   ComponentEventHandler,
 } from '../../types';
 
-export interface HierarchicalTreeSlotClassNames {
-  item: string;
-}
-
 export interface HierarchicalTreeProps extends UIComponentProps, ChildrenComponentProps {
   /** Index of the currently active subtree. */
   activeIndex?: number[] | number;
@@ -67,16 +63,14 @@ export interface HierarchicalTreeState {
   activeIndex: number[] | number;
 }
 
+export const hierarchicalTreeClassName = 'ui-hierarchicaltree';
+
 class HierarchicalTree extends AutoControlledComponent<WithAsProp<HierarchicalTreeProps>, HierarchicalTreeState> {
   static create: ShorthandFactory<HierarchicalTreeProps>;
 
   static displayName = 'HierarchicalTree';
 
-  static deprecated_className = 'ui-hierarchicaltree';
-
-  static slotClassNames: HierarchicalTreeSlotClassNames = {
-    item: `${HierarchicalTree.deprecated_className}__item`,
-  };
+  static deprecated_className = hierarchicalTreeClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -169,7 +163,6 @@ class HierarchicalTree extends AutoControlledComponent<WithAsProp<HierarchicalTr
     return _.map(items, (item: ShorthandValue<HierarchicalTreeItemProps>, index: number) =>
       HierarchicalTreeItem.create(item, {
         defaultProps: () => ({
-          className: HierarchicalTree.slotClassNames.item,
           index,
           exclusive,
           renderItemTitle,

--- a/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTreeItem.tsx
@@ -29,7 +29,6 @@ import {
 } from '../../types';
 
 export interface HierarchicalTreeItemSlotClassNames {
-  title: string;
   subtree: string;
 }
 
@@ -66,17 +65,19 @@ export interface HierarchicalTreeItemProps extends UIComponentProps, ChildrenCom
   title?: ShorthandValue<HierarchicalTreeTitleProps>;
 }
 
+export const hierarchicalTreeItemClassName = 'ui-hierarchicaltree__item';
+export const hierarchicalTreeItemSlotClassNames: HierarchicalTreeItemSlotClassNames = {
+  subtree: `${hierarchicalTreeItemClassName}__subtree`,
+};
+
 class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemProps>> {
   static create: ShorthandFactory<HierarchicalTreeItemProps>;
 
   static displayName = 'HierarchicalTreeItem';
 
-  static deprecated_className = 'ui-hierarchicaltree__item';
+  static deprecated_className = hierarchicalTreeItemClassName;
 
-  static slotClassNames: HierarchicalTreeItemSlotClassNames = {
-    title: `${HierarchicalTreeItem.deprecated_className}__title`,
-    subtree: `${HierarchicalTreeItem.deprecated_className}__subtree`,
-  };
+  static slotClassNames = hierarchicalTreeItemSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -164,7 +165,6 @@ class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemPr
       <>
         {HierarchicalTreeTitle.create(title, {
           defaultProps: () => ({
-            className: HierarchicalTreeItem.slotClassNames.title,
             open,
             hasSubtree,
             as: hasSubtree ? 'span' : 'a',
@@ -177,7 +177,7 @@ class HierarchicalTreeItem extends UIComponent<WithAsProp<HierarchicalTreeItemPr
             {HierarchicalTree.create(items, {
               defaultProps: () => ({
                 accessibility: hierarchicalSubtreeBehavior,
-                className: HierarchicalTreeItem.slotClassNames.subtree,
+                className: hierarchicalTreeItemSlotClassNames.subtree,
                 exclusive,
                 renderItemTitle,
               }),

--- a/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/HierarchicalTree/HierarchicalTreeTitle.tsx
@@ -36,10 +36,12 @@ export interface HierarchicalTreeTitleProps extends UIComponentProps, ChildrenCo
   hasSubtree?: boolean;
 }
 
+export const hierarchicalTreeTitleClassName = 'ui-hierarchicaltree__title';
+
 class HierarchicalTreeTitle extends UIComponent<WithAsProp<HierarchicalTreeTitleProps>> {
   static create: ShorthandFactory<HierarchicalTreeTitleProps>;
 
-  static deprecated_className = 'ui-hierarchicaltree__title';
+  static deprecated_className = hierarchicalTreeTitleClassName;
 
   static displayName = 'HierarchicalTreeTitle';
 

--- a/packages/fluentui/react-northstar/src/components/Image/Image.tsx
+++ b/packages/fluentui/react-northstar/src/components/Image/Image.tsx
@@ -31,6 +31,7 @@ export interface ImageProps extends UIComponentProps, ImageBehaviorProps {
 }
 
 export type ImageStylesProps = Pick<ImageProps, 'avatar' | 'circular' | 'fluid'>;
+export const imageClassName = 'ui-image';
 
 const Image: React.FC<WithAsProp<ImageProps>> & FluentComponentStaticProps<ImageProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -59,7 +60,7 @@ const Image: React.FC<WithAsProp<ImageProps>> & FluentComponentStaticProps<Image
     rtl: context.rtl,
   });
   const { classes } = useStyles<ImageStylesProps>(Image.displayName, {
-    className: Image.deprecated_className,
+    className: imageClassName,
     mapPropsToStyles: () => ({
       avatar,
       circular,
@@ -84,7 +85,7 @@ const Image: React.FC<WithAsProp<ImageProps>> & FluentComponentStaticProps<Image
   return result;
 };
 
-Image.deprecated_className = 'ui-image';
+Image.deprecated_className = imageClassName;
 Image.displayName = 'Image';
 Image.defaultProps = {
   as: 'img',

--- a/packages/fluentui/react-northstar/src/components/Input/Input.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/Input.tsx
@@ -83,10 +83,16 @@ export interface InputState {
   hasValue?: boolean;
 }
 
+export const inputClassName = 'ui-input';
+export const inputSlotClassNames: InputSlotClassNames = {
+  input: `${inputClassName}__input`,
+  icon: `${inputClassName}__icon`,
+};
+
 class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> {
   inputRef = React.createRef<HTMLElement>();
 
-  static deprecated_className = 'ui-input';
+  static deprecated_className = inputClassName;
 
   static displayName = 'Input';
 
@@ -147,7 +153,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
     return Box.create(wrapper, {
       defaultProps: () => ({
         ...accessibility.attributes.root,
-        className: cx(Input.deprecated_className, className),
+        className: cx(inputClassName, className),
         children: (
           <>
             <Ref
@@ -163,7 +169,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
                   disabled,
                   type,
                   value,
-                  className: Input.slotClassNames.input,
+                  className: inputSlotClassNames.input,
                   styles: styles.input,
                   onChange: this.handleChange,
                   ...applyAccessibilityKeyHandlers(accessibility.keyHandlers.input, htmlInputProps),
@@ -172,7 +178,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
             </Ref>
             {Box.create(this.computeIcon(), {
               defaultProps: () => ({
-                className: Input.slotClassNames.icon,
+                className: inputSlotClassNames.icon,
                 styles: styles.icon,
               }),
               overrideProps: this.handleIconOverrides,
@@ -230,10 +236,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
   };
 }
 
-Input.slotClassNames = {
-  input: `${Input.deprecated_className}__input`,
-  icon: `${Input.deprecated_className}__icon`,
-};
+Input.slotClassNames = inputSlotClassNames;
 
 /**
  * An Input is a field used to elicit an input from a user.

--- a/packages/fluentui/react-northstar/src/themes/teams/components/HierarchicalTree/hierarchicalTreeItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/HierarchicalTree/hierarchicalTreeItemStyles.ts
@@ -1,7 +1,7 @@
 import { ICSSInJSStyle } from '@fluentui/styles';
 import { pxToRem } from '../../../../utils';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
-import HierarchicalTreeTitle from '../../../../components/HierarchicalTree/HierarchicalTreeTitle';
+import { hierarchicalTreeTitleClassName } from '../../../../components/HierarchicalTree/HierarchicalTreeTitle';
 
 const hierarchicalTreeItemStyles = {
   root: ({ theme: { siteVariables } }): ICSSInJSStyle => ({
@@ -9,7 +9,7 @@ const hierarchicalTreeItemStyles = {
     padding: `0 0 0 ${pxToRem(1)}`,
     ...getBorderFocusStyles({ variables: siteVariables })[':focus'],
     ':focus-visible': {
-      [`> .${HierarchicalTreeTitle.deprecated_className}`]: {
+      [`> .${hierarchicalTreeTitleClassName}`]: {
         position: 'relative',
         ...getBorderFocusStyles({ variables: siteVariables })[':focus-visible'],
       },

--- a/packages/fluentui/react-northstar/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/HierarchicalTree/HierarchicalTree-test.tsx
@@ -4,8 +4,8 @@ import * as keyboardKey from 'keyboard-key';
 import { isConformant } from 'test/specs/commonTests';
 import { mountWithProvider } from 'test/utils';
 import HierarchicalTree from 'src/components/HierarchicalTree/HierarchicalTree';
-import HierarchicalTreeTitle from 'src/components/HierarchicalTree/HierarchicalTreeTitle';
-import HierarchicalTreeItem from 'src/components/HierarchicalTree/HierarchicalTreeItem';
+import { hierarchicalTreeTitleClassName } from 'src/components/HierarchicalTree/HierarchicalTreeTitle';
+import { hierarchicalTreeItemClassName } from 'src/components/HierarchicalTree/HierarchicalTreeItem';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
 
 const items = [
@@ -56,9 +56,9 @@ const items = [
 ];
 
 const getTitles = (wrapper: ReactWrapper): CommonWrapper =>
-  wrapper.find(`.${HierarchicalTreeTitle.deprecated_className}`).filterWhere(n => typeof n.type() === 'string');
+  wrapper.find(`.${hierarchicalTreeTitleClassName}`).filterWhere(n => typeof n.type() === 'string');
 const getItems = (wrapper: ReactWrapper): CommonWrapper =>
-  wrapper.find(`.${HierarchicalTreeItem.deprecated_className}`).filterWhere(n => typeof n.type() === 'string');
+  wrapper.find(`.${hierarchicalTreeItemClassName}`).filterWhere(n => typeof n.type() === 'string');
 
 const checkOpenTitles = (wrapper: ReactWrapper, expected: string[]): void => {
   const titles = getTitles(wrapper);

--- a/packages/fluentui/react-northstar/test/specs/components/Input/Input-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Input/Input-test.tsx
@@ -6,7 +6,7 @@ import { ReactWrapper } from 'enzyme';
 import { mountWithProvider as mount } from 'test/utils';
 import { isConformant, implementsShorthandProp, implementsWrapperProp } from 'test/specs/commonTests';
 
-import Input from 'src/components/Input/Input';
+import Input, { inputSlotClassNames } from 'src/components/Input/Input';
 import Box from 'src/components/Box/Box';
 
 const testValue = 'test value';
@@ -65,7 +65,7 @@ describe('Input', () => {
       const wrapper = mount(<Input clearable defaultValue={faker.lorem.word()} onChange={onChange} />);
 
       wrapper
-        .find(`.${Input.slotClassNames.icon}`)
+        .find(`.${inputSlotClassNames.icon}`)
         .first()
         .simulate('click');
       expect(onChange).toBeCalledTimes(1);
@@ -124,7 +124,7 @@ describe('Input', () => {
       const inputComp = mount(<Input clearable />);
       const domNode = getInputDomNode(inputComp);
       setUserInputValue(inputComp, testValue); // user types into the input
-      const iconComp = inputComp.find(`Box[className~="${Input.slotClassNames.icon}"]`);
+      const iconComp = inputComp.find(`Box[className~="${inputSlotClassNames.icon}"]`);
 
       expect(domNode.value).toEqual(testValue); // input value is the one typed by the user
       expect(iconComp.length).toBeGreaterThan(0); // the 'x' icon appears
@@ -132,7 +132,7 @@ describe('Input', () => {
       iconComp.simulate('click'); // user clicks on 'x' icon
 
       expect(domNode.value).toEqual(''); // input value gets cleared
-      expect(inputComp.find(`Box[className~="${Input.slotClassNames.icon}"]`).length).toEqual(0); // the 'x' icon disappears
+      expect(inputComp.find(`Box[className~="${inputSlotClassNames.icon}"]`).length).toEqual(0); // the 'x' icon disappears
     });
   });
 


### PR DESCRIPTION
**BREAKING CHANGES**
This PR removes `Header.slotClassNames`, `Form.slotClassNames`, dedicated component's classnames should be used

```
// Before
import { Header, Form } from '@fluentui/react-northstar';

console.log(Header.slotClassNames.description);
console.log(Form.slotClassNames.field);

// After
import { headerDescriptionClassName, formFieldClassName} from '@fluentui/react-northstar';

console.log(headerDescriptionClassName);
console.log(formFieldClassName);
```

Also, `HierarchicalTreeItemSlotClassNames`'s `title` slot,  is removed, `HierarchicalTreeTitle`'s className should be used 

```
// Before
import { HierarchicalTreeItem } from '@fluentui/react-northstar';

console.log(HierarchicalTreeItem.slotClassNames.title);

// After
import { hierarchicalTreeTitleClassName } from '@fluentui/react-northstar';

console.log(hierarchicalTreeTitleClassName);
```