### PR TITLE
fix(Carousel): handle the case where getItemPositionText is not passed

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -55,6 +55,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Replace `escape` with `encodeURIComponent` in the svg urls in Teams theme @mnajdova ([#12742](https://github.com/microsoft/fluentui/pull/12742))
+- Check for `getItemPositionText` in `Carousel` before rendering the pagination text @silviuavram ([#12791](https://github.com/microsoft/fluentui/pull/12791))
 
 <!--------------------------------[ v0.48.0 ]------------------------------- -->
 ## [v0.48.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.48.0) (2020-04-15)

--- a/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
@@ -9,7 +9,8 @@ const doList = [
     'Add textual representation for `CarouselItem`. Use `aria-label` attribute ( refer to{' '}
     {link('reported issue', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1040924')} for details).
   </Text>,
-  'Provide  localized string of the "carousel" using `ariaRoleDescription` prop.',
+  'Provide localized string for items positioning using `getItemPositionText` prop.',
+  'Provide localized string of the "carousel" using `ariaRoleDescription` prop.',
   'Provide label to the carousel using `ariaLabel` prop.',
   <Box>
     If carousel contains `navigation`:

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -448,13 +448,13 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
           },
         }),
       })
-    ) : (
+    ) : getItemPositionText ? (
       <Text
         aria-hidden="true"
         className={carouselSlotClassNames.pagination}
         content={getItemPositionText(activeIndex, items.length)}
       />
-    );
+    ) : null;
   };
 
   renderComponent({ ElementType, classes, accessibility, unhandledProps }) {

--- a/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Carousel/Carousel-test.tsx
@@ -266,5 +266,12 @@ describe('Carousel', () => {
       expect(wrapper.state('activeIndex')).toEqual(1);
       expect(document.activeElement.firstElementChild.innerHTML).toEqual('item2');
     });
+
+    it('should show no pagination if getItemPositionText is not passed', () => {
+      const wrapper = renderCarousel({ getItemPositionText: undefined });
+      const paginationWrapper = getPaginationWrapper(wrapper);
+
+      expect(paginationWrapper.exists()).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes https://github.com/microsoft/fluent-ui-react/issues/2337
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Add a check for the `getItemPositionText` before rendering the pagination text.
Add Best Practices entry for users to provide the localised string for this prop.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12791)