### PR TITLE
chore(TableRow): Convert to FC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - changed `createShorthand` signature, to use the optional `shorthandConfig` static on the component @mnajdova ([#12783](https://github.com/microsoft/fluentui/pull/12783))
 - Restricted prop sets in the `Video` component which are passed to styles functions @assuncaocharles ([#12799](https://github.com/microsoft/fluentui/pull/12799))
 - Restricted prop sets in the `SplitButton` component which are passed to styles functions @assuncaocharles ([#12809](https://github.com/microsoft/fluentui/pull/12809))
+- Restricted prop sets in the `TableRow` component which are passed to styles functions @pompomon, @assuncaocharles ([#12797](https://github.com/microsoft/fluentui/pull/12797))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))

--- a/packages/fluentui/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Table/gridHeaderRowBehavior.ts
@@ -3,6 +3,7 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { FocusZoneDirection } from '../../focusZone/types';
 import * as keyboardKey from 'keyboard-key';
 import gridHeaderCellBehavior from './gridHeaderCellBehavior';
+import { GridRowBehaviorProps } from './gridRowBehavior';
 
 /**
  * @specification
@@ -14,7 +15,7 @@ import gridHeaderCellBehavior from './gridHeaderCellBehavior';
  * Triggers 'unsetRowTabbable' action using 'shiftKey' + 'Tab' key on 'root'.
  * Applies 'gridHeaderCellBehavior' for 'cell' child component.
  */
-const gridHeaderRowBehavior: Accessibility = props => ({
+const gridHeaderRowBehavior: Accessibility<GridRowBehaviorProps> = props => ({
   attributes: {
     root: {
       [IS_FOCUSABLE_ATTRIBUTE]: true,

--- a/packages/fluentui/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Table/gridRowNestedBehavior.ts
@@ -3,6 +3,7 @@ import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { FocusZoneDirection } from '../../focusZone/types';
 import * as keyboardKey from 'keyboard-key';
 import gridCellBehavior from './gridCellBehavior';
+import { GridRowBehaviorProps } from './gridRowBehavior';
 
 /**
  * @specification
@@ -15,7 +16,7 @@ import gridCellBehavior from './gridCellBehavior';
  * Triggers 'unsetRowTabbable' action using 'shiftKey' + 'Tab' key on 'root'.
  * Applies 'gridCellBehavior' for 'cell' child component.
  */
-const gridRowNestedBehavior: Accessibility = props => ({
+const gridRowNestedBehavior: Accessibility<GridRowBehaviorProps> = props => ({
   attributes: {
     root: {
       [IS_FOCUSABLE_ATTRIBUTE]: true,

--- a/packages/fluentui/accessibility/src/behaviors/Table/tableRowBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Table/tableRowBehavior.ts
@@ -1,6 +1,7 @@
 import { Accessibility } from '../../types';
 import tableCellBehavior from './tableCellBehavior';
 import tableHeaderCellBehavior from './tableHeaderCellBehavior';
+import { GridRowBehaviorProps } from './gridRowBehavior';
 
 /**
  * @description
@@ -8,7 +9,7 @@ import tableHeaderCellBehavior from './tableHeaderCellBehavior';
  * @specification
  * Adds role='row'.
  */
-const tableRowBehavior: Accessibility = props => ({
+const tableRowBehavior: Accessibility<GridRowBehaviorProps> = props => ({
   attributes: {
     root: {
       role: 'row',

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -102,6 +102,7 @@ export { default as gridNestedBehavior } from './Table/gridNestedBehavior';
 export { default as gridHeaderRowBehavior } from './Table/gridHeaderRowBehavior';
 export { default as gridHeaderCellBehavior } from './Table/gridHeaderCellBehavior';
 export { default as gridRowBehavior } from './Table/gridRowBehavior';
+export * from './Table/gridRowBehavior';
 export { default as gridRowNestedBehavior } from './Table/gridRowNestedBehavior';
 export { default as gridCellBehavior } from './Table/gridCellBehavior';
 export { default as gridCellMultipleFocusableBehavior } from './Table/gridCellMultipleFocusableBehavior';

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -14,6 +14,7 @@ import {
   ShorthandCollection,
   WithAsProp,
   withSafeTypeForAs,
+  ComponentEventHandler,
 } from '../../types';
 import { childrenExist, commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
 import TableCell, { TableCellProps } from './TableCell';
@@ -43,6 +44,14 @@ export interface TableRowProps extends UIComponentProps {
    * Whether a row is currently selected or not.
    */
   selected?: boolean;
+
+  /**
+   * Called on click.
+   *
+   * @param event - React's original SyntheticEvent.
+   * @param data - All props.
+   */
+  onClick?: ComponentEventHandler<TableRowProps>;
 }
 
 const handleVariablesOverrides = variables => predefinedProps => ({

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -158,6 +158,7 @@ TableRow.propTypes = {
   header: PropTypes.bool,
   compact: PropTypes.bool,
   selected: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 TableRow.handledProps = Object.keys(TableRow.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -1,5 +1,4 @@
-import { Accessibility, tableRowBehavior } from '@fluentui/accessibility';
-import { GridRowBehaviorProps } from '@fluentui/accessibility/dist/es/behaviors/Table/gridRowBehavior';
+import { Accessibility, tableRowBehavior, GridRowBehaviorProps } from '@fluentui/accessibility';
 import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -105,14 +105,14 @@ const TableRow: React.FC<WithAsProp<TableRowProps>> & FluentComponentStaticProps
 
   const renderCells = () => {
     // TODO: consider moving to useAccessibility()
-    const childBehavior = accessibility && accessibility({ header, selected }).childBehaviors;
+    const childBehaviors = accessibility && accessibility({ header, selected }).childBehaviors;
 
     return _.map(items, (item: TableCellProps, index: number) => {
       const overrideProps = handleVariablesOverrides(variables);
       return TableCell.create(item, {
         defaultProps: () =>
           getA11yProps('cell', {
-            accessibility: childBehavior ? childBehavior.cell : undefined,
+            accessibility: childBehaviors ? childBehaviors.cell : undefined,
             ...overrideProps,
           }),
       });

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -1,29 +1,29 @@
-import { ReactAccessibilityBehavior } from '@fluentui/react-bindings';
-import * as customPropTypes from '@fluentui/react-proptypes';
-import { Ref } from '@fluentui/react-component-ref';
-import * as PropTypes from 'prop-types';
-import * as _ from 'lodash';
-import * as React from 'react';
-import TableCell, { TableCellProps } from './TableCell';
-import {
-  UIComponent,
-  RenderResultConfig,
-  UIComponentProps,
-  commonPropTypes,
-  ShorthandFactory,
-  createShorthandFactory,
-  applyAccessibilityKeyHandlers,
-  childrenExist,
-} from '../../utils';
-import { ShorthandCollection, WithAsProp, withSafeTypeForAs } from '../../types';
 import { Accessibility, tableRowBehavior } from '@fluentui/accessibility';
-import { ComponentVariablesObject, mergeComponentVariables } from '@fluentui/styles';
+import { GridRowBehaviorProps } from '@fluentui/accessibility/dist/es/behaviors/Table/gridRowBehavior';
+import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
+import { Ref } from '@fluentui/react-component-ref';
+import * as customPropTypes from '@fluentui/react-proptypes';
+import { mergeComponentVariables } from '@fluentui/styles';
+import * as _ from 'lodash';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import {
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+  ShorthandCollection,
+  WithAsProp,
+  withSafeTypeForAs,
+} from '../../types';
+import { childrenExist, commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
+import TableCell, { TableCellProps } from './TableCell';
 
 export interface TableRowProps extends UIComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    * */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<GridRowBehaviorProps>;
 
   /**
    * Row cells
@@ -52,94 +52,111 @@ const handleVariablesOverrides = variables => predefinedProps => ({
 
 export const tableRowClassName = 'ui-table__row';
 
-class TableRow extends UIComponent<WithAsProp<TableRowProps>> {
-  static displayName = 'TableRow';
+export type TableRowStylesProps = Pick<TableRowProps, 'header' | 'compact'>;
 
-  static deprecated_className = tableRowClassName;
+const TableRow: React.FC<WithAsProp<TableRowProps>> & FluentComponentStaticProps<TableRowProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(TableRow.displayName, context.telemetry);
+  setStart();
+  const rowRef = React.useRef<HTMLElement>();
+  const { className, design, styles, items, header, compact, children, accessibility, variables, selected } = props;
 
-  static create: ShorthandFactory<TableRowProps>;
-
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false,
+  const hasChildren = childrenExist(children);
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(TableRow.handledProps, props);
+  const getA11yProps = useAccessibility(accessibility, {
+    debugName: TableRow.displayName,
+    actionHandlers: {
+      // https://github.com/microsoft/fluent-ui-react/issues/2150
+      unsetRowTabbable: e => {
+        rowRef.current.setAttribute('tabindex', '-1');
+      },
+      performClick: e => {
+        handleClick(e);
+      },
+    },
+    mapPropsToBehavior: () => ({
+      selected,
+      header,
     }),
-    content: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([PropTypes.arrayOf(customPropTypes.nodeContent), customPropTypes.nodeContent]),
-    ]),
-    items: customPropTypes.collectionShorthand,
-    header: PropTypes.bool,
-    compact: PropTypes.bool,
-    selected: PropTypes.bool,
-  };
+    rtl: context.rtl,
+  });
 
-  static defaultProps = {
-    accessibility: tableRowBehavior as Accessibility,
-  };
+  const { classes } = useStyles<TableRowStylesProps>(TableRow.displayName, {
+    className: tableRowClassName,
+    mapPropsToStyles: () => ({
+      header,
+      compact,
+    }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  rowRef = React.createRef<HTMLElement>();
-
-  actionHandlers = {
-    // https://github.com/microsoft/fluent-ui-react/issues/2150
-    unsetRowTabbable: e => {
-      this.rowRef.current.setAttribute('tabindex', '-1');
-    },
-    performClick: e => {
-      this.handleClick(e);
-    },
-  };
-
-  handleClick = (e: React.SyntheticEvent) => {
+  const handleClick = (e: React.SyntheticEvent) => {
     if (e.currentTarget === e.target) {
-      _.invoke(this.props, 'onClick', e, this.props);
+      _.invoke(props, 'onClick', e, props);
       e.preventDefault();
     }
   };
 
-  renderCells(accessibility: ReactAccessibilityBehavior, variables: ComponentVariablesObject) {
-    const { items } = this.props;
-
-    const cellAccessibility = accessibility.childBehaviors ? accessibility.childBehaviors.cell : undefined;
+  const renderCells = () => {
+    // TODO: consider moving to useAccessibility()
+    const childBehavior = accessibility && accessibility({ header, selected }).childBehaviors;
 
     return _.map(items, (item: TableCellProps, index: number) => {
-      const cellProps = {
-        accessibility: cellAccessibility as Accessibility,
-      };
       const overrideProps = handleVariablesOverrides(variables);
-
       return TableCell.create(item, {
-        defaultProps: () => cellProps,
-        overrideProps,
+        defaultProps: () =>
+          getA11yProps('cell', {
+            accessibility: childBehavior ? childBehavior.cell : undefined,
+            ...overrideProps,
+          }),
       });
     });
-  }
+  };
 
-  renderComponent({
-    accessibility,
-    ElementType,
-    classes,
-    variables,
-    unhandledProps,
-  }: RenderResultConfig<any>): React.ReactNode {
-    const { children } = this.props;
-    const hasChildren = childrenExist(children);
-
-    return (
-      <Ref innerRef={this.rowRef}>
+  const element = (
+    <Ref innerRef={rowRef}>
+      {getA11yProps.unstable_wrapWithFocusZone(
         <ElementType
-          className={classes.root}
-          onClick={this.handleClick}
-          {...accessibility.attributes.root}
-          {...unhandledProps}
-          {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
+          {...getA11yProps('root', {
+            className: classes.root,
+            onClick: handleClick,
+            ...unhandledProps,
+          })}
         >
           {hasChildren && children}
-          {!hasChildren && this.renderCells(accessibility, variables)}
-        </ElementType>
-      </Ref>
-    );
-  }
-}
+          {!hasChildren && renderCells()}
+        </ElementType>,
+      )}
+    </Ref>
+  );
+  setEnd();
+  return element;
+};
+
+TableRow.displayName = 'TableRow';
+
+TableRow.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false,
+  }),
+  items: customPropTypes.collectionShorthand,
+  header: PropTypes.bool,
+  compact: PropTypes.bool,
+  selected: PropTypes.bool,
+};
+
+TableRow.handledProps = Object.keys(TableRow.propTypes) as any;
+
+TableRow.defaultProps = {
+  accessibility: tableRowBehavior,
+};
 
 TableRow.create = createShorthandFactory({ Component: TableRow, mappedArrayProp: 'items' });
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableRowStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Table/tableRowStyles.ts
@@ -1,6 +1,6 @@
 import { ComponentStyleFunctionParam, ICSSInJSStyle } from '@fluentui/styles';
 import { TeamsTableVariables } from './tableVariables';
-import { TableRowProps } from '../../../../components/Table/TableRow';
+import { TableRowStylesProps } from '../../../../components/Table/TableRow';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 
 export default {
@@ -8,7 +8,7 @@ export default {
     props: { header, compact },
     variables: v,
     theme: { siteVariables },
-  }: ComponentStyleFunctionParam<TableRowProps, TeamsTableVariables>): ICSSInJSStyle => {
+  }: ComponentStyleFunctionParam<TableRowStylesProps, TeamsTableVariables>): ICSSInJSStyle => {
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
     });

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -74,7 +74,7 @@ import { VideoStylesProps } from '../../components/Video/Video';
 import { TreeItemStylesProps } from '../../components/Tree/TreeItem';
 import { TreeTitleStylesProps } from '../../components/Tree/TreeTitle';
 import { TableProps } from '../../components/Table/Table';
-import { TableRowProps } from '../../components/Table/TableRow';
+import { TableRowStylesProps } from '../../components/Table/TableRow';
 import { TableCellStylesProps } from '../../components/Table/TableCell';
 import { CardStylesProps } from '../../components/Card/Card';
 import { CardPreviewStylesProps } from '../../components/Card/CardPreview';
@@ -155,7 +155,7 @@ export type TeamsThemeStylesProps = {
   HierarchicalTreeTitle: HierarchicalTreeTitleProps;
   Video: VideoStylesProps;
   Table: TableProps;
-  TableRow: TableRowProps;
+  TableRow: TableRowStylesProps;
   TableCell: TableCellStylesProps;
   Card: CardStylesProps;
   CardPreview: CardPreviewStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Table/TableRow-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Table/TableRow-test.tsx
@@ -6,7 +6,7 @@ import TableCell from 'src/components/Table/TableCell';
 import TableRow from 'src/components/Table/TableRow';
 
 describe('TableRow', () => {
-  isConformant(TableRow);
+  isConformant(TableRow, { constructorName: 'TableRow' });
 
   describe('accessiblity', () => {
     handlesAccessibility(TableRow, { defaultRootRole: 'row' });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Convert TableRow to functional component and restrict props which are passed to styles to
`header`
`compact`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12797)