### PR TITLE
Downgrade ts-node, script type fixes

### DIFF
--- a/packages/fluentui/docs/src/types.ts
+++ b/packages/fluentui/docs/src/types.ts
@@ -38,7 +38,7 @@ export type ComponentInfo = {
   props: ComponentProp[];
   repoPath: string;
   subcomponentName: null | string;
-  subcomponents: string[];
+  subcomponents: string[] | null;
   type: 'component';
 };
 

--- a/scripts/dangerjs/detectNonApprovedDependencies/utils/getRuntimeDependencies.ts
+++ b/scripts/dangerjs/detectNonApprovedDependencies/utils/getRuntimeDependencies.ts
@@ -28,7 +28,7 @@ const getRuntimeDependencies = (packageName: string) => {
   return output
     .split('\n')
     .map(line => line.match(dependencyRegex))
-    .filter(match => !!match)
+    .filter((match): match is RegExpMatchArray => !!match)
     .map(match => match[1]);
 };
 

--- a/scripts/dangerjs/detectNonApprovedDependencies/utils/getVersionConstrains.ts
+++ b/scripts/dangerjs/detectNonApprovedDependencies/utils/getVersionConstrains.ts
@@ -11,7 +11,7 @@ type PackageJson = {
 
 type Constraints = { [PackageId: string]: string[] };
 
-const findPackageJsonOf = (dependencyPackageId: string, packagePath: string): string => {
+const findPackageJsonOf = (dependencyPackageId: string, packagePath: string): string | null => {
   if (!packagePath) {
     return null;
   }
@@ -70,7 +70,7 @@ export const getDependenciesVersionConstraints = async (
   dependencyChain: string[],
 ): Promise<Constraints> => {
   let detectedConstraints: Constraints = {};
-  const dependenciesWithConstraints = (await parsePackageJson(packageJsonPath)).dependencies;
+  const dependenciesWithConstraints = (await parsePackageJson(packageJsonPath)).dependencies || [];
 
   const pendingTasks = dependenciesWithConstraints.map(async dependencyPackageId => {
     if (isIgnored(dependencyPackageId)) {

--- a/scripts/gulp/plugins/gulp-component-menu-behaviors.ts
+++ b/scripts/gulp/plugins/gulp-component-menu-behaviors.ts
@@ -4,6 +4,7 @@ import through2 from 'through2';
 import Vinyl from 'vinyl';
 import _ from 'lodash';
 import fs from 'fs';
+import { Transform } from 'stream';
 
 const pluginName = 'gulp-component-menu-behaviors';
 const extract = require('extract-comments');
@@ -26,7 +27,7 @@ const getTextFromCommentToken = (commentTokens, tokenTitle): string => {
 
 export default () => {
   const result: BehaviorMenuItem[] = [];
-  function bufferContents(file, enc, cb) {
+  function bufferContents(this: Transform, file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
       return;
@@ -87,7 +88,7 @@ export default () => {
       .value();
   }
 
-  function endStream(cb) {
+  function endStream(this: Transform, cb) {
     const file = new Vinyl({
       path: './behaviorMenu.json',
       contents: Buffer.from(JSON.stringify(getParsedResults(), null, 2)),

--- a/scripts/gulp/plugins/gulp-component-menu.ts
+++ b/scripts/gulp/plugins/gulp-component-menu.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import through2 from 'through2';
 import Vinyl from 'vinyl';
+import { Transform } from 'stream';
 
 import config from '../../config';
 import getComponentInfo from './util/getComponentInfo';
@@ -18,7 +19,7 @@ type ComponentMenuItem = {
 export default (tsConfigPath: string) => {
   const result: ComponentMenuItem[] = [];
 
-  function bufferContents(file, enc, cb) {
+  function bufferContents(this: Transform, file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
       return;
@@ -62,7 +63,7 @@ export default (tsConfigPath: string) => {
     }
   }
 
-  function endStream(cb) {
+  function endStream(this: Transform, cb) {
     const file = new Vinyl({
       path: './componentMenu.json',
       contents: Buffer.from(JSON.stringify(_.sortBy(result, 'displayName'), null, 2)),

--- a/scripts/gulp/plugins/gulp-example-menu.ts
+++ b/scripts/gulp/plugins/gulp-example-menu.ts
@@ -1,6 +1,7 @@
 import gutil from 'gulp-util';
 import _ from 'lodash';
 import path from 'path';
+import { Transform } from 'stream';
 import through2 from 'through2';
 import Vinyl from 'vinyl';
 
@@ -36,7 +37,7 @@ export default () => {
     >
   > = {};
 
-  function bufferContents(file, enc, cb) {
+  function bufferContents(this: Transform, file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
       return;
@@ -76,7 +77,7 @@ export default () => {
     }
   }
 
-  function endStream(cb) {
+  function endStream(this: Transform, cb) {
     _.forEach(exampleFilesByDisplayName, (contents, displayName) => {
       const sortedContents = _.sortBy(contents, ['order', 'sectionName']).map(({ sectionName, examples }) => ({
         sectionName,

--- a/scripts/gulp/plugins/util/docgen.ts
+++ b/scripts/gulp/plugins/util/docgen.ts
@@ -339,7 +339,7 @@ export class Parser {
 
       const jsDocComment = this.findDocComment(prop);
 
-      let defaultValue = null;
+      let defaultValue: any = null;
 
       if (defaultProps[propName] !== undefined) {
         defaultValue = { value: defaultProps[propName] };

--- a/scripts/gulp/plugins/util/getComponentInfo.ts
+++ b/scripts/gulp/plugins/util/getComponentInfo.ts
@@ -11,7 +11,7 @@ import parseDocblock from './parseDocblock';
 import parseType from './parseType';
 import getShorthandInfo from './getShorthandInfo';
 
-const getAvailableBehaviors = (accessibilityProp: ComponentProp): BehaviorInfo[] => {
+const getAvailableBehaviors = (accessibilityProp: ComponentProp | undefined): BehaviorInfo[] | undefined => {
   const docTags = accessibilityProp && accessibilityProp.tags;
   const availableTag = _.find(docTags, { title: 'available' });
   const availableBehaviorNames = _.get(availableTag, 'description', '');
@@ -87,7 +87,7 @@ const getComponentInfo = (tsConfigPath: string, filepath: string, ignoredParentI
   const isChild = !isParent;
   const parentDisplayName = isParent ? null : dirname;
   // "Field" for "FormField" since it is accessed as "Form.Field" in the API
-  const subcomponentName = isParent ? null : info.displayName.replace(parentDisplayName, '');
+  const subcomponentName = isParent ? null : info.displayName.replace(parentDisplayName!, '');
 
   // "ListItem.js" is a subcomponent is the "List" directory
   const subcomponentRegExp = new RegExp(`^${dirname}\\w+\\.tsx$`);

--- a/scripts/gulp/plugins/util/getShorthandInfo.ts
+++ b/scripts/gulp/plugins/util/getShorthandInfo.ts
@@ -31,7 +31,7 @@ const isShorthandExpression = (componentName: string, path: NodePath<t.Assignmen
 
 const getShorthandInfo = (componentFile: t.File, componentName: string): ShorthandInfo => {
   let implementsCreateShorthand = false;
-  let mappedShorthandProp = undefined;
+  let mappedShorthandProp: string | undefined;
 
   Babel.traverse(componentFile, {
     AssignmentExpression: path => {
@@ -41,7 +41,7 @@ const getShorthandInfo = (componentFile: t.File, componentName: string): Shortha
         const config = path.get('right.arguments.0') as NodePath<t.ObjectExpression>;
         config.assertObjectExpression();
 
-        const mappedProperty = config.node.properties.find((property: t.ObjectProperty) => {
+        const mappedProperty = (config.node.properties as any[]).find((property: t.ObjectProperty) => {
           return t.isIdentifier(property.key, { name: 'mappedProp' });
         }) as t.ObjectProperty | null;
 
@@ -59,7 +59,7 @@ const getShorthandInfo = (componentFile: t.File, componentName: string): Shortha
 
   return {
     implementsCreateShorthand,
-    mappedShorthandProp,
+    mappedShorthandProp: mappedShorthandProp || '',
   };
 };
 

--- a/scripts/gulp/tasks/stats.ts
+++ b/scripts/gulp/tasks/stats.ts
@@ -131,7 +131,7 @@ task('stats', series(parallel('build:docs:component-info'), 'stats:build:bundle'
 
 function readSummaryPerfStats() {
   return _.chain(require(paths.perfDist('result.json')))
-    .mapKeys((value, key) => _.camelCase(key)) // mongodb does not allow dots in keys
+    .mapKeys((value, key) => _.camelCase(String(key))) // mongodb does not allow dots in keys
     .mapValues(result => ({
       actualTime: _.omit(result.actualTime, 'values'),
       renderComponentTime: {

--- a/scripts/gulp/tasks/test-dependencies/utils.ts
+++ b/scripts/gulp/tasks/test-dependencies/utils.ts
@@ -53,7 +53,7 @@ export const prepareWebpackConfig = (options: WebpackOptions) => {
             return modules[0].packageJson.name;
           });
 
-          return null;
+          return '';
         },
       }),
     ],

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -7,7 +7,7 @@ const fs = require('fs');
 
 const { clean } = require('./tasks/clean');
 const { copy } = require('./tasks/copy');
-const { jest, jestWatch } = require('./tasks/jest');
+const { jest: jestTask, jestWatch } = require('./tasks/jest');
 const { sass } = require('./tasks/sass');
 const { ts } = require('./tasks/ts');
 const { tslint } = require('./tasks/tslint');
@@ -49,7 +49,7 @@ module.exports = function preset() {
 
   task('clean', clean);
   task('copy', copy);
-  task('jest', jest);
+  task('jest', jestTask);
   task('jest-watch', jestWatch);
   task('sass', sass);
   task('ts:postprocess', postprocessTask());

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -142,7 +142,7 @@
     "tmp": "^0.0.33",
     "ts-jest": "24.0.1",
     "ts-loader": "^4.1.0",
-    "ts-node": "^8.4.1",
+    "ts-node": "^7.0.0",
     "tsconfig-paths": "^3.7.0",
     "tslint": "^5.7.0",
     "typescript": "3.7.2",

--- a/scripts/screener/screener.states.ts
+++ b/scripts/screener/screener.states.ts
@@ -43,6 +43,6 @@ const getStateForPath = (examplePath: string) => {
 const screenerStates = filteredPaths.reduce((states, examplePath) => {
   states.push(getStateForPath(examplePath));
   return states;
-}, []);
+}, [] as ReturnType<typeof getStateForPath>[]);
 
 export default screenerStates;

--- a/scripts/ts-node-register.js
+++ b/scripts/ts-node-register.js
@@ -1,3 +1,19 @@
-// Register ts-node so that it uses the scripts directory's tsconfig
 const tsNode = require('ts-node');
-tsNode.register({ dir: __dirname });
+const path = require('path');
+const { readConfig } = require('./read-config');
+
+// Until ts-node re-enables caching, we're using version 7 (before caching was disabled).
+// https://github.com/TypeStrong/ts-node/issues/951
+tsNode.register({
+  // Run in transpileOnly mode because with type checking it's very slow
+  transpileOnly: true,
+  // TODO: re-enable when upgrading ts-node to version which supports this
+  // // Register ts-node so that it uses the scripts directory's tsconfig
+  // dir: __dirname,
+  // Hack to work around lack of `dir` option: manually pass in tsconfig
+  compilerOptions: {
+    ...readConfig(path.join(__dirname, 'typescript/tsconfig.common.json')).compilerOptions,
+    ...readConfig(path.join(__dirname, 'tsconfig.json')).compilerOptions,
+  },
+  skipProject: true, // don't read tsconfig within ts-node
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,10 +3,12 @@
   // This config is used for running build scripts through ts-node
   "compilerOptions": {
     "module": "CommonJS",
+    "target": "ES2018", // Node 10 per https://kangax.github.io/compat-table/es2016plus/#node10_9
+    "lib": ["ES2018", "DOM"], // Node 10, occasional test-related stuff that uses DOM
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "noImplicitAny": false,
     "allowJs": true,
+    "noImplicitAny": false,
+    "strictNullChecks": false,
     "typeRoots": ["../typings", "../node_modules/@types"],
     "types": ["node", "webpack-env", "screener-runner"]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5101,11 +5101,6 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
-arg@^4.1.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
-  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
-
 argparse@^1.0.7, argparse@~1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -6353,7 +6348,7 @@ buffer-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-equal/-/buffer-equal-1.0.0.tgz#59616b498304d556abd466966b22eeda3eca5fbe"
   integrity sha1-WWFrSYME1Var1GaWayLu2j7KX74=
 
-buffer-from@1.x, buffer-from@^1.0.0:
+buffer-from@1.x, buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -8627,11 +8622,6 @@ diff@^3.1.0, diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
-
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -21332,16 +21322,19 @@ ts-loader@^4.1.0:
     micromatch "^3.1.4"
     semver "^5.0.1"
 
-ts-node@^8.4.1:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.6.2.tgz#7419a01391a818fbafa6f826a33c1a13e9464e35"
-  integrity sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==
+ts-node@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
+  integrity sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==
   dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
+    arrify "^1.0.0"
+    buffer-from "^1.1.0"
+    diff "^3.1.0"
     make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
     source-map-support "^0.5.6"
-    yn "3.1.1"
+    yn "^2.0.0"
 
 ts-pnp@^1.1.2:
   version "1.1.5"
@@ -22963,10 +22956,10 @@ yauzl@2.4.1:
   dependencies:
     fd-slicer "~1.0.1"
 
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
+  integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
 
 z-schema@~3.18.3:
   version "3.18.4"


### PR DESCRIPTION
Downgrade ts-node to version 7, which has caching (see #12789 discussion). 

Fix some type issues in script files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12824)