### PR TITLE
Prevent empty class generation

### DIFF
--- a/change/@fluentui-react-next-2020-05-06-22-52-49-preventEmptyClassGeneration.json
+++ b/change/@fluentui-react-next-2020-05-06-22-52-49-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "update snapshots for merge-styles change to not generate class with no styles",
+  "packageName": "@fluentui/react-next",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-07T05:52:49.208Z"
+}

--- a/change/@uifabric-date-time-2020-05-06-22-52-49-preventEmptyClassGeneration.json
+++ b/change/@uifabric-date-time-2020-05-06-22-52-49-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update snapshots for merge-styles change to not generate class with no styles",
+  "packageName": "@uifabric/date-time",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T05:52:20.735Z"
+}

--- a/change/@uifabric-experiments-2020-05-06-22-52-49-preventEmptyClassGeneration.json
+++ b/change/@uifabric-experiments-2020-05-06-22-52-49-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update snapshots for merge-styles change to not generate class with no styles",
+  "packageName": "@uifabric/experiments",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T05:52:30.422Z"
+}

--- a/change/@uifabric-merge-styles-2020-05-06-12-22-46-preventEmptyClassGeneration.json
+++ b/change/@uifabric-merge-styles-2020-05-06-12-22-46-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Prevent classname with empty style generation",
+  "packageName": "@uifabric/merge-styles",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T19:22:46.594Z"
+}

--- a/change/office-ui-fabric-react-2020-05-06-18-36-52-preventEmptyClassGeneration.json
+++ b/change/office-ui-fabric-react-2020-05-06-18-36-52-preventEmptyClassGeneration.json
@@ -1,8 +1,0 @@
-{
-  "type": "patch",
-  "comment": "update snapshot from merge-styles update that remove empty classname",
-  "packageName": "office-ui-fabric-react",
-  "email": "pingj@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-05-07T01:36:52.175Z"
-}

--- a/change/office-ui-fabric-react-2020-05-06-18-36-52-preventEmptyClassGeneration.json
+++ b/change/office-ui-fabric-react-2020-05-06-18-36-52-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update snapshot from merge-styles update that remove empty classname",
+  "packageName": "office-ui-fabric-react",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T01:36:52.175Z"
+}

--- a/change/office-ui-fabric-react-2020-05-06-22-52-49-preventEmptyClassGeneration.json
+++ b/change/office-ui-fabric-react-2020-05-06-22-52-49-preventEmptyClassGeneration.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update snapshots for merge-styles change to not generate class with no styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "pingj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T05:52:37.041Z"
+}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -54,9 +54,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <div
           className=

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1102,9 +1102,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
 
 exports[`Pagination render comboBox Pagination correctly 1`] = `
 <div
-  className=
-      ms-Pagination-container
-
+  className="ms-Pagination-container"
 >
   <button
     aria-disabled={true}

--- a/packages/merge-styles/src/mergeStyleSets.test.ts
+++ b/packages/merge-styles/src/mergeStyleSets.test.ts
@@ -1,5 +1,5 @@
 import { mergeStyleSets } from './mergeStyleSets';
-import { Stylesheet, InjectionMode } from './Stylesheet';
+import { Stylesheet, InjectionMode, IStyleSheetConfig } from './Stylesheet';
 import { IStyleSet } from './IStyleSet';
 import { IStyleFunctionOrObject } from './IStyleFunction';
 import { IStyle } from './IStyle';
@@ -147,6 +147,21 @@ describe('mergeStyleSets', () => {
 
     expect(styleSet2).toEqual({ root: 'ms-Foo ms-Bar root-1', subComponentStyles: {} });
     expect(_stylesheet.getRules()).toEqual('.root-0{background:red;}' + '.root-1{background:green;}');
+  });
+
+  it('can merge correctly when class names are provided by application', () => {
+    _stylesheet.setConfig({ namespace: 'ns' });
+    _stylesheet.getClassNameCache()['ltr&displayNametestdisplayblock'] = 'test-0';
+
+    const styles = mergeStyleSets({ test: ['test-0'] });
+    const styles2 = mergeStyleSets({ test: { display: 'block' } });
+    const styles3 = mergeStyleSets({ root: [{ background: 'red' }, 'test-0'] });
+
+    expect(styles.test).toBe('test-0');
+    expect(styles2.test).toBe('test-0');
+    expect(styles3.root).toBe('test-0 ns-root-0');
+
+    _stylesheet.setConfig({ namespace: undefined });
   });
 
   describe('typings tests', () => {

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -224,11 +224,13 @@ export function mergeCssSets(
 
       const { classes, objects } = extractStyleParts(styles);
 
-      const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
+      if (objects?.length) {
+        const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
 
-      if (registration) {
-        registrations.push(registration);
-        classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+        if (registration) {
+          registrations.push(registration);
+          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+        }
       } else {
         classNameSet[styleSetArea] = classes.join(' ');
       }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -224,16 +224,13 @@ export function mergeCssSets(
 
       const { classes, objects } = extractStyleParts(styles);
 
-      if (objects && objects.length === 0) {
-        classNameSet[styleSetArea] = classes.join(' ');
-      } else {
-        const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
+      const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
 
+      if (registration) {
         registrations.push(registration);
-
-        if (registration) {
-          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
-        }
+        classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+      } else {
+        classNameSet[styleSetArea] = classes.join(' ');
       }
     }
   }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -224,13 +224,11 @@ export function mergeCssSets(
 
       const { classes, objects } = extractStyleParts(styles);
 
-      if (objects?.length) {
-        const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
+      const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
 
-        if (registration) {
-          registrations.push(registration);
-          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
-        }
+      if (registration) {
+        registrations.push(registration);
+        classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
       } else {
         classNameSet[styleSetArea] = classes.join(' ');
       }

--- a/packages/merge-styles/src/mergeStyleSets.ts
+++ b/packages/merge-styles/src/mergeStyleSets.ts
@@ -223,12 +223,17 @@ export function mergeCssSets(
       const styles: IStyle = (concatenatedStyleSet as any)[styleSetArea];
 
       const { classes, objects } = extractStyleParts(styles);
-      const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
 
-      registrations.push(registration);
+      if (objects && objects.length === 0) {
+        classNameSet[styleSetArea] = classes.join(' ');
+      } else {
+        const registration = styleToRegistration(options || {}, { displayName: styleSetArea }, objects);
 
-      if (registration) {
-        classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+        registrations.push(registration);
+
+        if (registration) {
+          classNameSet[styleSetArea] = classes.concat([registration.className]).join(' ');
+        }
       }
     }
   }

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -1,4 +1,4 @@
-import { IRawStyle, IStyle, IStyleBaseArray } from './IStyle';
+import { IRawStyle, IStyle } from './IStyle';
 
 import { Stylesheet } from './Stylesheet';
 import { kebabRules } from './transforms/kebabRules';

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -214,10 +214,6 @@ export interface IRegistration {
 }
 
 export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): IRegistration | undefined {
-  if (args.length > 1 && (args[1] as IStyleBaseArray)?.length === 0) {
-    return undefined;
-  }
-
   const rules: IRuleSet = extractRules(args);
   const key = getKeyForRules(options, rules);
 

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -1,4 +1,4 @@
-import { IRawStyle, IStyle, IStyleBaseArray } from './IStyle';
+import { IRawStyle, IStyle } from './IStyle';
 
 import { Stylesheet } from './Stylesheet';
 import { kebabRules } from './transforms/kebabRules';
@@ -214,10 +214,6 @@ export interface IRegistration {
 }
 
 export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): IRegistration | undefined {
-  if (args.length > 1 && (args[1] as IStyleBaseArray)?.length === 0) {
-    return undefined;
-  }
-
   const rules: IRuleSet = extractRules(args);
   const key = getKeyForRules(options, rules);
 

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -214,7 +214,7 @@ export interface IRegistration {
 }
 
 export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): IRegistration | undefined {
-  if (args.length > 1 && (args[1] as IStyleBaseArray).length === 0) {
+  if (args.length > 1 && (args[1] as IStyleBaseArray)?.length === 0) {
     return undefined;
   }
 

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -1,4 +1,4 @@
-import { IRawStyle, IStyle } from './IStyle';
+import { IRawStyle, IStyle, IStyleBaseArray } from './IStyle';
 
 import { Stylesheet } from './Stylesheet';
 import { kebabRules } from './transforms/kebabRules';
@@ -214,6 +214,10 @@ export interface IRegistration {
 }
 
 export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): IRegistration | undefined {
+  if (args.length > 1 && (args[1] as IStyleBaseArray).length === 0) {
+    return undefined;
+  }
+
   const rules: IRuleSet = extractRules(args);
   const key = getKeyForRules(options, rules);
 

--- a/packages/merge-styles/src/styleToClassName.ts
+++ b/packages/merge-styles/src/styleToClassName.ts
@@ -1,4 +1,4 @@
-import { IRawStyle, IStyle } from './IStyle';
+import { IRawStyle, IStyle, IStyleBaseArray } from './IStyle';
 
 import { Stylesheet } from './Stylesheet';
 import { kebabRules } from './transforms/kebabRules';
@@ -214,6 +214,10 @@ export interface IRegistration {
 }
 
 export function styleToRegistration(options: IStyleOptions, ...args: IStyle[]): IRegistration | undefined {
+  if (args.length > 1 && (args[1] as IStyleBaseArray)?.length === 0) {
+    return undefined;
+  }
+
   const rules: IRuleSet = extractRules(args);
   const key = getKeyForRules(options, rules);
 

--- a/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
@@ -3,9 +3,7 @@
 exports[`Announced does not initially render message 1`] = `
 <div
   aria-live="polite"
