### PR TITLE
Pivot: componentRef fixed, extra DOM element removed.

### DIFF
--- a/change/office-ui-fabric-react-2020-04-16-11-10-39-fix-pivot-ref.json
+++ b/change/office-ui-fabric-react-2020-04-16-11-10-39-fix-pivot-ref.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Pivot: componentRef now resolves correctly, unnecessary DOM element removed.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-16T18:10:39.565Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -135,10 +135,13 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     const items = linkCollection.links.map(l => this._renderPivotLink(linkCollection, l, selectedKey));
 
     return (
-      <FocusZone componentRef={this._focusZone} direction={FocusZoneDirection.horizontal}>
-        <div className={this._classNames.root} role="tablist">
-          {items}
-        </div>
+      <FocusZone
+        className={this._classNames.root}
+        role="tablist"
+        componentRef={this._focusZone}
+        direction={FocusZoneDirection.horizontal}
+      >
+        {items}
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -7,6 +7,7 @@ import {
   divProperties,
   classNamesFunction,
   warn,
+  initializeComponentRef,
 } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
@@ -52,6 +53,8 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
 
   constructor(props: IPivotProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     if (process.env.NODE_ENV !== 'production') {
       warnDeprecations(PivotName, props, {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-
+import { mount } from 'enzyme';
 import { resetIds } from '../../Utilities';
 
-import { Pivot, PivotItem, PivotLinkFormat, PivotLinkSize } from './index';
+import { Pivot, PivotItem, PivotLinkFormat, PivotLinkSize, IPivot } from './index';
 
 describe('Pivot', () => {
   beforeEach(() => {
@@ -20,6 +20,21 @@ describe('Pivot', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('can be focused', () => {
+    const pivotRef = React.createRef<IPivot>();
+
+    mount(
+      <Pivot componentRef={pivotRef}>
+        <PivotItem id="link1" headerText="Link 1" />
+        <PivotItem id="link2" headerText="Link 2" />
+      </Pivot>,
+    );
+
+    pivotRef.current!.focus();
+    expect(document.activeElement).toBeTruthy();
+    expect(document.activeElement!.id).toEqual('link1');
   });
 
   it('supports JSX expressions', () => {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
@@ -27,16 +27,23 @@ describe('Pivot', () => {
 
     mount(
       <Pivot componentRef={pivotRef}>
-        <PivotItem headerText="Link 1" headerButtonProps={{ 'data-is-visible': true }} />
-        <PivotItem headerText="Link 2" headerButtonProps={{ 'data-is-visible': true }} />
+        <PivotItem headerText="Link 1" />
+        <PivotItem headerText="Link 2" />
       </Pivot>,
     );
 
-    expect(pivotRef.current).toBeTruthy();
+    // Instruct FocusZone to treat all elements as visible.
+    (HTMLElement.prototype as any).isVisible = true;
 
-    pivotRef.current!.focus();
-    expect(document.activeElement).toBeTruthy();
-    expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
+    try {
+      expect(pivotRef.current).toBeTruthy();
+
+      pivotRef.current!.focus();
+      expect(document.activeElement).toBeTruthy();
+      expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
+    } finally {
+      delete (HTMLElement.prototype as any).isVisible;
+    }
   });
 
   it('supports JSX expressions', () => {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.test.tsx
@@ -27,14 +27,16 @@ describe('Pivot', () => {
 
     mount(
       <Pivot componentRef={pivotRef}>
-        <PivotItem id="link1" headerText="Link 1" />
-        <PivotItem id="link2" headerText="Link 2" />
+        <PivotItem headerText="Link 1" headerButtonProps={{ 'data-is-visible': true }} />
+        <PivotItem headerText="Link 2" headerButtonProps={{ 'data-is-visible': true }} />
       </Pivot>,
     );
 
+    expect(pivotRef.current).toBeTruthy();
+
     pivotRef.current!.focus();
     expect(document.activeElement).toBeTruthy();
-    expect(document.activeElement!.id).toEqual('link1');
+    expect(document.activeElement!.textContent?.trim()).toEqual('Link 1');
   });
 
   it('supports JSX expressions', () => {

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -7,365 +7,361 @@ exports[`Pivot renders link Pivot correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            Test Link 1
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content=""
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name=""
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -7,377 +7,373 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="test"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="test"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            test
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Test Link (20+)"
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name="Test Link"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="test"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="test"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              test
-            </span>
+             
+            Test Link
           </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link (20+)"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-count
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link
-            </span>
-            <span
-              className=
-                  ms-Pivot-count
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               (
-              20+
-              )
-            </span>
+             (
+            20+
+            )
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -396,365 +392,361 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            Test Link 1
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Test Link 2"
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name="Test Link 2"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            Test Link 2
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link 2"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link 2"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 2
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -774,557 +766,553 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content=" (12)"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-count
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             (
+            12
+            )
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Test Link (12)"
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name="Test Link"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content=" (12)"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-count
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               (
-              12
-              )
-            </span>
+             
+            Test Link
+          </span>
+          <span
+            className=
+                ms-Pivot-count
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             (
+            12
+            )
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Text with icon xx"
+      data-is-focusable={true}
+      id="Pivot0-Tab2"
+      name="Text with icon"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link (12)"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link
-            </span>
-            <span
-              className=
-                  ms-Pivot-count
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               (
-              12
-              )
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Text with icon xx"
-        data-is-focusable={true}
-        id="Pivot0-Tab2"
-        name="Text with icon"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-icon
+                ms-Pivot-icon
 
-            >
-              <i
-                aria-hidden={true}
-                className=
-
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons-1";
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
-                    }
-                data-icon-name="Recent"
-              >
-                
-              </i>
-            </span>
-            <span
+          >
+            <i
+              aria-hidden={true}
               className=
-                  ms-Pivot-text
+
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     display: inline-block;
-                    vertical-align: top;
+                    font-family: "FabricMDL2Icons-1";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
                   }
+              data-icon-name="Recent"
             >
-               
-              Text with icon
-            </span>
+              
+            </i>
+          </span>
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            Text with icon
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -1342,366 +1330,362 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
+        ms-Pivot--large
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
-          ms-Pivot--large
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
-            color: #0078d4;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            font-size: 18px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            Test Link 1
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 18px;
+            font-weight: 400;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content=""
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name=""
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              
-            </span>
+             
+            
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -1719,385 +1703,381 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
+        ms-Pivot--large
+        ms-Pivot--tabs
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
-          ms-Pivot--large
-          ms-Pivot--tabs
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: #0078d4;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
-            color: #0078d4;
+            color: #ffffff;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
+            font-size: 18px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
+            height: 44px;
+            line-height: 44px;
             margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #106ebe;
+            color: #ffffff;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline-offset: -1px;
+            outline: none;
+          }
+          &:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: auto;
+            left: 0px;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            transition: none;
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          .ms-Fabric--isFocusVisible &:focus::before {
+            background: transparent;
+            height: auto;
+            transition: none;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background: Highlight;
+            color: HighlightText;
+            font-weight: 600;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #0078d4;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #ffffff;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #106ebe;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #005a9e;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: auto;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-              transition: none;
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              -ms-high-contrast-adjust: none;
-              background: Highlight;
-              color: HighlightText;
-              font-weight: 600;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            Test Link 1
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 18px;
+            font-weight: 400;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 0px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #0078d4;
+            color: #ffffff;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            color: #000000;
+            outline-offset: -1px;
+            outline: none;
+          }
+          &:active {
+            background-color: #0078d4;
+            color: #ffffff;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          .ms-Fabric--isFocusVisible &:focus::before {
+            background: transparent;
+            height: auto;
+            transition: none;
+          }
+      data-content=""
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name=""
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #0078d4;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              color: #000000;
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #0078d4;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              
-            </span>
+             
+            
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -2115,365 +2095,361 @@ exports[`Pivot renders link Pivot correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            Test Link 1
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content=""
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name=""
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -2491,384 +2467,380 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
+        ms-Pivot--tabs
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
-          ms-Pivot--tabs
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: #0078d4;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
-            color: #0078d4;
+            color: #ffffff;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
+            height: 44px;
+            line-height: 44px;
             margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #106ebe;
+            color: #ffffff;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline-offset: -1px;
+            outline: none;
+          }
+          &:active {
+            background-color: #005a9e;
+            color: #ffffff;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: auto;
+            left: 0px;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+            transition: none;
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          .ms-Fabric--isFocusVisible &:focus::before {
+            background: transparent;
+            height: auto;
+            transition: none;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: none;
+            background: Highlight;
+            color: HighlightText;
+            font-weight: 600;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #0078d4;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #ffffff;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #106ebe;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #005a9e;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: auto;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-              transition: none;
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              -ms-high-contrast-adjust: none;
-              background: Highlight;
-              color: HighlightText;
-              font-weight: 600;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            Test Link 1
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 0px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 10px;
+            padding-right: 10px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+            vertical-align: top;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #0078d4;
+            color: #ffffff;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            color: #000000;
+            outline-offset: -1px;
+            outline: none;
+          }
+          &:active {
+            background-color: #0078d4;
+            color: #ffffff;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          .ms-Fabric--isFocusVisible &:focus::before {
+            background: transparent;
+            height: auto;
+            transition: none;
+          }
+      data-content=""
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name=""
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #0078d4;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              color: #000000;
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #0078d4;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              
-            </span>
+             
+            
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"
@@ -2886,365 +2858,361 @@ exports[`Pivot supports JSX expressions 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={false}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
-            color: #0078d4;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Test Link 1"
+      data-is-focusable={true}
+      id="Pivot0-Tab0"
+      name="Test Link 1"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={false}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 1
-            </span>
+             
+            Test Link 1
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={true}
+      </span>
+    </button>
+    <button
+      aria-selected={true}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="Test Link 3"
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name="Test Link 3"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 3"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link 3"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Test Link 3
-            </span>
+             
+            Test Link 3
           </span>
         </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -11,531 +11,527 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-describedby="ktp-layer-id ktp-a"
+        aria-selected={true}
         className=
-            ms-Pivot
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
               color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="Pivot 1"
+        data-is-focusable={true}
+        data-ktp-execute-target="ktp-a"
+        data-ktp-target="ktp-a"
+        id="Pivot0-Tab0"
+        name="Pivot 1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Pivot 1
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-describedby="ktp-layer-id ktp-b"
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Pivot 2"
+        data-is-focusable={true}
+        data-ktp-execute-target="ktp-b"
+        data-ktp-target="ktp-b"
+        id="Pivot0-Tab1"
+        name="Pivot 2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-describedby="ktp-layer-id ktp-a"
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="Pivot 1"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-a"
-          data-ktp-target="ktp-a"
-          id="Pivot0-Tab0"
-          name="Pivot 1"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Pivot 1
-              </span>
+               
+              Pivot 2
             </span>
           </span>
-        </button>
-        <button
-          aria-describedby="ktp-layer-id ktp-b"
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-describedby="ktp-layer-id ktp-c"
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Pivot 3"
+        data-is-focusable={true}
+        data-ktp-execute-target="ktp-c"
+        data-ktp-target="ktp-c"
+        id="Pivot0-Tab2"
+        name="Pivot 3"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Pivot 2"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-b"
-          data-ktp-target="ktp-b"
-          id="Pivot0-Tab1"
-          name="Pivot 2"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Pivot 2
-              </span>
+               
+              Pivot 3
             </span>
           </span>
-        </button>
-        <button
-          aria-describedby="ktp-layer-id ktp-c"
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Pivot 3"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-c"
-          data-ktp-target="ktp-c"
-          id="Pivot0-Tab2"
-          name="Pivot 3"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
-              className=
-                  ms-Pivot-linkContent
-                  {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
-                  }
-            >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Pivot 3
-              </span>
-            </span>
-          </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -8,524 +8,520 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
   <div
     className=
         ms-FocusZone
+        ms-Pivot
         &:focus {
           outline: none;
+        }
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #0078d4;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          white-space: nowrap;
         }
     data-focuszone-id="FocusZone1"
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
+    role="tablist"
   >
-    <div
+    <button
+      aria-selected={true}
       className=
-          ms-Pivot
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          is-selected
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            box-shadow: none;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
             box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
             color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: #0078d4;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){&:before {
+            background-color: Highlight;
+          }
+          &:hover::before {
+            left: 0px;
+            right: 0px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: Highlight;
+          }
+      data-content="My Files"
+      data-is-focusable={true}
+      data-order={1}
+      data-title="My Files Title"
+      id="Pivot0-Tab0"
+      name="My Files"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
+        className=
+            ms-Button-flexContainer
+            {
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
+            }
+        data-automationid="splitbuttonprimary"
+      >
+        <span
+          className=
+              ms-Pivot-linkContent
+              {
+                flex: 0 1 100%;
+              }
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
+        >
+          <span
+            className=
+                ms-Pivot-text
+                {
+                  display: inline-block;
+                  vertical-align: top;
+                }
+          >
+             
+            My Files
+          </span>
+        </span>
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
             position: relative;
-            white-space: nowrap;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
           }
-      role="tablist"
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Recent"
+      data-is-focusable={true}
+      id="Pivot0-Tab1"
+      name="Recent"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
     >
-      <button
-        aria-selected={true}
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="My Files"
-        data-is-focusable={true}
-        data-order={1}
-        data-title="My Files Title"
-        id="Pivot0-Tab0"
-        name="My Files"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              My Files
-            </span>
+             
+            Recent
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className=
+          ms-Button
+          ms-Button--action
+          ms-Button--command
+          ms-Pivot-link
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: transparent;
+            border-radius: 0px;
+            border: 0px;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: pointer;
+            display: inline-block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 44px;
+            line-height: 44px;
+            margin-right: 8px;
+            outline: transparent;
+            padding-bottom: 0;
+            padding-left: 8px;
+            padding-right: 8px;
+            padding-top: 0;
+            position: relative;
+            text-align: center;
+            text-decoration: none;
+            user-select: none;
+          }
+          &::-moz-focus-inner {
+            border: 0;
+          }
+          .ms-Fabric--isFocusVisible &:focus:after {
+            border: 0px;
+            bottom: 2px;
+            content: attr(data-content);
+            left: 2px;
+            outline: 1px solid #605e5c;
+            position: relative;
+            right: 2px;
+            top: 2px;
+            z-index: 1;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+            border: none;
+            bottom: -2px;
+            left: -2px;
+            outline-color: ButtonText;
+            right: -2px;
+            top: -2px;
+          }
+          &:active > * {
+            left: 0px;
+            position: relative;
+            top: 0px;
+          }
+          &:hover {
+            background-color: #f3f2f1;
+            color: #201f1e;
+            cursor: pointer;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+            color: Highlight;
+          }
+          &:hover .ms-Button-icon {
+            color: #0078d4;
+          }
+          &:focus {
+            outline: none;
+          }
+          &:active {
+            background-color: #edebe9;
+            color: #201f1e;
+          }
+          &:active .ms-Button-icon {
+            color: #004578;
+          }
+          &:before {
+            background-color: transparent;
+            bottom: 0px;
+            content: "";
+            height: 2px;
+            left: 8px;
+            position: absolute;
+            right: 8px;
+            transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                right 0.267s cubic-bezier(.1,.25,.75,.9);
+          }
+          &:after {
+            color: transparent;
+            content: attr(data-content);
+            display: block;
+            font-weight: 700;
+            height: 1px;
+            overflow: hidden;
+            visibility: hidden;
+          }
+          .ms-Fabric--isFocusVisible &:focus {
+            outline: 1px solid #605e5c;
+          }
+      data-content="Shared with me"
+      data-is-focusable={true}
+      id="Pivot0-Tab2"
+      name="Shared with me"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseUp={[Function]}
+      role="tab"
+      type="button"
+    >
+      <span
         className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
+            ms-Button-flexContainer
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              align-items: center;
+              display: flex;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: flex-start;
             }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Recent"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Recent"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+        data-automationid="splitbuttonprimary"
       >
         <span
           className=
-              ms-Button-flexContainer
+              ms-Pivot-linkContent
               {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                flex: 0 1 100%;
               }
-          data-automationid="splitbuttonprimary"
+              & > *  {
+                margin-left: 4px;
+              }
+              & > *:first-child {
+                margin-left: 0px;
+              }
         >
           <span
             className=
-                ms-Pivot-linkContent
+                ms-Pivot-text
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inline-block;
+                  vertical-align: top;
                 }
           >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Recent
-            </span>
+             
+            Shared with me
           </span>
         </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Shared with me"
-        data-is-focusable={true}
-        id="Pivot0-Tab2"
-        name="Shared with me"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Shared with me
-            </span>
-          </span>
-        </span>
-      </button>
-    </div>
+      </span>
+    </button>
   </div>
   <div
     aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -9,552 +9,922 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
     <div
       className=
           ms-FocusZone
+          ms-Pivot
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
               color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="My Files (42) xx"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="My Files"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-icon
+
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-0";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                data-icon-name="Emoji2"
+              >
+                
+              </i>
+            </span>
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              My Files
+            </span>
+            <span
+              className=
+                  ms-Pivot-count
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               (
+              42
+              )
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content=" (23) xx"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="My Files (42) xx"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="My Files"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-icon
+
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-1";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                data-icon-name="Recent"
+              >
+                
+              </i>
+            </span>
+            <span
+              className=
+                  ms-Pivot-count
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-icon
-
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons-0";
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                  data-icon-name="Emoji2"
-                >
-                  
-                </i>
-              </span>
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                My Files
-              </span>
-              <span
-                className=
-                    ms-Pivot-count
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 (
-                42
-                )
-              </span>
+               (
+              23
+              )
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Placeholder xx"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Placeholder"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content=" (23) xx"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-icon
+
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-0";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                data-icon-name="Globe"
+              >
+                
+              </i>
+            </span>
+            <span
+              className=
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-icon
-
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons-1";
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                  data-icon-name="Recent"
-                >
-                  
-                </i>
-              </span>
-              <span
-                className=
-                    ms-Pivot-count
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 (
-                23
-                )
-              </span>
+               
+              Placeholder
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Shared with me (1) xx"
+        data-is-focusable={true}
+        id="Pivot0-Tab3"
+        name="Shared with me"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Placeholder xx"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Placeholder"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
+            <span
+              className=
+                  ms-Pivot-icon
+
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-4";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                data-icon-name="Ringer"
+              >
+                
+              </i>
+            </span>
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Shared with me
+            </span>
+            <span
+              className=
+                  ms-Pivot-count
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               (
+              1
+              )
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Customized Rendering (10) xx"
+        data-is-focusable={true}
+        id="Pivot0-Tab4"
+        name="Customized Rendering"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span>
             <span
               className=
                   ms-Pivot-linkContent
@@ -600,187 +970,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     }
               >
                  
-                Placeholder
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Shared with me (1) xx"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Shared with me"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
-              className=
-                  ms-Pivot-linkContent
-                  {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
-                  }
-            >
-              <span
-                className=
-                    ms-Pivot-icon
-
-              >
-                <i
-                  aria-hidden={true}
-                  className=
-
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons-4";
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                  data-icon-name="Ringer"
-                >
-                  
-                </i>
-              </span>
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Shared with me
+                Customized Rendering
               </span>
               <span
                 className=
@@ -791,229 +981,35 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     }
               >
                  (
-                1
+                10
                 )
               </span>
             </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Customized Rendering (10) xx"
-          data-is-focusable={true}
-          id="Pivot0-Tab4"
-          name="Customized Rendering"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span>
-              <span
-                className=
-                    ms-Pivot-linkContent
-                    {
-                      flex: 0 1 100%;
-                    }
-                    & > *  {
-                      margin-left: 4px;
-                    }
-                    & > *:first-child {
-                      margin-left: 0px;
-                    }
-              >
-                <span
-                  className=
-                      ms-Pivot-icon
+            <i
+              aria-hidden={true}
+              className=
 
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          display: inline-block;
-                          font-family: "FabricMDL2Icons-0";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                    data-icon-name="Globe"
-                  >
-                    
-                  </i>
-                </span>
-                <span
-                  className=
-                      ms-Pivot-text
-                      {
-                        display: inline-block;
-                        vertical-align: top;
-                      }
-                >
-                   
-                  Customized Rendering
-                </span>
-                <span
-                  className=
-                      ms-Pivot-count
-                      {
-                        display: inline-block;
-                        vertical-align: top;
-                      }
-                >
-                   (
-                  10
-                  )
-                </span>
-              </span>
-              <i
-                aria-hidden={true}
-                className=
-
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons-0";
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
-                    }
-                data-icon-name="Airplane"
-                style={
-                  Object {
-                    "color": "red",
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons-0";
+                    font-style: normal;
+                    font-weight: normal;
+                    speak: none;
                   }
+              data-icon-name="Airplane"
+              style={
+                Object {
+                  "color": "red",
                 }
-              >
-                
-              </i>
-            </span>
+              }
+            >
+              
+            </i>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -9,523 +9,519 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
+          ms-Pivot--large
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
-            ms-Pivot--large
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
-              color: #0078d4;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              font-size: 18px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="My Files"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="My Files"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="My Files"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="My Files"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                My Files
-              </span>
+               
+              My Files
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Recent"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Recent"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Recent"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Recent"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Recent
-              </span>
+               
+              Recent
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Shared with me"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Shared with me"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Shared with me"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Shared with me"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Shared with me
-              </span>
+               
+              Shared with me
             </span>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -36,715 +36,711 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
+          ms-Pivot--large
+          ms-Pivot--tabs
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: #0078d4;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
-              color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
+              font-size: 18px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
+              height: 44px;
+              line-height: 44px;
               margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #106ebe;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #005a9e;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: auto;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              transition: none;
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background: Highlight;
+              color: HighlightText;
+              font-weight: 600;
+            }
+        data-content="Foo"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="Foo"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Foo
-              </span>
+               
+              Foo
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bar"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Bar"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bar
-              </span>
+               
+              Bar
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bas"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Bas"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bas
-              </span>
+               
+              Bas
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Biz"
+        data-is-focusable={true}
+        id="Pivot0-Tab3"
+        name="Biz"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Biz
-              </span>
+               
+              Biz
             </span>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -9,522 +9,518 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
               color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="My Files"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="My Files"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              My Files
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Recent"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Recent"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="My Files"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="My Files"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                My Files
-              </span>
+               
+              Recent
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Shared with me"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Shared with me"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Recent"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Recent"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Recent
-              </span>
+               
+              Shared with me
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Shared with me"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Shared with me"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
-              className=
-                  ms-Pivot-linkContent
-                  {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
-                  }
-            >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Shared with me
-              </span>
-            </span>
-          </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -9,715 +9,711 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
+          ms-Pivot--large
+          ms-Pivot--tabs
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: #0078d4;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
-              color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
+              font-size: 18px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
+              height: 44px;
+              line-height: 44px;
               margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #106ebe;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #005a9e;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: auto;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              transition: none;
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background: Highlight;
+              color: HighlightText;
+              font-weight: 600;
+            }
+        data-content="Foo"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="Foo"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Foo
-              </span>
+               
+              Foo
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bar"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Bar"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bar
-              </span>
+               
+              Bar
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bas"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Bas"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bas
-              </span>
+               
+              Bas
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Biz"
+        data-is-focusable={true}
+        id="Pivot0-Tab3"
+        name="Biz"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Biz
-              </span>
+               
+              Biz
             </span>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -21,522 +21,518 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
               color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="Rectangle red"
+        data-is-focusable={true}
+        id="ShapeColorPivot_rectangleRed"
+        name="Rectangle red"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Rectangle red
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Square red"
+        data-is-focusable={true}
+        id="ShapeColorPivot_squareRed"
+        name="Square red"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="Rectangle red"
-          data-is-focusable={true}
-          id="ShapeColorPivot_rectangleRed"
-          name="Rectangle red"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Rectangle red
-              </span>
+               
+              Square red
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Rectangle green"
+        data-is-focusable={true}
+        id="ShapeColorPivot_rectangleGreen"
+        name="Rectangle green"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Square red"
-          data-is-focusable={true}
-          id="ShapeColorPivot_squareRed"
-          name="Square red"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Square red
-              </span>
+               
+              Rectangle green
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Rectangle green"
-          data-is-focusable={true}
-          id="ShapeColorPivot_rectangleGreen"
-          name="Rectangle green"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
-              className=
-                  ms-Pivot-linkContent
-                  {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
-                  }
-            >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Rectangle green
-              </span>
-            </span>
-          </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -9,714 +9,710 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
     <div
       className=
           ms-FocusZone
+          ms-Pivot
+          ms-Pivot--tabs
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
-            ms-Pivot--tabs
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: #0078d4;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
-              color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
+              height: 44px;
+              line-height: 44px;
               margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #106ebe;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #005a9e;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: auto;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              transition: none;
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background: Highlight;
+              color: HighlightText;
+              font-weight: 600;
+            }
+        data-content="Foo"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="Foo"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Foo
-              </span>
+               
+              Foo
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bar"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Bar"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bar
-              </span>
+               
+              Bar
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bas"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Bas"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bas
-              </span>
+               
+              Bas
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Biz"
+        data-is-focusable={true}
+        id="Pivot0-Tab3"
+        name="Biz"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Biz
-              </span>
+               
+              Biz
             </span>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -9,715 +9,711 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
     <div
       className=
           ms-FocusZone
+          ms-Pivot
+          ms-Pivot--large
+          ms-Pivot--tabs
           &:focus {
             outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
           }
       data-focuszone-id="FocusZone1"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
+      role="tablist"
     >
-      <div
+      <button
+        aria-selected={true}
         className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              background-color: #0078d4;
+              border-radius: 0px;
+              border: 0px;
               box-sizing: border-box;
-              color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
+              font-size: 18px;
               font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
+              height: 44px;
+              line-height: 44px;
               margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
               position: relative;
-              white-space: nowrap;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
             }
-        role="tablist"
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #106ebe;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #005a9e;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: auto;
+              left: 0px;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              transition: none;
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background: Highlight;
+              color: HighlightText;
+              font-weight: 600;
+            }
+        data-content="Foo"
+        data-is-focusable={true}
+        id="Pivot0-Tab0"
+        name="Foo"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
       >
-        <button
-          aria-selected={true}
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Foo
-              </span>
+               
+              Foo
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bar"
+        data-is-focusable={true}
+        id="Pivot0-Tab1"
+        name="Bar"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bar
-              </span>
+               
+              Bar
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Bas"
+        data-is-focusable={true}
+        id="Pivot0-Tab2"
+        name="Bas"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Bas
-              </span>
+               
+              Bas
             </span>
           </span>
-        </button>
-        <button
-          aria-selected={false}
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: #ffffff;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 18px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 0px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 10px;
+              padding-right: 10px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              vertical-align: top;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #0078d4;
+              color: #ffffff;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              color: #000000;
+              outline-offset: -1px;
+              outline: none;
+            }
+            &:active {
+              background-color: #0078d4;
+              color: #ffffff;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            .ms-Fabric--isFocusVisible &:focus::before {
+              background: transparent;
+              height: auto;
+              transition: none;
+            }
+        data-content="Biz"
+        data-is-focusable={true}
+        id="Pivot0-Tab3"
+        name="Biz"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
           className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
+              ms-Button-flexContainer
               {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+          data-automationid="splitbuttonprimary"
         >
           <span
             className=
-                ms-Button-flexContainer
+                ms-Pivot-linkContent
                 {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  flex: 0 1 100%;
                 }
-            data-automationid="splitbuttonprimary"
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
           >
             <span
               className=
-                  ms-Pivot-linkContent
+                  ms-Pivot-text
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inline-block;
+                    vertical-align: top;
                   }
             >
-              <span
-                className=
-                    ms-Pivot-text
-                    {
-                      display: inline-block;
-                      vertical-align: top;
-                    }
-              >
-                 
-                Biz
-              </span>
+               
+              Biz
             </span>
           </span>
-        </button>
-      </div>
+        </span>
+      </button>
     </div>
     <div
       aria-labelledby="Pivot0-Tab0"


### PR DESCRIPTION
#### Description of changes

In looking into `Pivot`, we found that `componentRef` was not resolving correctly resolving due to the move to `React.Component` from `BaseComponent`. Added a focus test to validate.

In the process, we saw that FocusZone was adding an unnecessary extra `div` to the hierarchy, not referenced in class names, and was causing the new test to fail due to thinking the extra element was not visible.

To address the test passing, I've simplified the DOM to remove the extra element. While we typically avoid DOM changes, I believe this one is safe to remove.

#### Focus areas to test

Pivot still works, passes all tests. Snapshots updated.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12748)