### PR TITLE
Change useBoolean to preserve toggle callback identity

### DIFF
--- a/change/@uifabric-react-hooks-2020-04-28-17-35-54-useBoolean-callback.json
+++ b/change/@uifabric-react-hooks-2020-04-28-17-35-54-useBoolean-callback.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Change useBoolean to preserve toggle callback identity",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T00:35:54.629Z"
+}

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -91,7 +91,7 @@ The hook returns a tuple containing the current value and an object with callbac
 
 - `setTrue: () => void`: Set the value to true. Always has the same identity.
 - `setFalse: () => void`: Set the value to false. Always has the same identity.
-- `toggle: () => void`: Toggle the value. If the value is currently true, this will be the `setFalse` callback. If it's currently false, this will be the `setTrue` callback.
+- `toggle: () => void`: Toggle the value. Always has the same identity.
 
 ### Example
 

--- a/packages/react-hooks/src/useBoolean.test.tsx
+++ b/packages/react-hooks/src/useBoolean.test.tsx
@@ -34,6 +34,7 @@ describe('useBoolean', () => {
     // Callbacks should be the same
     expect(callbacks!.setTrue).toBe(result1.setTrue);
     expect(callbacks!.setFalse).toBe(result1.setFalse);
+    expect(callbacks!.toggle).toBe(result1.toggle);
   });
 
   it('updates the value', () => {
@@ -68,19 +69,14 @@ describe('useBoolean', () => {
     };
 
     mount(<TestComponent />);
-    // correct callback used
-    expect(callbacks!.toggle).toBe(callbacks!.setFalse);
 
     // Toggle the value
     act(() => callbacks.toggle());
     // correct new value
     expect(value!).toBe(false);
-    // correct new callback
-    expect(callbacks!.toggle).toBe(callbacks!.setTrue);
 
     // Toggle again
     act(() => callbacks.toggle());
     expect(value!).toBe(true);
-    expect(callbacks!.toggle).toBe(callbacks!.setFalse);
   });
 });

--- a/packages/react-hooks/src/useBoolean.ts
+++ b/packages/react-hooks/src/useBoolean.ts
@@ -7,30 +7,32 @@ export interface IUseBooleanCallbacks {
   setTrue: () => void;
   /** Set the value to false. Always has the same identity. */
   setFalse: () => void;
-  /**
-   * Toggle the value. If `value` is true, this will be the `setFalse` callback.
-   * If `value` is false, this will be the `setTrue` callback.
-   */
+  /** Toggle the value. Always has the same identity. */
   toggle: () => void;
 }
 
 /**
  * Hook to store a value and generate callbacks for setting the value to true or false.
- * The identity of the `setTrue` and `setFalse` callbacks will always stay the same.
+ * The identity of the callbacks will always stay the same.
  *
  * @param initialState - Initial value
  * @returns Array with the current value and an object containing the updater callbacks.
  */
 export function useBoolean(initialState: boolean): [boolean, IUseBooleanCallbacks] {
   const [value, setValue] = React.useState(initialState);
-  const setTrue = useConstCallback(() => setValue(true));
-  const setFalse = useConstCallback(() => setValue(false));
-  return [
-    value,
-    {
-      setTrue,
-      setFalse,
-      toggle: value ? setFalse : setTrue,
-    },
-  ];
+  // Storing the value in a ref is redundant but allows the `toggle` callback to have a
+  // constant identity, which overall is probably better for consumers' perf.
+  const valueRef = React.useRef(value);
+
+  const setTrue = useConstCallback(() => {
+    setValue(true);
+    valueRef.current = true;
+  });
+  const setFalse = useConstCallback(() => {
+    setValue(false);
+    valueRef.current = false;
+  });
+  const toggle = useConstCallback(() => (valueRef.current ? setFalse() : setTrue()));
+
+  return [value, { setTrue, setFalse, toggle }];
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

For the `useBoolean` `toggle` callback, previously I had it return the `setFalse` callback when `value` was `true` and `setTrue` otherwise. This means that when a consumer passes `toggle` as a prop or includes it as an argument to `useMemo` or `useCallback`, it will mutate every time the value changes, which is probably not ideal. (Noticed this when reviewing @czearing's example updates.)

This PR changes the hook to store `value` in a ref (in addition to state) so the current value is always accessible to the `toggle` callback without mutating its identity.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12912)