### PR TITLE
chore: export consts for className and slotClassNames and remove internal static usages part 6

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - removed `Card.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12731](https://github.com/microsoft/fluentui/pull/12731))
 - removed `Header.slotClassNames`, `Form.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 - removed `HierarchicalTreeItemSlotClassNames`'s `title` slot, `HierarchicalTreeTitle`'s className should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
+- removed `Menu.slotClassNames`, dedicated component's classNames should be used @mnajdova ([#12736](https://github.com/microsoft/fluentui/pull/12736))
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))
@@ -35,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Carousel`*, `Chat`*, `Checkbox` @mnajdova ([#12733](https://github.com/microsoft/fluentui/pull/12733))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Dialog`*, `Divider`, `Dropdown`*, `Embed` @mnajdova ([#12734](https://github.com/microsoft/fluentui/pull/12734))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Flex`*, `Form`*, `Grid`, `Header`*, `HierarchicalTree`*, `Image`, `Input` @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
+- Export `componentNameClassName` and `componentNameSlotClassName` const inside `ItemLayout`, `Label`*, `Layout`, `List`*, `Loader`, `Menu`* @mnajdova ([#12736](https://github.com/microsoft/fluentui/pull/12736))
 
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))

--- a/packages/fluentui/docs/src/examples/components/Chat/Usage/ChatExampleInScrollable.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Chat/Usage/ChatExampleInScrollable.shorthand.steps.ts
@@ -2,7 +2,7 @@ import {
   chatClassName,
   chatItemClassName,
   chatMessageSlotClassNames,
-  MenuItem,
+  menuItemClassName,
   chatMessageClassName,
 } from '@fluentui/react-northstar';
 
@@ -11,7 +11,7 @@ const selectors = {
   item: (itemIndex: number) => `.${chatItemClassName}:nth-child(${itemIndex}) .${chatMessageClassName}`,
   maxActions: '#actions-to-max',
   moreAction: (itemIndex: number) =>
-    `.${chatItemClassName}:nth-child(${itemIndex}) .${chatMessageSlotClassNames.actionMenu} :nth-child(7) .${MenuItem.deprecated_className}`,
+    `.${chatItemClassName}:nth-child(${itemIndex}) .${chatMessageSlotClassNames.actionMenu} :nth-child(7) .${menuItemClassName}`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { List } from '@fluentui/react-northstar';
+import { List, listClassName } from '@fluentui/react-northstar';
 
 const selectors = {
-  list: `.${List.deprecated_className}`,
+  list: `.${listClassName}`,
   item: (itemIndex: number) =>
     `.${List.deprecated_className} .${List.Item.deprecated_className}:nth-of-type(${itemIndex})`,
 };

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.shorthand.steps.ts
@@ -1,7 +1,7 @@
-import { List } from '@fluentui/react-northstar';
+import { List, listClassName } from '@fluentui/react-northstar';
 
 const selectors = {
-  list: `.${List.deprecated_className}`,
+  list: `.${listClassName}`,
   item: (itemIndex: number) =>
     `.${List.deprecated_className} .${List.Item.deprecated_className}:nth-of-type(${itemIndex})`,
 };

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleToolbar.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleToolbar.shorthand.steps.ts
@@ -1,10 +1,10 @@
-import { Menu } from '@fluentui/react-northstar';
+import { menuClassName } from '@fluentui/react-northstar';
 import getScreenerSteps from '../commonScreenerSteps';
 
 const selectors = {
-  menu: `.${Menu.deprecated_className}`,
-  item: (itemIndex: number) => `.${Menu.deprecated_className} li:nth-child(${itemIndex}) a`,
-  lastItem: `.${Menu.deprecated_className} li:last-child a`,
+  menu: `.${menuClassName}`,
+  item: (itemIndex: number) => `.${menuClassName} li:nth-child(${itemIndex}) a`,
+  lastItem: `.${menuClassName} li:last-child a`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithTooltip.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithTooltip.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Menu } from '@fluentui/react-northstar';
+import { menuClassName } from '@fluentui/react-northstar';
 
 const selectors = {
-  menu: `.${Menu.deprecated_className}`,
-  item: (itemIndex: number) => `.${Menu.deprecated_className} li:nth-child(${itemIndex}) a`,
+  menu: `.${menuClassName}`,
+  item: (itemIndex: number) => `.${menuClassName} li:nth-child(${itemIndex}) a`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Menu/commonScreenerSteps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/commonScreenerSteps.ts
@@ -1,4 +1,4 @@
-import { Menu } from '@fluentui/react-northstar';
+import { menuClassName } from '@fluentui/react-northstar';
 
 interface StepsOptions {
   vertical?: boolean;
@@ -7,8 +7,8 @@ interface StepsOptions {
 }
 
 export const selectors = {
-  menu: `.${Menu.deprecated_className}`,
-  item: (itemIndex: number) => `.${Menu.deprecated_className} li:nth-child(${itemIndex}) a`,
+  menu: `.${menuClassName}`,
+  item: (itemIndex: number) => `.${menuClassName} li:nth-child(${itemIndex}) a`,
 };
 
 const getScreenerSteps = ({ vertical, startItem = 2, endItem = 3 }: StepsOptions = {}): ScreenerSteps => [

--- a/packages/fluentui/react-northstar/src/components/ItemLayout/ItemLayout.tsx
+++ b/packages/fluentui/react-northstar/src/components/ItemLayout/ItemLayout.tsx
@@ -53,14 +53,25 @@ export interface ItemLayoutProps extends UIComponentProps, ContentComponentProps
   endMediaCSS?: React.CSSProperties;
 }
 
+export const itemLayoutClassName = 'ui-itemlayout';
+export const itemLayoutSlotClassNames: ItemLayoutSlotClassNames = {
+  header: `${itemLayoutClassName}__header`,
+  headerMedia: `${itemLayoutClassName}__headerMedia`,
+  main: `${itemLayoutClassName}__main`,
+  content: `${itemLayoutClassName}__content`,
+  contentMedia: `${itemLayoutClassName}__contentMedia`,
+  media: `${itemLayoutClassName}__media`,
+  endMedia: `${itemLayoutClassName}__endMedia`,
+};
+
 class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
   static create: ShorthandFactory<ItemLayoutProps>;
 
   static displayName = 'ItemLayout';
 
-  static deprecated_className = 'ui-itemlayout';
+  static deprecated_className = itemLayoutClassName;
 
-  static slotClassNames: ItemLayoutSlotClassNames;
+  static slotClassNames = itemLayoutSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -98,7 +109,7 @@ class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
 
       return (
         <div
-          className={ItemLayout.slotClassNames.main}
+          className={itemLayoutSlotClassNames.main}
           style={{
             gridTemplateRows: '1fr 1fr',
           }}
@@ -112,8 +123,8 @@ class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
     renderHeaderArea: (props, state, classes) => {
       const { debug, header, headerMedia, headerCSS, headerMediaCSS } = props;
 
-      const mergedClasses = cx(ItemLayout.slotClassNames.header, classes.header);
-      const mediaClasses = cx(ItemLayout.slotClassNames.headerMedia, classes.headerMedia);
+      const mergedClasses = cx(itemLayoutSlotClassNames.header, classes.header);
+      const mediaClasses = cx(itemLayoutSlotClassNames.headerMedia, classes.headerMedia);
 
       return !header && !headerMedia ? null : (
         <Layout
@@ -137,8 +148,8 @@ class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
     renderContentArea: (props, state, classes) => {
       const { debug, content, contentMedia, contentCSS, contentMediaCSS } = props;
 
-      const mergedClasses = cx(ItemLayout.slotClassNames.content, classes.content);
-      const mediaClasses = cx(ItemLayout.slotClassNames.contentMedia, classes.contentMedia);
+      const mergedClasses = cx(itemLayoutSlotClassNames.content, classes.content);
+      const mediaClasses = cx(itemLayoutSlotClassNames.contentMedia, classes.contentMedia);
 
       return !content && !contentMedia ? null : (
         <Layout
@@ -167,8 +178,8 @@ class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
     const mainArea = renderMainArea(this.props, this.state, classes);
     const endArea = endMedia;
 
-    const mergedMediaClasses = cx(ItemLayout.slotClassNames.media, classes.media);
-    const mergedEndMediaClasses = cx(ItemLayout.slotClassNames.endMedia, classes.endMedia);
+    const mergedMediaClasses = cx(itemLayoutSlotClassNames.media, classes.media);
+    const mergedEndMediaClasses = cx(itemLayoutSlotClassNames.endMedia, classes.endMedia);
 
     return (
       <Layout
@@ -202,15 +213,7 @@ class ItemLayout extends UIComponent<WithAsProp<ItemLayoutProps>, any> {
 }
 
 ItemLayout.create = createShorthandFactory({ Component: ItemLayout, mappedProp: 'content' });
-ItemLayout.slotClassNames = {
-  header: `${ItemLayout.deprecated_className}__header`,
-  headerMedia: `${ItemLayout.deprecated_className}__headerMedia`,
-  main: `${ItemLayout.deprecated_className}__main`,
-  content: `${ItemLayout.deprecated_className}__content`,
-  contentMedia: `${ItemLayout.deprecated_className}__contentMedia`,
-  media: `${ItemLayout.deprecated_className}__media`,
-  endMedia: `${ItemLayout.deprecated_className}__endMedia`,
-};
+ItemLayout.slotClassNames = itemLayoutSlotClassNames;
 
 /**
  * (DEPRECATED) The Item Layout handles layout styles for menu items, list items and other similar item templates.

--- a/packages/fluentui/react-northstar/src/components/Label/Label.tsx
+++ b/packages/fluentui/react-northstar/src/components/Label/Label.tsx
@@ -63,6 +63,7 @@ export type LabelStylesProps = Pick<LabelProps, 'circular' | 'color' | 'imagePos
   hasIcon: boolean;
   hasActionableIcon: boolean;
 };
+export const labelClassName = 'ui-label';
 
 const Label: React.FC<WithAsProp<LabelProps>> & FluentComponentStaticProps = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -90,7 +91,7 @@ const Label: React.FC<WithAsProp<LabelProps>> & FluentComponentStaticProps = pro
     rtl: context.rtl,
   });
   const { classes, styles: resolvedStyles } = useStyles<LabelStylesProps>(Label.displayName, {
-    className: Label.deprecated_className,
+    className: labelClassName,
     mapPropsToStyles: () => ({
       hasActionableIcon: _.has(icon, 'onClick'),
       hasImage: !!image,
@@ -165,7 +166,7 @@ const Label: React.FC<WithAsProp<LabelProps>> & FluentComponentStaticProps = pro
 };
 
 Label.displayName = 'Label';
-Label.deprecated_className = 'ui-label';
+Label.deprecated_className = labelClassName;
 
 Label.propTypes = {
   ...commonPropTypes.createCommon({ color: true, content: 'shorthand' }),

--- a/packages/fluentui/react-northstar/src/components/Layout/Layout.tsx
+++ b/packages/fluentui/react-northstar/src/components/Layout/Layout.tsx
@@ -46,12 +46,23 @@ export interface LayoutProps extends UIComponentProps {
   vertical?: boolean;
 }
 
+export const layoutClassName = 'ui-layout';
+export const layoutSlotClassNames: LayoutSlotClassNames = {
+  start: `${layoutClassName}__start`,
+  main: `${layoutClassName}__main`,
+  end: `${layoutClassName}__end`,
+  gap: `${layoutClassName}__gap`,
+  reducedStart: `${layoutClassName}--reduced__start`,
+  reducedMain: `${layoutClassName}--reduced__main`,
+  reducedEnd: `${layoutClassName}--reduced__end`,
+};
+
 class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
-  static deprecated_className = 'ui-layout';
+  static deprecated_className = layoutClassName;
 
   static displayName = 'Layout';
 
-  static slotClassNames: LayoutSlotClassNames;
+  static slotClassNames = layoutSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -102,7 +113,7 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
       return (
         start && (
           <div
-            className={cx(Layout.slotClassNames.start, classes.start)}
+            className={cx(layoutSlotClassNames.start, classes.start)}
             {...rtlTextContainer.getAttributes({ forElements: [start] })}
           >
             {start}
@@ -115,7 +126,7 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
       return (
         main && (
           <div
-            className={cx(Layout.slotClassNames.main, classes.main)}
+            className={cx(layoutSlotClassNames.main, classes.main)}
             {...rtlTextContainer.getAttributes({ forElements: [main] })}
           >
             {main}
@@ -128,7 +139,7 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
       return (
         end && (
           <div
-            className={cx(Layout.slotClassNames.end, classes.end)}
+            className={cx(layoutSlotClassNames.end, classes.end)}
             {...rtlTextContainer.getAttributes({ forElements: [end] })}
           >
             {end}
@@ -140,7 +151,7 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
     // Heads up!
     // IE11 Doesn't support grid-gap, insert virtual columns instead
     renderGap({ gap, classes }) {
-      return gap && <span className={cx(Layout.slotClassNames.gap, classes.gap)} />;
+      return gap && <span className={cx(layoutSlotClassNames.gap, classes.gap)} />;
     },
   };
 
@@ -176,9 +187,9 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
     if (reducing && isSingleArea) {
       const composedClasses = cx(
         classes.root,
-        startArea && Layout.slotClassNames.reducedStart,
-        mainArea && Layout.slotClassNames.reducedMain,
-        endArea && Layout.slotClassNames.reducedEnd,
+        startArea && layoutSlotClassNames.reducedStart,
+        mainArea && layoutSlotClassNames.reducedMain,
+        endArea && layoutSlotClassNames.reducedEnd,
       );
       return (
         <ElementType {...unhandledProps} className={composedClasses}>
@@ -199,15 +210,7 @@ class Layout extends UIComponent<WithAsProp<LayoutProps>, any> {
   }
 }
 
-Layout.slotClassNames = {
-  start: `${Layout.deprecated_className}__start`,
-  main: `${Layout.deprecated_className}__main`,
-  end: `${Layout.deprecated_className}__end`,
-  gap: `${Layout.deprecated_className}__gap`,
-  reducedStart: `${Layout.deprecated_className}--reduced__start`,
-  reducedMain: `${Layout.deprecated_className}--reduced__main`,
-  reducedEnd: `${Layout.deprecated_className}--reduced__end`,
-};
+Layout.slotClassNames = layoutSlotClassNames;
 
 /**
  * (DEPRECATED) A layout is a utility for arranging the content of a component.

--- a/packages/fluentui/react-northstar/src/components/List/List.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/List.tsx
@@ -77,6 +77,7 @@ export interface ListProps extends UIComponentProps, ChildrenComponentProps {
 }
 
 export type ListStylesProps = Pick<ListProps, 'debug' | 'horizontal'> & { isListTag: boolean };
+export const listClassName = 'ui-list';
 
 const List: React.FC<WithAsProp<ListProps>> &
   FluentComponentStaticProps<ListProps> & {
@@ -119,7 +120,7 @@ const List: React.FC<WithAsProp<ListProps>> &
     rtl: context.rtl,
   });
   const { classes } = useStyles<ListStylesProps>(List.displayName, {
-    className: List.deprecated_className,
+    className: listClassName,
     mapPropsToStyles: () => ({ isListTag: as === 'ol' || as === 'ul', debug, horizontal }),
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
     rtl: context.rtl,
@@ -175,7 +176,7 @@ const List: React.FC<WithAsProp<ListProps>> &
   return element;
 };
 
-List.deprecated_className = 'ui-list';
+List.deprecated_className = listClassName;
 List.displayName = 'List';
 
 List.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -76,6 +76,19 @@ export type ListItemStylesProps = Pick<
   hasHeaderMedia?: boolean;
 };
 
+export const listItemClassName = 'ui-list__item';
+export const listItemSlotClassNames: ListItemSlotClassNames = {
+  header: `${listItemClassName}__header`,
+  headerMedia: `${listItemClassName}__headerMedia`,
+  headerWrapper: `${listItemClassName}__headerWrapper`,
+  main: `${listItemClassName}__main`,
+  content: `${listItemClassName}__content`,
+  contentMedia: `${listItemClassName}__contentMedia`,
+  contentWrapper: `${listItemClassName}__contentWrapper`,
+  media: `${listItemClassName}__media`,
+  endMedia: `${listItemClassName}__endMedia`,
+};
+
 const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
   FluentComponentStaticProps<ListItemProps> & {
     slotClassNames: ListItemSlotClassNames;
@@ -135,7 +148,7 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
     rtl: context.rtl,
   });
   const { classes, styles: resolvedStyles } = useStyles<ListItemStylesProps>(ListItem.displayName, {
-    className: ListItem.deprecated_className,
+    className: listItemClassName,
     mapPropsToStyles: () => ({
       debug,
       navigable,
@@ -164,37 +177,37 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
 
   const contentElement = Box.create(content, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.content,
+      className: listItemSlotClassNames.content,
       styles: resolvedStyles.content,
     }),
   });
   const contentMediaElement = Box.create(contentMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.contentMedia,
+      className: listItemSlotClassNames.contentMedia,
       styles: resolvedStyles.contentMedia,
     }),
   });
   const headerElement = Box.create(header, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.header,
+      className: listItemSlotClassNames.header,
       styles: resolvedStyles.header,
     }),
   });
   const headerMediaElement = Box.create(headerMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.headerMedia,
+      className: listItemSlotClassNames.headerMedia,
       styles: resolvedStyles.headerMedia,
     }),
   });
   const endMediaElement = Box.create(endMedia, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.endMedia,
+      className: listItemSlotClassNames.endMedia,
       styles: resolvedStyles.endMedia,
     }),
   });
   const mediaElement = Box.create(media, {
     defaultProps: () => ({
-      className: ListItem.slotClassNames.media,
+      className: listItemSlotClassNames.media,
       styles: resolvedStyles.media,
     }),
   });
@@ -209,15 +222,15 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
     >
       {mediaElement}
 
-      <div className={cx(ListItem.slotClassNames.main, classes.main)}>
+      <div className={cx(listItemSlotClassNames.main, classes.main)}>
         {(headerElement || headerMediaElement) && (
-          <div className={cx(ListItem.slotClassNames.headerWrapper, classes.headerWrapper)}>
+          <div className={cx(listItemSlotClassNames.headerWrapper, classes.headerWrapper)}>
             {headerElement}
             {headerMediaElement}
           </div>
         )}
         {(contentElement || contentMediaElement) && (
-          <div className={cx(ListItem.slotClassNames.contentWrapper, classes.contentWrapper)}>
+          <div className={cx(listItemSlotClassNames.contentWrapper, classes.contentWrapper)}>
             {contentElement}
             {contentMediaElement}
           </div>
@@ -233,7 +246,7 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
   return element;
 };
 
-ListItem.deprecated_className = 'ui-list__item';
+ListItem.deprecated_className = listItemClassName;
 ListItem.displayName = 'ListItem';
 
 ListItem.defaultProps = {
@@ -269,17 +282,7 @@ ListItem.propTypes = {
 };
 ListItem.handledProps = Object.keys(ListItem.propTypes) as any;
 
-ListItem.slotClassNames = {
-  header: `${ListItem.deprecated_className}__header`,
-  headerMedia: `${ListItem.deprecated_className}__headerMedia`,
-  headerWrapper: `${ListItem.deprecated_className}__headerWrapper`,
-  main: `${ListItem.deprecated_className}__main`,
-  content: `${ListItem.deprecated_className}__content`,
-  contentMedia: `${ListItem.deprecated_className}__contentMedia`,
-  contentWrapper: `${ListItem.deprecated_className}__contentWrapper`,
-  media: `${ListItem.deprecated_className}__media`,
-  endMedia: `${ListItem.deprecated_className}__endMedia`,
-};
+ListItem.slotClassNames = listItemSlotClassNames;
 
 ListItem.create = createShorthandFactory({ Component: ListItem, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
@@ -53,18 +53,21 @@ export interface LoaderState {
   labelId: string;
 }
 
+export const loaderClassName = 'ui-loader';
+export const loaderSlotClassNames: LoaderSlotClassNames = {
+  indicator: `${loaderClassName}__indicator`,
+  label: `${loaderClassName}__label`,
+  svg: `${loaderClassName}__svg`,
+};
+
 /**
  * A loader alerts a user that content is being loaded or processed and they should wait for the activity to complete.
  */
 class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
   static create: ShorthandFactory<LoaderProps>;
   static displayName = 'Loader';
-  static deprecated_className = 'ui-loader';
-  static slotClassNames: LoaderSlotClassNames = {
-    indicator: `${Loader.deprecated_className}__indicator`,
-    label: `${Loader.deprecated_className}__label`,
-    svg: `${Loader.deprecated_className}__svg`,
-  };
+  static deprecated_className = loaderClassName;
+  static slotClassNames = loaderSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -126,7 +129,7 @@ class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
     const { visible, labelId } = this.state;
 
     const svgElement = Box.create(svg, {
-      defaultProps: () => ({ className: Loader.slotClassNames.svg, styles: styles.svg }),
+      defaultProps: () => ({ className: loaderSlotClassNames.svg, styles: styles.svg }),
     });
 
     return (
@@ -135,13 +138,13 @@ class Loader extends UIComponent<WithAsProp<LoaderProps>, LoaderState> {
           {Box.create(indicator, {
             defaultProps: () => ({
               children: svgElement,
-              className: Loader.slotClassNames.indicator,
+              className: loaderSlotClassNames.indicator,
               styles: styles.indicator,
             }),
           })}
           {Text.create(label, {
             defaultProps: () => ({
-              className: Loader.slotClassNames.label,
+              className: loaderSlotClassNames.label,
               styles: styles.label,
               id: labelId,
             }),

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -25,11 +25,6 @@ import { BoxProps } from '../Box/Box';
 
 export type MenuShorthandKinds = 'divider' | 'item';
 
-export interface MenuSlotClassNames {
-  divider: string;
-  item: string;
-}
-
 export interface MenuProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
@@ -99,15 +94,12 @@ export interface MenuState {
   activeIndex?: number | string;
 }
 
+export const menuClassName = 'ui-menu';
+
 class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
   static displayName = 'Menu';
 
-  static deprecated_className = 'ui-menu';
-
-  static slotClassNames: MenuSlotClassNames = {
-    divider: `${Menu.deprecated_className}__divider`,
-    item: `${Menu.deprecated_className}__item`,
-  };
+  static deprecated_className = menuClassName;
 
   static create: ShorthandFactory<MenuProps>;
 
@@ -203,7 +195,6 @@ class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
       if (kind === 'divider') {
         return MenuDivider.create(item, {
           defaultProps: () => ({
-            className: Menu.slotClassNames.divider,
             primary,
             secondary,
             vertical,
@@ -219,7 +210,6 @@ class Menu extends AutoControlledComponent<WithAsProp<MenuProps>, MenuState> {
 
       return MenuItem.create(item, {
         defaultProps: () => ({
-          className: Menu.slotClassNames.item,
           iconOnly,
           pills,
           pointing,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -25,12 +25,14 @@ export interface MenuDividerProps extends UIComponentProps, ChildrenComponentPro
   inSubmenu?: boolean;
 }
 
+export const menuDividerClassName = 'ui-menu__divider';
+
 class MenuDivider extends UIComponent<WithAsProp<MenuDividerProps>> {
   static displayName = 'MenuDivider';
 
   static create: ShorthandFactory<MenuDividerProps>;
 
-  static deprecated_className = 'ui-menu__divider';
+  static deprecated_className = menuDividerClassName;
 
   static defaultProps = {
     as: 'li',

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -139,16 +139,19 @@ export interface MenuItemState {
   menuOpen: boolean;
 }
 
+export const menuItemClassName = 'ui-menu__item';
+export const menuItemSlotClassNames: MenuItemSlotClassNames = {
+  submenu: `${menuItemClassName}__submenu`,
+  wrapper: `${menuItemClassName}__wrapper`,
+  indicator: `${menuItemClassName}__indicator`,
+};
+
 class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuItemState> {
   static displayName = 'MenuItem';
 
   static deprecated_className = 'ui-menu__item';
 
-  static slotClassNames: MenuItemSlotClassNames = {
-    submenu: `${MenuItem.deprecated_className}__submenu`,
-    wrapper: `${MenuItem.deprecated_className}__wrapper`,
-    indicator: `${MenuItem.deprecated_className}__indicator`,
-  };
+  static slotClassNames: MenuItemSlotClassNames = menuItemSlotClassNames;
 
   static create: ShorthandFactory<MenuItemProps>;
 
@@ -236,7 +239,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
             Box.create(indicator, {
               defaultProps: () => ({
                 as: 'span',
-                className: MenuItem.slotClassNames.indicator,
+                className: menuItemSlotClassNames.indicator,
                 styles: styles.indicator,
                 accessibility: indicatorBehavior,
               }),
@@ -257,7 +260,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
               {Menu.create(menu, {
                 defaultProps: () => ({
                   accessibility: submenuBehavior,
-                  className: MenuItem.slotClassNames.submenu,
+                  className: menuItemSlotClassNames.submenu,
                   vertical: true,
                   primary,
                   secondary,
@@ -275,7 +278,7 @@ class MenuItem extends AutoControlledComponent<WithAsProp<MenuItemProps>, MenuIt
     if (wrapper) {
       return Box.create(wrapper, {
         defaultProps: () => ({
-          className: cx(MenuItem.slotClassNames.wrapper, classes.wrapper),
+          className: cx(menuItemSlotClassNames.wrapper, classes.wrapper),
           ...accessibility.attributes.wrapper,
           ...applyAccessibilityKeyHandlers(accessibility.keyHandlers.wrapper, wrapper),
         }),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import { unstable_createAnimationStyles as createAnimationStyles } from '@fluentui/react-bindings';
 import { pxToRem } from '../../../../utils';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import Loader from '../../../../components/Loader/Loader';
+import { loaderSlotClassNames } from '../../../../components/Loader/Loader';
 import { ButtonStylesProps } from '../../../../components/Button/Button';
 import { ButtonVariables } from './buttonVariables';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
@@ -243,11 +243,11 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
   }),
 
   loader: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    [`& .${Loader.slotClassNames.indicator}`]: {
+    [`& .${loaderSlotClassNames.indicator}`]: {
       width: p.size === 'small' ? v.sizeSmallLoaderSize : v.loaderSize,
       height: p.size === 'small' ? v.sizeSmallLoaderSize : v.loaderSize,
     },
-    [`& .${Loader.slotClassNames.svg}`]: {
+    [`& .${loaderSlotClassNames.svg}`]: {
       ':before': {
         animationName: {
           to: {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/List/listItemStyles.ts
@@ -1,7 +1,7 @@
 import { pxToRem } from '../../../../utils';
 import { screenReaderContainerStyles } from '../../../../utils/accessibility/Styles/accessibilityStyles';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { default as ListItem, ListItemStylesProps } from '../../../../components/List/ListItem';
+import { ListItemStylesProps, listItemSlotClassNames } from '../../../../components/List/ListItem';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 import { ListItemVariables } from './listItemVariables';
 
@@ -16,18 +16,18 @@ const selectableHoverStyle = (p: ListItemStylesProps, v): ICSSInJSStyle => ({
   color: v.selectableFocusHoverColor,
   cursor: 'pointer',
 
-  [`& .${ListItem.slotClassNames.header}`]: { color: 'inherit' },
-  [`& .${ListItem.slotClassNames.content}`]: { color: 'inherit' },
+  [`& .${listItemSlotClassNames.header}`]: { color: 'inherit' },
+  [`& .${listItemSlotClassNames.content}`]: { color: 'inherit' },
 
   // hide the header media and content media on hover
-  [`& .${ListItem.slotClassNames.headerMedia}`]: {
+  [`& .${listItemSlotClassNames.headerMedia}`]: {
     ...screenReaderContainerStyles,
     color: 'inherit',
   },
-  [`& .${ListItem.slotClassNames.contentMedia}`]: { display: 'none', color: 'inherit' },
+  [`& .${listItemSlotClassNames.contentMedia}`]: { display: 'none', color: 'inherit' },
 
   // show the end media on hover
-  [`& .${ListItem.slotClassNames.endMedia}`]: { display: 'block', color: 'inherit' },
+  [`& .${listItemSlotClassNames.endMedia}`]: { display: 'block', color: 'inherit' },
 });
 
 const selectedStyle = variables => ({
@@ -50,7 +50,7 @@ const listItemStyles: ComponentSlotStylesPrepared<ListItemStylesProps, ListItemV
         position: 'relative',
 
         // hide the end media by default
-        [`& .${ListItem.slotClassNames.endMedia}`]: { display: 'none' },
+        [`& .${listItemSlotClassNames.endMedia}`]: { display: 'none' },
 
         '&:hover': selectableHoverStyle(p, v),
         ':focus': borderFocusStyles[':focus'],

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -1,7 +1,12 @@
 import { pxToRem } from '../../../../utils';
 import { StrictColorScheme, ItemType } from '../../../types';
 import { MenuVariables, menuColorAreas } from './menuVariables';
-import MenuItem, { MenuItemProps, MenuItemState } from '../../../../components/Menu/MenuItem';
+import {
+  MenuItemProps,
+  MenuItemState,
+  menuItemClassName,
+  menuItemSlotClassNames,
+} from '../../../../components/Menu/MenuItem';
 import { getColorScheme } from '../../colors';
 import getIconFillOrOutlineStyles from '../../getIconFillOrOutlineStyles';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
@@ -254,7 +259,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
           color: v.iconOnlyColorHover,
         }),
 
-        [`&>.${MenuItem.deprecated_className}>.${MenuItem.slotClassNames.indicator}`]: {
+        [`&>.${menuItemClassName}>.${menuItemSlotClassNames.indicator}`]: {
           backgroundImage: submenuIndicatorUrl(v.indicatorColorHover, vertical),
 
           ...(primary && {

--- a/packages/fluentui/react-northstar/test/specs/components/Loader/Loader-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Loader/Loader-test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Loader from 'src/components/Loader/Loader';
+import Loader, { loaderClassName } from 'src/components/Loader/Loader';
 import { isConformant } from 'test/specs/commonTests';
 import { mountWithProvider } from 'test/utils';
 
@@ -17,7 +17,7 @@ describe('Loader', () => {
     it('renders children only when "delay" is passed', () => {
       jest.useFakeTimers();
 
-      const selector = `.${Loader.deprecated_className}`;
+      const selector = `.${loaderClassName}`;
       const wrapper = mountWithProvider(<Loader delay={500} />);
 
       expect(wrapper.find(selector).exists()).toBe(false);

--- a/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
@@ -7,7 +7,7 @@ import { isConformant } from 'test/specs/commonTests';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
 import { mountWithProvider, findIntrinsicElement } from '../../../utils';
 import { menuClassName } from 'src/components/Menu/Menu';
-import { menuItemClassName } from 'src/components/Menu/Menuitem';
+import { menuItemClassName } from 'src/components/Menu/MenuItem';
 import MenuButton from 'src/components/MenuButton/MenuButton';
 import { buttonClassName } from 'src/components/Button/Button';
 import implementsPopperProps from 'test/specs/commonTests/implementsPopperProps';

--- a/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
@@ -6,7 +6,8 @@ import SplitButtonToggle from 'src/components/SplitButton/SplitButtonToggle';
 import { isConformant } from 'test/specs/commonTests';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
 import { mountWithProvider, findIntrinsicElement } from '../../../utils';
-import Menu from 'src/components/Menu/Menu';
+import { menuClassName } from 'src/components/Menu/Menu';
+import { menuItemClassName } from 'src/components/Menu/Menuitem';
 import MenuButton from 'src/components/MenuButton/MenuButton';
 import { buttonClassName } from 'src/components/Button/Button';
 import implementsPopperProps from 'test/specs/commonTests/implementsPopperProps';
@@ -17,10 +18,8 @@ const getToggleButton = (wrapper: ReactWrapper): CommonWrapper =>
   findIntrinsicElement(wrapper, `.${SplitButtonToggle.deprecated_className}`);
 const getMainButton = (wrapper: ReactWrapper): CommonWrapper =>
   findIntrinsicElement(wrapper, `.${MenuButton.deprecated_className} .${buttonClassName}`);
-const getMenuItems = (wrapper: ReactWrapper): CommonWrapper =>
-  findIntrinsicElement(wrapper, `.${Menu.slotClassNames.item}`);
-const getMenu = (wrapper: ReactWrapper): CommonWrapper =>
-  findIntrinsicElement(wrapper, `.${Menu.deprecated_className}`);
+const getMenuItems = (wrapper: ReactWrapper): CommonWrapper => findIntrinsicElement(wrapper, `.${menuItemClassName}`);
+const getMenu = (wrapper: ReactWrapper): CommonWrapper => findIntrinsicElement(wrapper, `.${menuClassName}`);
 
 describe('SplitButton', () => {
   isConformant(SplitButton, { autoControlledProps: ['open'] });


### PR DESCRIPTION
**BREAKING CHANGES**

This PR removes `Menu.slotClassNames`, dedicated component's classnames should be used

```
// Before
import { Menu } from '@fluentui/react-northstar';

console.log(Menu.slotClassNames.item);
console.log(Menu.slotClassNames.divider);

// After
import { menuItemClassName, menuDividerClassName } from '@fluentui/react-northstar';

console.log(menuItemClassName);
console.log(menuDividerClassName);
```
