### PR TITLE
Provide full Nav group state for render overrides

### DIFF
--- a/change/office-ui-fabric-react-2020-04-23-21-31-33-nav-groups.json
+++ b/change/office-ui-fabric-react-2020-04-23-21-31-33-nav-groups.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Pass all relevant state to Nav group render override",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T04:31:33.602Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5754,7 +5754,7 @@ export interface INavProps {
     linkAs?: IComponentAs<INavButtonProps>;
     onLinkClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onLinkExpandClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
-    onRenderGroupHeader?: IRenderFunction<INavLinkGroup>;
+    onRenderGroupHeader?: IRenderFunction<IRenderGroupHeaderProps>;
     onRenderLink?: IRenderFunction<INavLink>;
     // @deprecated
     selectedAriaLabel?: string;
@@ -6540,6 +6540,11 @@ export interface IRatingStyles {
     rootIsLarge: IStyle;
     // (undocumented)
     rootIsSmall: IStyle;
+}
+
+// @public (undocumented)
+export interface IRenderGroupHeaderProps extends INavLinkGroup {
+    isExpanded?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
@@ -5,7 +5,8 @@ import * as renderer from 'react-test-renderer';
 
 import { Nav } from './Nav';
 import { NavBase } from './Nav.base';
-import { INavLink } from './Nav.types';
+import { INavLink, IRenderGroupHeaderProps, INavLinkGroup, INavButtonProps } from './Nav.types';
+import { IRenderFunction, IComponentAsProps } from '@uifabric/utilities';
 
 const linkOne: INavLink = {
   key: 'Bing',
@@ -37,6 +38,54 @@ describe('Nav', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('render Nav with overrides correctly', () => {
+    // tslint:disable-next-line:function-name
+    function LinkAs(props: IComponentAsProps<INavButtonProps>): JSX.Element | null {
+      const { defaultRender: DefaultRender, ...buttonProps } = props;
+
+      if (!DefaultRender) {
+        return null;
+      }
+
+      return (
+        <div data-test="button-override">
+          <DefaultRender {...buttonProps} />
+        </div>
+      );
+    }
+
+    function onRenderNavLink(props?: INavLink, defaultRender?: IRenderFunction<INavLink>): JSX.Element | null {
+      if (!props || !defaultRender) {
+        return null;
+      }
+
+      return <div data-test="link-override">{defaultRender(props)}</div>;
+    }
+
+    function onRenderGroupHeader(
+      props?: IRenderGroupHeaderProps,
+      defaultRender?: IRenderFunction<IRenderGroupHeaderProps>,
+    ): JSX.Element | null {
+      if (!props || !defaultRender) {
+        return null;
+      }
+
+      return <div data-test="header-override">{defaultRender(props)}</div>;
+    }
+    const groups: INavLinkGroup[] = [
+      {
+        name: 'Group',
+        links: [linkOne, linkTwo],
+      },
+    ];
+
+    const component = renderer.create(
+      <Nav groups={groups} onRenderGroupHeader={onRenderGroupHeader} onRenderLink={onRenderNavLink} linkAs={LinkAs} />,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
   });
 
   it('calls onClick() correctly', () => {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -5,6 +5,16 @@ import { IIconProps } from '../Icon/Icon.types';
 import { IButtonProps } from '../Button/Button.types';
 
 /**
+ * {@doccategory Nav}
+ */
+export interface IRenderGroupHeaderProps extends INavLinkGroup {
+  /**
+   * Whether or not the group is presently expanded.
+   */
+  isExpanded?: boolean;
+}
+
+/**
  * {@docCategory Nav}
  */
 export interface INav {
@@ -59,7 +69,7 @@ export interface INavProps {
    * Used to customize how content inside the group header is rendered
    * @defaultvalue Default group header rendering
    */
-  onRenderGroupHeader?: IRenderFunction<INavLinkGroup>;
+  onRenderGroupHeader?: IRenderFunction<IRenderGroupHeaderProps>;
 
   /**
    * Render a custom link in place of the normal one.

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -1,5 +1,469 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Nav render Nav with overrides correctly 1`] = `
+<div
+  className=
+      ms-FocusZone
+      &:focus {
+        outline: none;
+      }
+  data-focuszone-id="FocusZone4"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+>
+  <nav
+    className=
+        ms-Nav
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          overflow-y: auto;
+          user-select: none;
+        }
+    role="navigation"
+  >
+    <div
+      className="ms-Nav-group is-expanded"
+    >
+      <div
+        data-test="header-override"
+      >
+        <button
+          aria-expanded={true}
+          className=
+              ms-Nav-chevronButton
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: transparent;
+                border-bottom: 1px solid #edebe9;
+                border: none;
+                color: #323130;
+                cursor: pointer;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 18px;
+                font-weight: 400;
+                height: 44px;
+                line-height: 44px;
+                margin-bottom: 5px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 5px;
+                outline: transparent;
+                overflow: hidden;
+                padding-bottom: 0px,;
+                padding-left: 28px;
+                padding-right: 20px,;
+                padding-top: 0px,;
+                position: relative;
+                text-align: left;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+                width: 100%;
+              }
+              &::-moz-focus-inner {
+                border: 0;
+              }
+              .ms-Fabric--isFocusVisible &:focus:after {
+                border: 1px solid #ffffff;
+                bottom: 1px;
+                content: "";
+                left: 1px;
+                outline: 1px solid #605e5c;
+                position: absolute;
+                right: 1px;
+                top: 1px;
+                z-index: 1;
+              }
+              &:visited {
+                color: #323130;
+              }
+          onClick={[Function]}
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Nav-chevron
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  height: 44px;
+                  left: 8px;
+                  line-height: 44px;
+                  position: absolute;
+                  speak: none;
+                  transform: rotate(-180deg);
+                  transition: transform .1s linear;
+                }
+            data-icon-name="ChevronDown"
+          >
+            
+          </i>
+          Group
+        </button>
+      </div>
+      <div
+        className=
+            ms-Nav-groupContent
+            {
+              animation-duration: 0.367s;
+              animation-fill-mode: both;
+              animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(0,-20px,0);}to{transform:translate3d(0,0,0);};
+              animation-timing-function: cubic-bezier(.1,.9,.2,1);
+              display: block;
+              margin-bottom: 40px;
+            }
+      >
+        <ul
+          className=
+              ms-Nav-navItems
+              {
+                list-style-type: none;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+              }
+          role="list"
+        >
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="Bing"
+            >
+              <div
+                data-test="button-override"
+              >
+                <a
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 2px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 44px;
+                        line-height: 44px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 27px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-color: transparent;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        border-color: WindowText;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f3f2f1;
+                      }
+                  data-is-focusable={true}
+                  href="http://localhost/#/testing1"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  title="Bing"
+                >
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <div
+                      data-test="link-override"
+                    >
+                      <div
+                        className=
+                            ms-Nav-linkText
+                            {
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              overflow: hidden;
+                              text-align: left;
+                              text-overflow: ellipsis;
+                              vertical-align: middle;
+                            }
+                      >
+                        Bing
+                      </div>
+                    </div>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </li>
+          <li
+            className=
+                ms-Nav-navItem
+                {
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                }
+            role="listitem"
+          >
+            <div
+              className=
+                  ms-Nav-compositeLink
+                  {
+                    color: #323130;
+                    display: block;
+                    position: relative;
+                  }
+              name="OneDrive"
+            >
+              <div
+                data-test="button-override"
+              >
+                <a
+                  className=
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Nav-link
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 2px;
+                        border: 1px solid transparent;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
+                        display: block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 44px;
+                        line-height: 44px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 27px;
+                        padding-right: 20px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        white-space: nowrap;
+                        width: 100%;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        color: #0078d4;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:active {
+                        color: #000000;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-color: transparent;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        border-color: WindowText;
+                      }
+                      .ms-Nav-compositeLink:hover & {
+                        background-color: #f3f2f1;
+                      }
+                  data-is-focusable={true}
+                  href="http://localhost/#/testing2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  title="OneDrive"
+                >
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <div
+                      data-test="link-override"
+                    >
+                      <div
+                        className=
+                            ms-Nav-linkText
+                            {
+                              margin-bottom: 0;
+                              margin-left: 4px;
+                              margin-right: 4px;
+                              margin-top: 0;
+                              overflow: hidden;
+                              text-align: left;
+                              text-overflow: ellipsis;
+                              vertical-align: middle;
+                            }
+                      >
+                        OneDrive
+                      </div>
+                    </div>
+                  </span>
+                </a>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</div>
+`;
+
 exports[`Nav renders Nav correctly 1`] = `
 <div
   className=


### PR DESCRIPTION
Reworked the `Nav` component's `onRenderHeader` override so that it receives the final `isExpanded` state along with an `onHeaderClick` that actually handles expand/collapse logic. This way, overrides can focus on altering the appearance and do not need to re-implement expand/collapse.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12854)