### PR TITLE
docs(Dropdown): add a tip of using itemToString when items are objects

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Dropdown/BestPractices/DropdownBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/BestPractices/DropdownBestPractices.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import ComponentBestPractices from '../../../../components/ComponentBestPractices';
 
 const doList = [
+  'Provide a function that returns the string equivalent of your item if it is an object using the `itemToString` prop',
   'Provide `getA11ySelectionMessage`, `getA11yStatusMessage`, `noResultsMessage` and `loadingMessage` props to visualize dropdown state correctly.',
   'Provide `aria-label` to `triggerButton` slot for non-searchable variants if the placeholder prop is not used.',
 ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes https://github.com/microsoft/fluent-ui-react/issues/2336
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

For the case when items are objects, `itemToString` must be used to supply the string equivalent.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12793)