### PR TITLE
chore(DialogFooter): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `AccordionContent` component which are passed to styles functions, @assuncaocharles ([#12875](https://github.com/microsoft/fluentui/pull/12875))
 - Restricted prop sets in the `Embed` component which are passed to styles functions, @assuncaocharles ([#12918](https://github.com/microsoft/fluentui/pull/12918))
 - Restricted prop sets in the `CarouselNavigationItem` component which are passed to styles functions, @assuncaocharles ([#12920](https://github.com/microsoft/fluentui/pull/12920))
+- Restricted prop sets in the `DialogFooter` component which are passed to styles functions, @assuncaocharles ([#12979](https://github.com/microsoft/fluentui/pull/12979))
 - Restricted prop sets in the `CarouselItem` component which are passed to styles functions, @assuncaocharles ([#12938](https://github.com/microsoft/fluentui/pull/12938))
 
 ### Fixes

--- a/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 
 import { WithAsProp, withSafeTypeForAs, FluentComponentStaticProps, ProviderContextPrepared } from '../../types';
-import { useTelemetry, getElementType, useUnhandledProps, useStyles } from '@fluentui/react-bindings';
+import { useTelemetry, getElementType, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
 import { Accessibility } from '@fluentui/accessibility';
 
 export interface DialogFooterProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -29,10 +29,13 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DialogFooter.displayName, context.telemetry);
   setStart();
-  const { children, content, className, design, styles, variables } = props;
+  const { children, content, className, design, styles, variables, accessibility } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DialogFooter.handledProps, props);
-
+  const getA11yProps = useAccessibility<never>(accessibility, {
+    debugName: DialogFooter.displayName,
+    rtl: context.rtl,
+  });
   const { classes } = useStyles<DialogFooterStylesProps>(DialogFooter.displayName, {
     className: dialogFooterClassName,
     mapPropsToInlineStyles: () => ({
@@ -44,7 +47,7 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
     rtl: context.rtl,
   });
   const element = (
-    <ElementType className={classes.root} {...unhandledProps}>
+    <ElementType {...getA11yProps('root', { className: classes.root, ...unhandledProps })}>
       {childrenExist(children) ? children : content}
     </ElementType>
   );
@@ -54,11 +57,11 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
 
 DialogFooter.displayName = 'DialogFooter';
 
-DialogFooter.handledProps = Object.keys(DialogFooter.propTypes) as any;
-
 DialogFooter.propTypes = {
   ...commonPropTypes.createCommon(),
 };
+
+DialogFooter.handledProps = Object.keys(DialogFooter.propTypes) as any;
 
 DialogFooter.create = createShorthandFactory({ Component: DialogFooter, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../utils';
 
 import { WithAsProp, withSafeTypeForAs, FluentComponentStaticProps, ProviderContextPrepared } from '../../types';
-import { useTelemetry, getElementType, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
+import { useTelemetry, getElementType, useUnhandledProps, useStyles } from '@fluentui/react-bindings';
 import { Accessibility } from '@fluentui/accessibility';
 
 export interface DialogFooterProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -29,13 +29,10 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DialogFooter.displayName, context.telemetry);
   setStart();
-  const { children, content, className, design, styles, variables, accessibility } = props;
+  const { children, content, className, design, styles, variables } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DialogFooter.handledProps, props);
-  const getA11yProps = useAccessibility<never>(accessibility, {
-    debugName: DialogFooter.displayName,
-    rtl: context.rtl,
-  });
+
   const { classes } = useStyles<DialogFooterStylesProps>(DialogFooter.displayName, {
     className: dialogFooterClassName,
     mapPropsToInlineStyles: () => ({
@@ -47,7 +44,7 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
     rtl: context.rtl,
   });
   const element = (
-    <ElementType {...getA11yProps('root', { className: classes.root, ...unhandledProps })}>
+    <ElementType className={classes.root} {...unhandledProps}>
       {childrenExist(children) ? children : content}
     </ElementType>
   );
@@ -56,9 +53,7 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
 };
 
 DialogFooter.displayName = 'DialogFooter';
-DialogFooter.defaultProps = {
-  accessibility: {} as Accessibility,
-};
+
 DialogFooter.handledProps = Object.keys(DialogFooter.propTypes) as any;
 
 DialogFooter.propTypes = {

--- a/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
@@ -1,41 +1,66 @@
 import * as React from 'react';
-
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 import {
   createShorthandFactory,
-  UIComponent,
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
   commonPropTypes,
-  ShorthandFactory,
   childrenExist,
 } from '../../utils';
 
-import { WithAsProp, withSafeTypeForAs } from '../../types';
+import { WithAsProp, withSafeTypeForAs, FluentComponentStaticProps, ProviderContextPrepared } from '../../types';
+import { useTelemetry, getElementType, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
+import { Accessibility } from '@fluentui/accessibility';
 
-export interface DialogFooterProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {}
+export interface DialogFooterProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
+  /**
+   * Accessibility behavior if overridden by the user.
+   */
+  accessibility?: Accessibility<never>;
+}
 export const dialogFooterClassName = 'ui-dialog__footer';
 
-class DialogFooter extends UIComponent<WithAsProp<DialogFooterProps>> {
-  static create: ShorthandFactory<DialogFooterProps>;
+export type DialogFooterStylesProps = never;
 
-  static displayName = 'DialogFooter';
-  static deprecated_className = dialogFooterClassName;
+export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
+  FluentComponentStaticProps<DialogFooterProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(DialogFooter.displayName, context.telemetry);
+  setStart();
+  const { children, content, className, design, styles, variables } = props;
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(DialogFooter.handledProps, props);
+  const getA11yProps = useAccessibility(props.accessibility, {
+    debugName: DialogFooter.displayName,
+    rtl: context.rtl,
+  });
+  const { classes } = useStyles<DialogFooterStylesProps>(DialogFooter.displayName, {
+    className: dialogFooterClassName,
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
+  const element = (
+    <ElementType {...getA11yProps('root', { className: classes.root, ...unhandledProps })}>
+      {childrenExist(children) ? children : content}
+    </ElementType>
+  );
+  setEnd();
+  return element;
+};
 
-  static propTypes = {
-    ...commonPropTypes.createCommon(),
-  };
+DialogFooter.displayName = 'DialogFooter';
+DialogFooter.handledProps = Object.keys(DialogFooter.propTypes) as any;
 
-  renderComponent({ accessibility, ElementType, classes, unhandledProps }): React.ReactNode {
-    const { children, content } = this.props;
-
-    return (
-      <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
-        {childrenExist(children) ? children : content}
-      </ElementType>
-    );
-  }
-}
+DialogFooter.propTypes = {
+  ...commonPropTypes.createCommon(),
+};
 
 DialogFooter.create = createShorthandFactory({ Component: DialogFooter, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
@@ -29,10 +29,10 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DialogFooter.displayName, context.telemetry);
   setStart();
-  const { children, content, className, design, styles, variables } = props;
+  const { children, content, className, design, styles, variables, accessibility } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DialogFooter.handledProps, props);
-  const getA11yProps = useAccessibility(props.accessibility, {
+  const getA11yProps = useAccessibility<never>(accessibility, {
     debugName: DialogFooter.displayName,
     rtl: context.rtl,
   });
@@ -56,6 +56,9 @@ export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
 };
 
 DialogFooter.displayName = 'DialogFooter';
+DialogFooter.defaultProps = {
+  accessibility: {} as Accessibility,
+};
 DialogFooter.handledProps = Object.keys(DialogFooter.propTypes) as any;
 
 DialogFooter.propTypes = {

--- a/packages/fluentui/react-northstar/test/specs/components/Dialog/DialogFooter-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dialog/DialogFooter-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests';
 import DialogFooter from 'src/components/Dialog/DialogFooter';
 
 describe('DialogFooter', () => {
-  isConformant(DialogFooter);
+  isConformant(DialogFooter, { constructorName: 'DialogFooter' });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

Converting `DialogFooter` from class component to functional. Any props are not longer passed to styles function.

Related to #12237

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12979)