### PR TITLE
chore(Toolbar): Fix menu always open bug

### DIFF
--- a/packages/fluentui/e2e/tests/toolbarMenu-test.ts
+++ b/packages/fluentui/e2e/tests/toolbarMenu-test.ts
@@ -23,6 +23,17 @@ describe('Toolbar menu on', () => {
     expect(await e2e.exists(toolbarMenu)).toBe(false);
   });
 
+  it('Should toggle the menu', async () => {
+    // opens menu
+    await e2e.clickOn(menuTrigger);
+    expect(await e2e.exists(toolbarMenu)).toBe(true);
+
+    await e2e.clickOn(menuTrigger);
+
+    expect(await e2e.isFocused(menuTrigger)).toBe(true);
+    expect(await e2e.exists(toolbarMenu)).toBe(false);
+  });
+
   it('Shift+TAB moves focus to previous tabbable element before toolbar', async () => {
     // opens menu
     await e2e.clickOn(menuTrigger);

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -237,7 +237,7 @@ const ToolbarItem: React.FC<WithAsProp<ToolbarItemProps>> & FluentComponentStati
         );
       });
 
-      if (!isInsideorMenuTrigger) {
+      if (!isInsideOrMenuTrigger) {
         trySetMenuOpen(false, e);
       }
     },

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -230,11 +230,14 @@ const ToolbarItem: React.FC<WithAsProp<ToolbarItemProps>> & FluentComponentStati
 
   const handleMenuOverrides = (getRefs: GetRefs) => (predefinedProps: ToolbarMenuProps) => ({
     onBlur: (e: React.FocusEvent) => {
-      const isInside = _.some(getRefs(), (childRef: NodeRef) => {
-        return childRef.current.contains(e.relatedTarget as HTMLElement);
+      const isInsideorMenuTrigger = _.some(getRefs(), (childRef: NodeRef) => {
+        return (
+          childRef.current.contains(e.relatedTarget as HTMLElement) ||
+          itemRef.current.contains(e.relatedTarget as HTMLElement)
+        );
       });
 
-      if (!isInside) {
+      if (!isInsideorMenuTrigger) {
         trySetMenuOpen(false, e);
       }
     },

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -230,7 +230,7 @@ const ToolbarItem: React.FC<WithAsProp<ToolbarItemProps>> & FluentComponentStati
 
   const handleMenuOverrides = (getRefs: GetRefs) => (predefinedProps: ToolbarMenuProps) => ({
     onBlur: (e: React.FocusEvent) => {
-      const isInsideorMenuTrigger = _.some(getRefs(), (childRef: NodeRef) => {
+      const isInsideOrMenuTrigger = _.some(getRefs(), (childRef: NodeRef) => {
         return (
           childRef.current.contains(e.relatedTarget as HTMLElement) ||
           itemRef.current.contains(e.relatedTarget as HTMLElement)


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #2327
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Prevents menu to remain open when toggling by menu button. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12792)