### PR TITLE
ContextualMenu: Improve perf by doing less merge styles

### DIFF
--- a/change/@uifabric-utilities-2020-04-16-13-45-59-xgao-menu-perf.json
+++ b/change/@uifabric-utilities-2020-04-16-13-45-59-xgao-menu-perf.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "classNamesFunction: fix not traversing the changed styles function",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-16T20:45:59.092Z"
+}

--- a/change/office-ui-fabric-react-2020-04-16-13-45-59-xgao-menu-perf.json
+++ b/change/office-ui-fabric-react-2020-04-16-13-45-59-xgao-menu-perf.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Improve perf by doing less merge styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-16T20:44:11.171Z"
+}

--- a/packages/utilities/src/classNamesFunction.test.ts
+++ b/packages/utilities/src/classNamesFunction.test.ts
@@ -19,28 +19,42 @@ describe('classNamesFunction', () => {
   });
 
   it('can cache rules', () => {
-    let styleFunctionCalled = false;
+    let styleFunction1Called = false;
+    let styleFunction2Called = false;
     const getClassNames = classNamesFunction<{ a: number; b: string }, { root: IStyle }>();
-    const getStyles = (props: { a: number; b: string }) => {
-      styleFunctionCalled = true;
+    const getStyles1 = (props: { a: number; b: string }) => {
+      styleFunction1Called = true;
       return {
         root: { width: props.a },
       };
     };
 
-    const classNames = getClassNames(getStyles, { a: 1, b: 'test' });
-    expect(styleFunctionCalled).toEqual(true);
-    styleFunctionCalled = false;
+    const getStyles2 = (props: { a: number; b: string }) => {
+      styleFunction2Called = true;
+      return {
+        root: { height: props.a },
+      };
+    };
 
-    expect(getClassNames(getStyles, { a: 1, b: 'test' })).toEqual(classNames);
-    expect(styleFunctionCalled).toEqual(false);
+    const classNames1 = getClassNames(getStyles1, { a: 1, b: 'test' });
+    const classNames2 = getClassNames(getStyles2, { a: 1, b: 'test' });
+    expect(styleFunction1Called).toEqual(true);
+    expect(styleFunction2Called).toEqual(true);
+    styleFunction1Called = false;
+    styleFunction2Called = false;
 
-    expect(getClassNames(getStyles, { a: 2, b: 'test' })).not.toEqual(classNames);
-    expect(styleFunctionCalled).toEqual(true);
+    expect(getClassNames(getStyles1, { a: 1, b: 'test' })).toEqual(classNames1);
+    expect(styleFunction1Called).toEqual(false);
 
-    styleFunctionCalled = false;
-    getClassNames(getStyles, { a: 2, b: 'test' });
-    expect(styleFunctionCalled).toEqual(false);
+    expect(getClassNames(getStyles2, { a: 1, b: 'test' })).toEqual(classNames2);
+    expect(styleFunction2Called).toEqual(false);
+
+    expect(getClassNames(getStyles1, { a: 2, b: 'test' })).not.toEqual(classNames1);
+    expect(styleFunction1Called).toEqual(true);
+    styleFunction1Called = false;
+
+    getClassNames(getStyles1, { a: 2, b: 'test' });
+    expect(styleFunction1Called).toEqual(false);
   });
 
   describe('ltr/rtl from theme', () => {

--- a/packages/utilities/src/classNamesFunction.ts
+++ b/packages/utilities/src/classNamesFunction.ts
@@ -133,12 +133,17 @@ function _traverseEdge(current: Map<any, any>, value: any): Map<any, any> {
 }
 
 function _traverseMap(current: Map<any, any>, inputs: any[] | Object): Map<any, any> {
-  // The styled helper will generate the styles function and will attach the cached
-  // inputs (consisting of the default styles, customzied styles, and user provided styles.)
-  // These should be used as cache keys for deriving the memoized value.
-  if (typeof inputs === 'function' && (inputs as any).__cachedInputs__) {
-    for (const input of (inputs as any).__cachedInputs__) {
-      current = _traverseEdge(current, input);
+  if (typeof inputs === 'function') {
+    const cachedInputsFromStyled = (inputs as any).__cachedInputs__;
+    if (cachedInputsFromStyled) {
+      // The styled helper will generate the styles function and will attach the cached
+      // inputs (consisting of the default styles, customzied styles, and user provided styles.)
+      // These should be used as cache keys for deriving the memoized value.
+      for (const input of (inputs as any).__cachedInputs__) {
+        current = _traverseEdge(current, input);
+      }
+    } else {
+      current = _traverseEdge(current, inputs);
     }
   } else if (typeof inputs === 'object') {
     for (const propName in inputs) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
1. Improve contextualmenu perf by doing less styles calculation. (see flamegrill result)
2. Found and fixed a bug in `classNamesFunction` that it doesn't traverse the `styleFunctionOrObject` unless it has `__cachedInputs__` (only applies when it's used with `styled`)
3. enable caching for `getClassNames` and `getContextualMenuItemClassNames` (i don't see reason to disable)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12752)