### PR TITLE
Add "useRenderFunction" react hook to generate a parameterless render function based on whether a custom render function was provided

### DIFF
--- a/change/@uifabric-react-hooks-2020-04-17-20-48-50-function-useRenderFunction.json
+++ b/change/@uifabric-react-hooks-2020-04-17-20-48-50-function-useRenderFunction.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add \"useRenderFunction\" react hook to generate a parameterless render function based on whether a custom render function was provided.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-17T20:48:50.304Z"
+}

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -109,3 +109,32 @@ const MyComponent = () => {
   // ... code that shows a dialog when a button is clicked ...
 };
 ```
+
+## useRenderFunction
+
+`function useRenderFunction<TProps extends {}, TRenderFunctionName extends RenderFunctionNames<TProps>>(props: TProps, renderFunctionName: TRenderFunctionName, defaultRender: (props: TProps) => JSX.Element | null): () => JSX.Element | null`
+
+Hook to return a rendering function that can be overridden by a custom rendering function in component properties.
+
+The hook returns a parameterless function to render the element according to the custom rendering function, if provided, or the default function otherwise.
+
+Example
+
+```tsx
+import { useRenderFunction } from '@uifabric/react-hooks';
+import { IRenderFunction } from '@uifabric/utilities';
+
+interface IMyComponentProps {
+  onRenderContent?: IRenderFunction<IMyComponentProps>;
+}
+
+const MyComponent = props => {
+  const renderContent = useBoolean(props, 'onRenderContent', () => <div>I'm the default!</div>);
+
+  return <section>{renderContent()}</section>;
+  // ^^^ Instead of:
+  // const _renderContent = () => <div>I'm the default!</div>;
+  // const { onRenderContent = _renderContent } = props;
+  // return <section>{onRenderContent(props, _renderContent)}</section>
+};
+```

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -4,12 +4,19 @@
 
 ```ts
 
+import { IRenderFunction } from '@uifabric/utilities';
+
 // @public
 export interface IUseBooleanCallbacks {
     setFalse: () => void;
     setTrue: () => void;
     toggle: () => void;
 }
+
+// @public
+export type RenderFunctionNames<TProps extends {}> = {
+    [K in keyof TProps]: any extends TProps[K] ? never : IRenderFunction<TProps> extends TProps[K] ? K : never;
+}[keyof TProps];
 
 // @public
 export function useBoolean(initialState: boolean): [boolean, IUseBooleanCallbacks];
@@ -22,6 +29,9 @@ export function useConstCallback<T extends (...args: any[]) => any>(callback: T)
 
 // @public
 export function useId(prefix?: string): string;
+
+// @public
+export function useRenderFunction<TProps extends {}, TRenderFunctionName extends RenderFunctionNames<TProps>>(props: TProps, renderFunctionName: TRenderFunctionName, defaultRender: (props: TProps) => JSX.Element | null): () => JSX.Element | null;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -3,3 +3,4 @@ export * from './useBoolean';
 export * from './useConst';
 export * from './useConstCallback';
 export * from './useId';
+export * from './useRenderFunction';

--- a/packages/react-hooks/src/useRenderFunction.test.tsx
+++ b/packages/react-hooks/src/useRenderFunction.test.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { useRenderFunction } from './useRenderFunction';
+import { IRenderFunction } from '@uifabric/utilities';
+
+interface ITestComponentProps {
+  onRenderContent?: IRenderFunction<ITestComponentProps>;
+}
+
+describe('useRenderFunction', () => {
+  const defaulRenderContent = () => <div id="default" />;
+  const TestComponent = (props: ITestComponentProps) => {
+    const renderContent = useRenderFunction(props, 'onRenderContent', defaulRenderContent);
+
+    return renderContent();
+  };
+
+  it('uses the default render when no custom render is provided', () => {
+    const wrapper = mount(<TestComponent />);
+
+    // Default id node should be rendered
+    expect(wrapper.getDOMNode()?.id).toBe('default');
+  });
+
+  it('uses the latest custom render', () => {
+    const wrapper = mount(<TestComponent onRenderContent={() => <div id="first" />} />);
+
+    expect(wrapper.getDOMNode()?.id).toBe('first');
+
+    wrapper.setProps({ onRenderContent: () => <div id="second" /> });
+    expect(wrapper.getDOMNode()?.id).toBe('second');
+  });
+
+  it('passes the props and default renderer to the custom renderer', () => {
+    const onRenderContent = jasmine.createSpy().and.returnValue(null);
+    const props: ITestComponentProps = {
+      onRenderContent,
+    };
+    mount(<TestComponent {...props} />);
+
+    expect(onRenderContent).toHaveBeenCalledWith(props, defaulRenderContent);
+  });
+});

--- a/packages/react-hooks/src/useRenderFunction.test.tsx
+++ b/packages/react-hooks/src/useRenderFunction.test.tsx
@@ -23,7 +23,8 @@ describe('useRenderFunction', () => {
   });
 
   it('uses the latest custom render', () => {
-    const wrapper = mount(<TestComponent onRenderContent={() => <div id="first" />} />);
+    const onRenderContent = () => <div id="first" />;
+    const wrapper = mount(<TestComponent onRenderContent={onRenderContent} />);
 
     expect(wrapper.getDOMNode()?.id).toBe('first');
 

--- a/packages/react-hooks/src/useRenderFunction.ts
+++ b/packages/react-hooks/src/useRenderFunction.ts
@@ -1,0 +1,29 @@
+import { IRenderFunction } from '@uifabric/utilities';
+import { useCallback } from 'react';
+
+/**
+ * Generic type to extract the name of all properties of type IRenderFunction<TProps>
+ */
+export type RenderFunctionNames<TProps extends {}> = {
+  // tslint:disable-next-line:no-any  This is used to filter out any properties of "any" type
+  [K in keyof TProps]: any extends TProps[K] ? never : IRenderFunction<TProps> extends TProps[K] ? K : never;
+}[keyof TProps];
+
+/**
+ * Hook to return a rendering function that can be overridden by a custom rendering function in component properties
+ * @param props- Component properties
+ * @param renderFunctionName- Property name for the optional custom rendering function
+ * @param defaultRender- Function used to render the component if no custom rendering function is passed; this value is
+ *  also passed on as a parameter to any custom rendering function.
+ */
+export function useRenderFunction<TProps extends {}, TRenderFunctionName extends RenderFunctionNames<TProps>>(
+  props: TProps,
+  renderFunctionName: TRenderFunctionName,
+  defaultRender: (props: TProps) => JSX.Element | null,
+): () => JSX.Element | null {
+  const propsRenderFunction: IRenderFunction<TProps> | undefined = props[renderFunctionName];
+  return useCallback(
+    propsRenderFunction ? () => propsRenderFunction(props, defaultRender) : () => defaultRender(props),
+    [propsRenderFunction],
+  );
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

As part of the function migration work, this change adds another handy hook to cover common cases in Fabric components.

Rather than splitting the custom rendering logic across props destructuring and JSX rendering, as is [currently the norm](https://github.com/microsoft/fluentui/blob/e86cb37304000c112bc355ef5d0235ea23cee34e/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx#L193): 
```tsx
    const {
      // ...
      onRenderLabel= this._onRenderLabel,
    } = this.props;

  // ...
    return (
      <div className={this._classNames.root}>
        <div className={this._classNames.wrapper}>
          {onRenderLabel(this.props, this._onRenderLabel)}
  // ...
```

instead you can use a one-line hook call:
```tsx
  const renderLabel = useRenderFunction(props, 'onRenderLabel', _onRenderLabel);

  // ...
    return (
      <div className={_classNames.root}>
        <div className={_classNames.wrapper}>
          {renderLabel()}
```

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12772)