### PR TITLE
Styling package: fixing tsconfig, removing unneeded array spread in ColorPicker

### DIFF
--- a/change/@uifabric-styling-2020-05-04-17-29-29-fix-cleanup.json
+++ b/change/@uifabric-styling-2020-05-04-17-29-29-fix-cleanup.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Styling tsconfing: adding noImplicitAnies and noUnusedLocals.",
+  "packageName": "@uifabric/styling",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T00:29:29.477Z"
+}

--- a/change/office-ui-fabric-react-2020-05-04-17-31-04-fix-cleanup.json
+++ b/change/office-ui-fabric-react-2020-05-04-17-31-04-fix-cleanup.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ColorPicker: removing unneeded array spread.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T00:31:04.536Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -238,7 +238,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
             </thead>
             <tbody>
               <tr>
-                {...colorComponents.map((comp: ColorComponent) => {
+                {colorComponents.map((comp: ColorComponent) => {
                   if ((comp === 'a' || comp === 't') && alphaSliderHidden) {
                     return null;
                   }

--- a/packages/styling/src/interfaces/IEffects.ts
+++ b/packages/styling/src/interfaces/IEffects.ts
@@ -1,5 +1,3 @@
-import { IRawStyle } from '@uifabric/merge-styles';
-
 /**
  * Experimental interface for decorative styling in a theme.
  * {@docCategory IEffects}

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -84,7 +84,7 @@ function _getFontBaseUrl(): string {
   let win = getWindow();
 
   // tslint:disable-next-line:no-string-literal no-any
-  let fabricConfig: IFabricConfig = win ? win['FabricConfig'] : undefined;
+  let fabricConfig: IFabricConfig = win ? (win as any).FabricConfig : undefined;
 
   return fabricConfig && fabricConfig.fontBaseUrl !== undefined ? fabricConfig.fontBaseUrl : DefaultBaseUrl;
 }

--- a/packages/styling/src/styles/DefaultFontStyles.ts
+++ b/packages/styling/src/styles/DefaultFontStyles.ts
@@ -84,7 +84,7 @@ function _getFontBaseUrl(): string {
   let win = getWindow();
 
   // tslint:disable-next-line:no-any
-  const fabricConfig: IFabricConfig | undefined = win?.FabricConfig;
+  const fabricConfig: IFabricConfig | undefined = (win as any)?.FabricConfig;
 
   return fabricConfig && fabricConfig.fontBaseUrl !== undefined ? fabricConfig.fontBaseUrl : DefaultBaseUrl;
 }

--- a/packages/styling/src/styles/getGlobalClassNames.test.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.test.ts
@@ -1,6 +1,7 @@
 import { getGlobalClassNames } from './getGlobalClassNames';
 import { createTheme } from './theme';
 import { Stylesheet } from '@uifabric/merge-styles';
+import { ITheme } from '../interfaces/ITheme';
 
 const styleSheet = Stylesheet.getInstance();
 
@@ -19,10 +20,9 @@ describe('getGlobalClassNames', () => {
   });
 
   describe('calls are memoized', () => {
-    // tslint:disable-next-line:no-any
-    let theme: any;
-    // tslint:disable-next-line:no-any
-    let globalClassnames: any;
+    let theme: ITheme;
+    let globalClassnames: { [key: string]: string };
+
     beforeAll(() => {
       theme = createTheme({ disableGlobalClassNames: true });
       globalClassnames = { root: 'ms-Memoized' };

--- a/packages/styling/src/styles/getGlobalClassNames.test.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.test.ts
@@ -19,7 +19,10 @@ describe('getGlobalClassNames', () => {
   });
 
   describe('calls are memoized', () => {
-    let theme, globalClassnames;
+    // tslint:disable-next-line:no-any
+    let theme: any;
+    // tslint:disable-next-line:no-any
+    let globalClassnames: any;
     beforeAll(() => {
       theme = createTheme({ disableGlobalClassNames: true });
       globalClassnames = { root: 'ms-Memoized' };

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -15,7 +15,8 @@ const _getGlobalClassNames = memoizeFunction(
     if (disableGlobalClassNames) {
       // disable global classnames
       return Object.keys(classNames).reduce((acc: {}, className: string) => {
-        acc[className] = styleSheet.getClassName(classNames[className]);
+        // tslint:disable-next-line:no-any
+        (acc as any)[className] = styleSheet.getClassName((classNames as any)[className]);
         return acc;
       }, {});
     }

--- a/packages/styling/src/styles/theme.test.ts
+++ b/packages/styling/src/styles/theme.test.ts
@@ -1,5 +1,4 @@
 import { registerOnThemeChangeCallback, removeOnThemeChangeCallback, loadTheme, getTheme } from './theme';
-import { IPartialTheme } from '../interfaces/index';
 import { IRawStyle } from '@uifabric/merge-styles';
 import { DefaultFontStyles } from './DefaultFontStyles';
 

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -97,11 +97,11 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
   const lines = {};
 
   for (const fontName of Object.keys(theme.fonts)) {
-    // tslint:disable-next-line:no-any
-    const font = (theme.fonts as any)[fontName];
+    const font = theme.fonts[fontName as keyof IFontStyles];
     for (const propName of Object.keys(font)) {
       const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
-      let value = font[propName];
+      // tslint:disable-next-line:no-any
+      let value = (font as any)[propName];
       if (propName === 'fontSize' && typeof value === 'number') {
         // if it's a number, convert it to px by default like our theming system does
         value = value + 'px';

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -5,6 +5,7 @@ import { DefaultPalette } from './DefaultPalette';
 import { DefaultSpacing } from './DefaultSpacing';
 import { loadTheme as legacyLoadTheme } from '@microsoft/load-themed-styles';
 import { DefaultEffects } from './DefaultEffects';
+import { IRawStyle } from '@uifabric/merge-styles';
 
 let _theme: ITheme = createTheme({
   palette: DefaultPalette,
@@ -94,20 +95,20 @@ export function loadTheme(theme: IPartialTheme, depComments: boolean = false): I
  * @param theme - The theme object
  */
 function _loadFonts(theme: ITheme): { [name: string]: string } {
-  const lines = {};
+  const lines: { [key: string]: string } = {};
 
   for (const fontName of Object.keys(theme.fonts)) {
-    const font = theme.fonts[fontName as keyof IFontStyles];
+    const font: IRawStyle = theme.fonts[fontName as keyof IFontStyles];
+
     for (const propName of Object.keys(font)) {
-      const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
-      // tslint:disable-next-line:no-any
-      let value = (font as any)[propName];
+      const name: string = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
+      let value = font[propName as keyof IRawStyle] as string;
+
       if (propName === 'fontSize' && typeof value === 'number') {
         // if it's a number, convert it to px by default like our theming system does
         value = value + 'px';
       }
-      // tslint:disable-next-line:no-any
-      (lines as any)[name] = value;
+      lines[name] = value;
     }
   }
   return lines;

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -97,7 +97,8 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
   const lines = {};
 
   for (const fontName of Object.keys(theme.fonts)) {
-    const font = theme.fonts[fontName];
+    // tslint:disable-next-line:no-any
+    const font = (theme.fonts as any)[fontName];
     for (const propName of Object.keys(font)) {
       const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
       let value = font[propName];
@@ -105,7 +106,8 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
         // if it's a number, convert it to px by default like our theming system does
         value = value + 'px';
       }
-      lines[name] = value;
+      // tslint:disable-next-line:no-any
+      (lines as any)[name] = value;
     }
   }
   return lines;
@@ -133,13 +135,21 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
 
   if (theme.defaultFontStyle) {
     for (const fontStyle of Object.keys(defaultFontStyles)) {
-      defaultFontStyles[fontStyle] = merge({}, defaultFontStyles[fontStyle], theme.defaultFontStyle);
+      // tslint:disable-next-line:no-any
+      (defaultFontStyles as any)[fontStyle] = merge({}, (defaultFontStyles as any)[fontStyle], theme.defaultFontStyle);
     }
   }
 
   if (theme.fonts) {
     for (const fontStyle of Object.keys(theme.fonts)) {
-      defaultFontStyles[fontStyle] = merge({}, defaultFontStyles[fontStyle], theme.fonts[fontStyle]);
+      // tslint:disable-next-line:no-any
+      (defaultFontStyles as any)[fontStyle] = merge(
+        {},
+        // tslint:disable-next-line:no-any
+        (defaultFontStyles as any)[fontStyle],
+        // tslint:disable-next-line:no-any
+        (theme.fonts as any)[fontStyle],
+      );
     }
   }
 
@@ -161,22 +171,6 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
       ...theme.effects,
     },
   };
-}
-
-/**
- * Helper to pull a given property name from a given set of sources, in order, if available.
- * Otherwise returns the property name.
- */
-function _expandFrom<TRetVal, TMapType>(propertyName: string | TRetVal | undefined, ...maps: TMapType[]): TRetVal {
-  if (propertyName) {
-    for (const map of maps) {
-      if (map[propertyName as string]) {
-        return map[propertyName as string];
-      }
-    }
-  }
-
-  return propertyName as TRetVal;
 }
 
 // Generates all the semantic slot colors based on the Fabric palette.

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -214,7 +214,8 @@ export function setIconOptions(options: Partial<IIconOptions>): void {
 }
 
 let _missingIcons: string[] = [];
-let _missingIconsTimer: number | undefined = undefined;
+// tslint:disable-next-line:no-any
+let _missingIconsTimer: any = undefined;
 
 function _warnDuplicateIcon(iconName: string): void {
   const options = _iconSettings.__options;

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es5",
     "outDir": "lib",
     "module": "commonjs",
@@ -15,7 +16,6 @@
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
     "preserveConstEnums": true,
-    "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "custom-global", "node"]
   },

--- a/packages/styling/tsconfig.json
+++ b/packages/styling/tsconfig.json
@@ -1,25 +1,23 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "lib",
     "target": "es5",
+    "outDir": "lib",
     "module": "commonjs",
+    "lib": ["es5", "es2015.promise", "dom"],
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,
     "experimentalDecorators": true,
     "importHelpers": true,
-    "moduleResolution": "node",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
     "strictNullChecks": true,
     "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
     "preserveConstEnums": true,
-    "lib": ["es5", "dom"],
+    "skipLibCheck": true,
     "typeRoots": ["../../node_modules/@types", "../../typings"],
-    "types": ["jest", "webpack-env", "custom-global"],
-    "paths": {
-      "@uifabric/styling": ["./src"]
-    }
+    "types": ["jest", "custom-global", "node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
In going through trying to pull in v7 dependencies into the v0 doc site, we ran into some missing tsconfig cleanup items:

* enable tsconfig rules for no implicit anys and no unused locals
* removing unneeded spread in ColorPicker, which was causing issues with babel


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/12994)