-  className=
-
-
+  className=""
   role="status"
 />
 `;
@@ -13,9 +11,7 @@ exports[`Announced does not initially render message 1`] = `
 exports[`Announced renders message after delay 1`] = `
 <div
   aria-live="polite"
-  className=
-
-
+  className=""
   role="status"
 >
   <div

--- a/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
@@ -3,7 +3,9 @@
 exports[`Announced does not initially render message 1`] = `
 <div
   aria-live="polite"
-  className=""
+  className=
+
+
   role="status"
 />
 `;
@@ -11,7 +13,9 @@ exports[`Announced does not initially render message 1`] = `
 exports[`Announced renders message after delay 1`] = `
 <div
   aria-live="polite"
-  className=""
+  className=
+
+
   role="status"
 >
   <div

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -155,9 +153,7 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -286,9 +282,7 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -426,9 +420,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -862,9 +854,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -974,9 +964,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         checked={true}
@@ -1103,9 +1091,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=
@@ -1532,9 +1518,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         checked={true}
@@ -1755,9 +1739,7 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-ChoiceField-wrapper
-
+      className="ms-ChoiceField-wrapper"
     >
       <input
         className=

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -26,7 +26,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -153,7 +155,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -282,7 +286,9 @@ exports[`ChoiceGroupOption custom renders correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -420,7 +426,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -854,7 +862,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -964,7 +974,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         checked={true}
@@ -1091,7 +1103,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=
@@ -1518,7 +1532,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         checked={true}
@@ -1739,7 +1755,9 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
   >
     <div
-      className="ms-ChoiceField-wrapper"
+      className=
+          ms-ChoiceField-wrapper
+
     >
       <input
         className=

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
 <div
-  className=
-      testClassName
-
+  className="testClassName"
 >
   <div
     className=
@@ -20,9 +18,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
     role="radiogroup"
   >
     <div
-      className=
-          ms-ChoiceFieldGroup-flexContainer
-
+      className="ms-ChoiceFieldGroup-flexContainer"
     >
       <div
         className=
@@ -48,9 +44,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             autoFocus={true}
@@ -187,9 +181,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -324,9 +316,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -444,9 +434,7 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
 
 exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
 <div
-  className=
-      testClassName
-
+  className="testClassName"
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -496,9 +484,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
       test label
     </label>
     <div
-      className=
-          ms-ChoiceFieldGroup-flexContainer
-
+      className="ms-ChoiceFieldGroup-flexContainer"
     >
       <div
         className=
@@ -524,9 +510,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             autoFocus={true}
@@ -663,9 +647,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -800,9 +782,7 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
 <div
-  className="testClassName"
+  className=
+      testClassName
+
 >
   <div
     className=
@@ -18,7 +20,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
     role="radiogroup"
   >
     <div
-      className="ms-ChoiceFieldGroup-flexContainer"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
     >
       <div
         className=
@@ -44,7 +48,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             autoFocus={true}
@@ -181,7 +187,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -316,7 +324,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -434,7 +444,9 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
 
 exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
 <div
-  className="testClassName"
+  className=
+      testClassName
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -484,7 +496,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
       test label
     </label>
     <div
-      className="ms-ChoiceFieldGroup-flexContainer"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
     >
       <div
         className=
@@ -510,7 +524,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             autoFocus={true}
@@ -647,7 +663,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -782,7 +800,9 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -322,9 +322,7 @@ exports[`ColorPicker renders correctly 1`] = `
             Blue
           </td>
           <td
-            className=
-
-
+            className=""
           >
             Alpha
           </td>
@@ -371,9 +369,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -529,9 +525,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -687,9 +681,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -845,9 +837,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -1003,9 +993,7 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -1478,9 +1466,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
             Blue
           </td>
           <td
-            className=
-
-
+            className=""
           >
             Alpha
           </td>
@@ -1527,9 +1513,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -1685,9 +1669,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -1843,9 +1825,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -2001,9 +1981,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -2159,9 +2137,7 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -2658,9 +2634,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -2816,9 +2790,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -2974,9 +2946,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -3132,9 +3102,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=
@@ -3290,9 +3258,7 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <div
                   className=

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -322,7 +322,9 @@ exports[`ColorPicker renders correctly 1`] = `
             Blue
           </td>
           <td
-            className=""
+            className=
+
+
           >
             Alpha
           </td>
