### PR TITLE
fix(theme): replace escape with encodeURIComponent in the svg urls in Teams theme

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,6 +44,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))
 
+### Fixes
+- Replace `escape` with `encodeURIComponent` in the svg urls in Teams theme @mnajdova ([#12742](https://github.com/microsoft/fluentui/pull/12742))
+
 <!--------------------------------[ v0.48.0 ]------------------------------- -->
 ## [v0.48.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.48.0) (2020-04-15)
 [Compare changes](https://github.com/OfficeDev/office-ui-fabric-react/compare/fluentuizero_v0.47.1..@fluentui/react-northstar_v0.48.0)

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/activeIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/activeIndicatorUrl.ts
@@ -1,9 +1,9 @@
 export default (color: string, active: boolean) => {
   return active
-    ? `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${escape(
+    ? `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
         color,
       )}' viewBox='8 8 16 16'%3E%3Cpath d='M16 19l3.5-4h-7z' /%3E%3C/svg%3E")`
-    : `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${escape(
+    : `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
         color,
       )}' viewBox='8 8 16 16'%3E%3Cpath d='M19 16l-4-3.5v7z' /%3E%3C/svg%3E")`;
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Checkbox/checkboxIndicatorUrl.ts
@@ -1,6 +1,6 @@
 export default (color: string, backgroundColor: string) =>
