### PR TITLE
update iOS source code links and names

### DIFF
--- a/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSAvatarView`
+`AvatarView` in Swift, `MSFAvatarView` in Objective-C
 
 ### Source code
 
-[MSAvatarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/MSAvatarView.swift)
+[AvatarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/AvatarView.swift)
 
 ### Sample code
 
-[MSAvatarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSAvatarViewDemoController.swift)
+[AvatarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/AvatarViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
+++ b/apps/fabric-website/src/pages/Controls/AvatarPage/docs/ios/AvatarOverview.md
@@ -1,8 +1,8 @@
-`MSAvatarView` displays either a photo or the initials of a person on circular background and displays entity or group on square background.
+`AvatarView` displays either a photo or the initials of a person on circular background and displays entity or group on square background.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 
-### Intials
+### Initials
 
 <img className="off" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_avatar_02_initials.png?text=LightMode" />
 <img className="on" src="https://static2.sharepointonline.com/files/fabric/fabric-website/images/controls/ios/updated/img_avatar_02_initials_dark.png?text=DarkMode" />

--- a/apps/fabric-website/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/BottomNavigationPage/docs/ios/BottomNavigationImplementation.md
@@ -1,15 +1,15 @@
 ### Control name
 
-`MSTabBarView`
+`TabBarView` in Swift, `MSFTabBarView` in Objective-C
 
-`MSTabBarItem`
+`TabBarItem` in Swift, `MSFTabBarItem` in Objective-C
 
 ### Source code
 
-[MSTabBarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/MSTabBarView.swift)
+[TabBarView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/TabBarView.swift)
 
-[MSTabBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/MSTabBarItem.swift)
+[TabBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tab%20Bar/TabBarItem.swift)
 
 ### Sample code
 
-[MSTabBarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSTabBarViewDemoController.swift)
+[TabBarView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TabBarViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
@@ -4,8 +4,8 @@
 
 ### Source code
 
-[Button](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSButton.swift)
+[Button](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Button.swift)
 
 ### Sample code
 
-[Button demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSButtonDemoController.swift)
+[Button demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ButtonDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/docs/ios/ButtonImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSButton`
+`Button` in Swift, `MSFButton` in Objective-C
 
 ### Source code
 
-[MSButton](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSButton.swift)
+[Button](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSButton.swift)
 
 ### Sample code
 
