### PR TITLE
Fix MessageBar high contrast issues

### DIFF
--- a/change/@uifabric-styling-2020-05-06-16-31-20-messagebar-link.json
+++ b/change/@uifabric-styling-2020-05-06-16-31-20-messagebar-link.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update semantic colors doc comments",
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-06T23:31:20.042Z"
+}

--- a/change/@uifabric-utilities-2020-05-08-11-01-52-messagebar-link.json
+++ b/change/@uifabric-utilities-2020-05-08-11-01-52-messagebar-link.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix customizer doc comment formatting",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-08T18:01:52.779Z"
+}

--- a/change/office-ui-fabric-react-2020-05-06-16-31-20-messagebar-link.json
+++ b/change/office-ui-fabric-react-2020-05-06-16-31-20-messagebar-link.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Restore style overrides for Link inside MessageBar in high contrast",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-06T23:31:11.055Z"
+}

--- a/change/office-ui-fabric-react-2020-05-06-16-31-20-messagebar-link.json
+++ b/change/office-ui-fabric-react-2020-05-06-16-31-20-messagebar-link.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Restore style overrides for Link inside MessageBar in high contrast",
+  "comment": "MessageBar: Restore style overrides for Link inside MessageBar in high contrast; use dismissButtonAriaLabel as title too",
   "packageName": "office-ui-fabric-react",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
@@ -11,7 +11,7 @@ export const getStyles = memoizeFunction(
             inset: 1,
             highContrastStyle: {
               outlineOffset: '-4px',
-              outlineColor: 'ActiveBorder',
+              outline: '1px solid Window',
             },
             borderColor: 'transparent',
           }),

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -75,6 +75,14 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           },
         },
       },
