### PR TITLE
update MessageBarButton border color

### DIFF
--- a/change/office-ui-fabric-react-2020-04-29-14-30-19-update_MessageBarButtonBorder_color.json
+++ b/change/office-ui-fabric-react-2020-04-29-14-30-19-update_MessageBarButtonBorder_color.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update MessageBarButtonBorder color",
+  "packageName": "office-ui-fabric-react",
+  "email": "chrismo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-29T21:30:19.251Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
@@ -1,28 +1,25 @@
 import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, getFocusStyle } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
-import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
 
 export const getStyles = memoizeFunction(
-  (theme: ITheme, customStyles?: IButtonStyles, focusInset?: string, focusColor?: string): IButtonStyles => {
-    const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const messageBarButtonStyles: IButtonStyles = {
-      root: [
-        getFocusStyle(theme, {
-          inset: 1,
-          highContrastStyle: {
-            outlineOffset: '-4px',
-            outlineColor: 'ActiveBorder',
+  (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles =>
+    concatStyleSets(
+      {
+        root: [
+          getFocusStyle(theme, {
+            inset: 1,
+            highContrastStyle: {
+              outlineOffset: '-4px',
+              outlineColor: 'ActiveBorder',
+            },
+            borderColor: 'transparent',
+          }),
+          {
+            height: 24,
           },
-          borderColor: 'transparent',
-        }),
-        {
-          height: 24,
-          borderColor: theme.palette.neutralTertiaryAlt,
-        },
-      ],
-    };
-
-    return concatStyleSets(baseButtonStyles, messageBarButtonStyles, customStyles)!;
-  },
+        ],
+      },
+      customStyles,
+    ),
 );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9184
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates default MessageBarButton border to match designs.

Previously MessageBarButton overrode the borderColor to be `theme.palette.neutralTertiaryAlt`.  I've removed this override to allow it to take on the default button border styles. 

Alternatively we could consider adding a new slot, `MessageButtonBorder`, if we want to ensure more consistency.

|Before | After
|-|-|
|![beforeLight](https://user-images.githubusercontent.com/601657/80648272-bd715b80-8a24-11ea-9d33-52c8376e7b56.png)|![afterLight](https://user-images.githubusercontent.com/601657/80648266-bc402e80-8a24-11ea-8940-982f79cd81c8.png)|
|![beforeDark](https://user-images.githubusercontent.com/601657/80648274-bd715b80-8a24-11ea-8f09-b2de6e0ad544.png)|![afterDark](https://user-images.githubusercontent.com/601657/80648268-bcd8c500-8a24-11ea-9ec7-80809ab3e84f.png)|



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12932)