### PR TITLE
Disabling live code editing until the OOM error can be pinpointed.

### DIFF
--- a/change/@uifabric-example-app-base-2020-04-17-17-53-58-fix-disable-editor.json
+++ b/change/@uifabric-example-app-base-2020-04-17-17-53-58-fix-disable-editor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Doc site: disable live code editing until it does not cause infinite loops resulting in browser crashes.",
+  "packageName": "@uifabric/example-app-base",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-18T00:53:58.194Z"
+}

--- a/change/@uifabric-example-app-base-2020-04-17-17-53-58-fix-disable-editor.json
+++ b/change/@uifabric-example-app-base-2020-04-17-17-53-58-fix-disable-editor.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Doc site: disable live code editing until it does not cause infinite loops resulting in browser crashes.",
+  "comment": "Doc site: disable live code editing until we have a fix for the OOM errors.",
   "packageName": "@uifabric/example-app-base",
   "email": "dzearing@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -168,6 +168,7 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
               </div>
               {isCodeVisible ? (
                 <EditorWrapper
+                  useEditor={false}
                   code={latestCode}
                   supportedPackages={editorSupportedPackages}
                   editorClassName={classNames.code}


### PR DESCRIPTION
Addresses #12754.

After a couple hours, I haven't been able to repro the OOM with a local deployment. I have an idea of where it's coming from but will take some refactoring to simplify the error handling of the live code editing.

This change disables live code editing until we have a real fix. I did not disable specific examples, as I don't know what the root cause is and can't guarantee there aren't other examples hitting this.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12776)