@@ -369,7 +371,9 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -525,7 +529,9 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -681,7 +687,9 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -837,7 +845,9 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -993,7 +1003,9 @@ exports[`ColorPicker renders correctly 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -1466,7 +1478,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
             Blue
           </td>
           <td
-            className=""
+            className=
+
+
           >
             Alpha
           </td>
@@ -1513,7 +1527,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -1669,7 +1685,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -1825,7 +1843,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -1981,7 +2001,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -2137,7 +2159,9 @@ exports[`ColorPicker renders correctly with preview 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -2634,7 +2658,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -2790,7 +2816,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -2946,7 +2974,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -3102,7 +3132,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=
@@ -3258,7 +3290,9 @@ exports[`ColorPicker renders correctly with transparency 1`] = `
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <div
                   className=

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -54,9 +54,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -54,7 +54,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -95,9 +95,7 @@ exports[`DetailsHeader can render 1`] = `
     role="columnheader"
   >
     <span
-      className=
-          ms-DetailsHeader-checkTooltip
-
+      className="ms-DetailsHeader-checkTooltip"
     >
       <div
         aria-checked={false}
@@ -1022,9 +1020,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     role="columnheader"
   >
     <span
-      className=
-          ms-DetailsHeader-checkTooltip
-
+      className="ms-DetailsHeader-checkTooltip"
     >
       <div
         className=
@@ -1820,9 +1816,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     role="columnheader"
   >
     <span
-      className=
-          ms-DetailsHeader-checkTooltip
-
+      className="ms-DetailsHeader-checkTooltip"
     >
       <div
         aria-checked={false}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -95,7 +95,9 @@ exports[`DetailsHeader can render 1`] = `
     role="columnheader"
   >
     <span
-      className="ms-DetailsHeader-checkTooltip"
+      className=
+          ms-DetailsHeader-checkTooltip
+
     >
       <div
         aria-checked={false}
@@ -1020,7 +1022,9 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
     role="columnheader"
   >
     <span
-      className="ms-DetailsHeader-checkTooltip"
+      className=
+          ms-DetailsHeader-checkTooltip
+
     >
       <div
         className=
@@ -1816,7 +1820,9 @@ exports[`DetailsHeader renders accessible labels 1`] = `
     role="columnheader"
   >
     <span
-      className="ms-DetailsHeader-checkTooltip"
+      className=
+          ms-DetailsHeader-checkTooltip
+
     >
       <div
         aria-checked={false}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -41,9 +41,7 @@ exports[`DetailsList renders List correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`DetailsList renders List correctly 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -528,9 +524,7 @@ exports[`DetailsList renders List correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -658,9 +652,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -758,9 +750,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -1740,9 +1730,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1871,9 +1859,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1971,9 +1957,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -2358,9 +2342,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2489,9 +2471,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2589,9 +2569,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -3356,9 +3334,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3486,9 +3462,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3586,9 +3560,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -4583,9 +4555,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -4713,9 +4683,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -5044,9 +5012,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -41,7 +41,9 @@ exports[`DetailsList renders List correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`DetailsList renders List correctly 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -524,7 +528,9 @@ exports[`DetailsList renders List correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -652,7 +658,9 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -750,7 +758,9 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -1730,7 +1740,9 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1859,7 +1871,9 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1957,7 +1971,9 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -2342,7 +2358,9 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2471,7 +2489,9 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2569,7 +2589,9 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -3334,7 +3356,9 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3462,7 +3486,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3560,7 +3586,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -4555,7 +4583,9 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -4683,7 +4713,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -5012,7 +5044,9 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -41,9 +41,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -740,9 +736,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -890,9 +884,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -990,9 +982,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -1589,9 +1579,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1834,7 +1822,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       className=
           ms-DetailsRow-check
           ms-Check-checkHost
-
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -2250,9 +2237,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2350,9 +2335,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -2949,9 +2932,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3099,9 +3080,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3199,9 +3178,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -3798,9 +3775,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -41,7 +41,9 @@ exports[`DetailsRow renders details list row correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`DetailsRow renders details list row correctly 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -736,7 +740,9 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -884,7 +890,9 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -982,7 +990,9 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -1579,7 +1589,9 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1822,6 +1834,7 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
       className=
           ms-DetailsRow-check
           ms-Check-checkHost
+
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -2237,7 +2250,9 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -2335,7 +2350,9 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -2932,7 +2949,9 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3080,7 +3099,9 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -3178,7 +3199,9 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -3775,7 +3798,9 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -42,7 +42,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -140,7 +142,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -335,7 +339,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -42,9 +42,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -142,9 +140,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -339,9 +335,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 <div
-  className=
-      ms-Dropdown-container
-
+  className="ms-Dropdown-container"
 >
   <div
     aria-expanded="false"
@@ -181,9 +179,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 
 exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
 <div
-  className=
-      ms-Dropdown-container
-
+  className="ms-Dropdown-container"
 >
   <div
     aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 <div
-  className="ms-Dropdown-container"
+  className=
+      ms-Dropdown-container
+
 >
   <div
     aria-expanded="false"
@@ -179,7 +181,9 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 
 exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
 <div
-  className="ms-Dropdown-container"
+  className=
+      ms-Dropdown-container
+
 >
   <div
     aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -28,10 +28,7 @@ exports[`Nav renders Nav correctly 1`] = `
     role="navigation"
   >
     <div
-      className=
-          ms-Nav-group
-          is-expanded
-
+      className="ms-Nav-group is-expanded"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -28,7 +28,10 @@ exports[`Nav renders Nav correctly 1`] = `
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -60,9 +60,7 @@ exports[`Panel renders Panel correctly 1`] = `
     <div
       aria-labelledby="Panel0-headerText"
       aria-modal="true"
-      className=
-
-
+      className=""
       onKeyDown={[Function]}
       role="dialog"
       style={

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -60,7 +60,9 @@ exports[`Panel renders Panel correctly 1`] = `
     <div
       aria-labelledby="Panel0-headerText"
       aria-modal="true"
-      className=""
+      className=
+
+
       onKeyDown={[Function]}
       role="dialog"
       style={

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1277,9 +1277,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               }
         >
           <span
-            className=
-                ms-Pivot-icon
-
+            className="ms-Pivot-icon"
           >
             <i
               aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1277,7 +1277,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               }
         >
           <span
-            className="ms-Pivot-icon"
+            className=
+                ms-Pivot-icon
+
           >
             <i
               aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -1229,10 +1229,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
   tabIndex={-1}
 >
   <div
-    className=
-        ms-TeachingBubble-header
-        ms-TeachingBubble-image
-
+    className="ms-TeachingBubble-header ms-TeachingBubble-image"
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -1229,7 +1229,10 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
   tabIndex={-1}
 >
   <div
-    className="ms-TeachingBubble-header ms-TeachingBubble-image"
+    className=
+        ms-TeachingBubble-header
+        ms-TeachingBubble-image
+
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -24,9 +24,7 @@ exports[`MaskedTextField renders correctly 1`] = `
       }
 >
   <div
-    className=
-        ms-TextField-wrapper
-
+    className="ms-TextField-wrapper"
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -24,7 +24,9 @@ exports[`MaskedTextField renders correctly 1`] = `
       }
 >
   <div
-    className="ms-TextField-wrapper"
+    className=
+        ms-TextField-wrapper
+
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -25,9 +25,7 @@ exports[`TextField snapshots renders correctly 1`] = `
       }
 >
   <div
-    className=
-        ms-TextField-wrapper
-
+    className="ms-TextField-wrapper"
   >
     <label
       className=
@@ -696,9 +694,7 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
       }
 >
   <div
-    className=
-        ms-TextField-wrapper
-
+    className="ms-TextField-wrapper"
   >
     <label
       className=
@@ -872,9 +868,7 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
       }
 >
   <div
-    className=
-        ms-TextField-wrapper
-
+    className="ms-TextField-wrapper"
   >
     <label
       className=
@@ -1050,9 +1044,7 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
       }
 >
   <div
-    className=
-        ms-TextField-wrapper
-
+    className="ms-TextField-wrapper"
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -25,7 +25,9 @@ exports[`TextField snapshots renders correctly 1`] = `
       }
 >
   <div
-    className="ms-TextField-wrapper"
+    className=
+        ms-TextField-wrapper
+
   >
     <label
       className=
@@ -694,7 +696,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
       }
 >
   <div
-    className="ms-TextField-wrapper"
+    className=
+        ms-TextField-wrapper
+
   >
     <label
       className=
@@ -868,7 +872,9 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
       }
 >
   <div
-    className="ms-TextField-wrapper"
+    className=
+        ms-TextField-wrapper
+
   >
     <label
       className=
@@ -1044,7 +1050,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
       }
 >
   <div
-    className="ms-TextField-wrapper"
+    className=
+        ms-TextField-wrapper
+
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -102,9 +102,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
           role="grid"
         >
           <div
-            className=
-                ms-DetailsList-headerWrapper
-
+            className="ms-DetailsList-headerWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -202,9 +200,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                 role="columnheader"
               >
                 <span
-                  className=
-                      ms-DetailsHeader-checkTooltip
-
+                  className="ms-DetailsHeader-checkTooltip"
                 >
                   <div
                     aria-checked={false}
@@ -1184,9 +1180,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
             </div>
           </div>
           <div
-            className=
-                ms-DetailsList-contentWrapper
-
+            className="ms-DetailsList-contentWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1378,7 +1372,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2022,7 +2015,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2666,7 +2658,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3310,7 +3301,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3954,7 +3944,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4598,7 +4587,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5242,7 +5230,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5886,7 +5873,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -6530,7 +6516,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -7174,7 +7159,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -102,7 +102,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
           role="grid"
         >
           <div
-            className="ms-DetailsList-headerWrapper"
+            className=
+                ms-DetailsList-headerWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -200,7 +202,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                 role="columnheader"
               >
                 <span
-                  className="ms-DetailsHeader-checkTooltip"
+                  className=
+                      ms-DetailsHeader-checkTooltip
+
                 >
                   <div
                     aria-checked={false}
@@ -1180,7 +1184,9 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
             </div>
           </div>
           <div
-            className="ms-DetailsList-contentWrapper"
+            className=
+                ms-DetailsList-contentWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1372,6 +1378,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2015,6 +2022,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2658,6 +2666,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3301,6 +3310,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3944,6 +3954,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4587,6 +4598,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5230,6 +5242,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5873,6 +5886,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -6516,6 +6530,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -7159,6 +7174,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -50,9 +50,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -150,9 +148,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -1132,9 +1128,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1324,7 +1318,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2042,7 +2035,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2760,7 +2752,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3478,7 +3469,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4196,7 +4186,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4914,7 +4903,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5632,7 +5620,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -6350,7 +6337,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -7068,7 +7054,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -7786,7 +7771,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -50,7 +50,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -148,7 +150,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -1128,7 +1132,9 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1318,6 +1324,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2035,6 +2042,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2752,6 +2760,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3469,6 +3478,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4186,6 +4196,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4903,6 +4914,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5620,6 +5632,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -6337,6 +6350,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -7054,6 +7068,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -7771,6 +7786,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -40,15 +40,11 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
   </span>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
-    className=
-        ms-BasePicker
-
+    className="ms-BasePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -40,11 +40,15 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
   </span>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
-    className="ms-BasePicker"
+    className=
+        ms-BasePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -11,9 +11,7 @@ Array [
         }
   >
     <div
-      className=
-          ms-Dropdown-container
-
+      className="ms-Dropdown-container"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -11,7 +11,9 @@ Array [
         }
   >
     <div
