### PR TITLE
fix(ToolbarMenuItem): execute click on Enter and Spaceabar for checked version

### DIFF
--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuItemCheckboxBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuItemCheckboxBehavior.ts
@@ -1,3 +1,4 @@
+import * as keyboardKey from 'keyboard-key';
 import { Accessibility } from '../../types';
 
 /**
@@ -16,6 +17,13 @@ const toolbarMenuItemCheckboxBehavior: Accessibility<ToolbarMenuItemCheckboxBeha
       'aria-checked': props.active,
       'aria-disabled': props.disabled,
       role: 'menuitemcheckbox',
+    },
+  },
+  keyActions: {
+    root: {
+      performClick: {
+        keyCombinations: [{ keyCode: keyboardKey.Enter }, { keyCode: keyboardKey.Spacebar }],
+      },
     },
   },
 });

--- a/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuItemCheckboxBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Toolbar/toolbarMenuItemCheckboxBehavior.ts
@@ -3,10 +3,11 @@ import { Accessibility } from '../../types';
 
 /**
  * @specification
- *  Adds attribute 'aria-checked=true' based on the property 'active'.
- *  Adds attribute 'aria-disabled=true' based on the property 'disabled'.
- *  Adds role='menuitemcheckbox'.
+ * Adds attribute 'aria-checked=true' based on the property 'active'.
+ * Adds attribute 'aria-disabled=true' based on the property 'disabled'.
+ * Adds role='menuitemcheckbox'.
  * Adds role 'presentation' to 'wrapper' slot.
+ * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  */
 const toolbarMenuItemCheckboxBehavior: Accessibility<ToolbarMenuItemCheckboxBehaviorProps> = props => ({
   attributes: {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -177,6 +177,7 @@ const ToolbarMenuItem: React.FC<WithAsProp<ToolbarMenuItemProps>> &
     debugName: ToolbarMenuItem.displayName,
     mapPropsToBehavior: () => ({
       menu,
+      active,
       menuOpen,
       disabled,
       'aria-label': props['aria-label'],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Checkbox variation of ToolbarMenuItem did not have `performClick` action in the behavior. Correcting that here.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12837)