### PR TITLE
chore(Divider): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Embed` component which are passed to styles functions, @assuncaocharles ([#12918](https://github.com/microsoft/fluentui/pull/12918))
 - Restricted prop sets in the `CarouselNavigationItem` component which are passed to styles functions, @assuncaocharles ([#12920](https://github.com/microsoft/fluentui/pull/12920))
 - Restricted prop sets in the `CarouselItem` component which are passed to styles functions, @assuncaocharles ([#12938](https://github.com/microsoft/fluentui/pull/12938))
+- Restricted prop sets in the `Divider` component which are passed to styles functions, @assuncaocharles ([#12977](https://github.com/microsoft/fluentui/pull/12977))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))

--- a/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
@@ -95,9 +95,9 @@ export const Divider: React.FC<WithAsProp<DividerProps>> & FluentComponentStatic
     <ElementType
       {...getA11yProps('root', {
         className: classes.root,
+        ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
         ...unhandledProps,
       })}
-      {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
     >
       {childrenExist(children) ? children : content}
     </ElementType>

--- a/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
@@ -25,7 +25,7 @@ export interface DividerProps
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<never>;
 
   /** A divider can be fitted, without any space above or below it. */
   fitted?: boolean;
@@ -42,7 +42,6 @@ export interface DividerProps
 
 export type DividerStylesProps = Required<
   Pick<DividerProps, 'color' | 'fitted' | 'size' | 'important' | 'vertical'> & {
-    hasChildren: boolean;
     hasContent: boolean;
   }
 >;
@@ -69,15 +68,14 @@ export const Divider: React.FC<WithAsProp<DividerProps>> & FluentComponentStatic
   } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Divider.handledProps, props);
-  const getA11yProps = useAccessibility(accessibility, {
+  const getA11yProps = useAccessibility<never>(accessibility, {
     debugName: Divider.displayName,
     rtl: context.rtl,
   });
   const { classes } = useStyles<DividerStylesProps>(Divider.displayName, {
     className: dividerClassName,
     mapPropsToStyles: () => ({
-      hasChildren: childrenExist(children),
-      hasContent: !!content,
+      hasContent: childrenExist(children) || !!content,
       color,
       fitted,
       size,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
@@ -1,16 +1,16 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import * as _ from 'lodash';
 
-import { childrenExist, pxToRem } from '../../../../utils';
+import { pxToRem } from '../../../../utils';
 import { StrictColorScheme, ItemType } from '../../../types';
 import { DividerVariables, dividerColorAreas } from './dividerVariables';
-import { DividerProps } from '../../../../components/Divider/Divider';
+import { DividerStylesProps } from '../../../../components/Divider/Divider';
 
 const beforeAndAfter = (
   size: number,
   variables: DividerVariables,
   colors: StrictColorScheme<ItemType<typeof dividerColorAreas>>,
-  props: DividerProps,
+  props: DividerStylesProps,
 ): ICSSInJSStyle => ({
   content: '""',
   flex: 1,
@@ -18,9 +18,9 @@ const beforeAndAfter = (
   background: _.get(colors, 'foreground', variables.dividerColor),
 });
 
-const dividerStyles: ComponentSlotStylesPrepared<DividerProps, DividerVariables> = {
+const dividerStyles: ComponentSlotStylesPrepared<DividerStylesProps, DividerVariables> = {
   root: ({ props, variables }): ICSSInJSStyle => {
-    const { children, color, fitted, size, important, content, vertical } = props;
+    const { hasChildren, color, fitted, size, important, hasContent, vertical } = props;
     const colors = variables.colorScheme[color];
     return {
       color: _.get(colors, 'foreground', variables.textColor),
@@ -33,7 +33,7 @@ const dividerStyles: ComponentSlotStylesPrepared<DividerProps, DividerVariables>
         fontWeight: variables.importantFontWeight,
       }),
       ...(vertical && { height: '100%' }),
-      ...(childrenExist(children) || content
+      ...(hasChildren || hasContent
         ? {
             textAlign: 'center',
             fontSize: pxToRem(12 + size),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
@@ -20,7 +20,7 @@ const beforeAndAfter = (
 
 const dividerStyles: ComponentSlotStylesPrepared<DividerStylesProps, DividerVariables> = {
   root: ({ props, variables }): ICSSInJSStyle => {
-    const { hasChildren, color, fitted, size, important, hasContent, vertical } = props;
+    const { color, fitted, size, important, hasContent, vertical } = props;
     const colors = variables.colorScheme[color];
     return {
       color: _.get(colors, 'foreground', variables.textColor),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Divider/dividerStyles.ts
@@ -33,7 +33,7 @@ const dividerStyles: ComponentSlotStylesPrepared<DividerStylesProps, DividerVari
         fontWeight: variables.importantFontWeight,
       }),
       ...(vertical && { height: '100%' }),
-      ...(hasChildren || hasContent
+      ...(hasContent
         ? {
             textAlign: 'center',
             fontSize: pxToRem(12 + size),

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -27,7 +27,7 @@ import { ChatItemStylesProps } from '../../components/Chat/ChatItem';
 import { ChatMessageStylesProps } from '../../components/Chat/ChatMessage';
 import { ChatStylesProps } from '../../components/Chat/Chat';
 import { CheckboxStylesProps } from '../../components/Checkbox/Checkbox';
-import { DividerProps } from '../../components/Divider/Divider';
+import { DividerStylesProps } from '../../components/Divider/Divider';
 import { DialogProps } from '../../components/Dialog/Dialog';
 import { DropdownProps } from '../../components/Dropdown/Dropdown';
 import { EmbedStylesProps } from '../../components/Embed/Embed';
@@ -108,7 +108,7 @@ export type TeamsThemeStylesProps = {
   ChatItem: ChatItemStylesProps;
   ChatMessage: ChatMessageStylesProps;
   Checkbox: CheckboxStylesProps;
-  Divider: DividerProps;
+  Divider: DividerStylesProps;
   Dialog: DialogProps;
   Dropdown: DropdownProps;
   Embed: EmbedStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Divider/Divider-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Divider/Divider-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests';
 import Divider from 'src/components/Divider/Divider';
 
 describe('Divider', () => {
-  isConformant(Divider);
+  isConformant(Divider, { constructorName: 'Divider' });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `Divider` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `Divider`    |
| --------- |
| `hasChildren` |
| `hasContent` |
| `color` |
| `fitted` |
| `size` |
| `important` |
| `vertical` |

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12977)