### PR TITLE
chore(AccordionTitle): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `SplitButton` component which are passed to styles functions @assuncaocharles ([#12809](https://github.com/microsoft/fluentui/pull/12809))
 - Restricted prop sets in the `TableRow` component which are passed to styles functions @pompomon, @assuncaocharles ([#12797](https://github.com/microsoft/fluentui/pull/12797))
 - Restricted prop sets in the `TextArea` component which are passed to styles functions, @assuncaocharles ([#12857](https://github.com/microsoft/fluentui/pull/12857))
+- Restricted prop sets in the `AccordionTitle` component which are passed to styles functions, @assuncaocharles ([#12874](https://github.com/microsoft/fluentui/pull/12874))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))

--- a/packages/fluentui/accessibility/src/behaviors/Accordion/accordionTitleBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Accordion/accordionTitleBehavior.ts
@@ -43,7 +43,7 @@ const accordionTitleBehavior: Accessibility<AccordionTitleBehaviorProps> = props
 
 export default accordionTitleBehavior;
 
-type AccordionTitleBehaviorProps = {
+export type AccordionTitleBehaviorProps = {
   /** Element type. */
   as?: string;
   /** Whether or not the title is in the open state. */

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -71,6 +71,7 @@ export { default as statusBehavior } from './Status/statusBehavior';
 export { default as embedBehavior } from './Embed/embedBehavior';
 export { default as accordionBehavior } from './Accordion/accordionBehavior';
 export { default as accordionTitleBehavior } from './Accordion/accordionTitleBehavior';
+export * from './Accordion/accordionTitleBehavior';
 export { default as accordionContentBehavior } from './Accordion/accordionContentBehavior';
 export { default as checkboxBehavior } from './Checkbox/checkboxBehavior';
 export * from './Checkbox/checkboxBehavior';

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -1,4 +1,4 @@
-import { accordionTitleBehavior, indicatorBehavior } from '@fluentui/accessibility';
+import { accordionTitleBehavior, Accessibility, AccordionTitleBehaviorProps } from '@fluentui/accessibility';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
@@ -8,18 +8,24 @@ import * as React from 'react';
 import {
   childrenExist,
   createShorthandFactory,
-  UIComponent,
   UIComponentProps,
   ContentComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
-  applyAccessibilityKeyHandlers,
-  ShorthandFactory,
-  ShorthandConfig,
 } from '../../utils';
-import { WithAsProp, ComponentEventHandler, ShorthandValue, withSafeTypeForAs } from '../../types';
+import {
+  WithAsProp,
+  ComponentEventHandler,
+  ShorthandValue,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
 import Box, { BoxProps } from '../Box/Box';
+import { getElementType, useTelemetry, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 
 export interface AccordionTitleSlotClassNames {
   contentWrapper: string;
@@ -29,6 +35,11 @@ export interface AccordionTitleProps
   extends UIComponentProps,
     ContentComponentProps<ShorthandValue<BoxProps>>,
     ChildrenComponentProps {
+  /**
+   * Accessibility behavior if overridden by the user.
+   */
+  accessibility?: Accessibility<AccordionTitleBehaviorProps>;
+
   /** Id of the content it owns. */
   accordionContentId?: string;
 
@@ -74,113 +85,166 @@ export const accordionTitleSlotClassNames: AccordionTitleSlotClassNames = {
   contentWrapper: `${accordionTitleClassName}__content-wrapper`,
 };
 
-class AccordionTitle extends UIComponent<WithAsProp<AccordionTitleProps>, any> {
-  static displayName = 'AccordionTitle';
+export type AccordionTitleStylesProps = Required<Pick<AccordionTitleProps, 'disabled' | 'active'>> & {
+  content: boolean;
+};
 
-  static create: ShorthandFactory<AccordionTitleProps>;
-  static shorthandConfig: ShorthandConfig<AccordionTitleProps> = {
-    mappedProp: 'content',
-  };
+export const AccordionTitle: React.FC<WithAsProp<AccordionTitleProps>> &
+  FluentComponentStaticProps<AccordionTitleProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(AccordionTitle.displayName, context.telemetry);
+  setStart();
+  const {
+    contentRef,
+    children,
+    content,
+    indicator,
+    contentWrapper,
+    disabled,
+    accessibility,
+    canBeCollapsed,
+    as,
+    active,
+    accordionContentId,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(AccordionTitle.handledProps, props);
 
-  static deprecated_className = accordionTitleClassName;
-
-  static propTypes = {
-    ...commonPropTypes.createCommon({ content: 'shorthand' }),
-    accordionContentId: PropTypes.string,
-    active: PropTypes.bool,
-    contentRef: customPropTypes.ref,
-    contentWrapper: customPropTypes.wrapperShorthand,
-    canBeCollapsed: PropTypes.bool,
-    disabled: PropTypes.bool,
-    index: PropTypes.number,
-    onClick: PropTypes.func,
-    indicator: customPropTypes.shorthandAllowingChildren,
-  };
-
-  static defaultProps = {
-    accessibility: accordionTitleBehavior,
-    as: 'dt',
-    contentRef: _.noop,
-    indicator: {},
-    contentWrapper: {},
-  };
-
-  actionHandlers = {
-    performClick: e => {
-      e.preventDefault();
-      this.handleClick(e);
+  const getA11yProps = useAccessibility<AccordionTitleBehaviorProps>(accessibility, {
+    debugName: AccordionTitle.displayName,
+    actionHandlers: {
+      performClick: e => {
+        e.preventDefault();
+        e.stopPropagation();
+        handleClick(e);
+      },
     },
-  };
+    mapPropsToBehavior: () => ({
+      content: true,
+      canBeCollapsed,
+      as,
+      active,
+      disabled,
+      accordionContentId,
+    }),
+    rtl: context.rtl,
+  });
 
-  handleClick = (e: React.SyntheticEvent) => {
-    if (!this.props.disabled) {
-      _.invoke(this.props, 'onClick', e, this.props);
+  const { classes, styles: resolvedStyles } = useStyles<AccordionTitleStylesProps>(AccordionTitle.displayName, {
+    className: accordionTitleClassName,
+    mapPropsToStyles: () => ({
+      disabled,
+      content: !!content,
+      active,
+    }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
+
+  const handleClick = (e: React.SyntheticEvent) => {
+    if (!disabled) {
+      _.invoke(props, 'onClick', e, props);
     }
   };
 
-  handleFocus = (e: React.SyntheticEvent) => {
+  const handleFocus = (e: React.SyntheticEvent) => {
     e.stopPropagation();
-    _.invoke(this.props, 'onFocus', e, this.props);
+    _.invoke(props, 'onFocus', e, props);
   };
 
-  handleWrapperOverrides = predefinedProps => ({
+  const handleWrapperOverrides = predefinedProps => ({
     onFocus: (e: React.FocusEvent) => {
-      this.handleFocus(e);
-      _.invoke(predefinedProps, 'onFocus', e, this.props);
+      handleFocus(e);
+      _.invoke(predefinedProps, 'onFocus', e, props);
     },
     onClick: (e: React.MouseEvent) => {
-      this.handleClick(e);
-      _.invoke(predefinedProps, 'onClick', e, this.props);
+      handleClick(e);
+      _.invoke(predefinedProps, 'onClick', e, props);
     },
   });
 
-  renderComponent({ ElementType, classes, unhandledProps, styles, accessibility }) {
-    const { contentRef, children, content, indicator, contentWrapper } = this.props;
-
-    const contentWrapperElement = (
-      <Ref innerRef={contentRef}>
-        {Box.create(contentWrapper, {
-          defaultProps: () => ({
+  const contentWrapperElement = (
+    <Ref innerRef={contentRef}>
+      {Box.create(contentWrapper, {
+        defaultProps: () =>
+          getA11yProps('content', {
             className: accordionTitleSlotClassNames.contentWrapper,
-            styles: styles.contentWrapper,
-            ...accessibility.attributes.content,
-            ...applyAccessibilityKeyHandlers(accessibility.keyHandlers.content, unhandledProps),
+            styles: resolvedStyles.contentWrapper,
           }),
-          overrideProps: predefinedProps => ({
-            children: (
-              <>
-                {Box.create(indicator, {
-                  defaultProps: () => ({
-                    styles: styles.indicator,
-                    accessibility: indicatorBehavior,
+        overrideProps: predefinedProps => ({
+          children: (
+            <>
+              {Box.create(indicator, {
+                defaultProps: () =>
+                  getA11yProps('indicator', {
+                    styles: resolvedStyles.indicator,
                   }),
-                })}
-                {Box.create(content, {
-                  defaultProps: () => ({
-                    styles: styles.content,
-                  }),
-                })}
-              </>
-            ),
-            ...this.handleWrapperOverrides(predefinedProps),
-          }),
-        })}
-      </Ref>
-    );
+              })}
+              {Box.create(content, {
+                defaultProps: () => ({
+                  styles: resolvedStyles.content,
+                }),
+              })}
+            </>
+          ),
+          ...handleWrapperOverrides(predefinedProps),
+        }),
+      })}
+    </Ref>
+  );
 
-    return (
-      <ElementType
-        className={classes.root}
-        {...rtlTextContainer.getAttributes({ forElements: [children] })}
-        {...accessibility.attributes.root}
-        {...unhandledProps}
-        {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
-      >
-        {childrenExist(children) ? children : contentWrapperElement}
-      </ElementType>
-    );
-  }
-}
+  const element = (
+    <ElementType
+      {...rtlTextContainer.getAttributes({ forElements: [children] })}
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...unhandledProps,
+      })}
+    >
+      {childrenExist(children) ? children : contentWrapperElement}
+    </ElementType>
+  );
+  setEnd();
+  return element;
+};
+
+AccordionTitle.displayName = 'AccordionTitle';
+
+AccordionTitle.shorthandConfig = {
+  mappedProp: 'content',
+};
+
+AccordionTitle.propTypes = {
+  ...commonPropTypes.createCommon({ content: 'shorthand' }),
+  accordionContentId: PropTypes.string,
+  active: PropTypes.bool,
+  contentRef: customPropTypes.ref,
+  contentWrapper: customPropTypes.wrapperShorthand,
+  canBeCollapsed: PropTypes.bool,
+  disabled: PropTypes.bool,
+  index: PropTypes.number,
+  onClick: PropTypes.func,
+  indicator: customPropTypes.shorthandAllowingChildren,
+};
+
+AccordionTitle.handledProps = Object.keys(AccordionTitle.propTypes) as any;
+
+AccordionTitle.defaultProps = {
+  accessibility: accordionTitleBehavior,
+  as: 'dt',
+  contentRef: _.noop,
+  indicator: {},
+  contentWrapper: {},
+};
 
 AccordionTitle.create = createShorthandFactory({ Component: AccordionTitle, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -124,7 +124,7 @@ export const AccordionTitle: React.FC<WithAsProp<AccordionTitleProps>> &
       },
     },
     mapPropsToBehavior: () => ({
-      content: true,
+      hasContent: !!content,
       canBeCollapsed,
       as,
       active,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionTitleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionTitleStyles.ts
@@ -1,10 +1,10 @@
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { AccordionTitleProps } from '../../../../components/Accordion/AccordionTitle';
+import { AccordionTitleStylesProps } from '../../../../components/Accordion/AccordionTitle';
 import { AccordionVariables } from './accordionVariables';
 import activeIndicatorUrl from './activeIndicatorUrl';
 import { pxToRem } from '../../../../utils';
 
-const accordionTitleStyles: ComponentSlotStylesPrepared<AccordionTitleProps, AccordionVariables> = {
+const accordionTitleStyles: ComponentSlotStylesPrepared<AccordionTitleStylesProps, AccordionVariables> = {
   root: ({ props: p }) => ({
     display: 'inline-block',
     verticalAlign: 'middle',

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -10,7 +10,7 @@ import {
 
 import { AccordionContentProps } from '../../components/Accordion/AccordionContent';
 import { AccordionProps } from '../../components/Accordion/Accordion';
-import { AccordionTitleProps } from '../../components/Accordion/AccordionTitle';
+import { AccordionTitleStylesProps } from '../../components/Accordion/AccordionTitle';
 import { AlertStylesProps } from '../../components/Alert/Alert';
 import { AnimationProps } from '../../components/Animation/Animation';
 import { AttachmentProps } from '../../components/Attachment/Attachment';
@@ -88,7 +88,7 @@ import { SplitButtonStylesProps } from '../../components/SplitButton/SplitButton
 
 export type TeamsThemeStylesProps = {
   Accordion: AccordionProps;
-  AccordionTitle: AccordionTitleProps;
+  AccordionTitle: AccordionTitleStylesProps;
   AccordionContent: AccordionContentProps;
   Alert: AlertStylesProps;
   Animation: AnimationProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Accordion/AccordionTitle-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Accordion/AccordionTitle-test.tsx
@@ -6,6 +6,7 @@ import { mountWithProvider } from 'test/utils';
 
 describe('AccordionTitle', () => {
   isConformant(AccordionTitle, {
+    constructorName: 'AccordionTitle',
     eventTargets: {
       onClick: `.${accordionTitleSlotClassNames.contentWrapper}`,
     },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `AccordionTitle` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `AccordionTitle`    |
| --------- |
| `disabled` |
| `content` |
| `active` |

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12874)