-[MSButton demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSButtonDemoController.swift)
+[Button demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSButtonDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ChipPage/docs/ios/ChipImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ChipPage/docs/ios/ChipImplementation.md
@@ -1,17 +1,17 @@
 ### Control name
 
-`MSBadgeView` Individual chip/badge object
+`BadgeView` in Swift, `MSFBadgeView` in Objective-C: Individual chip/badge object
 
-`MSBadgeField` Input field lets users type in names that get resolved into badges, enabled delete and drag & drop.
+`BadgeField` in Swift, `MSFBadgeField` in Objective-C: Input field lets users type in names that get resolved into badges, enabled delete and drag & drop.
 
 ### Source code
 
-[MSBadgeView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/MSBadgeView.swift)
+[BadgeView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/BadgeView.swift)
 
-[MSBadgeField](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/MSBadgeField.swift)
+[BadgeField](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Badge%20Field/BadgeField.swift)
 
 ### Sample code
 
-[MSBadgeView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSBadgeViewDemoController.swift)
+[BadgeView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeViewDemoController.swift)
 
-[MSBadgeField demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSBadgeFieldDemoController.swift)
+[BadgeField demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/BadgeFieldDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/DatePickerPage/docs/ios/DateTimePickerImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSDateTimePicker`
+`DateTimePicker` in Swift, `MSFDateTimePicker` in Objective-C
 
 ### Source code
 
-[MSDateTimePicker](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Date%20Time%20Pickers/MSDateTimePicker.swift)
+[DateTimePicker](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Date%20Time%20Pickers/DateTimePicker.swift)
 
 ### Sample code
 
-[MSDateTimePicker demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSDateTimePickerDemoController.swift)
+[DateTimePicker demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/DateTimePickerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/DrawerPage/docs/ios/DrawerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/DrawerPage/docs/ios/DrawerImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSDrawerController`
+`DrawerController` in Swift, `MSFDrawerController` in Objective-C
 
 ### Source code
 
-[MSDrawerController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Drawer/MSDrawerController.swift)
+[DrawerController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Drawer/DrawerController.swift)
 
 ### Sample code
 
-[MSDrawerController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSDrawerDemoController.swift)
+[DrawerController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/DrawerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/ListCellsPage/docs/ios/ListCellsImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ListCellsPage/docs/ios/ListCellsImplementation.md
@@ -1,35 +1,35 @@
 ### Control name
 
-`MSTableViewCell`
+`TableViewCell` in Swift, `MSFTableViewCell` in Objective-C
 
-`MSActionsCell`
+`ActionsCell` in Swift, `MSFActionsCell` in Objective-C
 
-`MSActivityIndicatorCell`
+`ActivityIndicatorCell` in Swift, `MSFActivityIndicatorCell` in Objective-C
 
-`MSCenteredLabelCell`
+`CenteredLabelCell` in Swift, `MSFCenteredLabelCell` in Objective-C
 
-`MSBooleanCell`
+`BooleanCell` in Swift, `MSFBooleanCell` in Objective-C
 
-`MSTableViewHeaderFooterView`
+`TableViewHeaderFooterView` in Swift, `MSFTableViewHeaderFooterView` in Objective-C
 
 ### Source code
 
-[MSTableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSTableViewCell.swift)
+[TableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewCell.swift)
 
-[MSActionsCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSActionsCell.swift)
+[ActionsCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/ActionsCell.swift)
 
-[MSActivityIndicatorCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSActivityIndicatorCell.swift)
+[ActivityIndicatorCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/ActivityIndicatorCell.swift)
 
-[MSCenteredLabelCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSCenteredLabelCell.swift)
+[CenteredLabelCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/CenteredLabelCell.swift)
 
-[MSBooleanCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSBooleanCell.swift)
+[BooleanCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/BooleanCell.swift)
 
-[MSTableViewHeaderFooterView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSTableViewHeaderFooterView.swift)
+[TableViewHeaderFooterView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewHeaderFooterView.swift)
 
 ### Sample code
 
-[MSTableViewCell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSTableViewCellDemoController.swift)
+[TableViewCell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellDemoController.swift)
 
 [Other cells demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/OtherCellsDemoController.swift)
 
-[MSTableViewHeaderFooterView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSTableViewHeaderFooterViewDemoController.swift)
+[TableViewHeaderFooterView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewHeaderFooterViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSNotificationView`
+`NotificationView` in Swift, `MSFNotificationView` in Objective-C
 
 ### Source code
 
-[MSNotificationView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Notification/MSNotificationView.swift)
+[NotificationView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Notification/NotificationView.swift)
 
 ### Sample code
 
-[MSNotificationView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSNotificationViewDemoController.swift)
+[NotificationView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/NotificationViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
+++ b/apps/fabric-website/src/pages/Controls/MessageBarPage/docs/ios/MessageBarOverview.md
@@ -1,4 +1,4 @@
-`MSNotificationView` can be used to present a toast (`.primaryToast` and `.neutralToast` styles) or a message bar (`.primaryBar`, `.primaryOutlineBar`, and `.neutralBar` styles) with information and actions at the bottom of the screen.
+`NotificationView` can be used to present a toast (`.primaryToast` and `.neutralToast` styles) or a message bar (`.primaryBar`, `.primaryOutlineBar`, and `.neutralBar` styles) with information and actions at the bottom of the screen.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 

--- a/apps/fabric-website/src/pages/Controls/NavBarPage/docs/ios/NavBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/NavBarPage/docs/ios/NavBarImplementation.md
@@ -1,15 +1,15 @@
 ### Control name
 
-`MSNavigationController`
+`NavigationController` in Swift, `MSFNavigationController` in Objective-C
 
-`MSSearchBar`
+`SearchBar` in Swift, `MSFSearchBar` in Objective-C
 
 ### Source code
 
-[MSNavigationController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Navigation/MSNavigationController.swift)
+[NavigationController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Navigation/NavigationController.swift)
 
-[MSSearchBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSSearchBar.swift)
+[SearchBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/SearchBar.swift)
 
 ### Sample code
 
-[MSNavigationController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSNavigationControllerDemoController.swift)
+[NavigationController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/NavigationControllerDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaImplementation.md
@@ -1,15 +1,15 @@
 ### Control names
 
-`MSPersonaListView`
+`PersonaListView` in Swift, `MSFPersonaListView` in Objective-C
 
-`MSPersonaCell`
+`PersonaCell` in Swift, `MSFPersonaCell` in Objective-C
 
 ### Source code
 
-[MSPersonaListView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/MSPersonaListView.swift)
+[PersonaListView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/PersonaListView.swift)
 
-[MSPersonaCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/MSPersonaCell.swift)
+[PersonaCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/People%20Picker/PersonaCell.swift)
 
 ### Sample code
 
-[MSPersonaListView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSPersonaListViewDemoController.swift)
+[PersonaListView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PersonaListViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaOverview.md
+++ b/apps/fabric-website/src/pages/Controls/PersonaPage/docs/ios/PersonaOverview.md
@@ -4,7 +4,7 @@ Persona controls display the profile picture and online status of the user. When
 
 Besides a profile picture, Persona controls can include text elements. The user's full name can show alongside other metadata, such as job title, company, and more.
 
-Persona controls are also available as a performant list view. The `MSPersonaListView` controls are perfect for listing many people. Examples of this may be an Address Book or a People Picker auto-complete experience.
+Persona controls are also available as a performant list view. The `PersonaListView` controls are perfect for listing many people. Examples of this may be an Address Book or a People Picker auto-complete experience.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 

--- a/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarImplementation.md
@@ -1,19 +1,19 @@
 ### Control name
 
-`MSPillButtonBar`
+`PillButtonBar` in Swift, `MSFPillButtonBar` in Objective-C
 
-`MSPillButtonBarItem`
+`PillButtonBarItem` in Swift, `MSFPillButtonBarItem` in Objective-C
 
-`MSPillButtonBarDelegate`
+`PillButtonBarDelegate` in Swift, `MSFPillButtonBarDelegate` in Objective-C
 
 ### Source code
 
-[MSPillButtonBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/MSPillButtonBar.swift)
+[PillButtonBar](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
-[MSPillButtonBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/MSPillButtonBar.swift)
+[PillButtonBarItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
-[MSPillButtonBarDelegate](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/MSPillButtonBar.swift)
+[PillButtonBarDelegate](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Pill%20Button%20Bar/PillButtonBar.swift)
 
 ### Sample code
 
-[MSPillButtonBar demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSPillButtonBarDemoController.swift)
+[PillButtonBar demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PillButtonBarDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarOverview.md
+++ b/apps/fabric-website/src/pages/Controls/PillButtonBarPage/docs/ios/PillButtonBarOverview.md
@@ -1,4 +1,4 @@
-`MSPillButtonBar` is a horizontal scrollable list of pill-shaped text buttons in which only one button can be selected at a given time.
+`PillButtonBar` is a horizontal scrollable list of pill-shaped text buttons in which only one button can be selected at a given time.
 
 <!-- prettier-ignore-start -->
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">

--- a/apps/fabric-website/src/pages/Controls/PivotPage/docs/ios/PivotImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PivotPage/docs/ios/PivotImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSSegmentedControl`
+`SegmentedControl` in Swift, `MSFSegmentedControl` in Objective-C
 
 ### Source code
 
-[MSSegmentedControl](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSSegmentedControl.swift)
+[SegmentedControl](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/SegmentedControl.swift)
 
 ### Sample code
 
-[MSSegmentedControl demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSSegmentedControlDemoController.swift)
+[SegmentedControl demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/SegmentedControlDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
@@ -2,9 +2,13 @@
 
 `PopupMenuController` in Swift, `MSFPopupMenuController` in Objective-C
 
+`PopupMenuItem` in Swift, `MSFPopupMenuItem` in Objective-C
+
 ### Source code
 
 [PopupMenuController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/PopupMenuController.swift)
+
+[PopupMenuItem](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/PopupMenuItem.swift)
 
 ### Sample code
 

--- a/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSPopupMenuController`
+`PopupMenuController` in Swift, `MSFPopupMenuController` in Objective-C
 
 ### Source code
 
-[MSPopupMenuController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/MSPopupMenuController.swift)
+[PopupMenuController](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Popup%20Menu/PopupMenuController.swift)
 
 ### Sample code
 
-[MSPopupMenuController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSPopupMenuDemoController.swift)
+[PopupMenuController demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/PopupMenuDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/ios/SeparatorImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/SeparatorPage/docs/ios/SeparatorImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSSeparator`
+`Separator` in Swift, `MSFSeparator` in Objective-C
 
 ### Source code
 
-[MSSeparator](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSSeparator.swift)
+[Separator](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Separator.swift)
 
 ### Sample code
 
-[Used in MSTableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/MSTableViewCell.swift)
+[Used in TableViewCell](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Table%20View/TableViewCell.swift)

--- a/apps/fabric-website/src/pages/Controls/ShimmerPage/docs/ios/ShimmerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/ShimmerPage/docs/ios/ShimmerImplementation.md
@@ -1,17 +1,17 @@
 ### Control name
 
-`MSShimmerView`
+`ShimmerView` in Swift, `MSFShimmerView` in Objective-C
 
-`MSShimmerLinesView`
+`ShimmerLinesView` in Swift, `MSFShimmerLinesView` in Objective-C
 
 ### Source code
 
-[MSShimmerView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/MSShimmerView.swift)
+[ShimmerView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/ShimmerView.swift)
 
-[MSShimmerLinesView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/MSShimmerLinesView.swift)
+[ShimmerLinesView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Shimmer/ShimmerLinesView.swift)
 
 ### Sample code
 
-[MSShimmerView in Table View Cell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSTableViewCellShimmerDemoController.swift)
+[ShimmerView in Table View Cell demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TableViewCellShimmerDemoController.swift)
 
-[MSShimmerLinesView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSShimmerLinesViewDemoController.swift)
+[ShimmerLinesView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ShimmerLinesViewDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerImplementation.md
@@ -1,17 +1,17 @@
 ### Control name
 
-`MSActivityIndicatorView` The spinning element.
+`ActivityIndicatorView`in Swift, `MSFActivityIndicatorView` in Objective-C: The spinning element.
 
-`MSHUD` The overlay with large spinner and modes.
+`HUD` in Swift, `MSFHUD` in Objective-C: The overlay with large spinner and modes.
 
 ### Source code
 
-[MSActivityIndicatorView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSActivityIndicatorView.swift)
+[ActivityIndicatorView](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/ActivityIndicatorView.swift)
 
-[MSHUD](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/HUD/MSHUD.swift)
+[HUD](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/HUD/HUD.swift)
 
 ### Sample code
 
-[MSActivityIndicatorView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSActivityIndicatorViewDemoController.swift)
+[ActivityIndicatorView demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/ActivityIndicatorViewDemoController.swift)
 
-[MSHUD demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSHUDDemoController.swift)
+[HUD demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/HUDDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
+++ b/apps/fabric-website/src/pages/Controls/SpinnerPage/docs/ios/SpinnerOverview.md
@@ -4,7 +4,7 @@ For pauses between 2 seconds and 400 milliseconds, adding animations may actuall
 
 Use a standalone spinner when you need a progress indicator on an existing surface (such as a view that's already displayed but no content is shown yet, or when the user pulls-to-refresh, revealing the empty space above the scrolling list).
 
-For actions that happen "between views", you can use the progress indicator that lives in its own overlay, the `MSHUD`.
+For actions that happen "between views", you can use the progress indicator that lives in its own overlay, the `HUD`.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 

--- a/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSLabel`
+`Label` in Swift, `MSFLabel` in Objective-C
 
 ### Source code
 
-[MSLabel](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/MSLabel.swift)
+[Label](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Controls/Label.swift)
 
 ### Sample code
 
-[MSLabel demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSLabelDemoController.swift)
+[Label demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/LabelDemoController.swift)

--- a/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextOverview.md
+++ b/apps/fabric-website/src/pages/Controls/TextPage/docs/ios/TextOverview.md
@@ -1,4 +1,4 @@
-Use `MSLabel` to standardize text across your app.
+Use `Label` to standardize text across your app.
 
 <DisplayToggle onText="Dark" offText="Light" label="Theme Switcher">
 

--- a/apps/fabric-website/src/pages/Controls/TooltipPage/docs/ios/TooltipImplementation.md
+++ b/apps/fabric-website/src/pages/Controls/TooltipPage/docs/ios/TooltipImplementation.md
@@ -1,11 +1,11 @@
 ### Control name
 
-`MSTooltip`
+`Tooltip` in Swift, `MSFTooltip` in Objective-C
 
 ### Source code
 
-[MSTooltip](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tooltip/MSTooltip.swift)
+[Tooltip](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI/Tooltip/Tooltip.swift)
 
 ### Sample code
 
-[MSTooltip demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/MSTooltipDemoController.swift)
+[Tooltip demo](https://github.com/microsoft/fluentui-apple/blob/master/ios/FluentUI.Demo/FluentUI.Demo/Demos/TooltipDemoController.swift)


### PR DESCRIPTION
Recently, sdk filenames have changed and controls names are different.
class MSFFoo for ObjC and class Foo for Swift

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12957)