### PR TITLE
chore(AccordionContent): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Table` component which are passed to styles functions @assuncaocharles ([#12860](https://github.com/microsoft/fluentui/pull/12860))
 - Restricted prop sets in the `TextArea` component which are passed to styles functions, @assuncaocharles ([#12857](https://github.com/microsoft/fluentui/pull/12857))
 - Restricted prop sets in the `AccordionTitle` component which are passed to styles functions, @assuncaocharles ([#12874](https://github.com/microsoft/fluentui/pull/12874))
+- Restricted prop sets in the `AccordionContent` component which are passed to styles functions, @assuncaocharles ([#12875](https://github.com/microsoft/fluentui/pull/12875))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))

--- a/packages/fluentui/accessibility/src/behaviors/Accordion/accordionContentBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Accordion/accordionContentBehavior.ts
@@ -19,7 +19,7 @@ const accordionContentBehavior: Accessibility<AccordionContentBehaviorProps> = p
 
 export default accordionContentBehavior;
 
-type AccordionContentBehaviorProps = {
+export type AccordionContentBehaviorProps = {
   /** id of the accordion title element. */
   accordionTitleId?: string;
 };

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -73,6 +73,7 @@ export { default as accordionBehavior } from './Accordion/accordionBehavior';
 export { default as accordionTitleBehavior } from './Accordion/accordionTitleBehavior';
 export * from './Accordion/accordionTitleBehavior';
 export { default as accordionContentBehavior } from './Accordion/accordionContentBehavior';
+export * from './Accordion/accordionContentBehavior';
 export { default as checkboxBehavior } from './Checkbox/checkboxBehavior';
 export * from './Checkbox/checkboxBehavior';
 export * from './Tooltip/tooltipAsDescriptionBehavior';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionContentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Accordion/accordionContentStyles.ts
@@ -1,7 +1,7 @@
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { AccordionContentProps } from '../../../../components/Accordion/AccordionContent';
+import { AccordionContentStylesProps } from '../../../../components/Accordion/AccordionContent';
 
-const accordionContentStyles: ComponentSlotStylesPrepared<AccordionContentProps> = {
+const accordionContentStyles: ComponentSlotStylesPrepared<AccordionContentStylesProps> = {
   root: ({ props }) => ({
     display: 'none',
     verticalAlign: 'middle',

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -8,7 +8,7 @@ import {
   PrimitiveColors,
 } from '../types';
 
-import { AccordionContentProps } from '../../components/Accordion/AccordionContent';
+import { AccordionContentStylesProps } from '../../components/Accordion/AccordionContent';
 import { AccordionProps } from '../../components/Accordion/Accordion';
 import { AccordionTitleStylesProps } from '../../components/Accordion/AccordionTitle';
 import { AlertStylesProps } from '../../components/Alert/Alert';
@@ -89,7 +89,7 @@ import { SplitButtonStylesProps } from '../../components/SplitButton/SplitButton
 export type TeamsThemeStylesProps = {
   Accordion: AccordionProps;
   AccordionTitle: AccordionTitleStylesProps;
-  AccordionContent: AccordionContentProps;
+  AccordionContent: AccordionContentStylesProps;
   Alert: AlertStylesProps;
   Animation: AnimationProps;
   Attachment: AttachmentProps;

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -88,8 +88,8 @@ import { SplitButtonStylesProps } from '../../components/SplitButton/SplitButton
 
 export type TeamsThemeStylesProps = {
   Accordion: AccordionProps;
-  AccordionTitle: AccordionTitleStylesProps;
   AccordionContent: AccordionContentStylesProps;
+  AccordionTitle: AccordionTitleStylesProps;
   Alert: AlertStylesProps;
   Animation: AnimationProps;
   Attachment: AttachmentProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Accordion/AccordionContent-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Accordion/AccordionContent-test.tsx
@@ -5,7 +5,7 @@ import { isConformant, handlesAccessibility, getRenderedAttribute } from 'test/s
 import { mountWithProviderAndGetComponent } from 'test/utils';
 
 describe('AccordionContent', () => {
-  isConformant(AccordionContent);
+  isConformant(AccordionContent, { constructorName: 'AccordionContent' });
 
   describe('accessiblity', () => {
     handlesAccessibility(AccordionContent);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `AccordionTitle` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `AccordionContent`    |
| --------- |
| `active` |

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12875)