### PR TITLE
Update Picker.CustomResult.Example.tsx

### DIFF
--- a/change/office-ui-fabric-react-2020-04-25-09-08-19-patch-1.json
+++ b/change/office-ui-fabric-react-2020-04-25-09-08-19-patch-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Picker.CustomResult.Example.tsx",
+  "packageName": "office-ui-fabric-react",
+  "email": "patrick@nubo.eu",
+  "dependentChangeType": "patch",
+  "date": "2020-04-25T07:08:19.743Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
@@ -377,7 +377,7 @@ export class PickerCustomResultExample extends React.Component<{}, IPeoplePicker
     });
   };
 
-  private _onFilterChanged(filterText: string, items: IFullDocumentCardProps[]): IFullDocumentCardProps[] {
+  private _onFilterChanged(filterText: string, items?: IFullDocumentCardProps[]): IFullDocumentCardProps[] {
     if (!items)
        return [];
     

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
@@ -378,6 +378,9 @@ export class PickerCustomResultExample extends React.Component<{}, IPeoplePicker
   };
 
   private _onFilterChanged(filterText: string, items: IFullDocumentCardProps[]): IFullDocumentCardProps[] {
+    if (!items)
+       return [];
+    
     return filterText
       ? data
           .filter(

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
@@ -378,9 +378,10 @@ export class PickerCustomResultExample extends React.Component<{}, IPeoplePicker
   };
 
   private _onFilterChanged(filterText: string, items?: IFullDocumentCardProps[]): IFullDocumentCardProps[] {
-    if (!items)
-       return [];
-    
+    if (!items) {
+      return [];
+    }
+
     return filterText
       ? data
           .filter(


### PR DESCRIPTION
Fixes the error "Argument of type 'IFullDocumentCardProps[] | undefined' is not assignable to parameter of type 'IFullDocumentCardProps[] in the example"

#### Description of changes

When integrating the example in a react component, an exception of type "Argument of type 'IFullDocumentCardProps[] | undefined' is not assignable to parameter of type 'IFullDocumentCardProps[] in the example" is thrown when _onFilterChanged is called.

Tested in Edge


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12795)