### PR TITLE
chore: use proper tsconfig.json in docgen

### DIFF
--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -37,8 +37,6 @@
     "access": "public"
   },
   "scripts": {
-    "clean:force": "gulp clean:cache && gulp clean:docs && gulp clean:docs:component-info",
-    "build:info": "gulp build:docs:component-info",
     "build": "gulp build:docs",
     "start": "gulp docs"
   }

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -37,6 +37,8 @@
     "access": "public"
   },
   "scripts": {
+    "clean:force": "gulp clean:cache && gulp clean:docs && gulp clean:docs:component-info",
+    "build:info": "gulp build:docs:component-info",
     "build": "gulp build:docs",
     "start": "gulp docs"
   }

--- a/scripts/gulp/plugins/gulp-component-menu.ts
+++ b/scripts/gulp/plugins/gulp-component-menu.ts
@@ -15,7 +15,7 @@ type ComponentMenuItem = {
   type: string;
 };
 
-export default () => {
+export default (tsConfigPath: string) => {
   const result: ComponentMenuItem[] = [];
 
   function bufferContents(file, enc, cb) {
@@ -40,7 +40,7 @@ export default () => {
         const jsonInfo = fs.readFileSync(infoFilePath);
         componentInfo = JSON.parse(jsonInfo.toString());
       } else {
-        componentInfo = getComponentInfo(file.path, []);
+        componentInfo = getComponentInfo(tsConfigPath, file.path, []);
       }
 
       if (componentInfo.isParent) {

--- a/scripts/gulp/plugins/gulp-react-docgen.ts
+++ b/scripts/gulp/plugins/gulp-react-docgen.ts
@@ -11,7 +11,7 @@ const { paths } = config;
 
 const pluginName = 'gulp-react-docgen';
 
-export default (ignoredInterfaces: string[] = []) =>
+export default (tsConfigPath: string, ignoredInterfaces: string[] = []) =>
   through2.obj(function bufferContents(file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
@@ -25,7 +25,7 @@ export default (ignoredInterfaces: string[] = []) =>
 
     try {
       const infoFilename = file.basename.replace(/\.tsx$/, '.info.json');
-      const contents = getComponentInfo(file.path, ignoredInterfaces);
+      const contents = getComponentInfo(tsConfigPath, file.path, ignoredInterfaces);
 
       // Forcing the base & cwd to be paths.base() to make sure this is cached & restored at the right location
       const infoFile = new Vinyl({

--- a/scripts/gulp/plugins/util/docgen.ts
+++ b/scripts/gulp/plugins/util/docgen.ts
@@ -87,7 +87,15 @@ const defaultOptions: ts.CompilerOptions = {
   allowUnreachableCode: true,
 };
 
-const reactComponentSymbolNames = ['StatelessComponent', 'Stateless', 'StyledComponentClass', 'FunctionComponent'];
+const reactComponentSymbolNames = [
+  'StatelessComponent',
+  'Stateless',
+  'StyledComponentClass',
+  'FunctionComponent',
+
+  // magic for ComponentWithAs
+  '__type',
+];
 
 type MaybeIntersectType = ts.Type & { types?: ts.Type[] };
 

--- a/scripts/gulp/plugins/util/getComponentInfo.ts
+++ b/scripts/gulp/plugins/util/getComponentInfo.ts
@@ -30,7 +30,7 @@ const getAvailableBehaviors = (accessibilityProp: ComponentProp): BehaviorInfo[]
     }));
 };
 
-const getComponentInfo = (filepath: string, ignoredParentInterfaces: string[]): ComponentInfo => {
+const getComponentInfo = (tsConfigPath: string, filepath: string, ignoredParentInterfaces: string[]): ComponentInfo => {
   const absPath = path.resolve(process.cwd(), filepath);
 
   const dir = path.dirname(absPath);
@@ -42,7 +42,7 @@ const getComponentInfo = (filepath: string, ignoredParentInterfaces: string[]): 
   // "element" for "src/elements/Button/Button.js"
   const componentType = path.basename(path.dirname(dir)).replace(/s$/, '') as ComponentInfo['type'];
 
-  const components = docgen.withDefaultConfig().parse(absPath);
+  const components = docgen.withCustomConfig(tsConfigPath, {}).parse(absPath);
 
   if (!components.length) {
     throw new Error(`Could not find a component definition in "${filepath}".`);

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -55,8 +55,6 @@ task('clean:docs', () =>
   ),
 );
 
-task('clean:docs:component-info', () => del([paths.docsSrc('componentInfo')], { force: true }));
-
 // ----------------------------------------
 // Build
 // ----------------------------------------

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -74,7 +74,7 @@ task('build:docs:component-info', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
     .pipe(
       cache(gulpReactDocgen(paths.docs('tsconfig.json'), ['DOMAttributes', 'HTMLAttributes']), {
-        name: 'componentInfo-1',
+        name: 'componentInfo-2',
       }),
     )
     .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() })),

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -62,7 +62,7 @@ task('clean:docs:component-info', () => del([paths.docsSrc('componentInfo')], { 
 // ----------------------------------------
 
 const componentsSrc = [
-  `${paths.posix.packageSrc('react-northstar')}/components/*/[A-Z]ttach*.tsx`,
+  `${paths.posix.packageSrc('react-northstar')}/components/*/[A-Z]*.tsx`,
   `${paths.posix.packageSrc('react-bindings')}/FocusZone/[A-Z]!(*.types).tsx`,
   `${paths.posix.packageSrc('react-component-ref')}/[A-Z]*.tsx`,
 ];

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -55,12 +55,14 @@ task('clean:docs', () =>
   ),
 );
 
+task('clean:docs:component-info', () => del([paths.docsSrc('componentInfo')], { force: true }));
+
 // ----------------------------------------
 // Build
 // ----------------------------------------
 
 const componentsSrc = [
-  `${paths.posix.packageSrc('react-northstar')}/components/*/[A-Z]*.tsx`,
+  `${paths.posix.packageSrc('react-northstar')}/components/*/[A-Z]ttach*.tsx`,
   `${paths.posix.packageSrc('react-bindings')}/FocusZone/[A-Z]!(*.types).tsx`,
   `${paths.posix.packageSrc('react-component-ref')}/[A-Z]*.tsx`,
 ];
@@ -72,13 +74,17 @@ const schemaSrc = `${paths.posix.packages('ability-attributes')}/schema.json`;
 
 task('build:docs:component-info', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
-    .pipe(cache(gulpReactDocgen(['DOMAttributes', 'HTMLAttributes']), { name: 'componentInfo-1' }))
+    .pipe(
+      cache(gulpReactDocgen(paths.docs('tsconfig.json'), ['DOMAttributes', 'HTMLAttributes']), {
+        name: 'componentInfo-1',
+      }),
+    )
     .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() })),
 );
 
 task('build:docs:component-menu', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-menu') })
-    .pipe(gulpComponentMenu())
+    .pipe(gulpComponentMenu(paths.docs('tsconfig.json')))
     .pipe(dest(paths.docsSrc())),
 );
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

During work on #12745 I have notices that my changes fail `gulp-plugin-docgen` without any reasons. During our investigation via @mnajdova we found out that default `tsconfig.json` that will be used for generating info files doesn't have required aliases (for `@fluentui/react-compose` as an example).

![image](https://user-images.githubusercontent.com/14183168/79556344-3e356c80-80a1-11ea-900a-64a2647d8e98.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12757)