### PR TITLE
Sochhay/webkit text size adjust

### DIFF
--- a/change/@uifabric-merge-styles-2020-04-16-12-33-20-sochhay-webkitTextSizeAdjust.json
+++ b/change/@uifabric-merge-styles-2020-04-16-12-33-20-sochhay-webkitTextSizeAdjust.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add WebkitTextSizeAdjust and textSizeAdjust as a valid CSS property",
+  "packageName": "@uifabric/merge-styles",
+  "email": "sochhay@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-16T19:33:20.850Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -335,6 +335,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     textOverlineWidth?: ICSSRule | ICSSPixelUnitRule;
     textRendering?: ICSSRule | string;
     textShadow?: ICSSRule | string;
+    textSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
     textTransform?: ICSSRule | string;
     textUnderlinePosition?: ICSSRule | string;
     textUnderlineStyle?: ICSSRule | string;
@@ -367,6 +368,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     WebkitFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
     WebkitOverflowScrolling?: 'auto' | 'touch';
     WebkitTapHighlightColor?: string;
+    WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
     whiteSpace?: ICSSRule | string;
     widows?: ICSSRule | number;
     width?: ICSSRule | ICSSPixelUnitRule;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -308,6 +308,12 @@ export interface IRawStyleBase extends IRawFontStyle {
   WebkitTapHighlightColor?: string;
 
   /**
+   * (Webkit specific) controls the text inflation algorithm used on some smartphones and tablets.
+   * Other browsers will ignore this property.
+   */
+  WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
+
+  /**
    * Aligns a flex container's lines within the flex container when there is extra space
    * in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
    */
@@ -1833,6 +1839,12 @@ export interface IRawStyleBase extends IRawFontStyle {
    * text, along with optional color and blur radius values.
    */
   textShadow?: ICSSRule | string;
+
+  /**
+   * The text-size-adjust CSS property controls the text inflation algorithm used
+   * on some smartphones and tablets. Other browsers will ignore this property.
+   */
+  textSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
 
   /**
    * This property transforms text for styling purposes. (It has no effect on the


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: None
- [x] Include a change request file using `$ yarn change`

#### Description of changes
add `WebkitTextSizeAdjust` and `textSizeAdjust` as a valid CSS property

These properties prevent adjustments of font size after orientation changes in iOS.
#### Focus areas to test
Should have no impact on anything.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12751)