### PR TITLE
Make dark theme inverted

### DIFF
--- a/change/@uifabric-theme-samples-2020-04-22-07-26-58-make_dark_theme_inverted.json
+++ b/change/@uifabric-theme-samples-2020-04-22-07-26-58-make_dark_theme_inverted.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "set isInverted for dark sample theme",
+  "packageName": "@uifabric/theme-samples",
+  "email": "chrismo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-22T14:26:57.935Z"
+}

--- a/packages/theme-samples/src/DarkCustomizations.ts
+++ b/packages/theme-samples/src/DarkCustomizations.ts
@@ -53,6 +53,7 @@ const DarkTheme: ITheme = createTheme({
     menuItemText: DarkDefaultPalette.neutralPrimary,
     menuItemTextHovered: DarkDefaultPalette.neutralDark,
   },
+  isInverted: true,
 });
 
 export const PeoplePickerItemStyles = (


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Setting the `isInverted` flag true on the dark sample theme will result in components rendering as expected on the website.  For example, on the [page for the MessageBar component](https://developer.microsoft.com/en-us/fluentui#/controls/web/messagebar), selecting dark mode does not show the expected colors.

(Note: after this change the colors for message bar in dark mode still won't be ideal, and I'll have a separate PR coming to address that)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12819)