-      className="ms-Dropdown-container"
+      className=
+          ms-Dropdown-container
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -698,9 +698,7 @@ Array [
       </div>
     </div>
     <div
-      className=
-          ms-Dropdown-container
-
+      className="ms-Dropdown-container"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -698,7 +698,9 @@ Array [
       </div>
     </div>
     <div
-      className="ms-Dropdown-container"
+      className=
+          ms-Dropdown-container
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] = `
 <div
-  className=
-
-
+  className=""
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -54,9 +52,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
       Pick one
     </label>
     <div
-      className=
-          ms-ChoiceFieldGroup-flexContainer
-
+      className="ms-ChoiceFieldGroup-flexContainer"
     >
       <div
         className=
@@ -82,9 +78,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -219,9 +213,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={true}
@@ -356,9 +348,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -474,9 +464,7 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] = `
 <div
-  className=""
+  className=
+
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -52,7 +54,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
       Pick one
     </label>
     <div
-      className="ms-ChoiceFieldGroup-flexContainer"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
     >
       <div
         className=
@@ -78,7 +82,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -213,7 +219,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={true}
@@ -348,7 +356,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -464,7 +474,9 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly 1`] = `
 <div
-  className=
-
-
+  className=""
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -49,9 +47,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
       Pick one
     </label>
     <div
-      className=
-          ms-ChoiceFieldGroup-flexContainer
-
+      className="ms-ChoiceFieldGroup-flexContainer"
     >
       <div
         className=
@@ -77,9 +73,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -213,9 +207,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={true}
@@ -349,9 +341,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -466,9 +456,7 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly 1`] = `
 <div
-  className=""
+  className=
+
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -47,7 +49,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
       Pick one
     </label>
     <div
-      className="ms-ChoiceFieldGroup-flexContainer"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
     >
       <div
         className=
@@ -73,7 +77,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -207,7 +213,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={true}
@@ -341,7 +349,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -456,7 +466,9 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`] = `
 <div
-  className=
-
-
+  className=""
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -49,9 +47,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
       Pick one
     </label>
     <div
-      className=
-          ms-ChoiceFieldGroup-flexContainer
-
+      className="ms-ChoiceFieldGroup-flexContainer"
     >
       <div
         className=
@@ -77,9 +73,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             aria-label="Mark displayed items as read after - Press tab for further action"
@@ -394,9 +388,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={true}
@@ -530,9 +522,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -647,9 +637,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`] = `
 <div
-  className=""
+  className=
+
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -47,7 +49,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
       Pick one
     </label>
     <div
-      className="ms-ChoiceFieldGroup-flexContainer"
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
     >
       <div
         className=
@@ -73,7 +77,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             aria-label="Mark displayed items as read after - Press tab for further action"
@@ -388,7 +394,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={true}
@@ -522,7 +530,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -637,7 +647,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] = `
 <div
-  className=
-
-
+  className=""
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -87,9 +85,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={true}
@@ -314,9 +310,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}
@@ -523,9 +517,7 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] = `
 <div
-  className=""
+  className=
+
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -85,7 +87,9 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={true}
@@ -310,7 +314,9 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}
@@ -517,7 +523,9 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] = `
 <div
-  className=
-
-
+  className=""
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -87,9 +85,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={true}
@@ -399,9 +395,7 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-ChoiceField-wrapper
-
+          className="ms-ChoiceField-wrapper"
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] = `
 <div
-  className=""
+  className=
+
+
 >
   <div
     aria-labelledby="ChoiceGroup0-label"
@@ -85,7 +87,9 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={true}
@@ -395,7 +399,9 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-ChoiceField-wrapper"
+          className=
+              ms-ChoiceField-wrapper
+
         >
           <input
             checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -73,9 +73,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
     </div>
   </label>
   <div
-    className=
-
-
+    className=""
   >
     <div
       aria-labelledby="labelElement0"
@@ -92,9 +90,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
       role="radiogroup"
     >
       <div
-        className=
-            ms-ChoiceFieldGroup-flexContainer
-
+        className="ms-ChoiceFieldGroup-flexContainer"
       >
         <div
           className=
@@ -120,9 +116,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className=
-                ms-ChoiceField-wrapper
-
+            className="ms-ChoiceField-wrapper"
           >
             <input
               checked={false}
@@ -256,9 +250,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className=
-                ms-ChoiceField-wrapper
-
+            className="ms-ChoiceField-wrapper"
           >
             <input
               checked={true}
@@ -392,9 +384,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className=
-                ms-ChoiceField-wrapper
-
+            className="ms-ChoiceField-wrapper"
           >
             <input
               checked={false}
@@ -509,9 +499,7 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className=
-                ms-ChoiceField-wrapper
-
+            className="ms-ChoiceField-wrapper"
           >
             <input
               checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -73,7 +73,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
     </div>
   </label>
   <div
-    className=""
+    className=
+
+
   >
     <div
       aria-labelledby="labelElement0"
@@ -90,7 +92,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
       role="radiogroup"
     >
       <div
-        className="ms-ChoiceFieldGroup-flexContainer"
+        className=
+            ms-ChoiceFieldGroup-flexContainer
+
       >
         <div
           className=
@@ -116,7 +120,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className="ms-ChoiceField-wrapper"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               checked={false}
@@ -250,7 +256,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className="ms-ChoiceField-wrapper"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               checked={true}
@@ -384,7 +392,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className="ms-ChoiceField-wrapper"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               checked={false}
@@ -499,7 +509,9 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
         >
           <div
-            className="ms-ChoiceField-wrapper"
+            className=
+                ms-ChoiceField-wrapper
+
           >
             <input
               checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -10,9 +10,7 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         }
   >
     <div
-      className=
-          ms-Dropdown-container
-
+      className="ms-Dropdown-container"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -10,7 +10,9 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         }
   >
     <div
-      className="ms-Dropdown-container"
+      className=
+          ms-Dropdown-container
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -358,9 +358,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               Blue
             </td>
             <td
-              className=
-
-
+              className=""
             >
               Alpha
             </td>
@@ -407,9 +405,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className=
-                      ms-TextField-wrapper
-
+                  className="ms-TextField-wrapper"
                 >
                   <div
                     className=
@@ -565,9 +561,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className=
-                      ms-TextField-wrapper
-
+                  className="ms-TextField-wrapper"
                 >
                   <div
                     className=
@@ -723,9 +717,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className=
-                      ms-TextField-wrapper
-
+                  className="ms-TextField-wrapper"
                 >
                   <div
                     className=
@@ -881,9 +873,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className=
-                      ms-TextField-wrapper
-
+                  className="ms-TextField-wrapper"
                 >
                   <div
                     className=
@@ -1039,9 +1029,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className=
-                      ms-TextField-wrapper
-
+                  className="ms-TextField-wrapper"
                 >
                   <div
                     className=
@@ -1305,9 +1293,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       </div>
     </div>
     <div
-      className=
-
-
+      className=""
     >
       <div
         aria-labelledby="ChoiceGroup17-label"
@@ -1352,9 +1338,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
           Alpha slider type
         </label>
         <div
-          className=
-              ms-ChoiceFieldGroup-flexContainer
-
+          className="ms-ChoiceFieldGroup-flexContainer"
         >
           <div
             className=
@@ -1380,9 +1364,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={true}
@@ -1516,9 +1498,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -1652,9 +1632,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -358,7 +358,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               Blue
             </td>
             <td
-              className=""
+              className=
+
+
             >
               Alpha
             </td>
@@ -405,7 +407,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField-wrapper
+
                 >
                   <div
                     className=
@@ -561,7 +565,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField-wrapper
+
                 >
                   <div
                     className=
@@ -717,7 +723,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField-wrapper
+
                 >
                   <div
                     className=
@@ -873,7 +881,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField-wrapper
+
                 >
                   <div
                     className=
@@ -1029,7 +1039,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                     }
               >
                 <div
-                  className="ms-TextField-wrapper"
+                  className=
+                      ms-TextField-wrapper
+
                 >
                   <div
                     className=
@@ -1293,7 +1305,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
       </div>
     </div>
     <div
-      className=""
+      className=
+
+
     >
       <div
         aria-labelledby="ChoiceGroup17-label"
@@ -1338,7 +1352,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
           Alpha slider type
         </label>
         <div
-          className="ms-ChoiceFieldGroup-flexContainer"
+          className=
+              ms-ChoiceFieldGroup-flexContainer
+
         >
           <div
             className=
@@ -1364,7 +1380,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={true}
@@ -1498,7 +1516,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -1632,7 +1652,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -154,9 +154,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       </label>
     </div>
     <div
-      className=
-          ms-Dropdown-container
-
+      className="ms-Dropdown-container"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -154,7 +154,9 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       </label>
     </div>
     <div
-      className="ms-Dropdown-container"
+      className=
+          ms-Dropdown-container
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -56,9 +56,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -56,7 +56,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -61,9 +61,7 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -61,7 +61,9 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -57,9 +57,7 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=
@@ -266,9 +264,7 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -57,7 +57,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=
@@ -264,7 +266,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -59,9 +59,7 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -59,7 +59,9 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -59,9 +59,7 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -59,7 +59,9 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -62,9 +62,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=
@@ -307,9 +305,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -62,7 +62,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=
@@ -305,7 +307,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -56,9 +56,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -56,7 +56,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -811,9 +811,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -856,9 +854,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -957,9 +953,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -1470,9 +1464,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1663,7 +1655,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2068,7 +2059,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2473,7 +2463,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2878,7 +2867,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3283,7 +3271,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3688,7 +3675,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4093,7 +4079,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4498,7 +4483,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4903,7 +4887,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5308,7 +5291,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -811,7 +811,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -854,7 +856,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -953,7 +957,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -1464,7 +1470,9 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1655,6 +1663,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2059,6 +2068,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2463,6 +2473,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2867,6 +2878,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3271,6 +3283,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3675,6 +3688,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4079,6 +4093,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4483,6 +4498,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4887,6 +4903,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5291,6 +5308,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -63,9 +63,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -163,9 +161,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -765,9 +761,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -958,7 +952,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1420,7 +1413,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1882,7 +1874,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2344,7 +2335,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2806,7 +2796,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3268,7 +3257,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3730,7 +3718,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4192,7 +4179,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4654,7 +4640,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5116,7 +5101,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -63,7 +63,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -161,7 +163,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -761,7 +765,9 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -952,6 +958,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1413,6 +1420,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1874,6 +1882,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2335,6 +2344,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2796,6 +2806,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3257,6 +3268,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3718,6 +3730,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4179,6 +4192,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4640,6 +4654,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -5101,6 +5116,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -34,9 +34,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -64,9 +62,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=
@@ -211,9 +207,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -264,9 +258,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
           role="grid"
         >
           <div
