### PR TITLE
GroupedList: Allowing for expand icon override

### DIFF
--- a/change/office-ui-fabric-react-2020-05-05-13-02-08-bcoard-AddGroupedListExpandIconOverride.json
+++ b/change/office-ui-fabric-react-2020-05-05-13-02-08-bcoard-AddGroupedListExpandIconOverride.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add custom expand icon support to Group Header",
+  "packageName": "office-ui-fabric-react",
+  "email": "bcoard@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-05T20:02:07.936Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4917,6 +4917,7 @@ export interface IGroupFooterStyles {
 export interface IGroupHeaderProps extends IGroupDividerProps {
     ariaPosInSet?: number;
     ariaSetSize?: number;
+    expandButtonIcon?: string;
     expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
     groupedListId?: string;
     selectAllButtonProps?: React.HTMLAttributes<HTMLButtonElement>;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -60,6 +60,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       onRenderTitle = this._onRenderTitle,
       isCollapsedGroupSelectVisible = true,
       expandButtonProps,
+      expandButtonIcon,
       selectAllButtonProps,
       theme,
       styles,
@@ -133,7 +134,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
           >
             <Icon
               className={this._classNames.expandIsCollapsed}
-              iconName={isRTL ? 'ChevronLeftMed' : 'ChevronRightMed'}
+              iconName={expandButtonIcon || (isRTL ? 'ChevronLeftMed' : 'ChevronRightMed')}
             />
           </button>
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
@@ -16,7 +16,7 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
   /** Native props for the GroupHeader expand and collapse button */
   expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
 
-  /** Defines the expand icon for group headers. If not set, the default icon will be used */
+  /** Defines the name of a custom icon to be used for group headers. If not set, the default icon will be used */
   expandButtonIcon?: string;
 
   /** Native props for the GroupHeader select all button */

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
@@ -16,6 +16,9 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
   /** Native props for the GroupHeader expand and collapse button */
   expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
 
+  /** Defines the expand icon for group headers. If not set, the default icon will be used */
+  expandButtonIcon?: string;
+
   /** Native props for the GroupHeader select all button */
   selectAllButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

This change will allow developers to specify a custom expand icon for Group Headers used in Grouped List and Grouped Details List. If no icon is specified the default, current, icon will be used.

#### Focus areas to test

1. The default icon shouldn't change if no icon override is set.
2. If an icon override is set it should be visible to the end user.
3. If an icon override is set it should rotate as expected, even in RTL.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13011)