### PR TITLE
Fixing stylis import.

### DIFF
--- a/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
@@ -6,7 +6,7 @@ import { Renderer, RendererChange } from './types';
 
 // `stylis@3` is a CJS library, there are known issues with them:
 // https://github.com/rollup/rollup/issues/1267#issuecomment-446681320
-const Stylis = (_Stylis as any).default || _Stylis
+const Stylis = (_Stylis as any).default || _Stylis;
 
 // We use Stylis only for vendor prefixing, all other capabilities are disabled
 const stylis = new Stylis({

--- a/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
@@ -1,6 +1,5 @@
 import { RULE_TYPE } from 'fela-utils';
-// @ts-ignore
-import Stylis from 'stylis';
+import * as Stylis from 'stylis';
 
 import { Renderer, RendererChange } from './types';
 

--- a/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
@@ -1,7 +1,12 @@
 import { RULE_TYPE } from 'fela-utils';
-import * as Stylis from 'stylis';
+// @ts-ignore
+import _Stylis from 'stylis';
 
 import { Renderer, RendererChange } from './types';
+
+// `stylis@3` is a CJS library, there are known issues with them:
+// https://github.com/rollup/rollup/issues/1267#issuecomment-446681320
+const Stylis = (_Stylis as any).default || _Stylis
 
 // We use Stylis only for vendor prefixing, all other capabilities are disabled
 const stylis = new Stylis({


### PR DESCRIPTION
I am getting errors from my local project using northstar code complaining about the `stylis` import:

![image](https://user-images.githubusercontent.com/1110944/80673595-8b7fe980-8a64-11ea-84fc-32cc6dd81f05.png)

Changing the import to:

```tsx
import * as Stylis from 'stylis';
```

Seems to resolve my project. It seems to break northstar build though.

@layershifter any ideas? 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12910)