### PR TITLE
ContextualMenu: add aria-selected to checked menu items

### DIFF
--- a/change/office-ui-fabric-react-2020-04-30-14-38-07-fix-accessibility-issues.json
+++ b/change/office-ui-fabric-react-2020-04-30-14-38-07-fix-accessibility-issues.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix accessibility issue",
+  "packageName": "office-ui-fabric-react",
+  "email": "xiameng@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-04-30T21:38:07.855Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -70,8 +70,8 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': isItemDisabled(item),
-      'aria-checked': itemRole == 'menuitemcheckbox' && canCheck ? !!isChecked : undefined,
-      'aria-selected': itemRole == 'menuitem' && canCheck ? !!isChecked : undefined,
+      'aria-checked': itemRole === 'menuitemcheckbox' && canCheck ? !!isChecked : undefined,
+      'aria-selected': itemRole === 'menuitem' && canCheck ? !!isChecked : undefined,
       role: itemRole,
       // tslint:disable-next-line:deprecation
       style: item.style,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -6,6 +6,7 @@ import { getIsChecked, isItemDisabled, hasSubmenu, getMenuItemAriaRole } from '.
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
 import { IKeytipProps } from '../../Keytip/Keytip.types';
+import { itemButton } from '../../pickers/Suggestions/Suggestions.scss';
 
 export class ContextualMenuButton extends ContextualMenuItemWrapper {
   private _btn = React.createRef<HTMLButtonElement>();
@@ -50,6 +51,8 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
     // Do not add the disabled attribute to the button so that it is focusable
     delete buttonNativeProperties.disabled;
 
+    const itemRole = item.role || defaultRole;
+
     const itemButtonProperties = {
       className: classNames.root,
       onClick: this._onItemClick,
@@ -65,11 +68,12 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-haspopup': itemHasSubmenu || undefined,
       'aria-owns': item.key === expandedMenuItemKey ? subMenuId : undefined,
       'aria-expanded': itemHasSubmenu ? item.key === expandedMenuItemKey : undefined,
-      'aria-selected': canCheck ? !!isChecked : undefined,
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': isItemDisabled(item),
-      role: item.role || defaultRole,
+      'aria-checked': itemRole == 'menuitemcheckbox' && canCheck ? !!isChecked : undefined,
+      'aria-selected': itemRole == 'menuitem' && canCheck ? !!isChecked : undefined,
+      role: itemRole,
       // tslint:disable-next-line:deprecation
       style: item.style,
     };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -6,7 +6,6 @@ import { getIsChecked, isItemDisabled, hasSubmenu, getMenuItemAriaRole } from '.
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
 import { IKeytipProps } from '../../Keytip/Keytip.types';
-import { itemButton } from '../../pickers/Suggestions/Suggestions.scss';
 
 export class ContextualMenuButton extends ContextualMenuItemWrapper {
   private _btn = React.createRef<HTMLButtonElement>();

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -65,7 +65,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-haspopup': itemHasSubmenu || undefined,
       'aria-owns': item.key === expandedMenuItemKey ? subMenuId : undefined,
       'aria-expanded': itemHasSubmenu ? item.key === expandedMenuItemKey : undefined,
-      'aria-checked': canCheck ? !!isChecked : undefined,
+      'aria-selected': canCheck ? !!isChecked : undefined,
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': isItemDisabled(item),


### PR DESCRIPTION
#### Pull request checklist
- [x] Include a change request file using `$ yarn change`

#### Description of changes
In contextmenubutton drop down, aria-checked is not a valid aria property for announciator to announce the checked state. Change aria-checked to aria-selected


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12952)