### PR TITLE
chore(getComponentInfo): update getShorthandInfo.ts

### DIFF
--- a/scripts/gulp/plugins/util/getShorthandInfo.ts
+++ b/scripts/gulp/plugins/util/getShorthandInfo.ts
@@ -8,6 +8,24 @@ type ShorthandInfo = Required<Pick<ComponentInfo, 'implementsCreateShorthand' | 
 
 /**
  * Checks that an expression matches signature:
+ * [componentName].shorthandConfig = {[config]}
+ */
+const isShorthandConfigExpression = (componentName: string, path: NodePath<t.AssignmentExpression>): boolean => {
+  const left = path.get('left');
+  const right = path.get('right');
+
+  if (!left.isMemberExpression() || !right.isObjectExpression()) {
+    return false;
+  }
+
+  const object = left.get('object');
+  const property = left.get('property') as NodePath<t.Identifier>;
+
+  return object.isIdentifier({ name: componentName }) && property.isIdentifier({ name: 'shorthandConfig' });
+};
+
+/**
+ * Checks that an expression matches signature:
  * [componentName].create = createShorthandFactory([config])
  */
 const isShorthandExpression = (componentName: string, path: NodePath<t.AssignmentExpression>): boolean => {
@@ -31,11 +49,22 @@ const isShorthandExpression = (componentName: string, path: NodePath<t.Assignmen
 
 const getShorthandInfo = (componentFile: t.File, componentName: string): ShorthandInfo => {
   let implementsCreateShorthand = false;
-  let mappedShorthandProp: string | undefined;
+  let mappedShorthandProp: string = 'children';
 
   Babel.traverse(componentFile, {
     AssignmentExpression: path => {
-      if (isShorthandExpression(componentName, path)) {
+      if (isShorthandConfigExpression(componentName, path)) {
+        const configProperties = path.get('right.properties') as NodePath<t.ObjectProperty>[];
+        const mappedProperty = configProperties.find((property: NodePath<t.ObjectProperty>) => {
+          return (property.get('key') as NodePath<t.Identifier>).isIdentifier({ name: 'mappedProp' });
+        });
+
+        if (mappedProperty) {
+          // @ts-ignore
+          t.assertStringLiteral(mappedProperty.node.value);
+          mappedShorthandProp = (mappedProperty.node.value as t.StringLiteral).value;
+        }
+      } else if (isShorthandExpression(componentName, path)) {
         implementsCreateShorthand = true;
 
         const config = path.get('right.arguments.0') as NodePath<t.ObjectExpression>;
@@ -43,15 +72,12 @@ const getShorthandInfo = (componentFile: t.File, componentName: string): Shortha
 
         const mappedProperty = (config.node.properties as any[]).find((property: t.ObjectProperty) => {
           return t.isIdentifier(property.key, { name: 'mappedProp' });
-        }) as t.ObjectProperty | null;
+        }) as t.ObjectProperty | undefined;
 
         if (mappedProperty) {
           // @ts-ignore
           t.assertStringLiteral(mappedProperty.value);
           mappedShorthandProp = (mappedProperty.value as t.StringLiteral).value;
-        } else {
-          // `mappedProp` is optional in `createShorthandFactory()`
-          mappedShorthandProp = 'children';
         }
       }
     },
@@ -59,7 +85,7 @@ const getShorthandInfo = (componentFile: t.File, componentName: string): Shortha
 
   return {
     implementsCreateShorthand,
-    mappedShorthandProp: mappedShorthandProp || '',
+    mappedShorthandProp,
   };
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In https://github.com/microsoft/fluentui/pull/12783 was introduced `shorthandConfig`, after `.create()` static will be removed we will not be longer able to gather info about `mappedProp`. This PR fixes this.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12985)