### PR TITLE
Add an imperitive focus call to handleTouch

### DIFF
--- a/change/office-ui-fabric-react-2020-04-30-08-38-06-fixSplitButtonFocusIssue.json
+++ b/change/office-ui-fabric-react-2020-04-30-08-38-06-fixSplitButtonFocusIssue.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "lego6245@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T15:38:06.762Z"
+}

--- a/change/office-ui-fabric-react-2020-04-30-08-38-06-fixSplitButtonFocusIssue.json
+++ b/change/office-ui-fabric-react-2020-04-30-08-38-06-fixSplitButtonFocusIssue.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "packageName": "office-ui-fabric-react",
-  "email": "lego6245@gmail.com",
-  "dependentChangeType": "patch",
-  "date": "2020-04-30T15:38:06.762Z"
-}

--- a/change/office-ui-fabric-react-2020-04-30-08-39-01-fixSplitButtonFocusIssue.json
+++ b/change/office-ui-fabric-react-2020-04-30-08-39-01-fixSplitButtonFocusIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix focus returning to input fields in touch scenarios",
+  "packageName": "office-ui-fabric-react",
+  "email": "lego6245@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T15:39:01.383Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -861,7 +861,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   }
 
   private _handleTouchAndPointerEvent() {
-    // Touch and pointer events don't focus the button naturally.
+    // Touch and pointer events don't focus the button naturally, so adding an imperative focus call to guarantee this behavior.
     this.focus();
 
     // If we already have an existing timeeout from a previous touch and pointer event

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -136,31 +136,31 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
     this._classNames = getClassNames
       ? getClassNames(
-        theme!,
-        className!,
-        variantClassName!,
-        iconProps && iconProps.className,
-        menuIconProps && menuIconProps.className,
-        isPrimaryButtonDisabled!,
-        checked!,
-        !menuHidden,
-        !!this.props.menuProps,
-        this.props.split,
-        !!allowDisabledFocus,
-      )
+          theme!,
+          className!,
+          variantClassName!,
+          iconProps && iconProps.className,
+          menuIconProps && menuIconProps.className,
+          isPrimaryButtonDisabled!,
+          checked!,
+          !menuHidden,
+          !!this.props.menuProps,
+          this.props.split,
+          !!allowDisabledFocus,
+        )
       : getBaseButtonClassNames(
-        theme!,
-        styles!,
-        className!,
-        variantClassName!,
-        iconProps && iconProps.className,
-        menuIconProps && menuIconProps.className,
-        isPrimaryButtonDisabled!,
-        !!this.props.menuProps,
-        checked!,
-        !menuHidden,
-        this.props.split,
-      );
+          theme!,
+          styles!,
+          className!,
+          variantClassName!,
+          iconProps && iconProps.className,
+          menuIconProps && menuIconProps.className,
+          isPrimaryButtonDisabled!,
+          !!this.props.menuProps,
+          checked!,
+          !menuHidden,
+          this.props.split,
+        );
 
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     // Anchor tag cannot be disabled hence in disabled state rendering
@@ -345,8 +345,8 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {(keytipAttributes: any): JSX.Element => Button(keytipAttributes)}
       </KeytipData>
     ) : (
-        Button()
-      );
+      Button()
+    );
 
     if (menuProps && menuProps.doNotLayer) {
       return (
@@ -642,8 +642,8 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {(keytipAttributes: any): JSX.Element => SplitButton(keytipAttributes)}
       </KeytipData>
     ) : (
-        SplitButton()
-      );
+      SplitButton()
+    );
   }
 
   private _onSplitContainerFocusCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
@@ -861,7 +861,8 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   }
 
   private _handleTouchAndPointerEvent() {
-    // Touch and pointer events don't focus the button naturally, so adding an imperative focus call to guarantee this behavior.
+    // Touch and pointer events don't focus the button naturally,
+    // so adding an imperative focus call to guarantee this behavior.
     this.focus();
 
     // If we already have an existing timeeout from a previous touch and pointer event

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -136,31 +136,31 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
     this._classNames = getClassNames
       ? getClassNames(
-          theme!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          isPrimaryButtonDisabled!,
-          checked!,
-          !menuHidden,
-          !!this.props.menuProps,
-          this.props.split,
-          !!allowDisabledFocus,
-        )
+        theme!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        isPrimaryButtonDisabled!,
+        checked!,
+        !menuHidden,
+        !!this.props.menuProps,
+        this.props.split,
+        !!allowDisabledFocus,
+      )
       : getBaseButtonClassNames(
-          theme!,
-          styles!,
-          className!,
-          variantClassName!,
-          iconProps && iconProps.className,
-          menuIconProps && menuIconProps.className,
-          isPrimaryButtonDisabled!,
-          !!this.props.menuProps,
-          checked!,
-          !menuHidden,
-          this.props.split,
-        );
+        theme!,
+        styles!,
+        className!,
+        variantClassName!,
+        iconProps && iconProps.className,
+        menuIconProps && menuIconProps.className,
+        isPrimaryButtonDisabled!,
+        !!this.props.menuProps,
+        checked!,
+        !menuHidden,
+        this.props.split,
+      );
 
     const { _ariaDescriptionId, _labelId, _descriptionId } = this;
     // Anchor tag cannot be disabled hence in disabled state rendering
@@ -345,8 +345,8 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {(keytipAttributes: any): JSX.Element => Button(keytipAttributes)}
       </KeytipData>
     ) : (
-      Button()
-    );
+        Button()
+      );
 
     if (menuProps && menuProps.doNotLayer) {
       return (
@@ -642,8 +642,8 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
         {(keytipAttributes: any): JSX.Element => SplitButton(keytipAttributes)}
       </KeytipData>
     ) : (
-      SplitButton()
-    );
+        SplitButton()
+      );
   }
 
   private _onSplitContainerFocusCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
@@ -861,6 +861,9 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
   }
 
   private _handleTouchAndPointerEvent() {
+    // Touch and pointer events don't focus the button naturally.
+    this.focus();
+
     // If we already have an existing timeeout from a previous touch and pointer event
     // cancel that timeout so we can set a nwe one.
     if (this._lastTouchTimeoutId !== undefined) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12486 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Split buttons in touch scenarios would return to their last focused input when tapped twice. This made interactions with them more difficult. Adding an imperative `focus` call as part of handling the touch events, as suggested by @khmakoto, worked well to resolve this issue, and made the touch handling match closer to the click handling (which does this behavior as part of the browser handling of click events)

#### Focus areas to test

Button interactions in touch scenarios.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12946)