### PR TITLE
chore: export consts for className and slotClassNames and replace static usages part 7

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - removed `Header.slotClassNames`, `Form.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 - removed `HierarchicalTreeItemSlotClassNames`'s `title` slot, `HierarchicalTreeTitle`'s className should be used @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 - removed `Menu.slotClassNames`, dedicated component's classNames should be used @mnajdova ([#12736](https://github.com/microsoft/fluentui/pull/12736))
+- removed `RadioGroup.slotClassNames`, dedicated component's classnames should be used @mnajdova ([#12738](https://github.com/microsoft/fluentui/pull/12738))
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))
@@ -37,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Dialog`*, `Divider`, `Dropdown`*, `Embed` @mnajdova ([#12734](https://github.com/microsoft/fluentui/pull/12734))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `Flex`*, `Form`*, `Grid`, `Header`*, `HierarchicalTree`*, `Image`, `Input` @mnajdova ([#12735](https://github.com/microsoft/fluentui/pull/12735))
 - Export `componentNameClassName` and `componentNameSlotClassName` const inside `ItemLayout`, `Label`*, `Layout`, `List`*, `Loader`, `Menu`* @mnajdova ([#12736](https://github.com/microsoft/fluentui/pull/12736))
+- Export `componentNameClassName` and `componentNameSlotClassName` const inside `MenuButton`, `Popup`*, `Provider`, `RadioGroup`*, `Reaction`*, `Segment`, `Slider`*, `SplitButton`*, `Status`, `Slider`, `Table`* @mnajdova ([#12738](https://github.com/microsoft/fluentui/pull/12738))
 
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.steps.ts
@@ -1,8 +1,8 @@
-import { Reaction, chatMessageSlotClassNames } from '@fluentui/react-northstar';
+import { reactionClassName, chatMessageSlotClassNames } from '@fluentui/react-northstar';
 
 const selectors = {
   chatMessageContent: `.${chatMessageSlotClassNames.content}`,
-  reaction: `.${Reaction.deprecated_className}`,
+  reaction: `.${reactionClassName}`,
 };
 
 const config: ScreenerTestsConfig = {

--- a/packages/fluentui/docs/src/examples/components/Slider/commonScreenerSteps.ts
+++ b/packages/fluentui/docs/src/examples/components/Slider/commonScreenerSteps.ts
@@ -1,7 +1,7 @@
-import { Slider } from '@fluentui/react-northstar';
+import { sliderSlotClassNames } from '@fluentui/react-northstar';
 
 const selectors = {
-  input: `.${Slider.slotClassNames.input}`,
+  input: `.${sliderSlotClassNames.input}`,
 };
 
 const focusSliderStep: ScreenerStep = (builder, keys) => builder.keys('body', keys.tab);

--- a/packages/fluentui/docs/src/prototypes/table/ResponsiveTableContainer.tsx
+++ b/packages/fluentui/docs/src/prototypes/table/ResponsiveTableContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { TableCell, TableProps, Table } from '@fluentui/react-northstar';
+import { TableProps, Table, tableCellClassName } from '@fluentui/react-northstar';
 import calculateBreakpoints, { Column, Breakpoint } from './calculateBreakpoints';
 import * as _ from 'lodash';
 
@@ -38,7 +38,7 @@ const ResponsiveTableContainer: React.FC<ResponsiveTableProps> = props => {
                 ${breakpoint
                   .map(
                     column =>
-                      `#${responsiveTableID} .${TableCell.deprecated_className}:nth-child(${column.childIndex}) { display: none }`,
+                      `#${responsiveTableID} .${tableCellClassName}:nth-child(${column.childIndex}) { display: none }`,
                   )
                   .join('\n  ')}
               }`,

--- a/packages/fluentui/e2e/tests/popupClickHandling-example.tsx
+++ b/packages/fluentui/e2e/tests/popupClickHandling-example.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Button, Popup } from '@fluentui/react-northstar';
+import { Button, Popup, popupContentClassName } from '@fluentui/react-northstar';
 
 export const selectors = {
   triggerButtonId: 'trigger',
-  popupContentClass: Popup.slotClassNames.content,
+  popupContentClass: popupContentClassName,
   popupContentButtonId: 'content-button',
 };
 

--- a/packages/fluentui/e2e/tests/popupEscHandling-example.tsx
+++ b/packages/fluentui/e2e/tests/popupEscHandling-example.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Button, Dropdown, Popup, dropdownSlotClassNames } from '@fluentui/react-northstar';
+import { Button, Dropdown, Popup, dropdownSlotClassNames, popupContentClassName } from '@fluentui/react-northstar';
 
 const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange'];
 
 export const selectors = {
   popupTriggerId: 'trigger',
-  popupContentClass: Popup.slotClassNames.content,
+  popupContentClass: popupContentClassName,
   dropdownTriggerClass: dropdownSlotClassNames.triggerButton,
 };
 

--- a/packages/fluentui/e2e/tests/popupInMenu-example.tsx
+++ b/packages/fluentui/e2e/tests/popupInMenu-example.tsx
@@ -1,10 +1,18 @@
 import * as React from 'react';
-import { Menu, MenuItem, Popup, Button, ShorthandRenderFunction, MenuItemProps } from '@fluentui/react-northstar';
+import {
+  Menu,
+  MenuItem,
+  Popup,
+  Button,
+  ShorthandRenderFunction,
+  MenuItemProps,
+  popupContentClassName,
+} from '@fluentui/react-northstar';
 
 export const selectors = {
   menuId: 'menu',
   menuItemId: index => `menu-item-${index}`,
-  popupContentClass: Popup.slotClassNames.content,
+  popupContentClass: popupContentClassName,
   popupContentId: index => `popup-content-${index}`,
 };
 

--- a/packages/fluentui/e2e/tests/popupWithoutTrigger-example.tsx
+++ b/packages/fluentui/e2e/tests/popupWithoutTrigger-example.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Popup, Button, buttonClassName } from '@fluentui/react-northstar';
+import { Popup, Button, buttonClassName, popupContentClassName } from '@fluentui/react-northstar';
 
 export const selectors = {
-  popupContent: Popup.slotClassNames.content,
+  popupContent: popupContentClassName,
   button: buttonClassName,
 };
 

--- a/packages/fluentui/e2e/tests/tableNavigable-example.tsx
+++ b/packages/fluentui/e2e/tests/tableNavigable-example.tsx
@@ -1,4 +1,14 @@
-import { Table, Button, Flex, MenuButton, TableRow, TableCell, Ref, buttonClassName } from '@fluentui/react-northstar';
+import {
+  Table,
+  Button,
+  Flex,
+  MenuButton,
+  Ref,
+  tableRowClassName,
+  tableCellClassName,
+  buttonClassName,
+  tableSlotClassNames,
+} from '@fluentui/react-northstar';
 import {
   gridNestedBehavior,
   gridCellWithFocusableElementBehavior,
@@ -8,9 +18,9 @@ import * as React from 'react';
 
 export const selectors = {
   buttonClassName,
-  tableHeaderClass: Table.slotClassNames.header,
-  row: TableRow.deprecated_className,
-  cell: TableCell.deprecated_className,
+  tableHeaderClass: tableSlotClassNames.header,
+  row: tableRowClassName,
+  cell: tableCellClassName,
   beforeTableId: 'before-table',
   afterTableId: 'after-table',
   moreOptionsButtonId: 'more-options',

--- a/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/MenuButton/MenuButton.tsx
@@ -93,6 +93,11 @@ export interface MenuButtonState {
   triggerId: string;
 }
 
+export const menuButtonClassName = 'ui-menubutton';
+export const menuButtonSlotClassNames: MenuButtonSlotClassNames = {
+  menu: `${menuButtonClassName}__menu`,
+};
+
 /**
  * A MenuButton displays a menu connected to trigger element.
  * @accessibility
@@ -100,13 +105,11 @@ export interface MenuButtonState {
 export default class MenuButton extends AutoControlledComponent<MenuButtonProps, MenuButtonState> {
   static displayName = 'MenuButton';
 
-  static deprecated_className = 'ui-menubutton';
+  static deprecated_className = menuButtonClassName;
 
   static create: ShorthandFactory<MenuButtonProps>;
 
-  static slotClassNames: MenuButtonSlotClassNames = {
-    menu: `${MenuButton.deprecated_className}__menu`,
-  };
+  static slotClassNames = menuButtonSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -264,6 +267,7 @@ export default class MenuButton extends AutoControlledComponent<MenuButtonProps,
       defaultProps: () => ({
         ...accessibility.attributes.menu,
         vertical: true,
+        className: menuButtonSlotClassNames.menu,
       }),
       overrideProps: this.handleMenuOverrides,
     });

--- a/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/Popup.tsx
@@ -120,12 +120,13 @@ export interface PopupProps
   autoFocus?: boolean | AutoFocusZoneProps;
 }
 
+export const popupClassName = 'ui-popup';
+
 /**
  * A Popup displays a non-modal, often rich content, on top of its target element.
  */
 const Popup: React.FC<PopupProps> &
   FluentComponentStaticProps<PopupProps> & {
-    slotClassNames: PopupSlotClassNames;
     Content: typeof PopupContent;
   } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -545,11 +546,8 @@ const Popup: React.FC<PopupProps> &
   return element;
 };
 
-Popup.deprecated_className = 'ui-popup';
+Popup.deprecated_className = popupClassName;
 Popup.displayName = 'Popup';
-Popup.slotClassNames = {
-  content: `${Popup.deprecated_className}__content`,
-};
 
 Popup.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Popup/PopupContent.tsx
@@ -79,6 +79,11 @@ export type PopupContentStylesProps = Required<Pick<PopupContentProps, 'pointing
   basePlacement: PopperJs.BasePlacement;
 };
 
+export const popupContentClassName = 'ui-popup__content';
+export const popupContentSlotClassNames: PopupContentSlotClassNames = {
+  content: `${popupContentClassName}__content`,
+};
+
 const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
   FluentComponentStaticProps<PopupContentProps> & { slotClassNames: PopupContentSlotClassNames } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -105,7 +110,7 @@ const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
     rtl: context.rtl,
   });
   const { classes } = useStyles<PopupContentStylesProps>(PopupContent.displayName, {
-    className: PopupContent.deprecated_className,
+    className: popupContentClassName,
     mapPropsToStyles: () => ({
       basePlacement: getBasePlacement(placement, context.rtl),
       pointing,
@@ -135,7 +140,7 @@ const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
   const popupContent = (
     <>
       {pointing && <div className={classes.pointer} ref={pointerRef} />}
-      <div className={cx(PopupContent.slotClassNames.content, classes.content)}>
+      <div className={cx(popupContentSlotClassNames.content, classes.content)}>
         {childrenExist(children) ? children : content}
       </div>
     </>
@@ -167,7 +172,7 @@ const PopupContent: React.FC<WithAsProp<PopupContentProps>> &
 };
 
 PopupContent.displayName = 'PopupContent';
-PopupContent.deprecated_className = 'ui-popup__content';
+PopupContent.deprecated_className = popupContentClassName;
 
 PopupContent.propTypes = {
   ...commonPropTypes.createCommon(),
@@ -197,9 +202,7 @@ PopupContent.propTypes = {
 };
 PopupContent.handledProps = Object.keys(PopupContent.propTypes) as any;
 
-PopupContent.slotClassNames = {
-  content: `${PopupContent.deprecated_className}__content`,
-};
+PopupContent.slotClassNames = popupContentSlotClassNames;
 
 PopupContent.create = createShorthandFactory({ Component: PopupContent, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -86,6 +86,8 @@ const renderStaticStyles = (renderer: Renderer, theme: ThemeInput, siteVariables
   });
 };
 
+export const providerClassName = 'ui-provider';
+
 /**
  * The Provider passes the CSS-in-JS renderer, theme styles and other settings to Fluent UI components.
  */
@@ -132,7 +134,7 @@ const Provider: React.FC<WithAsProp<ProviderProps>> & {
   }
 
   const { classes } = unstable_getStyles({
-    className: Provider.deprecated_className,
+    className: providerClassName,
     displayNames: [Provider.displayName],
     props: {
       className,
@@ -196,7 +198,7 @@ const Provider: React.FC<WithAsProp<ProviderProps>> & {
   );
 };
 
-Provider.deprecated_className = 'ui-provider';
+Provider.deprecated_className = providerClassName;
 Provider.displayName = 'Provider';
 
 Provider.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroup.tsx
@@ -19,10 +19,6 @@ import {
 import RadioGroupItem, { RadioGroupItemProps } from './RadioGroupItem';
 import { WithAsProp, ComponentEventHandler, withSafeTypeForAs, ShorthandCollection } from '../../types';
 
-export interface RadioGroupSlotClassNames {
-  item: string;
-}
-
 export interface RadioGroupProps extends UIComponentProps, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility;
@@ -47,14 +43,12 @@ export interface RadioGroupProps extends UIComponentProps, ChildrenComponentProp
   vertical?: boolean;
 }
 
+export const radioGroupClassName = 'ui-radiogroup';
+
 class RadioGroup extends AutoControlledComponent<WithAsProp<RadioGroupProps>, any> {
   static displayName = 'RadioGroup';
 
-  static deprecated_className = 'ui-radiogroup';
-
-  static slotClassNames: RadioGroupSlotClassNames = {
-    item: `${RadioGroup.deprecated_className}__item`,
-  };
+  static deprecated_className = radioGroupClassName;
 
   static create: ShorthandFactory<RadioGroupProps>;
 
@@ -165,7 +159,6 @@ class RadioGroup extends AutoControlledComponent<WithAsProp<RadioGroupProps>, an
     return _.map(items, (item, index) =>
       RadioGroupItem.create(item, {
         defaultProps: () => ({
-          className: RadioGroup.slotClassNames.item,
           vertical,
           ...(index === 0 && isNoneValueSelected && { tabIndex: 0 }),
         }),

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -71,6 +71,11 @@ export interface RadioGroupItemState {
   checked: boolean;
 }
 
+export const radioGroupItemClassName = 'ui-radiogroup__item';
+export const radioGroupItemSlotClassNames: RadioGroupItemSlotClassNames = {
+  indicator: `${radioGroupItemClassName}__indicator`,
+};
+
 class RadioGroupItem extends AutoControlledComponent<WithAsProp<RadioGroupItemProps>, RadioGroupItemState> {
   elementRef = React.createRef<HTMLElement>();
 
@@ -78,11 +83,9 @@ class RadioGroupItem extends AutoControlledComponent<WithAsProp<RadioGroupItemPr
 
   static displayName = 'RadioGroupItem';
 
-  static deprecated_className = 'ui-radiogroup__item';
+  static deprecated_className = radioGroupItemClassName;
 
-  static slotClassNames: RadioGroupItemSlotClassNames = {
-    indicator: `${RadioGroupItem.deprecated_className}__indicator`,
-  };
+  static slotClassNames = radioGroupItemSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -148,7 +151,7 @@ class RadioGroupItem extends AutoControlledComponent<WithAsProp<RadioGroupItemPr
         >
           {Box.create(indicator, {
             defaultProps: () => ({
-              className: RadioGroupItem.slotClassNames.indicator,
+              className: radioGroupItemSlotClassNames.indicator,
               styles: styles.indicator,
             }),
           })}

--- a/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
@@ -36,10 +36,16 @@ export interface ReactionProps
   icon?: ShorthandValue<BoxProps>;
 }
 
+export const reactionClassName = 'ui-reaction';
+export const reactionSlotClassNames: ReactionSlotClassNames = {
+  icon: `${reactionClassName}__icon`,
+  content: `${reactionClassName}__content`,
+};
+
 class Reaction extends UIComponent<WithAsProp<ReactionProps>> {
   static create: ShorthandFactory<ReactionProps>;
 
-  static deprecated_className = 'ui-reaction';
+  static deprecated_className = reactionClassName;
 
   static slotClassNames: ReactionSlotClassNames;
 
@@ -74,13 +80,13 @@ class Reaction extends UIComponent<WithAsProp<ReactionProps>> {
           <>
             {Box.create(icon, {
               defaultProps: () => ({
-                className: Reaction.slotClassNames.icon,
+                className: reactionSlotClassNames.icon,
                 styles: styles.icon,
               }),
             })}
             {Box.create(content, {
               defaultProps: () => ({
-                className: Reaction.slotClassNames.content,
+                className: reactionSlotClassNames.content,
                 styles: styles.content,
               }),
             })}
@@ -92,10 +98,7 @@ class Reaction extends UIComponent<WithAsProp<ReactionProps>> {
 }
 
 Reaction.create = createShorthandFactory({ Component: Reaction, mappedProp: 'content' });
-Reaction.slotClassNames = {
-  icon: `${Reaction.deprecated_className}__icon`,
-  content: `${Reaction.deprecated_className}__content`,
-};
+Reaction.slotClassNames = reactionSlotClassNames;
 
 /**
  * A Reaction indicates user's emotion or perception.

--- a/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
@@ -27,12 +27,14 @@ export interface ReactionGroupProps extends UIComponentProps, ChildrenComponentP
   items?: ShorthandCollection<ReactionProps>;
 }
 
+export const reactionGroupClassName = 'ui-reactions';
+
 class ReactionGroup extends UIComponent<WithAsProp<ReactionGroupProps>> {
   static create: ShorthandFactory<ReactionGroupProps>;
 
   static displayName = 'ReactionGroup';
 
-  static deprecated_className = 'ui-reactions';
+  static deprecated_className = reactionGroupClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon(),

--- a/packages/fluentui/react-northstar/src/components/Segment/Segment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Segment/Segment.tsx
@@ -32,8 +32,10 @@ export interface SegmentProps
   inverted?: boolean;
 }
 
+export const segmentClassName = 'ui-segment';
+
 class Segment extends UIComponent<WithAsProp<SegmentProps>, any> {
-  static deprecated_className = 'ui-segment';
+  static deprecated_className = segmentClassName;
 
   static displayName = 'Segment';
 

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -116,6 +116,14 @@ export interface SliderProps
 }
 
 export type SliderStylesProps = Pick<SliderProps, 'fluid' | 'disabled' | 'vertical'>;
+export const sliderClassName = 'ui-slider';
+export const sliderSlotClassNames: SliderSlotClassNames = {
+  input: `${sliderClassName}__input`,
+  inputWrapper: `${sliderClassName}__input-wrapper`,
+  rail: `${sliderClassName}__rail`,
+  thumb: `${sliderClassName}__thumb`,
+  track: `${sliderClassName}__track`,
+};
 
 const Slider: React.FC<WithAsProp<SliderProps>> &
   FluentComponentStaticProps & { slotClassNames: SliderSlotClassNames } = props => {
@@ -170,7 +178,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
     }),
   });
   const { classes, styles: resolvedStyles } = useStyles<SliderStylesProps>(Slider.displayName, {
-    className: Slider.deprecated_className,
+    className: sliderClassName,
     mapPropsToStyles: () => ({
       fluid,
       vertical,
@@ -209,7 +217,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
       getA11Props('input', {
         ...htmlInputProps,
         as: 'input',
-        className: Slider.slotClassNames.input,
+        className: sliderSlotClassNames.input,
         fluid,
         min: numericMin,
         max: numericMax,
@@ -226,12 +234,12 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
     <ElementType {...getA11Props('root', { className: classes.root, ...restProps })}>
       <div
         {...getA11Props('inputWrapper', {
-          className: cx(Slider.slotClassNames.inputWrapper, classes.inputWrapper),
+          className: cx(sliderSlotClassNames.inputWrapper, classes.inputWrapper),
         })}
       >
-        <span {...getA11Props('rail', { className: cx(Slider.slotClassNames.rail, classes.rail) })} />
+        <span {...getA11Props('rail', { className: cx(sliderSlotClassNames.rail, classes.rail) })} />
         <span
-          {...getA11Props('track', { className: cx(Slider.slotClassNames.track, classes.track) })}
+          {...getA11Props('track', { className: cx(sliderSlotClassNames.track, classes.track) })}
           style={{ width: valueAsPercentage }}
         />
         <Ref
@@ -244,7 +252,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
         </Ref>
         {/* the thumb slot needs to appear after the input slot */}
         <span
-          {...getA11Props('thumb', { className: cx(Slider.slotClassNames.thumb, classes.thumb) })}
+          {...getA11Props('thumb', { className: cx(sliderSlotClassNames.thumb, classes.thumb) })}
           style={{ [context.rtl ? 'right' : 'left']: valueAsPercentage }}
         />
       </div>
@@ -255,16 +263,10 @@ const Slider: React.FC<WithAsProp<SliderProps>> &
   return element;
 };
 
-Slider.deprecated_className = 'ui-slider';
+Slider.deprecated_className = sliderClassName;
 Slider.displayName = 'Slider';
 
-Slider.slotClassNames = {
-  input: `${Slider.deprecated_className}__input`,
-  inputWrapper: `${Slider.deprecated_className}__input-wrapper`,
-  rail: `${Slider.deprecated_className}__rail`,
-  thumb: `${Slider.deprecated_className}__thumb`,
-  track: `${Slider.deprecated_className}__track`,
-};
+Slider.slotClassNames = sliderSlotClassNames;
 
 Slider.defaultProps = {
   accessibility: sliderBehavior,

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -91,6 +91,8 @@ export interface SplitButtonState {
   open: boolean;
 }
 
+export const splitButtonClassName = 'ui-splitbutton';
+
 class SplitButton extends AutoControlledComponent<WithAsProp<SplitButtonProps>, SplitButtonState> {
   static create: ShorthandFactory<SplitButton>;
 
@@ -98,7 +100,7 @@ class SplitButton extends AutoControlledComponent<WithAsProp<SplitButtonProps>, 
 
   static Toggle = SplitButtonToggle;
 
-  static deprecated_className = 'ui-splitbutton';
+  static deprecated_className = splitButtonClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButtonToggle.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButtonToggle.tsx
@@ -51,6 +51,7 @@ export interface SplitButtonToggleProps extends UIComponentProps, ContentCompone
 }
 
 export type SplitButtonToggleStylesProps = Pick<SplitButtonToggleProps, 'primary' | 'disabled' | 'size'>;
+export const splitButtonToggleClassName = 'ui-splitbutton__toggle';
 
 const SplitButtonToggle: React.FC<WithAsProp<SplitButtonToggleProps>> &
   FluentComponentStaticProps<SplitButtonToggleProps> = props => {
@@ -77,7 +78,7 @@ const SplitButtonToggle: React.FC<WithAsProp<SplitButtonToggleProps>> &
     rtl: context.rtl,
   });
   const { classes } = useStyles<SplitButtonToggleStylesProps>(SplitButtonToggle.displayName, {
-    className: SplitButtonToggle.deprecated_className,
+    className: splitButtonToggleClassName,
     mapPropsToStyles: () => ({
       primary,
       disabled,
@@ -129,7 +130,7 @@ SplitButtonToggle.defaultProps = {
 };
 
 SplitButtonToggle.displayName = 'SplitButtonToggle';
-SplitButtonToggle.deprecated_className = 'ui-splitbutton__toggle';
+SplitButtonToggle.deprecated_className = splitButtonToggleClassName;
 
 SplitButtonToggle.propTypes = {
   ...commonPropTypes.createCommon({}),

--- a/packages/fluentui/react-northstar/src/components/Status/Status.tsx
+++ b/packages/fluentui/react-northstar/src/components/Status/Status.tsx
@@ -34,6 +34,7 @@ export interface StatusProps extends UIComponentProps {
 }
 
 export type StatusStylesProps = Pick<StatusProps, 'color' | 'size' | 'state'>;
+export const statusClassName = 'ui-status';
 
 const Status: React.FC<WithAsProp<StatusProps>> & FluentComponentStaticProps = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -42,7 +43,7 @@ const Status: React.FC<WithAsProp<StatusProps>> & FluentComponentStaticProps = p
 
   const { className, color, icon, size, state, design, styles, variables } = props;
   const { classes, styles: resolvedStyles } = useStyles<StatusStylesProps>(Status.displayName, {
-    className: Status.deprecated_className,
+    className: statusClassName,
     mapPropsToStyles: () => ({
       color,
       size,
@@ -79,7 +80,7 @@ const Status: React.FC<WithAsProp<StatusProps>> & FluentComponentStaticProps = p
   return element;
 };
 
-Status.deprecated_className = 'ui-status';
+Status.deprecated_className = statusClassName;
 Status.displayName = 'Status';
 Status.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/SvgIcon/SvgIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/SvgIcon/SvgIcon.tsx
@@ -44,7 +44,7 @@ const SvgIcon: React.FC<WithAsProp<SvgIconProps & { children: SvgIconChildrenFn<
   } = props;
 
   const { classes } = useStyles<SvgIconStylesProps>(SvgIcon.displayName, {
-    className: SvgIcon.deprecated_className,
+    className: svgIconClassName,
     mapPropsToStyles: () => ({
       bordered,
       circular,

--- a/packages/fluentui/react-northstar/src/components/Table/Table.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/Table.tsx
@@ -46,16 +46,19 @@ const handleVariablesOverrides = variables => predefinedProps => ({
   variables: mergeComponentVariables(variables, predefinedProps.variables),
 });
 
+export const tableClassName = 'ui-table';
+export const tableSlotClassNames: TableSlotClassNames = {
+  header: `${tableClassName}__header`,
+};
+
 class Table extends UIComponent<WithAsProp<TableProps>> {
   static displayName = 'Table';
-  static deprecated_className = 'ui-table';
+  static deprecated_className = tableClassName;
 
   static Cell = TableCell;
   static Row = TableRow;
 
-  static slotClassNames: TableSlotClassNames = {
-    header: `${Table.deprecated_className}__header`,
-  };
+  static slotClassNames = tableSlotClassNames;
 
   static propTypes = {
     ...commonPropTypes.createCommon({
@@ -105,7 +108,7 @@ class Table extends UIComponent<WithAsProp<TableProps>> {
     const headerRowProps = {
       header: true,
       compact,
-      className: Table.slotClassNames.header,
+      className: tableSlotClassNames.header,
     } as TableRowProps;
 
     const overrideProps = handleVariablesOverrides(variables);

--- a/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableCell.tsx
@@ -46,6 +46,11 @@ export interface TableCellSlotClassNames {
   content: string;
 }
 
+export const tableCellClassName = 'ui-table__cell';
+export const tableCellSlotClassNames: TableCellSlotClassNames = {
+  content: `${tableCellClassName}__content`,
+};
+
 const TableCell: React.FC<WithAsProp<TableCellProps>> &
   FluentComponentStaticProps<TableCellProps> & {
     slotClassNames: TableCellSlotClassNames;
@@ -74,7 +79,7 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
   });
 
   const { classes, styles: resolvedStyles } = useStyles<TableCellStylesProps>(TableCell.displayName, {
-    className: TableCell.deprecated_className,
+    className: tableCellClassName,
     mapPropsToStyles: () => ({
       truncateContent,
     }),
@@ -107,7 +112,7 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
           {hasChildren
             ? children
             : Box.create(content, {
-                defaultProps: () => ({ styles: resolvedStyles.content }),
+                defaultProps: () => ({ className: tableCellSlotClassNames.content, styles: resolvedStyles.content }),
               })}
         </ElementType>,
       )}
@@ -119,11 +124,9 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
 
 TableCell.displayName = 'TableCell';
 
-TableCell.deprecated_className = 'ui-table__cell';
+TableCell.deprecated_className = tableCellClassName;
 
-TableCell.slotClassNames = {
-  content: `${TableCell.deprecated_className}__content`,
-};
+TableCell.slotClassNames = tableCellSlotClassNames;
 
 TableCell.propTypes = {
   ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -50,10 +50,12 @@ const handleVariablesOverrides = variables => predefinedProps => ({
   variables: mergeComponentVariables(variables, predefinedProps.variables),
 });
 
+export const tableRowClassName = 'ui-table__row';
+
 class TableRow extends UIComponent<WithAsProp<TableRowProps>> {
   static displayName = 'TableRow';
 
-  static deprecated_className = 'ui-table__row';
+  static deprecated_className = tableRowClassName;
 
   static create: ShorthandFactory<TableRowProps>;
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/MenuButton/menuButtonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/MenuButton/menuButtonStyles.ts
@@ -1,6 +1,6 @@
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
 import { MenuButtonProps } from '../../../../components/MenuButton/MenuButton';
-import PopupContent from '../../../../components/Popup/PopupContent';
+import { popupContentSlotClassNames } from '../../../../components/Popup/PopupContent';
 
 const menuButtonStyles: ComponentSlotStylesPrepared<MenuButtonProps> = {
   root: () => ({
@@ -8,7 +8,7 @@ const menuButtonStyles: ComponentSlotStylesPrepared<MenuButtonProps> = {
     display: 'inline-block',
   }),
   popupContent: () => ({
-    [`& .${PopupContent.slotClassNames.content}`]: {
+    [`& .${popupContentSlotClassNames.content}`]: {
       borderWidth: '0px',
       padding: '0px',
     },

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -1,7 +1,8 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import RadioGroupItem, {
+import {
   RadioGroupItemProps,
   RadioGroupItemState,
+  radioGroupItemSlotClassNames,
 } from '../../../../components/RadioGroup/RadioGroupItem';
 import { RadioGroupItemVariables } from './radioGroupItemVariables';
 import { pxToRem } from '../../../../utils';
@@ -36,7 +37,7 @@ const radioStyles: ComponentSlotStylesPrepared<RadioGroupItemProps & RadioGroupI
     ':hover': {
       color: v.textColorDefaultHoverFocus,
 
-      [`& .${RadioGroupItem.slotClassNames.indicator}`]: {
+      [`& .${radioGroupItemSlotClassNames.indicator}`]: {
         borderColor: v.textColorDefaultHoverFocus,
 
         ...(!p.disabled &&

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Reaction/reactionStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Reaction/reactionStyles.ts
@@ -1,10 +1,10 @@
 import { FontWeightProperty } from 'csstype';
 import { ICSSInJSStyle, ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { default as Reaction, ReactionProps } from '../../../../components/Reaction/Reaction';
+import { ReactionProps, reactionSlotClassNames } from '../../../../components/Reaction/Reaction';
 import { pxToRem } from '../../../../utils';
 import { ReactionVariables } from './reactionVariables';
 
-const contentClassNameSelector = `& .${Reaction.slotClassNames.content}`;
+const contentClassNameSelector = `& .${reactionSlotClassNames.content}`;
 
 const reactionStyles: ComponentSlotStylesPrepared<ReactionProps, ReactionVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Slider/sliderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Slider/sliderStyles.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SliderVariables } from './sliderVariables';
-import Slider, { SliderStylesProps } from '../../../../components/Slider/Slider';
+import { SliderStylesProps, sliderSlotClassNames } from '../../../../components/Slider/Slider';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 
@@ -22,7 +22,7 @@ const getCommonSlotStyles = (p: SliderStylesProps, v: SliderVariables): ICSSInJS
 });
 
 // this selector is used to identify the thumb slot from a previous sibling
-const thumbFromPreviousSiblingSelector = `&+ .${Slider.slotClassNames.thumb}`;
+const thumbFromPreviousSiblingSelector = `&+ .${sliderSlotClassNames.thumb}`;
 
 const getFluidStyles = (p: SliderStylesProps) => p.fluid && !p.vertical && { width: '100%' };
 

--- a/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/SplitButton/SplitButton-test.tsx
@@ -2,22 +2,22 @@ import * as React from 'react';
 import * as keyboardKey from 'keyboard-key';
 
 import SplitButton from 'src/components/SplitButton/SplitButton';
-import SplitButtonToggle from 'src/components/SplitButton/SplitButtonToggle';
+import { splitButtonToggleClassName } from 'src/components/SplitButton/SplitButtonToggle';
 import { isConformant } from 'test/specs/commonTests';
 import { ReactWrapper, CommonWrapper } from 'enzyme';
 import { mountWithProvider, findIntrinsicElement } from '../../../utils';
 import { menuClassName } from 'src/components/Menu/Menu';
 import { menuItemClassName } from 'src/components/Menu/MenuItem';
-import MenuButton from 'src/components/MenuButton/MenuButton';
+import { menuButtonClassName } from 'src/components/MenuButton/MenuButton';
 import { buttonClassName } from 'src/components/Button/Button';
 import implementsPopperProps from 'test/specs/commonTests/implementsPopperProps';
 
 const mockMenu = { items: ['1', '2', '3'] };
 
 const getToggleButton = (wrapper: ReactWrapper): CommonWrapper =>
-  findIntrinsicElement(wrapper, `.${SplitButtonToggle.deprecated_className}`);
+  findIntrinsicElement(wrapper, `.${splitButtonToggleClassName}`);
 const getMainButton = (wrapper: ReactWrapper): CommonWrapper =>
-  findIntrinsicElement(wrapper, `.${MenuButton.deprecated_className} .${buttonClassName}`);
+  findIntrinsicElement(wrapper, `.${menuButtonClassName} .${buttonClassName}`);
 const getMenuItems = (wrapper: ReactWrapper): CommonWrapper => findIntrinsicElement(wrapper, `.${menuItemClassName}`);
 const getMenu = (wrapper: ReactWrapper): CommonWrapper => findIntrinsicElement(wrapper, `.${menuClassName}`);
 


### PR DESCRIPTION
**BREAKING CHANGES**
This PR removes `RadioGroup.slotClassNames`, dedicated component's classnames should be used

```
// Before
import { RadioGroup } from '@fluentui/react-northstar';

console.log(RadioGroup.slotClassNames.item);

// After
import { radioGroupItemClassName } from '@fluentui/react-northstar';

console.log(radioGroupItemClassName);
```