-            className=
-                ms-DetailsList-headerWrapper
-
+            className="ms-DetailsList-headerWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -364,9 +356,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 role="columnheader"
               >
                 <span
-                  className=
-                      ms-DetailsHeader-checkTooltip
-
+                  className="ms-DetailsHeader-checkTooltip"
                 >
                   <div
                     aria-checked={false}
@@ -966,9 +956,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             </div>
           </div>
           <div
-            className=
-                ms-DetailsList-contentWrapper
-
+            className="ms-DetailsList-contentWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1159,7 +1147,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1621,7 +1608,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2083,7 +2069,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2545,7 +2530,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3007,7 +2991,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3469,7 +3452,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3931,7 +3913,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4393,7 +4374,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4855,7 +4835,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5317,7 +5296,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -34,7 +34,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -62,7 +64,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=
@@ -207,7 +211,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -258,7 +264,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
           role="grid"
         >
           <div
-            className="ms-DetailsList-headerWrapper"
+            className=
+                ms-DetailsList-headerWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -356,7 +364,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 role="columnheader"
               >
                 <span
-                  className="ms-DetailsHeader-checkTooltip"
+                  className=
+                      ms-DetailsHeader-checkTooltip
+
                 >
                   <div
                     aria-checked={false}
@@ -956,7 +966,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             </div>
           </div>
           <div
-            className="ms-DetailsList-contentWrapper"
+            className=
+                ms-DetailsList-contentWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1147,6 +1159,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1608,6 +1621,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2069,6 +2083,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2530,6 +2545,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2991,6 +3007,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3452,6 +3469,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3913,6 +3931,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4374,6 +4393,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4835,6 +4855,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5296,6 +5317,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -34,9 +34,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -64,9 +62,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=
@@ -211,9 +207,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -265,9 +259,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
           role="grid"
         >
           <div
-            className=
-                ms-DetailsList-headerWrapper
-
+            className="ms-DetailsList-headerWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -365,9 +357,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 role="columnheader"
               >
                 <span
-                  className=
-                      ms-DetailsHeader-checkTooltip
-
+                  className="ms-DetailsHeader-checkTooltip"
                 >
                   <div
                     aria-checked={false}
@@ -967,9 +957,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             </div>
           </div>
           <div
-            className=
-                ms-DetailsList-contentWrapper
-
+            className="ms-DetailsList-contentWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1161,7 +1149,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1624,7 +1611,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2087,7 +2073,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2550,7 +2535,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3013,7 +2997,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3476,7 +3459,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3939,7 +3921,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4402,7 +4383,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4865,7 +4845,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5328,7 +5307,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -34,7 +34,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -62,7 +64,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=
@@ -207,7 +211,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -259,7 +265,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
           role="grid"
         >
           <div
-            className="ms-DetailsList-headerWrapper"
+            className=
+                ms-DetailsList-headerWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -357,7 +365,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 role="columnheader"
               >
                 <span
-                  className="ms-DetailsHeader-checkTooltip"
+                  className=
+                      ms-DetailsHeader-checkTooltip
+
                 >
                   <div
                     aria-checked={false}
@@ -957,7 +967,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             </div>
           </div>
           <div
-            className="ms-DetailsList-contentWrapper"
+            className=
+                ms-DetailsList-contentWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1149,6 +1161,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1611,6 +1624,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2073,6 +2087,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2535,6 +2550,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2997,6 +3013,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3459,6 +3476,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3921,6 +3939,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4383,6 +4402,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4845,6 +4865,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5307,6 +5328,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -522,9 +518,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -715,7 +709,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1161,7 +1154,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1607,7 +1599,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2053,7 +2044,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2499,7 +2489,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2945,7 +2934,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3391,7 +3379,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3837,7 +3824,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4283,7 +4269,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4729,7 +4714,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -518,7 +522,9 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -709,6 +715,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1154,6 +1161,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1599,6 +1607,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2044,6 +2053,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2489,6 +2499,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2934,6 +2945,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3379,6 +3391,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3824,6 +3837,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4269,6 +4283,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4714,6 +4729,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -743,9 +739,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -936,7 +930,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1398,7 +1391,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1860,7 +1852,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2322,7 +2313,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2784,7 +2774,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -739,7 +743,9 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -930,6 +936,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1391,6 +1398,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1852,6 +1860,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2313,6 +2322,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2774,6 +2784,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -640,9 +636,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1061,7 +1055,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1475,7 +1468,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1889,7 +1881,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2303,7 +2294,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2717,7 +2707,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3131,7 +3120,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3545,7 +3533,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3959,7 +3946,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4373,7 +4359,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4787,7 +4772,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -636,7 +640,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1055,6 +1061,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1468,6 +1475,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1881,6 +1889,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2294,6 +2303,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2707,6 +2717,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3120,6 +3131,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3533,6 +3545,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3946,6 +3959,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4359,6 +4373,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4772,6 +4787,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -528,9 +524,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -722,7 +716,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1127,7 +1120,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1533,7 +1525,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1938,7 +1929,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2344,7 +2334,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2749,7 +2738,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3155,7 +3143,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3560,7 +3547,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3966,7 +3952,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4371,7 +4356,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -524,7 +528,9 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -716,6 +722,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1120,6 +1127,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1525,6 +1533,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1929,6 +1938,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2334,6 +2344,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2738,6 +2749,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3143,6 +3155,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3547,6 +3560,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3952,6 +3966,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4356,6 +4371,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -402,9 +402,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -549,9 +547,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
     </div>
     <div
       aria-live="polite"
-      className=
-
-
+      className=""
       role="status"
     />
   </div>
@@ -566,9 +562,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
   </div>
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -611,9 +605,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1323,9 +1315,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -402,7 +402,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -547,7 +549,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
     </div>
     <div
       aria-live="polite"
-      className=""
+      className=
+
+
       role="status"
     />
   </div>
@@ -562,7 +566,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
   </div>
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -605,7 +611,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1315,7 +1323,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -212,9 +212,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -381,9 +379,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -576,9 +572,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           role="grid"
         >
           <div
-            className=
-                ms-DetailsList-headerWrapper
-
+            className="ms-DetailsList-headerWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -676,9 +670,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 role="columnheader"
               >
                 <span
-                  className=
-                      ms-DetailsHeader-checkTooltip
-
+                  className="ms-DetailsHeader-checkTooltip"
                 >
                   <div
                     aria-checked={false}
@@ -1154,9 +1146,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
             </div>
           </div>
           <div
-            className=
-                ms-DetailsList-contentWrapper
-
+            className="ms-DetailsList-contentWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1349,7 +1339,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1756,7 +1745,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2163,7 +2151,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2570,7 +2557,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2977,7 +2963,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3384,7 +3369,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3791,7 +3775,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4198,7 +4181,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4605,7 +4587,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -5012,7 +4993,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
-
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -212,7 +212,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -379,7 +381,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -572,7 +576,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
           role="grid"
         >
           <div
-            className="ms-DetailsList-headerWrapper"
+            className=
+                ms-DetailsList-headerWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -670,7 +676,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 role="columnheader"
               >
                 <span
-                  className="ms-DetailsHeader-checkTooltip"
+                  className=
+                      ms-DetailsHeader-checkTooltip
+
                 >
                   <div
                     aria-checked={false}
@@ -1146,7 +1154,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
             </div>
           </div>
           <div
-            className="ms-DetailsList-contentWrapper"
+            className=
+                ms-DetailsList-contentWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -1339,6 +1349,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -1745,6 +1756,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2151,6 +2163,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2557,6 +2570,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -2963,6 +2977,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3369,6 +3384,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -3775,6 +3791,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4181,6 +4198,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4587,6 +4605,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;
@@ -4993,6 +5012,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                               className=
                                   ms-DetailsRow-check
                                   ms-Check-checkHost
