### PR TITLE
Dropdown: improve multi-select selected keys warnings

### DIFF
--- a/change/office-ui-fabric-react-2020-05-04-09-29-07-dropdown-props.json
+++ b/change/office-ui-fabric-react-2020-05-04-09-29-07-dropdown-props.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: improve multi-select selected keys warnings",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "e2a3e7d84a0297e4e1e36088ed8c5f17ee960d0b",
+  "dependentChangeType": "patch",
+  "date": "2020-05-04T16:29:07.433Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -102,6 +102,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
    * Keys of the selected items. If you provide this, you must maintain selection
    * state by observing onChange events and passing a new value in when changed.
    * Passing null in will clear the selection.
+   * Mutually exclusive with `defaultSelectedKeys`.
    */
   selectedKeys?: string[] | number[] | null;
 

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -40,6 +40,9 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
 
   /**
    * The key(s) that will be initially used to set a selected item.
+   *
+   * Mutually exclusive with `selectedKey`.
+   * For Dropdown in multi-select mode, use `defaultSelectedKeys` instead.
    */
   defaultSelectedKey?: string | number | string[] | number[] | null;
 
@@ -47,6 +50,9 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement>
    * The key(s) of the selected item. If you provide this, you must maintain selection
    * state by observing onChange events and passing a new value in when changed.
    * Note that passing in `null` will cause selection to be reset.
+   *
+   * Mutually exclusive with `defaultSelectedKey`.
+   * For Dropdown in multi-select mode, use `selectedKeys` instead.
    */
   selectedKey?: string | number | string[] | number[] | null;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12965
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Refine Dropdown's mutually exclusive prop warnings to be more correct and informative for multi-select and single-select cases.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12989)