### PR TITLE
Add `renderActiveOnly?` prop to Pivot component to control rendering of PivotItems 

### DIFF
--- a/change/@fluentui-react-next-2020-05-15-11-32-12-herincon-pivotRendering.json
+++ b/change/@fluentui-react-next-2020-05-15-11-32-12-herincon-pivotRendering.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Pivot: adding alwaysRender prop to `PivotItem` to allow for persistent `PivotItems` to control the amount of re-renders that happen",
+  "packageName": "@fluentui/react-next",
+  "email": "herincon@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-15T18:32:12.117Z"
+}

--- a/change/office-ui-fabric-react-2020-04-19-16-24-23-herincon-pivotRendering.json
+++ b/change/office-ui-fabric-react-2020-04-19-16-24-23-herincon-pivotRendering.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add pivot renderActive prop to controll re-rendering of pivot items",
+  "comment": "Pivot: Adding `alwaysRender` prop to `PivotItem` to allow for persistent `PivotItems` to control the amount of re-renders that happen.",
   "packageName": "office-ui-fabric-react",
   "email": "herincon@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-04-19-16-24-23-herincon-pivotRendering.json
+++ b/change/office-ui-fabric-react-2020-04-19-16-24-23-herincon-pivotRendering.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add pivot renderActive prop to controll re-rendering of pivot items",
+  "packageName": "office-ui-fabric-react",
+  "email": "herincon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-19T23:24:23.500Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6279,6 +6279,7 @@ export interface IPivot {
 
 // @public (undocumented)
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
+    alwaysRender?: boolean;
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
     headerButtonProps?: IButtonProps & {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -100,11 +100,16 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     this._classNames = this._getClassNames(this.props);
+    const { renderActiveOnly } = this.props;
 
     return (
       <div role="toolbar" {...divProps}>
         {this._renderPivotLinks(linkCollection, selectedKey)}
-        {selectedKey && this._renderPivotItem(linkCollection, selectedKey)}
+        {renderActiveOnly !== false
+          ? selectedKey && this._renderPivotItem(linkCollection, selectedKey)
+          : linkCollection.links.map(link =>
+              this._renderPivotItem(linkCollection, link.itemKey, selectedKey === link.itemKey),
+            )}
       </div>
     );
   }
@@ -208,7 +213,11 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   /**
    * Renders the current Pivot Item
    */