+
                                   {
                                     -moz-osx-font-smoothing: grayscale;
                                     -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -441,9 +441,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -541,9 +539,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -1174,9 +1170,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1794,7 +1788,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
-
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -2273,7 +2266,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
-
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -3584,7 +3576,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
-
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -4063,7 +4054,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
-
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -4542,7 +4532,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
-
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -441,7 +441,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -539,7 +541,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -1170,7 +1174,9 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -1788,6 +1794,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
+
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -2266,6 +2273,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
+
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -3576,6 +3584,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
+
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -4054,6 +4063,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
+
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;
@@ -4532,6 +4542,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         className=
                                             ms-DetailsRow-check
                                             ms-Check-checkHost
+
                                             {
                                               -moz-osx-font-smoothing: grayscale;
                                               -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -830,9 +826,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1450,7 +1444,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1921,7 +1914,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2392,7 +2384,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2863,7 +2854,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3334,7 +3324,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3805,7 +3794,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4276,7 +4264,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4747,7 +4734,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -5218,7 +5204,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -5689,7 +5674,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
-
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -826,7 +830,9 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -1444,6 +1450,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -1914,6 +1921,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2384,6 +2392,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -2854,6 +2863,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3324,6 +3334,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -3794,6 +3805,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4264,6 +4276,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -4734,6 +4747,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -5204,6 +5218,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;
@@ -5674,6 +5689,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       className=
                                           ms-DetailsRow-check
                                           ms-Check-checkHost
+
                                           {
                                             -moz-osx-font-smoothing: grayscale;
                                             -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -41,9 +41,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -141,9 +139,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             role="columnheader"
           >
             <span
-              className=
-                  ms-DetailsHeader-checkTooltip
-
+              className="ms-DetailsHeader-checkTooltip"
             >
               <div
                 aria-checked={false}
@@ -631,9 +627,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -824,7 +818,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1352,7 +1345,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1880,7 +1872,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2408,7 +2399,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2936,7 +2926,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3464,7 +3453,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3992,7 +3980,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4520,7 +4507,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -5048,7 +5034,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
-
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -41,7 +41,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -139,7 +141,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
             role="columnheader"
           >
             <span
-              className="ms-DetailsHeader-checkTooltip"
+              className=
+                  ms-DetailsHeader-checkTooltip
+
             >
               <div
                 aria-checked={false}
@@ -627,7 +631,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -818,6 +824,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1345,6 +1352,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -1872,6 +1880,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2399,6 +2408,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -2926,6 +2936,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3453,6 +3464,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -3980,6 +3992,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -4507,6 +4520,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;
@@ -5034,6 +5048,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                           className=
                               ms-DetailsRow-check
                               ms-Check-checkHost
+
                               {
                                 -moz-osx-font-smoothing: grayscale;
                                 -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -23,9 +23,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       }
 >
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <label
       className=
@@ -234,9 +232,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <label
       className=
@@ -435,9 +431,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -23,7 +23,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       }
 >
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <label
       className=
@@ -232,7 +234,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <label
       className=
@@ -431,7 +435,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     </div>
   </div>
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <label
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`] = `
 <div
-  className=
-      ms-Dropdown-container
-
+  className="ms-Dropdown-container"
 >
   <label
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`] = `
 <div
-  className="ms-Dropdown-container"
+  className=
+      ms-Dropdown-container
+
 >
   <label
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -2,9 +2,7 @@
 
 exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correctly 1`] = `
 <div
-  className=
-      ms-Dropdown-container
-
+  className="ms-Dropdown-container"
 >
   <label
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -2,7 +2,9 @@
 
 exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correctly 1`] = `
 <div
-  className="ms-Dropdown-container"
+  className=
+      ms-Dropdown-container
+
 >
   <label
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -23,9 +23,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       }
 >
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <label
       className=
@@ -259,9 +257,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -23,7 +23,9 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       }
 >
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <label
       className=
@@ -257,7 +259,9 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     </div>
   </div>
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -46,9 +46,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
         }
   >
     <div
-      className=
-          ms-Dropdown-container
-
+      className="ms-Dropdown-container"
     >
       <label
         className=
@@ -397,9 +395,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
     </button>
   </div>
   <div
-    className=
-        ms-Dropdown-container
-
+    className="ms-Dropdown-container"
   >
     <div
       aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -46,7 +46,9 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
         }
   >
     <div
-      className="ms-Dropdown-container"
+      className=
+          ms-Dropdown-container
+
     >
       <label
         className=
@@ -395,7 +397,9 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
     </button>
   </div>
   <div
-    className="ms-Dropdown-container"
+    className=
+        ms-Dropdown-container
+
   >
     <div
       aria-expanded="false"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -238,9 +238,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -238,7 +238,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -421,9 +421,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -421,7 +421,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -421,9 +421,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -421,7 +421,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -315,9 +315,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=
@@ -959,9 +957,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -315,7 +315,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=
@@ -957,7 +959,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -338,9 +338,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -533,9 +531,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -991,9 +987,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -1186,9 +1180,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -1644,9 +1636,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -1839,9 +1829,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -2297,9 +2285,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -2492,9 +2478,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -2950,9 +2934,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -3145,9 +3127,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -3603,9 +3583,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -3798,9 +3776,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -4256,9 +4232,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -4451,9 +4425,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -4909,9 +4881,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -5104,9 +5074,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -5562,9 +5530,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -5757,9 +5723,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -6215,9 +6179,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=
@@ -6410,9 +6372,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className=
-                ms-TextField-wrapper
-
+            className="ms-TextField-wrapper"
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -338,7 +338,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -531,7 +533,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -987,7 +991,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -1180,7 +1186,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -1636,7 +1644,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -1829,7 +1839,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -2285,7 +2297,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -2478,7 +2492,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -2934,7 +2950,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -3127,7 +3145,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -3583,7 +3603,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -3776,7 +3798,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -4232,7 +4256,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -4425,7 +4451,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -4881,7 +4909,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -5074,7 +5104,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -5530,7 +5562,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -5723,7 +5757,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -6179,7 +6215,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=
@@ -6372,7 +6410,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
         >
           <div
-            className="ms-TextField-wrapper"
+            className=
+                ms-TextField-wrapper
+
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -315,9 +315,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=
@@ -1174,9 +1172,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -315,7 +315,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=
@@ -1172,7 +1174,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -72,9 +72,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -172,9 +170,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -503,9 +499,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -695,7 +689,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1099,7 +1092,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1503,7 +1495,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1907,7 +1898,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2311,7 +2301,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2715,7 +2704,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3119,7 +3107,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3523,7 +3510,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3927,7 +3913,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4331,7 +4316,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -72,7 +72,9 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -170,7 +172,9 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -499,7 +503,9 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -689,6 +695,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1092,6 +1099,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1495,6 +1503,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1898,6 +1907,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2301,6 +2311,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2704,6 +2715,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3107,6 +3119,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3510,6 +3523,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3913,6 +3927,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4316,6 +4331,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
@@ -165,9 +165,7 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
       </span>
     </button>
     <div
-      className=
-          ms-HoverCard-host
-
+      className="ms-HoverCard-host"
       data-is-focusable={true}
     />
   </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
@@ -165,7 +165,9 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
       </span>
     </button>
     <div
-      className="ms-HoverCard-host"
+      className=
+          ms-HoverCard-host
+
       data-is-focusable={true}
     />
   </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -69,9 +69,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -169,9 +167,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -500,9 +496,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -692,7 +686,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -933,9 +926,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -1117,7 +1108,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1358,9 +1348,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -1542,7 +1530,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1783,9 +1770,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -1967,7 +1952,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2208,9 +2192,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -2392,7 +2374,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2633,9 +2614,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -2817,7 +2796,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3058,9 +3036,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -3242,7 +3218,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3483,9 +3458,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -3667,7 +3640,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3908,9 +3880,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -4092,7 +4062,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4333,9 +4302,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div
@@ -4517,7 +4484,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4758,9 +4724,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className=
-                                  ms-HoverCard-host
-
+                              className="ms-HoverCard-host"
                               data-is-focusable={true}
                             >
                               <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -69,7 +69,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -167,7 +169,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -496,7 +500,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -686,6 +692,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -926,7 +933,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -1108,6 +1117,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1348,7 +1358,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -1530,6 +1542,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1770,7 +1783,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -1952,6 +1967,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2192,7 +2208,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -2374,6 +2392,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2614,7 +2633,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -2796,6 +2817,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3036,7 +3058,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -3218,6 +3242,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3458,7 +3483,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -3640,6 +3667,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3880,7 +3908,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -4062,6 +4092,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4302,7 +4333,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div
@@ -4484,6 +4517,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4724,7 +4758,9 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                             }
                           >
                             <div
-                              className="ms-HoverCard-host"
+                              className=
+                                  ms-HoverCard-host
+
                               data-is-focusable={true}
                             >
                               <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -73,9 +73,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
         role="grid"
       >
         <div
-          className=
-              ms-DetailsList-headerWrapper
-
+          className="ms-DetailsList-headerWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -173,9 +171,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
               role="columnheader"
             >
               <span
-                className=
-                    ms-DetailsHeader-checkTooltip
-
+                className="ms-DetailsHeader-checkTooltip"
               >
                 <div
                   aria-checked={false}
@@ -504,9 +500,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
           </div>
         </div>
         <div
-          className=
-              ms-DetailsList-contentWrapper
-
+          className="ms-DetailsList-contentWrapper"
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -696,7 +690,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1113,7 +1106,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1530,7 +1522,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1947,7 +1938,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2364,7 +2354,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2781,7 +2770,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3198,7 +3186,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3615,7 +3602,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4032,7 +4018,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4449,7 +4434,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
-
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -73,7 +73,9 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
         role="grid"
       >
         <div
