### PR TITLE
chore(DropdownSearchInput): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `AccordionContent` component which are passed to styles functions, @assuncaocharles ([#12875](https://github.com/microsoft/fluentui/pull/12875))
 - Restricted prop sets in the `Embed` component which are passed to styles functions, @assuncaocharles ([#12918](https://github.com/microsoft/fluentui/pull/12918))
 - Restricted prop sets in the `CarouselNavigationItem` component which are passed to styles functions, @assuncaocharles ([#12920](https://github.com/microsoft/fluentui/pull/12920))
+- Restricted prop sets in the `DropdownSearchInput` component which are passed to styles functions, @assuncaocharles ([#12978](https://github.com/microsoft/fluentui/pull/12978))
 - Restricted prop sets in the `CarouselItem` component which are passed to styles functions, @assuncaocharles ([#12938](https://github.com/microsoft/fluentui/pull/12938))
 
 ### Fixes

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -2,17 +2,19 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
-
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+import { createShorthandFactory, commonPropTypes } from '../../utils';
 import {
-  UIComponent,
-  RenderResultConfig,
-  createShorthandFactory,
-  commonPropTypes,
-  ShorthandFactory,
-} from '../../utils';
-import { ComponentEventHandler, WithAsProp, withSafeTypeForAs } from '../../types';
+  ComponentEventHandler,
+  WithAsProp,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
 import { UIComponentProps } from '../../utils/commonPropInterfaces';
 import Input from '../Input/Input';
+import { useTelemetry, useStyles, useUnhandledProps } from '@fluentui/react-bindings';
 
 export interface DropdownSearchInputSlotClassNames {
   input: string;
@@ -77,74 +79,100 @@ export const dropdownSearchInputSlotClassNames: DropdownSearchInputSlotClassName
   wrapper: `${dropdownSearchInputClassName}__wrapper`,
 };
 
-class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProps>, any> {
-  static displayName = 'DropdownSearchInput';
-  static create: ShorthandFactory<DropdownSearchInputProps>;
-  static deprecated_className = dropdownSearchInputClassName;
+export type DropdownSearchInputStylesProps = Required<Pick<DropdownSearchInputProps, 'inline'>>;
 
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      accessibility: false,
-      children: false,
-      content: false,
-    }),
-    accessibilityInputProps: PropTypes.object,
-    accessibilityComboboxProps: PropTypes.object,
-    disabled: PropTypes.bool,
-    inline: PropTypes.bool,
-    inputRef: customPropTypes.ref,
-    onFocus: PropTypes.func,
-    onInputBlur: PropTypes.func,
-    onInputKeyDown: PropTypes.func,
-    onKeyUp: PropTypes.func,
-    placeholder: PropTypes.string,
+export const DropdownSearchInput: React.FC<WithAsProp<DropdownSearchInputProps>> &
+  FluentComponentStaticProps<DropdownSearchInputProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(DropdownSearchInput.displayName, context.telemetry);
+  setStart();
+  const {
+    accessibilityComboboxProps,
+    accessibilityInputProps,
+    inputRef,
+    inline,
+    placeholder,
+    disabled,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
+
+  const unhandledProps = useUnhandledProps(DropdownSearchInput.handledProps, props);
+
+  const { styles: ResolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
+    className: dropdownSearchInputClassName,
+    mapPropsToStyles: () => ({ inline }),
+    mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
+  });
+
+  const handleFocus = (e: React.SyntheticEvent) => {
+    _.invoke(props, 'onFocus', e, props);
   };
 
-  handleFocus = (e: React.SyntheticEvent) => {
-    _.invoke(this.props, 'onFocus', e, this.props);
+  const handleInputKeyDown = (e: React.SyntheticEvent) => {
+    _.invoke(props, 'onInputKeyDown', e, props);
   };
 
-  handleInputKeyDown = (e: React.SyntheticEvent) => {
-    _.invoke(this.props, 'onInputKeyDown', e, this.props);
+  const handleInputBlur = (e: React.SyntheticEvent) => {
+    _.invoke(props, 'onInputBlur', e, props);
   };
 
-  handleInputBlur = (e: React.SyntheticEvent) => {
-    _.invoke(this.props, 'onInputBlur', e, this.props);
+  const handleKeyUp = (e: React.SyntheticEvent) => {
+    _.invoke(props, 'onKeyUp', e, props);
   };
 
-  handleKeyUp = (e: React.SyntheticEvent) => {
-    _.invoke(this.props, 'onKeyUp', e, this.props);
-  };
+  const element = (
+    <Input
+      disabled={disabled}
+      inputRef={inputRef}
+      onFocus={handleFocus}
+      onKeyUp={handleKeyUp}
+      {...unhandledProps}
+      wrapper={{
+        className: dropdownSearchInputSlotClassNames.wrapper,
+        styles: ResolvedStyles.root,
+        ...accessibilityComboboxProps,
+        ...unhandledProps.wrapper,
+      }}
+      input={{
+        type: 'text',
+        className: dropdownSearchInputSlotClassNames.input,
+        styles: ResolvedStyles.input,
+        placeholder,
+        onBlur: handleInputBlur,
+        onKeyDown: handleInputKeyDown,
+        ...accessibilityInputProps,
+        ...unhandledProps.input,
+      }}
+    />
+  );
+  setEnd();
+  return element;
+};
 
-  renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownSearchInputProps>) {
-    const { accessibilityComboboxProps, accessibilityInputProps, inputRef, placeholder, disabled } = this.props;
-    return (
-      <Input
-        disabled={disabled}
-        inputRef={inputRef}
-        onFocus={this.handleFocus}
-        onKeyUp={this.handleKeyUp}
-        {...unhandledProps}
-        wrapper={{
-          className: dropdownSearchInputSlotClassNames.wrapper,
-          styles: styles.root,
-          ...accessibilityComboboxProps,
-          ...unhandledProps.wrapper,
-        }}
-        input={{
-          type: 'text',
-          className: dropdownSearchInputSlotClassNames.input,
-          styles: styles.input,
-          placeholder,
-          onBlur: this.handleInputBlur,
-          onKeyDown: this.handleInputKeyDown,
-          ...accessibilityInputProps,
-          ...unhandledProps.input,
-        }}
-      />
-    );
-  }
-}
+DropdownSearchInput.displayName = 'DropdownSearchInput';
+
+DropdownSearchInput.propTypes = {
+  ...commonPropTypes.createCommon({
+    accessibility: false,
+    children: false,
+    content: false,
+  }),
+  accessibilityInputProps: PropTypes.object,
+  accessibilityComboboxProps: PropTypes.object,
+  disabled: PropTypes.bool,
+  inline: PropTypes.bool,
+  inputRef: customPropTypes.ref,
+  onFocus: PropTypes.func,
+  onInputBlur: PropTypes.func,
+  onInputKeyDown: PropTypes.func,
+  onKeyUp: PropTypes.func,
+  placeholder: PropTypes.string,
+};
+
+DropdownSearchInput.handledProps = Object.keys(DropdownSearchInput.propTypes) as any;
 
 DropdownSearchInput.create = createShorthandFactory({ Component: DropdownSearchInput });
 

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -101,7 +101,7 @@ export const DropdownSearchInput: React.FC<WithAsProp<DropdownSearchInputProps>>
 
   const unhandledProps = useUnhandledProps(DropdownSearchInput.handledProps, props);
 
-  const { styles: ResolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
+  const { styles: resolvedStyles } = useStyles<DropdownSearchInputStylesProps>(DropdownSearchInput.displayName, {
     className: dropdownSearchInputClassName,
     mapPropsToStyles: () => ({ inline }),
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
@@ -132,14 +132,14 @@ export const DropdownSearchInput: React.FC<WithAsProp<DropdownSearchInputProps>>
       {...unhandledProps}
       wrapper={{
         className: dropdownSearchInputSlotClassNames.wrapper,
-        styles: ResolvedStyles.root,
+        styles: resolvedStyles.root,
         ...accessibilityComboboxProps,
         ...unhandledProps.wrapper,
       }}
       input={{
         type: 'text',
         className: dropdownSearchInputSlotClassNames.input,
-        styles: ResolvedStyles.input,
+        styles: resolvedStyles.input,
         placeholder,
         onBlur: handleInputBlur,
         onKeyDown: handleInputKeyDown,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownSearchInputStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Dropdown/dropdownSearchInputStyles.ts
@@ -1,8 +1,8 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { DropdownSearchInputProps } from '../../../../components/Dropdown/DropdownSearchInput';
+import { DropdownSearchInputStylesProps } from '../../../../components/Dropdown/DropdownSearchInput';
 import { DropdownVariables } from './dropdownVariables';
 
-const dropdownSearchInputStyles: ComponentSlotStylesPrepared<DropdownSearchInputProps, DropdownVariables> = {
+const dropdownSearchInputStyles: ComponentSlotStylesPrepared<DropdownSearchInputStylesProps, DropdownVariables> = {
   root: ({ variables: v }): ICSSInJSStyle => ({
     flexBasis: v.comboboxFlexBasis,
     flexGrow: 1,

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -30,6 +30,7 @@ import { CheckboxStylesProps } from '../../components/Checkbox/Checkbox';
 import { DividerProps } from '../../components/Divider/Divider';
 import { DialogProps } from '../../components/Dialog/Dialog';
 import { DropdownProps } from '../../components/Dropdown/Dropdown';
+import { DropdownSearchInputStylesProps } from '../../components/Dropdown/DropdownSearchInput';
 import { EmbedStylesProps } from '../../components/Embed/Embed';
 import { FlexItemStylesProps } from '../../components/Flex/FlexItem';
 import { FlexStylesProps } from '../../components/Flex/Flex';
@@ -111,6 +112,7 @@ export type TeamsThemeStylesProps = {
   Divider: DividerProps;
   Dialog: DialogProps;
   Dropdown: DropdownProps;
+  DropdownSearchInput: DropdownSearchInputStylesProps;
   Embed: EmbedStylesProps;
   Flex: FlexStylesProps;
   FlexItem: FlexItemStylesProps;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `DropdownSearchInput` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `DropdownSearchInput`    |
| --------- |
| `inline` |

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12978)