-  private _renderPivotItem(linkCollection: PivotLinkCollection, itemKey: string | undefined): JSX.Element | null {
+  private _renderPivotItem(
+    linkCollection: PivotLinkCollection,
+    itemKey: string | undefined,
+    isActive = true,
+  ): JSX.Element | null {
     if (this.props.headersOnly || !itemKey) {
       return null;
     }
@@ -217,7 +226,13 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     const selectedTabId = linkCollection.keyToTabIdMapping[itemKey];
 
     return (
-      <div role="tabpanel" aria-labelledby={selectedTabId} className={this._classNames.itemContainer}>
+      <div
+        role="tabpanel"
+        hidden={!isActive}
+        aria-hidden={!isActive}
+        aria-labelledby={selectedTabId}
+        className={this._classNames.itemContainer}
+      >
         {React.Children.toArray(this.props.children)[index]}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -211,7 +211,7 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   };
 
   /**
-   * Renders the current Pivot Item
+   * Renders a Pivot Item
    */
   private _renderPivotItem(
     linkCollection: PivotLinkCollection,

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -100,16 +100,16 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     this._classNames = this._getClassNames(this.props);
-    const { renderActiveOnly } = this.props;
 
     return (
       <div role="toolbar" {...divProps}>
         {this._renderPivotLinks(linkCollection, selectedKey)}
-        {renderActiveOnly !== false
-          ? selectedKey && this._renderPivotItem(linkCollection, selectedKey)
-          : linkCollection.links.map(link =>
+        {selectedKey &&
+          linkCollection.links.map(
+            link =>
+              (link.alwaysRender === true || selectedKey === link.itemKey) &&
               this._renderPivotItem(linkCollection, link.itemKey, selectedKey === link.itemKey),
-            )}
+          )}
       </div>
     );
   }
@@ -229,6 +229,7 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
       <div
         role="tabpanel"
         hidden={!isActive}
+        key={itemKey}
         aria-hidden={!isActive}
         aria-labelledby={selectedTabId}
         className={this._classNames.itemContainer}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -216,7 +216,7 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   private _renderPivotItem(
     linkCollection: PivotLinkCollection,
     itemKey: string | undefined,
-    isActive = true,
+    isActive: boolean,
   ): JSX.Element | null {
     if (this.props.headersOnly || !itemKey) {
       return null;

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -127,6 +127,13 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
       rootIsTabs && classNames.rootIsTabs,
       className,
     ],
+    itemContainer: {
+      selectors: {
+        '&[hidden]': {
+          display: 'none',
+        },
+      },
+    },
     link: [
       classNames.link,
       ...linkStyles(props),

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -108,7 +108,8 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
   getTabId?: (itemKey: string, index: number) => string;
 
   /**
-   * Whether to render only the active (selected) pivot item or render everything and only hide the inactive pivot items.
+   * Whether to render only the active (selected) pivot item
+   * or render everything and only hide the inactive pivot items.
    * Useful if you're rendering content that is expensive to mount.
    *
    * @defaultvalue true

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -106,6 +106,14 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
+
+  /**
+   * Whether to render only the active (selected) pivot item or render everything and only hide the inactive pivot items.
+   * Useful if you're rendering content that is expensive to mount.
+   *
+   * @defaultvalue true
+   */
+  renderActiveOnly?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -106,15 +106,6 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
-
-  /**
-   * Whether to render only the active (selected) pivot item
-   * or render everything and only hide the inactive pivot items.
-   * Useful if you're rendering content that is expensive to mount.
-   *
-   * @defaultvalue true
-   */
-  renderActiveOnly?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -56,17 +56,17 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
   itemIcon?: string;
 
   /**
-   * Optional custom renderer for the pivot item link
+   * Optional custom renderer for the pivot item link.
    */
   onRenderItemLink?: IRenderFunction<IPivotItemProps>;
 
   /**
-   * Optional keytip for this PivotItem
+   * Optional keytip for this PivotItem.
    */
   keytipProps?: IKeytipProps;
 
   /**
-   * Whether to always render the pivot item (regardless of whether it is selected or not)
+   * Defines whether to always render the pivot item (regardless of whether it is selected or not).
    * Useful if you're rendering content that is expensive to mount.
    *
    * @defaultvalue false

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -64,4 +64,12 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional keytip for this PivotItem
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * Whether to always render the pivot item (regardless of whether it is selected or not)
+   * Useful if you're rendering content that is expensive to mount.
+   *
+   * @defaultvalue false
+   */
+  alwaysRender?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -364,7 +364,14 @@ exports[`Pivot renders link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -376,7 +376,14 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -749,7 +756,14 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div
@@ -1313,7 +1327,14 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -1686,7 +1707,14 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2078,7 +2106,14 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2450,7 +2485,14 @@ exports[`Pivot renders link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2841,7 +2883,14 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -3213,7 +3262,14 @@ exports[`Pivot supports JSX expressions 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab1"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.AlwaysRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.AlwaysRender.Example.tsx
@@ -13,21 +13,21 @@ const ExpensiveToMount: React.FC = () => {
 };
 
 export const PivotRenderActiveOnlyExample: React.FC = () => {
-  const [activeOnly, setActiveOnly] = React.useState(true);
+  const [alwaysRender, setAlwaysRender] = React.useState(false);
 
   const toggleActiveOnly = () => {
-    setActiveOnly(!activeOnly);
+    setAlwaysRender(!alwaysRender);
   };
 
   return (
     <div>
-      <Toggle label="Render active only" inlineLabel checked={activeOnly} onChange={toggleActiveOnly} />
-      <Pivot aria-label="Separately Rendered Content Pivot Example" renderActiveOnly={activeOnly}>
-        <PivotItem headerText="Expensive component #1">
+      <Toggle label="Always render children" inlineLabel checked={alwaysRender} onChange={toggleActiveOnly} />
+      <Pivot aria-label="Separately Rendered Content Pivot Example">
+        <PivotItem headerText="Expensive component #1" alwaysRender={alwaysRender}>
           <ExpensiveToMount />
           Component #1
         </PivotItem>
-        <PivotItem headerText="Expensive component #2">
+        <PivotItem headerText="Expensive component #2" alwaysRender={alwaysRender}>
           <ExpensiveToMount />
           Component #2
         </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.AlwaysRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.AlwaysRender.Example.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const ExpensiveToMount: React.FC = () => {
   const [mounted, setMounted] = React.useState(false);
@@ -13,11 +14,7 @@ const ExpensiveToMount: React.FC = () => {
 };
 
 export const PivotRenderActiveOnlyExample: React.FC = () => {
-  const [alwaysRender, setAlwaysRender] = React.useState(false);
-
-  const toggleActiveOnly = () => {
-    setAlwaysRender(!alwaysRender);
-  };
+  const [alwaysRender, { toggle: toggleActiveOnly }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.RenderActiveOnly.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.RenderActiveOnly.Example.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+
+const ExpensiveToMount: React.FC = () => {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setTimeout(() => {
+      setMounted(true);
+    }, 3000);
+  }, []);
+  return <div>{mounted ? 'Rendered' : 'Mounting...'}</div>;
+};
+
+export const PivotRenderActiveOnlyExample: React.FC = () => {
+  const [activeOnly, setActiveOnly] = React.useState(true);
+
+  const toggleActiveOnly = () => {
+    setActiveOnly(!activeOnly);
+  };
+
+  return (
+    <div>
+      <Toggle label="Render active only" inlineLabel checked={activeOnly} onChange={toggleActiveOnly} />
+      <Pivot aria-label="Separately Rendered Content Pivot Example" renderActiveOnly={activeOnly}>
+        <PivotItem headerText="Expensive component #1">
+          <ExpensiveToMount />
+          Component #1
+        </PivotItem>
+        <PivotItem headerText="Expensive component #2">
+          <ExpensiveToMount />
+          Component #2
+        </PivotItem>
+      </Pivot>
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -534,7 +534,14 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
@@ -1,0 +1,520 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`] = `
+<div>
+  <div
+    className=
+        ms-Toggle
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 16px;
+            margin-right: 0px;
+            margin-top: 0px;
+            order: 1;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-break: break-all;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle0"
+      id="Toggle0-label"
+    >
+      Always render children
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={false}
+        aria-labelledby="Toggle0-label"
+        checked={false}
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #ffffff;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 20px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              border-color: #323130;
+            }
+            &:hover .ms-Toggle-thumb {
+              background-color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Toggle-thumb {
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+            }
+        data-is-focusable={true}
+        id="Toggle0"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <span
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #605e5c;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
+              }
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    aria-label="Separately Rendered Content Pivot Example"
+    role="toolbar"
+  >
+    <div
+      className=
+          ms-FocusZone
+          ms-Pivot
+          &:focus {
+            outline: none;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #0078d4;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+            white-space: nowrap;
+          }
+      data-focuszone-id="FocusZone2"
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onMouseDownCapture={[Function]}
+      role="tablist"
+    >
+      <button
+        aria-selected={true}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            is-selected
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: #0078d4;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){&:before {
+              background-color: Highlight;
+            }
+            &:hover::before {
+              left: 0px;
+              right: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: Highlight;
+            }
+        data-content="Expensive component #1"
+        data-is-focusable={true}
+        id="Pivot1-Tab0"
+        name="Expensive component #1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Expensive component #1
+            </span>
+          </span>
+        </span>
+      </button>
+      <button
+        aria-selected={false}
+        className=
+            ms-Button
+            ms-Button--action
+            ms-Button--command
+            ms-Pivot-link
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: 0px;
+              box-sizing: border-box;
+              color: #323130;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 44px;
+              line-height: 44px;
+              margin-right: 8px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 0px;
+              bottom: 2px;
+              content: attr(data-content);
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: relative;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:hover .ms-Button-icon {
+              color: #0078d4;
+            }
+            &:focus {
+              outline: none;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+            &:active .ms-Button-icon {
+              color: #004578;
+            }
+            &:before {
+              background-color: transparent;
+              bottom: 0px;
+              content: "";
+              height: 2px;
+              left: 8px;
+              position: absolute;
+              right: 8px;
+              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
+            }
+            &:after {
+              color: transparent;
+              content: attr(data-content);
+              display: block;
+              font-weight: 700;
+              height: 1px;
+              overflow: hidden;
+              visibility: hidden;
+            }
+            .ms-Fabric--isFocusVisible &:focus {
+              outline: 1px solid #605e5c;
+            }
+        data-content="Expensive component #2"
+        data-is-focusable={true}
+        id="Pivot1-Tab1"
+        name="Expensive component #2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="tab"
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: flex-start;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <span
+            className=
+                ms-Pivot-linkContent
+                {
+                  flex: 0 1 100%;
+                }
+                & > *  {
+                  margin-left: 4px;
+                }
+                & > *:first-child {
+                  margin-left: 0px;
+                }
+          >
+            <span
+              className=
+                  ms-Pivot-text
+                  {
+                    display: inline-block;
+                    vertical-align: top;
+                  }
+            >
+               
+              Expensive component #2
+            </span>
+          </span>
+        </span>
+      </button>
+    </div>
+    <div
+      aria-hidden={false}
+      aria-labelledby="Pivot1-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
+      role="tabpanel"
+    >
+      <div>
+        <div>
+          Mounting...
+        </div>
+        Component #1
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -524,7 +524,14 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    className=
+
+        &[hidden] {
+          display: none;
+        }
+    hidden={false}
     role="tabpanel"
   >
     <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -1002,7 +1002,14 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -524,7 +524,14 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -743,7 +743,14 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -716,7 +716,14 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.RenderActiveOnly.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.RenderActiveOnly.Example.tsx.shot
@@ -1,9 +1,147 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Pivot.RenderActiveOnly.Example.tsx correctly 1`] = `
 <div>
   <div
-    aria-label="Override Selected Item Pivot Example"
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          align-items: center;
+          display: flex;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 16px;
+            margin-right: 0px;
+            margin-top: 0px;
+            order: 1;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-break: break-all;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle0"
+      id="Toggle0-label"
+    >
+      Render active only
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={true}
+        aria-labelledby="Toggle0-label"
+        checked={true}
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 10px;
+              border: 1px solid #605e5c;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 20px;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 3px;
+              padding-right: 3px;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 40px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #005a9e;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
+        data-is-focusable={true}
+        id="Toggle0"
+        onChange={[Function]}
+        onClick={[Function]}
+        role="switch"
+        type="button"
+      >
+        <span
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: 50%;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                display: block;
+                height: 12px;
+                transition: all 0.1s ease;
+                width: 12px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
+        />
+      </button>
+    </div>
+  </div>
+  <div
+    aria-label="Separately Rendered Content Pivot Example"
     role="toolbar"
   >
     <div
@@ -33,7 +171,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      data-focuszone-id="FocusZone1"
+      data-focuszone-id="FocusZone2"
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
@@ -155,10 +293,10 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               color: Highlight;
             }
-        data-content="My Files"
+        data-content="Expensive component #1"
         data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="My Files"
+        id="Pivot1-Tab0"
+        name="Expensive component #1"
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyPress={[Function]}
@@ -202,7 +340,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                   }
             >
                
-              My Files
+              Expensive component #1
             </span>
           </span>
         </span>
@@ -312,10 +450,10 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             .ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid #605e5c;
             }
-        data-content="Recent"
+        data-content="Expensive component #2"
         data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Recent"
+        id="Pivot1-Tab1"
+        name="Expensive component #2"
         onClick={[Function]}
         onKeyDown={[Function]}
         onKeyPress={[Function]}
@@ -359,164 +497,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                   }
             >
                
-              Recent
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Shared with me"
-        data-is-focusable={true}
-        id="Pivot0-Tab2"
-        name="Shared with me"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
-                  }
-            >
-               
-              Shared with me
+              Expensive component #2
             </span>
           </span>
         </span>
@@ -524,7 +505,7 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
     </div>
     <div
       aria-hidden={false}
-      aria-labelledby="Pivot0-Tab0"
+      aria-labelledby="Pivot1-Tab0"
       className=
 
           &[hidden] {
@@ -534,151 +515,12 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
       role="tabpanel"
     >
       <div>
-        <label
-          className=
-              ms-Label
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow-wrap: break-word;
-                padding-bottom: 5px;
-                padding-left: 0;
-                padding-right: 0;
-                padding-top: 5px;
-                word-wrap: break-word;
-              }
-        >
-          Pivot #1
-        </label>
+        <div>
+          Mounting...
+        </div>
+        Component #1
       </div>
     </div>
   </div>
-  <button
-    className=
-        ms-Button
-        ms-Button--default
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #ffffff;
-          border-radius: 2px;
-          border: 1px solid #8a8886;
-          box-sizing: border-box;
-          color: #323130;
-          cursor: pointer;
-          display: inline-block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          min-width: 80px;
-          outline: transparent;
-          padding-bottom: 0;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-          position: relative;
-          text-align: center;
-          text-decoration: none;
-          user-select: none;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid transparent;
-          bottom: 2px;
-          content: "";
-          left: 2px;
-          outline: 1px solid #605e5c;
-          position: absolute;
-          right: 2px;
-          top: 2px;
-          z-index: 1;
-        }
-        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-          border: none;
-          bottom: -2px;
-          left: -2px;
-          outline-color: ButtonText;
-          right: -2px;
-          top: -2px;
-        }
-        &:active > * {
-          left: 0px;
-          position: relative;
-          top: 0px;
-        }
-        &:hover {
-          background-color: #f3f2f1;
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          border-color: Highlight;
-          color: Highlight;
-        }
-        &:active {
-          background-color: #edebe9;
-          color: #201f1e;
-        }
-    data-is-focusable={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    type="button"
-  >
-    <span
-      className=
-          ms-Button-flexContainer
-          {
-            align-items: center;
-            display: flex;
-            flex-wrap: nowrap;
-            height: 100%;
-            justify-content: center;
-          }
-      data-automationid="splitbuttonprimary"
-    >
-      <span
-        className=
-            ms-Button-textContainer
-            {
-              display: block;
-              flex-grow: 1;
-            }
-      >
-        <span
-          className=
-              ms-Button-label
-              {
-                display: block;
-                font-weight: 600;
-                line-height: 100%;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
-              }
-          id="id__11"
-        >
-          Select next item
-        </span>
-      </span>
-    </span>
-  </button>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -715,7 +715,14 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -716,7 +716,14 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
       </button>
     </div>
     <div
+      aria-hidden={false}
       aria-labelledby="Pivot0-Tab0"
+      className=
+
+          &[hidden] {
+            display: none;
+          }
+      hidden={false}
       role="tabpanel"
     >
       <div>

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -357,6 +357,7 @@ export interface IPivot {
 
 // @public (undocumented)
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
+    alwaysRender?: boolean;
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
     headerButtonProps?: IButtonProps & {

--- a/packages/react-next/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.base.tsx
@@ -104,7 +104,12 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     return (
       <div role="toolbar" {...divProps}>
         {this._renderPivotLinks(linkCollection, selectedKey)}
-        {selectedKey && this._renderPivotItem(linkCollection, selectedKey)}
+        {selectedKey &&
+          linkCollection.links.map(
+            link =>
+              (link.alwaysRender === true || selectedKey === link.itemKey) &&
+              this._renderPivotItem(linkCollection, link.itemKey, selectedKey === link.itemKey),
+          )}
       </div>
     );
   }
@@ -208,7 +213,11 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   /**
    * Renders the current Pivot Item
    */
-  private _renderPivotItem(linkCollection: PivotLinkCollection, itemKey: string | undefined): JSX.Element | null {
+  private _renderPivotItem(
+    linkCollection: PivotLinkCollection,
+    itemKey: string | undefined,
+    isActive: boolean,
+  ): JSX.Element | null {
     if (this.props.headersOnly || !itemKey) {
       return null;
     }
@@ -217,7 +226,14 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     const selectedTabId = linkCollection.keyToTabIdMapping[itemKey];
 
     return (
-      <div role="tabpanel" aria-labelledby={selectedTabId} className={this._classNames.itemContainer}>
+      <div
+        role="tabpanel"
+        hidden={!isActive}
+        key={itemKey}
+        aria-hidden={!isActive}
+        aria-labelledby={selectedTabId}
+        className={this._classNames.itemContainer}
+      >
         {React.Children.toArray(this.props.children)[index]}
       </div>
     );

--- a/packages/react-next/src/components/Pivot/PivotItem.types.ts
+++ b/packages/react-next/src/components/Pivot/PivotItem.types.ts
@@ -64,4 +64,12 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional keytip for this PivotItem
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * Defines whether to always render the pivot item (regardless of whether it is selected or not).
+   * Useful if you're rendering content that is expensive to mount.
+   *
+   * @defaultvalue false
+   */
+  alwaysRender?: boolean;
 }

--- a/packages/react-next/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/react-next/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -364,7 +364,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />

--- a/packages/react-next/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react-next/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -376,7 +376,9 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -749,7 +751,9 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div
@@ -1313,7 +1317,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -1686,7 +1692,9 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2078,7 +2086,9 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2450,7 +2460,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -2841,7 +2853,9 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab0"
+    hidden={false}
     role="tabpanel"
   >
     <div />
@@ -3213,7 +3227,9 @@ exports[`Pivot supports JSX expressions 1`] = `
     </button>
   </div>
   <div
+    aria-hidden={false}
     aria-labelledby="Pivot0-Tab1"
+    hidden={false}
     role="tabpanel"
   >
     <div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11965
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR:
- Adds a `renderActiveOnly` optional prop to the Pivot component to enable controlling of rendering of the PivotItems.
- Adds a story (example) to test the behaviour.

Expensive components (components that are costly to mount / render) have to be unmounted/ remounted with the current implementation every time a new PivotItem is shown. This PR adds a toggle (`false` by default, to maintain current behaviour) that instead renders everything on the first Pivot render and only hides the inactive PivotItems, thereby removing the extra mounts/unmounts.

Example of expensive components:

`<iframes>` have to load/reload everything every time a pivot changes. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12779)