-          className="ms-DetailsList-headerWrapper"
+          className=
+              ms-DetailsList-headerWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -171,7 +173,9 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
               role="columnheader"
             >
               <span
-                className="ms-DetailsHeader-checkTooltip"
+                className=
+                    ms-DetailsHeader-checkTooltip
+
               >
                 <div
                   aria-checked={false}
@@ -500,7 +504,9 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
           </div>
         </div>
         <div
-          className="ms-DetailsList-contentWrapper"
+          className=
+              ms-DetailsList-contentWrapper
+
           onKeyDown={[Function]}
           role="presentation"
         >
@@ -690,6 +696,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1106,6 +1113,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1522,6 +1530,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -1938,6 +1947,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2354,6 +2364,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -2770,6 +2781,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3186,6 +3198,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -3602,6 +3615,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4018,6 +4032,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
@@ -4434,6 +4449,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                             className=
                                 ms-DetailsRow-check
                                 ms-Check-checkHost
+
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -142,9 +142,7 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -142,7 +142,9 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -37,9 +37,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
-      className=
-
-
+      className=""
     >
       <div
         aria-labelledby="ChoiceGroup0-label"
@@ -85,9 +83,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           Select a MessageBar Example Below. To test in narrator, show one message at a time.
         </label>
         <div
-          className=
-              ms-ChoiceFieldGroup-flexContainer
-
+          className="ms-ChoiceFieldGroup-flexContainer"
         >
           <div
             className=
@@ -113,9 +109,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -249,9 +243,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -385,9 +377,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -521,9 +511,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -657,9 +645,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -793,9 +779,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -929,9 +913,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}
@@ -1065,9 +1047,7 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className=
-                  ms-ChoiceField-wrapper
-
+              className="ms-ChoiceField-wrapper"
             >
               <input
                 checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -37,7 +37,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
         }
   >
     <div
-      className=""
+      className=
+
+
     >
       <div
         aria-labelledby="ChoiceGroup0-label"
@@ -83,7 +85,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
           Select a MessageBar Example Below. To test in narrator, show one message at a time.
         </label>
         <div
-          className="ms-ChoiceFieldGroup-flexContainer"
+          className=
+              ms-ChoiceFieldGroup-flexContainer
+
         >
           <div
             className=
@@ -109,7 +113,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -243,7 +249,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -377,7 +385,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -511,7 +521,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -645,7 +657,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -779,7 +793,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -913,7 +929,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}
@@ -1047,7 +1065,9 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 }
           >
             <div
-              className="ms-ChoiceField-wrapper"
+              className=
+                  ms-ChoiceField-wrapper
+
             >
               <input
                 checked={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -33,10 +33,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
     role="navigation"
   >
     <div
-      className=
-          ms-Nav-group
-          is-expanded
-
+      className="ms-Nav-group is-expanded"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -33,7 +33,10 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -29,10 +29,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
     role="navigation"
   >
     <div
-      className=
-          ms-Nav-group
-          is-expanded
-
+      className="ms-Nav-group is-expanded"
     >
       <h3>
         Pages
@@ -373,10 +370,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
       </div>
     </div>
     <div
-      className=
-          ms-Nav-group
-          is-expanded
-
+      className="ms-Nav-group is-expanded"
     >
       <h3>
         More pages

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -29,7 +29,10 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <h3>
         Pages
@@ -370,7 +373,10 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
       </div>
     </div>
     <div
-      className="ms-Nav-group is-expanded"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <h3>
         More pages

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -29,10 +29,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
     role="navigation"
   >
     <div
-      className=
-          ms-Nav-group
-          is-expanded
-
+      className="ms-Nav-group is-expanded"
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -29,7 +29,10 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
     role="navigation"
   >
     <div
-      className="ms-Nav-group is-expanded"
+      className=
+          ms-Nav-group
+          is-expanded
+
     >
       <div
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -3,10 +3,7 @@
 exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1`] = `
 <div>
   <div
-    className=
-        ms-BasePicker
-        ms-PeoplePicker
-
+    className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -4,7 +4,10 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
 <div>
   <div>
     <div
-      className="ms-BasePicker ms-PeoplePicker"
+      className=
+          ms-BasePicker
+          ms-PeoplePicker
+
       onBlur={[Function]}
       onKeyDown={[Function]}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -4,10 +4,7 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
 <div>
   <div>
     <div
-      className=
-          ms-BasePicker
-          ms-PeoplePicker
-
+      className="ms-BasePicker ms-PeoplePicker"
       onBlur={[Function]}
       onKeyDown={[Function]}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -3,10 +3,7 @@
 exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx correctly 1`] = `
 <div>
   <div
-    className=
-        ms-BasePicker
-        ms-PeoplePicker
-
+    className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -6,7 +6,10 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
     onBlur={[Function]}
   >
     <div
-      className="ms-BasePicker ms-PeoplePicker"
+      className=
+          ms-BasePicker
+          ms-PeoplePicker
+
       onKeyDown={[Function]}
     >
       <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -6,10 +6,7 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
     onBlur={[Function]}
   >
     <div
-      className=
-          ms-BasePicker
-          ms-PeoplePicker
-
+      className="ms-BasePicker ms-PeoplePicker"
       onKeyDown={[Function]}
     >
       <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -3,10 +3,7 @@
 exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`] = `
 <div>
   <div
-    className=
-        ms-BasePicker
-        ms-PeoplePicker
-
+    className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -3,10 +3,7 @@
 exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx correctly 1`] = `
 <div>
   <div
-    className=
-        ms-BasePicker
-        ms-PeoplePicker
-
+    className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -3,10 +3,7 @@
 exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx correctly 1`] = `
 <div>
   <div
-    className=
-        ms-BasePicker
-        ms-PeoplePicker
-
+    className="ms-BasePicker ms-PeoplePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -3,7 +3,10 @@
 exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx correctly 1`] = `
 <div>
   <div
-    className="ms-BasePicker ms-PeoplePicker"
+    className=
+        ms-BasePicker
+        ms-PeoplePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -194,9 +194,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className=
-                  ms-Pivot-icon
-
+              className="ms-Pivot-icon"
             >
               <i
                 aria-hidden={true}
@@ -385,9 +383,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className=
-                  ms-Pivot-icon
-
+              className="ms-Pivot-icon"
             >
               <i
                 aria-hidden={true}
@@ -566,9 +562,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className=
-                  ms-Pivot-icon
-
+              className="ms-Pivot-icon"
             >
               <i
                 aria-hidden={true}
@@ -746,9 +740,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className=
-                  ms-Pivot-icon
-
+              className="ms-Pivot-icon"
             >
               <i
                 aria-hidden={true}
@@ -939,9 +931,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                   }
             >
               <span
-                className=
-                    ms-Pivot-icon
-
+                className="ms-Pivot-icon"
               >
                 <i
                   aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -194,7 +194,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className="ms-Pivot-icon"
+              className=
+                  ms-Pivot-icon
+
             >
               <i
                 aria-hidden={true}
@@ -383,7 +385,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className="ms-Pivot-icon"
+              className=
+                  ms-Pivot-icon
+
             >
               <i
                 aria-hidden={true}
@@ -562,7 +566,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className="ms-Pivot-icon"
+              className=
+                  ms-Pivot-icon
+
             >
               <i
                 aria-hidden={true}
@@ -740,7 +746,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 }
           >
             <span
-              className="ms-Pivot-icon"
+              className=
+                  ms-Pivot-icon
+
             >
               <i
                 aria-hidden={true}
@@ -931,7 +939,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                   }
             >
               <span
-                className="ms-Pivot-icon"
+                className=
+                    ms-Pivot-icon
+
               >
                 <i
                   aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4029,9 +4029,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4029,7 +4029,9 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -221,7 +221,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
           role="grid"
         >
           <div
-            className="ms-DetailsList-headerWrapper"
+            className=
+                ms-DetailsList-headerWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -464,7 +466,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
             </div>
           </div>
           <div
-            className="ms-DetailsList-contentWrapper"
+            className=
+                ms-DetailsList-contentWrapper
+
             onKeyDown={[Function]}
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -221,9 +221,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
           role="grid"
         >
           <div
-            className=
-                ms-DetailsList-headerWrapper
-
+            className="ms-DetailsList-headerWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >
@@ -466,9 +464,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
             </div>
           </div>
           <div
-            className=
-                ms-DetailsList-contentWrapper
-
+            className="ms-DetailsList-contentWrapper"
             onKeyDown={[Function]}
             role="presentation"
           >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3005,9 +3005,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -3231,9 +3229,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -3636,9 +3632,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             }
       >
         <div
-          className=
-              ms-TextField-wrapper
-
+          className="ms-TextField-wrapper"
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3005,7 +3005,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -3229,7 +3231,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -3632,7 +3636,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             }
       >
         <div
