### PR TITLE
fix(Accordion): Render title as div by default

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))
 - Fix `Ref` to react on props changes when `forwardRef` is used @mnajdova ([#12817](https://github.com/microsoft/fluentui/pull/12817))
+- Fix `AccordionTitle` to be rendered as `div` by default @pompomon ([#12840](https://github.com/microsoft/fluentui/pull/12840))
 
 ### Features
 - Add `body` slot to `Attachment` component @layershifter ([#12674](https://github.com/microsoft/fluentui/pull/12674))

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -157,7 +157,7 @@ class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
                 })}
                 {Box.create(content, {
                   defaultProps: () => ({
-                    as: 'span',
+                    as: 'div',
                     styles: styles.content,
                   }),
                 })}

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -157,7 +157,6 @@ class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
                 })}
                 {Box.create(content, {
                   defaultProps: () => ({
-                    as: 'div',
                     styles: styles.content,
                   }),
                 })}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix accordion title to be rendered as `div` instead of `span`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12840)