### PR TITLE
[filetype icons] Add to filemap 'pbiapp' (re-applied)

### DIFF
--- a/change/@uifabric-file-type-icons-2020-04-24-13-10-49-caperez-pbiapp_filetype.json
+++ b/change/@uifabric-file-type-icons-2020-04-24-13-10-49-caperez-pbiapp_filetype.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding 'pbiapp' entry in file type icon mapping file",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-24T20:10:49.834Z"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -330,6 +330,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   onetoc: {
     extensions: ['ms-one-stub', 'onetoc', 'onetoc2', 'onepkg'], // this icon represents a complete, logical notebook.
   },
+  pbiapp: {},
   pdf: {
     extensions: ['pdf'],
   },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: The entry 'pbiapp' (for non-file PowerBI items) was present in Fabric 6 but missing in Fabric 7. Causes no effect in existing apps.
- [x] Include a change request file using `$ yarn change`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12865)