-  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' style='background-color: ${escape(
+  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' style='background-color: ${encodeURIComponent(
     backgroundColor,
-  )}; padding: 2px;' focusable='false' viewBox='8 8 22.5 22.5'%3E%3Cg%3E%3Cpath fill='${escape(
+  )}; padding: 2px;' focusable='false' viewBox='8 8 22.5 22.5'%3E%3Cg%3E%3Cpath fill='${encodeURIComponent(
     color,
   )}' d='M23.5 11.875a.968.968 0 0 1-.289.711l-8.25 8.25c-.192.193-.43.289-.711.289s-.519-.096-.711-.289l-4.75-4.75a.965.965 0 0 1-.289-.711c0-.125.027-.25.082-.375s.129-.234.223-.328a.953.953 0 0 1 .695-.297c.135 0 .266.025.391.074.125.05.231.121.32.215l4.039 4.047 7.539-7.547a.886.886 0 0 1 .32-.215c.125-.049.255-.074.391-.074a1.004 1.004 0 0 1 .922.625.97.97 0 0 1 .078.375z' /%3E%3C/g%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/checkableIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/checkableIndicatorUrl.ts
@@ -1,5 +1,5 @@
 export default (color: string) => {
-  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' view-box='8 8 16 16'%3E%3Cg%3E%3Cpath d='M23.5 11.875a.968.968 0 0 1-.289.711l-8.25 8.25c-.192.193-.43.289-.711.289s-.519-.096-.711-.289l-4.75-4.75a.965.965 0 0 1-.289-.711c0-.125.027-.25.082-.375s.129-.234.223-.328a.953.953 0 0 1 .695-.297c.135 0 .266.025.391.074.125.05.231.121.32.215l4.039 4.047 7.539-7.547a.886.886 0 0 1 .32-.215c.125-.049.255-.074.391-.074a1.004 1.004 0 0 1 .922.625.97.97 0 0 1 .078.375z' /%3E%3C/g%3E%3C/svg%3E")`;
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/clearIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/clearIndicatorUrl.ts
@@ -1,4 +1,4 @@
 export default (color: string) =>
-  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' viewBox='8 8 16 16'%3E%3Cg%3E%3Cpath d='M17.414 16l3.89-3.89a1 1 0 1 0-1.415-1.413L16 14.586l-3.89-3.89a1 1 0 1 0-1.413 1.415L14.586 16l-3.89 3.89a1 1 0 1 0 1.415 1.413L16 17.414l3.89 3.89a.997.997 0 0 0 1.413 0 1 1 0 0 0 0-1.415L17.414 16z' /%3E%3C/g%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/toggleIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/toggleIndicatorUrl.ts
@@ -1,4 +1,4 @@
 export default (color: string) =>
-  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' viewBox='8 8 16 16'%3E%3Cpath d='M16.38 20.85l7-7a.485.485 0 0 0 0-.7.485.485 0 0 0-.7 0l-6.65 6.64-6.65-6.64a.485.485 0 0 0-.7 0 .485.485 0 0 0 0 .7l7 7c.1.1.21.15.35.15.14 0 .25-.05.35-.15z' /%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Embed/pauseIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Embed/pauseIndicatorUrl.ts
@@ -1,4 +1,4 @@
 export default (color: string) =>
-  `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' viewBox='6.5 6.5 19 19'%3E%3Cg%3E%3Cpath fill='${escape(
+  `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' viewBox='6.5 6.5 19 19'%3E%3Cg%3E%3Cpath fill='${encodeURIComponent(
     color,
   )}' d='M12.5 22V10h1v12h-1zM18.5 22V10h1v12h-1z' /%3E%3C/g%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Embed/playIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Embed/playIndicatorUrl.ts
@@ -1,4 +1,4 @@
 export default (color: string) =>
-  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' viewBox='6.5 6.5 19 19'%3E%3Cg%3E%3Cpath fill='${escape(
+  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' viewBox='6.5 6.5 19 19'%3E%3Cg%3E%3Cpath fill='${encodeURIComponent(
     color,
   )}' d='M22.055 15.867c0 .25-.062.49-.184.719a1.465 1.465 0 0 1-.496.547l-7.055 4.625c-.245.167-.519.25-.82.25-.203 0-.395-.04-.574-.121a1.574 1.574 0 0 1-.805-.805 1.381 1.381 0 0 1-.121-.574V11.43c0-.203.04-.396.121-.578.081-.182.188-.341.324-.477a1.56 1.56 0 0 1 .477-.324 1.457 1.457 0 0 1 1.375.113l7.055 4.445c.219.136.391.316.516.543s.187.465.187.715z' /%3E%3C/g%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/clearIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/clearIndicatorUrl.ts
@@ -1,4 +1,4 @@
 export default (color: string) =>
-  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' viewBox='8 8 16 16'%3E%3Cg%3E%3Cpath d='M17.414 16l3.89-3.89a1 1 0 1 0-1.415-1.413L16 14.586l-3.89-3.89a1 1 0 1 0-1.413 1.415L14.586 16l-3.89 3.89a1 1 0 1 0 1.415 1.413L16 17.414l3.89 3.89a.997.997 0 0 0 1.413 0 1 1 0 0 0 0-1.415L17.414 16z' /%3E%3C/g%3E%3C/svg%3E")`;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/submenuIndicatorUrl.ts
@@ -1,9 +1,9 @@
 export default (color: string, vertical: boolean) => {
   return vertical
-    ? `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${escape(
+    ? `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
         color,
       )}' viewBox='8 8 16 16'%3E%3Cpath d='M19 16l-4-3.5v7z' /%3E%3C/svg%3E")`
-    : `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${escape(
+    : `url("data:image/svg+xml, %3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' focusable='false' fill='${encodeURIComponent(
         color,
       )}' viewBox='8 8 16 16'%3E%3Cpath d='M16 19l3.5-4h-7z' /%3E%3C/svg%3E")`;
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/activeIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/activeIndicatorUrl.ts
@@ -1,5 +1,5 @@
 export default (color: string) => {
-  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' view-box='8 8 16 16'%3E%3Cg%3E%3Cpath d='M23.5 11.875a.968.968 0 0 1-.289.711l-8.25 8.25c-.192.193-.43.289-.711.289s-.519-.096-.711-.289l-4.75-4.75a.965.965 0 0 1-.289-.711c0-.125.027-.25.082-.375s.129-.234.223-.328a.953.953 0 0 1 .695-.297c.135 0 .266.025.391.074.125.05.231.121.32.215l4.039 4.047 7.539-7.547a.886.886 0 0 1 .32-.215c.125-.049.255-.074.391-.074a1.004 1.004 0 0 1 .922.625.97.97 0 0 1 .078.375z' /%3E%3C/g%3E%3C/svg%3E")`;
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/submenuIndicatorUrl.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/submenuIndicatorUrl.ts
@@ -1,5 +1,5 @@
 export default (color: string) => {
-  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${escape(
+  return `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' role='presentation' fill='${encodeURIComponent(
     color,
   )}' focusable='false' viewBox='8 8 16 16'%3E%3Cpath d='M19.49,16a.91.91,0,0,1-.29.7l-5,5a1,1,0,0,1-.71.3,1,1,0,0,1-1-1,1,1,0,0,1,.29-.7L17.08,16l-4.3-4.29a1,1,0,0,1-.29-.71,1,1,0,0,1,1.71-.71l5,5A1,1,0,0,1,19.49,16Z' /%3E%3C/svg%3E")`;
 };


### PR DESCRIPTION
Replaced js `escape()` as it is deprecated, with the `encodeURIComponent()` in all svg urls in Teams theme