-          className="ms-TextField-wrapper"
+          className=
+              ms-TextField-wrapper
+
         >
           <label
             className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -635,9 +635,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -862,9 +860,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -1089,9 +1085,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -635,7 +635,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -860,7 +862,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -1085,7 +1089,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1711,9 +1711,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <div
-              className=
-                  ms-Dropdown-container
-
+              className="ms-Dropdown-container"
             >
               <label
                 className=
@@ -1938,9 +1936,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <div
-              className=
-                  ms-Dropdown-container
-
+              className="ms-Dropdown-container"
             >
               <label
                 className=
@@ -2344,9 +2340,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
             >
               <div
-                className=
-                    ms-TextField-wrapper
-
+                className="ms-TextField-wrapper"
               >
                 <label
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1711,7 +1711,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <div
-              className="ms-Dropdown-container"
+              className=
+                  ms-Dropdown-container
+
             >
               <label
                 className=
@@ -1936,7 +1938,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <div
-              className="ms-Dropdown-container"
+              className=
+                  ms-Dropdown-container
+
             >
               <label
                 className=
@@ -2340,7 +2344,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
             >
               <div
-                className="ms-TextField-wrapper"
+                className=
+                    ms-TextField-wrapper
+
               >
                 <label
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -635,9 +635,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -862,9 +860,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=
@@ -1089,9 +1085,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className=
-            ms-Dropdown-container
-
+        className="ms-Dropdown-container"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -635,7 +635,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -860,7 +862,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=
@@ -1085,7 +1089,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           }
     >
       <div
-        className="ms-Dropdown-container"
+        className=
+            ms-Dropdown-container
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -156,7 +156,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   </div>
   Filter items in suggestions: This picker will filter added items from the search suggestions.
   <div
-    className="ms-BasePicker"
+    className=
+        ms-BasePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
@@ -256,7 +258,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   <br />
   Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
   <div
-    className="ms-BasePicker"
+    className=
+        ms-BasePicker
+
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -156,9 +156,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   </div>
   Filter items in suggestions: This picker will filter added items from the search suggestions.
   <div
-    className=
-        ms-BasePicker
-
+    className="ms-BasePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >
@@ -258,9 +256,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
   <br />
   Filter items on selected: This picker will show already-added suggestions but will not add duplicate tags.
   <div
-    className=
-        ms-BasePicker
-
+    className="ms-BasePicker"
     onBlur={[Function]}
     onKeyDown={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -42,9 +42,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -478,9 +476,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -42,7 +42,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -476,7 +478,9 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
@@ -42,9 +42,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
       role="grid"
     >
       <div
-        className=
-            ms-DetailsList-headerWrapper
-
+        className="ms-DetailsList-headerWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -478,9 +476,7 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className=
-            ms-DetailsList-contentWrapper
-
+        className="ms-DetailsList-contentWrapper"
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
@@ -42,7 +42,9 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
       role="grid"
     >
       <div
-        className="ms-DetailsList-headerWrapper"
+        className=
+            ms-DetailsList-headerWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >
@@ -476,7 +478,9 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
         </div>
       </div>
       <div
-        className="ms-DetailsList-contentWrapper"
+        className=
+            ms-DetailsList-contentWrapper
+
         onKeyDown={[Function]}
         role="presentation"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -66,9 +66,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -235,9 +233,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -406,9 +402,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -576,9 +570,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -751,9 +743,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <div
           className=
@@ -901,9 +891,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -1100,9 +1088,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -1272,9 +1258,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -1464,9 +1448,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -1634,9 +1616,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -66,7 +66,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -233,7 +235,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -402,7 +406,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -570,7 +576,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -743,7 +751,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <div
           className=
@@ -891,7 +901,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -1088,7 +1100,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -1258,7 +1272,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -1448,7 +1464,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -1616,7 +1634,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -652,9 +652,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -823,9 +821,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -652,7 +652,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -821,7 +823,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -45,9 +45,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=
@@ -214,9 +212,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -45,7 +45,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=
@@ -212,7 +214,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -46,9 +46,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <div
         className=
@@ -362,9 +360,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <div
         className=
@@ -575,9 +571,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -46,7 +46,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <div
         className=
@@ -360,7 +362,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <div
         className=
@@ -571,7 +575,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -49,9 +49,7 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -49,7 +49,9 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -67,9 +67,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -242,9 +240,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -419,9 +415,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -616,9 +610,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -788,9 +780,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -67,7 +67,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -240,7 +242,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -415,7 +419,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -610,7 +616,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -780,7 +788,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -66,9 +66,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -263,9 +261,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -484,9 +480,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=
@@ -680,9 +674,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className=
-            ms-TextField-wrapper
-
+        className="ms-TextField-wrapper"
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -66,7 +66,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -261,7 +263,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -480,7 +484,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=
@@ -674,7 +680,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
           }
     >
       <div
-        className="ms-TextField-wrapper"
+        className=
+            ms-TextField-wrapper
+
       >
         <label
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -63,9 +63,7 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=
@@ -241,9 +239,7 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         }
   >
     <div
-      className=
-          ms-TextField-wrapper
-
+      className="ms-TextField-wrapper"
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -63,7 +63,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=
@@ -239,7 +241,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         }
   >
     <div
-      className="ms-TextField-wrapper"
+      className=
+          ms-TextField-wrapper
+
     >
       <label
         className=

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`PeoplePicker renders correctly 1`] = `
 <div
-  className=
-      ms-BasePicker
-
+  className="ms-BasePicker"
   onBlur={[Function]}
   onKeyDown={[Function]}
 >
@@ -103,9 +101,7 @@ exports[`PeoplePicker renders correctly 1`] = `
 
 exports[`PeoplePicker renders correctly with preselected items 1`] = `
 <div
-  className=
-      ms-BasePicker
-
+  className="ms-BasePicker"
   onBlur={[Function]}
   onKeyDown={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`PeoplePicker renders correctly 1`] = `
 <div
-  className="ms-BasePicker"
+  className=
+      ms-BasePicker
+
   onBlur={[Function]}
   onKeyDown={[Function]}
 >
@@ -101,7 +103,9 @@ exports[`PeoplePicker renders correctly 1`] = `
 
 exports[`PeoplePicker renders correctly with preselected items 1`] = `
 <div
-  className="ms-BasePicker"
+  className=
+      ms-BasePicker
+
   onBlur={[Function]}
   onKeyDown={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -6,9 +6,7 @@ exports[`Suggestions renders a list properly 1`] = `
 >
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -2029,9 +2027,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
 >
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div
@@ -4054,9 +4050,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
 >
   <div
     aria-live="polite"
-    className=
-
-
+    className=""
     role="status"
   />
   <div

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -6,7 +6,9 @@ exports[`Suggestions renders a list properly 1`] = `
 >
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -2027,7 +2029,9 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
 >
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div
@@ -4050,7 +4054,9 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
 >
   <div
     aria-live="polite"
-    className=""
+    className=
+
+
     role="status"
   />
   <div

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`TagPicker renders correctly 1`] = `
 <div
-  className=
-      ms-BasePicker
-
+  className="ms-BasePicker"
   onBlur={[Function]}
   onKeyDown={[Function]}
 >
@@ -312,9 +310,7 @@ exports[`TagPicker renders correctly 1`] = `
 
 exports[`TagPicker renders picker with selected item correctly 1`] = `
 <div
-  className=
-      ms-BasePicker
-
+  className="ms-BasePicker"
   onBlur={[Function]}
   onKeyDown={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`TagPicker renders correctly 1`] = `
 <div
-  className="ms-BasePicker"
+  className=
+      ms-BasePicker
+
   onBlur={[Function]}
   onKeyDown={[Function]}
 >
@@ -310,7 +312,9 @@ exports[`TagPicker renders correctly 1`] = `
 
 exports[`TagPicker renders picker with selected item correctly 1`] = `
 <div
-  className="ms-BasePicker"
+  className=
+      ms-BasePicker
+
   onBlur={[Function]}
   onKeyDown={[Function]}
 >

--- a/packages/react-next/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react-next/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1277,9 +1277,7 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               }
         >
           <span
-            className=
-                ms-Pivot-icon
-
+            className="ms-Pivot-icon"
           >
             <i
               aria-hidden={true}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ X ] Include a change request file using `$ yarn change`

#### Description of changes
We notice classes generated with empty style when fabric styles were cached and provided by the APP in the fabric config. The change will prevent such classnames being generated, instead will use the existing provided classname directly. 

Snapshots are updated because we removed class names with empty styles. As a result, it becomes a static classname and not processed by jest-serializer-merge-styles plugin. 
For example, in style.ts wrapper: ['ms-textField-wrapper'] ( with no other style objects), used to output "ms-textField-wrapper wrapper-123" where wrapper-123 is an empty class. In unit test jest-serializer-merge-styles will then convert this into ms-textField-wrapper w/o quotes. After the change, wrapper-123 will not be generated and the output is just "ms-textField-wrapper".

Adding @xugao @dzearing as reviewer.
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13029)