### PR TITLE
fix(Tree): Generate id for string items

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -398,7 +398,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     const renderItems = (items: TreeItemProps[], level = 1, parent?: string): React.ReactElement[] => {
       return items.reduce((renderedItems: React.ReactElement[], item: TreeItemProps, index: number) => {
-        const { id = _.uniqueId() } = item;
+        const id = typeof item === 'string' ? item : item.id;
         const isSubtree = hasSubtree(item);
         const isSubtreeExpanded = isSubtree && this.isActiveItem(id);
         const isSelectedItem = this.isSelectedItem(item);

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -398,7 +398,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     const renderItems = (items: TreeItemProps[], level = 1, parent?: string): React.ReactElement[] => {
       return items.reduce((renderedItems: React.ReactElement[], item: TreeItemProps, index: number) => {
-        const { id } = item;
+        const { id = _.uniqueId() } = item;
         const isSubtree = hasSubtree(item);
         const isSubtreeExpanded = isSubtree && this.isActiveItem(id);
         const isSelectedItem = this.isSelectedItem(item);
@@ -415,6 +415,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             selected: isSelectedItem,
             selectable,
             renderItemTitle,
+            id,
             key: id,
             parent,
             level,

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -398,7 +398,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     const renderItems = (items: TreeItemProps[], level = 1, parent?: string): React.ReactElement[] => {
       return items.reduce((renderedItems: React.ReactElement[], item: TreeItemProps, index: number) => {
-        const id = typeof item === 'string' ? item : item.id;
+        const id = typeof item === 'string' ? _.uniqueId(item) : item.id;
         const isSubtree = hasSubtree(item);
         const isSubtreeExpanded = isSubtree && this.isActiveItem(id);
         const isSelectedItem = this.isSelectedItem(item);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -125,6 +125,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> & FluentComponentStaticProps
     selected,
     selectable,
     indeterminate,
+    id,
   } = props;
 
   const hasSubtreeItem = hasSubtree(props);
@@ -231,6 +232,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> & FluentComponentStaticProps
     <ElementType
       {...getA11Props('root', {
         className: classes.root,
+        id,
         selected,
         ...rtlTextContainer.getAttributes({ forElements: [children] }),
         ...unhandledProps,

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -73,6 +73,31 @@ const checkOpenTitles = (wrapper: ReactWrapper, expected: string[]): void => {
 describe('Tree', () => {
   isConformant(Tree, { autoControlledProps: ['activeItemIds'] });
 
+  describe('treeTitleIds', () => {
+    it('should add id for string items', () => {
+      const wrapper = mountWithProvider(
+        <Tree
+          items={[
+            {
+              id: '1',
+              title: '1',
+              items: ['item-1', 'item-2'],
+            },
+          ]}
+        />,
+      );
+      // expand tree
+      getTitles(wrapper)
+        .at(0)
+        .simulate('click'),
+        expect(
+          getItems(wrapper)
+            .at(1)
+            .prop('id'),
+        ).toBeDefined();
+    });
+  });
+
   describe('activeItemIds', () => {
     it('should contain index of item open at click', () => {
       const wrapper = mountWithProvider(<Tree items={items} />);

--- a/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Tree/Tree-test.tsx
@@ -89,12 +89,13 @@ describe('Tree', () => {
       // expand tree
       getTitles(wrapper)
         .at(0)
-        .simulate('click'),
-        expect(
-          getItems(wrapper)
-            .at(1)
-            .prop('id'),
-        ).toBeDefined();
+        .simulate('click');
+
+      expect(
+        getItems(wrapper)
+          .at(1)
+          .prop('id'),
+      ).toBeDefined();
     });
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We rely on "id" attribute and as string has no "id", then there is the error in the console. This PR generate `id` for string items and pass it down to `TreeItem` since it's a required prop. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12984)