+      !isButton && {
+        selectors: {
+          [HighContrastSelector]: {
+            // This is mainly for the case of the MessageBar, which sets MsHighContrastAdjust: none by default
+            MsHighContrastAdjust: 'auto',
+          },
+        },
+      },
 
       isDisabled && [
         'is-disabled',

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -78,7 +78,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
       !isButton && {
         selectors: {
           [HighContrastSelector]: {
-            // This is mainly for the case of the MessageBar, which sets MsHighContrastAdjust: none by default
+            // This is mainly for MessageBar, which sets MsHighContrastAdjust: none by default
             MsHighContrastAdjust: 'auto',
           },
         },

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -22,6 +22,7 @@ exports[`Link renders Link correctly 1`] = `
         outline: 1px solid WindowText;
       }
       @media screen and (-ms-high-contrast: active){& {
+        -ms-high-contrast-adjust: auto;
         border-bottom: none;
       }
       &:active {
@@ -139,6 +140,7 @@ exports[`Link renders Link with a custom class name 1`] = `
         outline: 1px solid WindowText;
       }
       @media screen and (-ms-high-contrast: active){& {
+        -ms-high-contrast-adjust: auto;
         border-bottom: none;
       }
       &:active {
@@ -258,6 +260,7 @@ exports[`Link renders disabled Link correctly 1`] = `
         outline: 1px solid WindowText;
       }
       @media screen and (-ms-high-contrast: active){& {
+        -ms-high-contrast-adjust: auto;
         border-bottom: none;
       }
       &:link {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -7,7 +7,6 @@ import {
   htmlElementProperties,
   css,
   initializeComponentRef,
-  Customizer,
 } from '../../Utilities';
 import { IconButton } from '../../Button';
 import { Icon } from '../../Icon';
@@ -150,34 +149,20 @@ export class MessageBarBase extends React.Component<IMessageBarProps, IMessageBa
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(this.props, htmlElementProperties, [
       'className',
     ]);
-    const theme = this.props.theme!;
-
-    const settings = {
-      theme: {
-        ...theme,
-        semanticColors: {
-          ...theme.semanticColors,
-          link: theme.semanticColors.messageLink,
-          linkHovered: theme.semanticColors.messageLinkHovered,
-        },
-      },
-    };
 
     return (
-      <Customizer settings={settings}>
-        <div
-          className={this._classNames.text}
-          id={this.state.labelId}
-          role="status"
-          aria-live={this._getAnnouncementPriority()}
-        >
-          <span className={this._classNames.innerText} {...nativeProps}>
-            <DelayedRender>
-              <span>{this.props.children}</span>
-            </DelayedRender>
-          </span>
-        </div>
-      </Customizer>
+      <div
+        className={this._classNames.text}
+        id={this.state.labelId}
+        role="status"
+        aria-live={this._getAnnouncementPriority()}
+      >
+        <span className={this._classNames.innerText} {...nativeProps}>
+          <DelayedRender>
+            <span>{this.props.children}</span>
+          </DelayedRender>
+        </span>
+      </div>
     );
   }
 

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -73,6 +73,7 @@ export class MessageBarBase extends React.Component<IMessageBarProps, IMessageBa
           className={this._classNames.dismissal}
           onClick={onDismiss}
           iconProps={dismissIconProps ? dismissIconProps : { iconName: 'Clear' }}
+          title={this.props.dismissButtonAriaLabel}
           ariaLabel={this.props.dismissButtonAriaLabel}
         />
       );

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -135,12 +135,11 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         display: 'flex',
         wordBreak: 'break-word',
         selectors: {
-          // In high contrast mode, Links within MessageBars must revert to the default color
-          // defined by the high contrast settings rather than following the theme colors.
-          '& .ms-Link': {
+          '.ms-Link': {
+            color: semanticColors.messageLink,
             selectors: {
-              [HighContrastSelector]: {
-                MsHighContrastAdjust: 'auto',
+              ':hover': {
+                color: semanticColors.messageLinkHovered,
               },
             },
           },
@@ -148,6 +147,14 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
             background: highContrastBackgroundColor[messageBarType],
             border: '1px solid WindowText',
             color: 'WindowText',
+            // will uncomment or remove depending on how the styling override in Link works
+            // selectors: {
+            //   '.ms-Link, .ms-Link:hover': {
+            //     // In high contrast mode, Links within MessageBars must revert to the default color
+            //     // defined by the high contrast settings rather than following the theme colors.
+            //     MsHighContrastAdjust: 'auto',
+            //   },
+            // },
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -93,8 +93,8 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
     getFocusStyle(theme, {
       inset: 1,
       highContrastStyle: {
-        outlineOffset: '-4px',
-        outlineColor: 'Window',
+        outlineOffset: '-6px',
+        outline: '1px solid Highlight',
       },
       borderColor: 'transparent',
     }),
@@ -144,17 +144,10 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
             },
           },
           [HighContrastSelector]: {
+            MsHighContrastAdjust: 'none',
             background: highContrastBackgroundColor[messageBarType],
             border: '1px solid WindowText',
             color: 'WindowText',
-            // will uncomment or remove depending on how the styling override in Link works
-            // selectors: {
-            //   '.ms-Link, .ms-Link:hover': {
-            //     // In high contrast mode, Links within MessageBars must revert to the default color
-            //     // defined by the high contrast settings rather than following the theme colors.
-            //     MsHighContrastAdjust: 'auto',
-            //   },
-            // },
           },
         },
       },
@@ -224,6 +217,8 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         whiteSpace: 'pre-wrap',
       },
       !isMultiline && {
+        // In high contrast this causes the top and bottom of links' focus outline to be clipped
+        // (not sure of a good way around that while still maintaining text clipping)
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -135,6 +135,15 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         display: 'flex',
         wordBreak: 'break-word',
         selectors: {
+          // In high contrast mode, Links within MessageBars must revert to the default color
+          // defined by the high contrast settings rather than following the theme colors.
+          '& .ms-Link': {
+            selectors: {
+              [HighContrastSelector]: {
+                MsHighContrastAdjust: 'auto',
+              },
+            },
+          },
           [HighContrastSelector]: {
             background: highContrastBackgroundColor[messageBarType],
             border: '1px solid WindowText',

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
         color: #004578;
       }
       @media screen and (-ms-high-contrast: active){& {
+        -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
         color: WindowText;

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -19,6 +19,12 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
         width: 100%;
         word-break: break-word;
       }
+      & .ms-Link {
+        color: #005A9E;
+      }
+      & .ms-Link:hover {
+        color: #004578;
+      }
       @media screen and (-ms-high-contrast: active){& {
         background: Window;
         border: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -1019,6 +1019,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         outline: 1px solid WindowText;
                       }
                       @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: auto;
                         border-bottom: none;
                       }
                       &:active {
@@ -1251,6 +1252,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         outline: 1px solid WindowText;
                       }
                       @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: auto;
                         border-bottom: none;
                       }
                       &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -349,6 +349,7 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             outline: 1px solid WindowText;
           }
           @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: auto;
             border-bottom: none;
           }
           &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -676,6 +676,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -564,6 +564,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     outline: none;
                   }
                   @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: auto;
                     border-bottom: none;
                   }
                   &:active {
@@ -673,6 +674,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     outline: none;
                   }
                   @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: auto;
                     border-bottom: none;
                   }
                   &:active {
@@ -782,6 +784,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     outline: none;
                   }
                   @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: auto;
                     border-bottom: none;
                   }
                   &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -145,6 +145,7 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   outline: none;
                 }
                 @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: auto;
                   border-bottom: none;
                 }
                 &:active {
@@ -254,6 +255,7 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   outline: none;
                 }
                 @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: auto;
                   border-bottom: none;
                 }
                 &:active {
@@ -363,6 +365,7 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   outline: none;
                 }
                 @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: auto;
                   border-bottom: none;
                 }
                 &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -402,6 +402,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             outline: 1px solid WindowText;
           }
           @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: auto;
             border-bottom: none;
           }
           &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -585,6 +585,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               outline: 1px solid WindowText;
             }
             @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: auto;
               border-bottom: none;
             }
             &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -586,6 +586,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               outline: 1px solid WindowText;
             }
             @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: auto;
               border-bottom: none;
             }
             &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -237,6 +237,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -886,6 +887,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -1535,6 +1537,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -2184,6 +2187,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -2833,6 +2837,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -3482,6 +3487,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -4131,6 +4137,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -4780,6 +4787,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -5429,6 +5437,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {
@@ -6078,6 +6087,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 outline: 1px solid WindowText;
               }
               @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: auto;
                 border-bottom: none;
               }
               &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1172,6 +1172,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                     outline: 1px solid WindowText;
                   }
                   @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: auto;
                     border-bottom: none;
                   }
                   &:active {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -26,6 +26,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid WindowText;
           }
           @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: auto;
             border-bottom: none;
           }
           &:active {
@@ -143,6 +144,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             outline: 1px solid WindowText;
           }
           @media screen and (-ms-high-contrast: active){& {
+            -ms-high-contrast-adjust: auto;
             border-bottom: none;
           }
           &:link {

--- a/packages/styling/src/interfaces/ISemanticColors.ts
+++ b/packages/styling/src/interfaces/ISemanticColors.ts
@@ -195,11 +195,11 @@ export interface ISemanticColors extends ISemanticTextColors {
    */
   successIcon: string;
   /**
-   * Color of links within a Message.
+   * Color of links within a message.
    */
   messageLink: string;
   /**
-   * Color of links within a Message when hovered.
+   * Color of links within a message when hovered.
    */
   messageLinkHovered: string;
 

--- a/packages/utilities/src/customizations/Customizer.types.tsx
+++ b/packages/utilities/src/customizations/Customizer.types.tsx
@@ -9,37 +9,34 @@ export type ICustomizerProps = IBaseProps &
      * Components can subscribe to receive the settings by using `customizable`.
      *
      * @example
-     * Settings can be represented by a plain object that contains the key value pairs.
      * ```
-     *  <Customizer settings={{ color: 'red' }} />
-     * ```
-     * or a function that receives the current settings and returns the new ones
-     * ```
-     *  <Customizer settings={(currentSettings) => ({ ...currentSettings, color: 'red' })} />
+     * // Settings can be represented by a plain object that contains the key value pairs.
+     * <Customizer settings={{ color: 'red' }} />
+     *
+     * // or a function that receives the current settings and returns the new ones
+     * <Customizer settings={(currentSettings) => ({ ...currentSettings, color: 'red' })} />
      * ```
      */
     settings: ISettings | ISettingsFunction;
+
     /**
      * Scoped settings are settings that are scoped to a specific scope. The
      * scope is the name that is passed to the `customizable` function when the
      * the component is customized.
      *
      * @example
-     * Scoped settings can be represented by a plain object that contains the key value pairs.
      * ```
-     *  const myScopedSettings = {
-     *    Button: { color: 'red' };
-     *  };
+     * // Scoped settings can be represented by a plain object that contains the key value pairs.
+     * const myScopedSettings = {
+     *   Button: { color: 'red' };
+     * };
+     * <Customizer scopedSettings={myScopedSettings} />
      *
-     *  <Customizer scopedSettings={myScopedSettings} />
-     * ```
-     * or a function that receives the current settings and returns the new ones
-     * ```
-     *  const myScopedSettings = {
-     *    Button: { color: 'red' };
-     *  };
-     *
-     *  <Customizer scopedSettings={(currentScopedSettings) => ({ ...currentScopedSettings, ...myScopedSettings })} />
+     * // or a function that receives the current settings and returns the new ones
+     * const myScopedSettings = {
+     *   Button: { color: 'red' };
+     * };
+     * <Customizer scopedSettings={(currentScopedSettings) => ({ ...currentScopedSettings, ...myScopedSettings })} />
      * ```
      */
     scopedSettings: ISettings | ISettingsFunction;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13019, fixes #13113, related to #11742 and #13012
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix high contrast issues with MessageBar:

**Background colors** were being dropped due to browser changes as described in #11742 and #13012. Fix by disabling high contrast adjustment.

**Link colors**: In high contrast mode, Links inside MessageBars should follow the OS high contrast theme's link color rather than using Fluent UI theme colors. #12821 removed the style override for this as part of a larger change

I also noticed that **button focus outlines** were missing in high contrast due to using the wrong color for the current way the MessageBar high contrast colors are handled.

Also fixes #13113, use dismissButtonAriaLabel as the dismiss button's tooltip as well.

How it looks today (incorrect):
![image](https://user-images.githubusercontent.com/5864305/82393868-6ac00980-99fc-11ea-89ab-5f34a900bee9.png)

How it's supposed to look (and will again after this PR):
![image](https://user-images.githubusercontent.com/5864305/81238872-0478c700-8fb8-11ea-8417-a4ed4b672a4d.png)

#### Focus areas to test

High contrast mode in Chromium Edge and IE/old Edge

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13034)