### PR TITLE
Fix SASS variable default values for theme.effects

### DIFF
--- a/change/@uifabric-styling-2020-04-21-16-03-48-phkuo-fixEffectsSass.json
+++ b/change/@uifabric-styling-2020-04-21-16-03-48-phkuo-fixEffectsSass.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "remove outdated comment",
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com",
+  "commit": "305d4629031039d2179eaae063cd6b2f091122d1",
+  "date": "2020-04-21T23:03:48.374Z"
+}

--- a/change/office-ui-fabric-react-2020-04-21-16-03-48-phkuo-fixEffectsSass.json
+++ b/change/office-ui-fabric-react-2020-04-21-16-03-48-phkuo-fixEffectsSass.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix SASS default values for theme.effects",
+  "packageName": "office-ui-fabric-react",
+  "email": "phkuo@microsoft.com",
+  "commit": "305d4629031039d2179eaae063cd6b2f091122d1",
+  "date": "2020-04-21T23:03:26.858Z"
+}

--- a/packages/office-ui-fabric-react/src/common/_effects.scss
+++ b/packages/office-ui-fabric-react/src/common/_effects.scss
@@ -1,16 +1,6 @@
-/** EXPERIMENTAL, use with box-shadow */
-$elevation4: '[theme:elevation4, default: 0 0 5px 0 rgba(0,0,0,.4)]';
-// Fluent value: $elevation4: '[theme:elevation4, default: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108)]';
-/** EXPERIMENTAL, use with box-shadow */
-$elevation8: '[theme:elevation8, default: 0 0 5px 0 rgba(0,0,0,.4)]';
-// Fluent value: $elevation8: '[theme:elevation8, default: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108)]';
-/** EXPERIMENTAL, use with box-shadow */
-$elevation16: '[theme:elevation16, default: 0 0 5px 0 rgba(0,0,0,.4)]';
-// Fluent value: $elevation16: '[theme:elevation16, default: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108)]';
-/** EXPERIMENTAL, use with box-shadow */
-$elevation64: '[theme:elevation64, default: 0 0 5px 0 rgba(0,0,0,.4)]';
-// Fluent value: $elevation64: '[theme:elevation64, default: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18)]';
+$elevation4: '[theme:elevation4, default: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108)]';
+$elevation8: '[theme:elevation8, default: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108)]';
+$elevation16: '[theme:elevation16, default: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108)]';
+$elevation64: '[theme:elevation64, default: 0 25.6px 57.6px 0 rgba(0, 0, 0, 0.22), 0 4.8px 14.4px 0 rgba(0, 0, 0, 0.18)]';
 
-/** EXPERIMENTAL, use with border-radius */
-$roundedCorner2: '[theme:roundedCorner2, default: 0]';
-// Fluent value: $roundedCorner2: '[theme:roundedCorner2, default: 2px]';
+$roundedCorner2: '[theme:roundedCorner2, default: 2px]';

--- a/packages/styling/src/styles/DefaultEffects.ts
+++ b/packages/styling/src/styles/DefaultEffects.ts
@@ -1,7 +1,6 @@
 import { IEffects } from '../interfaces/index';
 
 export const DefaultEffects: IEffects = {
-  // commented values are the defaults for Fluent
   elevation4: '0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108)',
   elevation8: '0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108)',
   elevation16: '0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108)',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12650 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The SASS variables provided for theme.effects (rounded corners and shadows) have incorrect default values.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12802)