### PR TITLE
chore: add isConformant test for exporting className consts

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -84,14 +84,14 @@ export interface TreeState {
   activeItemIds: string[];
 }
 
-export const treeClassNames = 'ui-tree';
+export const treeClassName = 'ui-tree';
 
 class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
   static create: ShorthandFactory<TreeProps>;
 
   static displayName = 'Tree';
 
-  static deprecated_className = treeClassNames;
+  static deprecated_className = treeClassName;
 
   static propTypes = {
     ...commonPropTypes.createCommon({

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -478,19 +478,20 @@ export default function isConformant(
   // ----------------------------------------
   // Handles className
   // ----------------------------------------
-  describe('static className (common)', () => {
+  describe('className const (common)', () => {
     const componentClassName = info.componentClassName || `ui-${Component.displayName}`.toLowerCase();
     const getClassesOfRootElement = component => {
-      const classes = component
+      return component
         .find('[className]')
         .hostNodes()
         .at(wrapperComponent ? 1 : 0)
         .prop('className');
-      return classes;
     };
 
-    test(`is a static equal to "${componentClassName}"`, () => {
-      expect(Component.deprecated_className).toEqual(componentClassName);
+    const constClassName = _.camelCase(`${Component.displayName}ClassName`);
+
+    test(`exports a const equal to "${componentClassName}"`, () => {
+      expect(FluentUI[constClassName]).toEqual(componentClassName);
     });
 
     test(`is applied to the root element`, () => {


### PR DESCRIPTION
Changed the `isConformant` test that checks for static className prop on the components to check for an `componentNameClassName` export in `@fluentui/react-northstar`