### PR TITLE
docs(Dropdown): add loading message in getA11yStatusMEssage

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleLoading.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleLoading.shorthand.tsx
@@ -15,6 +15,21 @@ const DropdownExampleLoading = () => {
       search
       items={inputItems}
       placeholder="Start typing a name"
+      getA11yStatusMessage={({ resultCount, previousResultCount }) => {
+        if (loading) {
+          return 'loading results';
+        }
+
+        if (!resultCount) {
+          return 'No results are available.';
+        }
+        if (resultCount !== previousResultCount) {
+          return `${resultCount} result${
+            resultCount === 1 ? ' is' : 's are'
+          } available, use up and down arrow keys to navigate. Press Enter key to select.`;
+        }
+        return '';
+      }}
     />
   );
 };

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Usage/DropdownExampleHeaderMessage.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Usage/DropdownExampleHeaderMessage.shorthand.tsx
@@ -66,9 +66,25 @@ const DropdownExampleSearch = () => {
       }}
       noResultsMessage="We couldn't find any matches."
       headerMessage={externalSearch ? "We couldn't find any matches, but you can search externally!" : undefined}
-      getA11yStatusMessage={({ resultCount }) =>
-        externalSearch ? 'no results, but you can search externally' : `${resultCount} results available`
-      }
+      getA11yStatusMessage={({ resultCount, previousResultCount }) => {
+        if (loading) {
+          return 'loading results';
+        }
+
+        if (externalSearch) {
+          return 'no results, but you can search externally';
+        }
+
+        if (!resultCount) {
+          return 'No results are available.';
+        }
+        if (resultCount !== previousResultCount) {
+          return `${resultCount} result${
+            resultCount === 1 ? ' is' : 's are'
+          } available, use up and down arrow keys to navigate. Press Enter key to select.`;
+        }
+        return '';
+      }}
       getA11ySelectionMessage={{
         onAdd: item => (item === externalSearchItem ? 'loading external results' : `${item} has been selected.`),
       }}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

If a dropdown is loading, we can also let the screen reader user know by returning an appropriate message as the dropdown status.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12838)