### PR TITLE
chore(CarouselItem): persist ID on carousel item

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -15,7 +15,6 @@ import {
   applyAccessibilityKeyHandlers,
   childrenExist,
   ChildrenComponentProps,
-  getOrGenerateIdFromShorthand,
   AutoControlledComponent,
   isFromKeyboard,
 } from '../../utils';

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -114,7 +114,6 @@ export interface CarouselState {
   activeIndex: number;
   prevActiveIndex: number;
   ariaLiveOn: boolean;
-  itemIds: string[];
   shouldFocusContainer: boolean;
   isFromKeyboard: boolean;
 }
@@ -170,15 +169,10 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
 
   static getAutoControlledStateFromProps(props: CarouselProps, state: CarouselState) {
     const { items } = props;
-    const { itemIds } = state;
 
     if (!items) {
       return null;
     }
-
-    return {
-      itemIds: items.map((item, index) => getOrGenerateIdFromShorthand('carousel-item-', item, itemIds[index])),
-    };
   }
 
   componentWillUnmount() {
@@ -211,7 +205,6 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
       activeIndex: 0,
       prevActiveIndex: -1,
       ariaLiveOn: false,
-      itemIds: [] as string[],
       shouldFocusContainer: false,
       isFromKeyboard: false,
     };
@@ -274,7 +267,7 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
 
   renderContent = (accessibility, classes, unhandledProps) => {
     const { getItemPositionText, items, circular } = this.props;
-    const { activeIndex, itemIds, prevActiveIndex } = this.state;
+    const { activeIndex, prevActiveIndex } = this.state;
 
     this.itemRefs = [];
 
@@ -322,7 +315,6 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
                     {CarouselItem.create(item, {
                       defaultProps: () => ({
                         active,
-                        id: itemIds[index],
                         navigation: !!this.props.navigation,
                         ...(getItemPositionText && {
                           itemPositionText: getItemPositionText(index, items.length),

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
@@ -121,6 +121,7 @@ CarouselItem.displayName = 'CarouselItem';
 
 CarouselItem.propTypes = {
   ...commonPropTypes.createCommon(),
+  id: PropTypes.string,
   active: PropTypes.bool,
   navigation: PropTypes.bool,
   itemPositionText: PropTypes.string,

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { carouselItemBehavior, CarouselItemBehaviorProps, Accessibility } from '@fluentui/accessibility';
-
+import * as _ from 'lodash';
 import {
   commonPropTypes,
   UIComponentProps,
@@ -37,6 +37,9 @@ export interface CarouselItemProps extends UIComponentProps, ChildrenComponentPr
 
   /** Whether or not navigation exists in carousel. */
   navigation?: boolean;
+
+  /** Item can have an ID */
+  id?: string;
 }
 
 export type CarouselItemStylesProps = never;
@@ -81,6 +84,8 @@ export const CarouselItem: React.FC<WithAsProp<CarouselItemProps>> &
     }),
   });
 
+  const id = React.useMemo(() => id || _.uniqueId('carousel-item-'), [props.id]);
+
   const { classes } = useStyles<CarouselItemStylesProps>(CarouselItem.displayName, {
     className: carouselItemClassName,
     mapPropsToInlineStyles: () => ({
@@ -96,6 +101,7 @@ export const CarouselItem: React.FC<WithAsProp<CarouselItemProps>> &
     <ElementType
       {...getA11yProps('root', {
         className: classes.root,
+        id,
         ...unhandledProps,
       })}
     >

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
@@ -84,7 +84,7 @@ export const CarouselItem: React.FC<WithAsProp<CarouselItemProps>> &
     }),
   });
 
-  const id = React.useMemo(() => id || _.uniqueId('carousel-item-'), [props.id]);
+  const id = React.useMemo(() => props.id || _.uniqueId('carousel-item-'), [props.id]);
 
   const { classes } = useStyles<CarouselItemStylesProps>(CarouselItem.displayName, {
     className: carouselItemClassName,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Create and use `id` on `CarouselItem` to avoid it on `Carousel`. See #12966 to understand the motivation 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13005)