### PR TITLE
Fix column prop passed into TilesList cells

### DIFF
--- a/change/@uifabric-experiments-2020-04-21-15-49-22-tiles-list-column.json
+++ b/change/@uifabric-experiments-2020-04-21-15-49-22-tiles-list-column.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect aria-colindex values in TilesList",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-21T22:49:22.462Z"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -226,7 +226,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
             item: item.content,
             finalSize: { width: 0, height: 0 },
             position: {
-              column: 0,
+              column,
             },
           })}
         </div>
@@ -256,7 +256,7 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
             item: item.content,
             finalSize,
             position: {
-              column: 0,
+              column,
             },
           })}
         </div>


### PR DESCRIPTION
Fixed a last-minute error introduced which set the `column` prop passed to `onRenderCell` callbacks to be `0` for all calls. This impinges the new behavior from properly providing accessibility cues.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12801)