### PR TITLE
Checkbox: Fix High Contrast in Edge Chromium

### DIFF
--- a/change/@fluentui-react-next-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
+++ b/change/@fluentui-react-next-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Checkbox: fix high contrast styles in Edge Chromium",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T00:40:25.872Z"
+}

--- a/change/@uifabric-merge-styles-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
+++ b/change/@uifabric-merge-styles-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add forcedColorAdjust",
+  "packageName": "@uifabric/merge-styles",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T00:40:01.659Z"
+}

--- a/change/@uifabric-styling-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
+++ b/change/@uifabric-styling-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add selector to turn off high contrast adjustment in (only) Edge Chromium browser",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T00:41:19.401Z"
+}

--- a/change/office-ui-fabric-react-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
+++ b/change/office-ui-fabric-react-2020-05-06-17-41-19-xgao-new-edge-hc-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Checkbox: fix high contrast styles in Edge Chromium",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-07T00:40:14.674Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -209,6 +209,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse';
     float?: ICSSRule | string;
     flowFrom?: ICSSRule | string;
+    forcedColorAdjust?: 'auto' | 'none';
     gridArea?: ICSSRule | string;
     gridAutoColumns?: ICSSRule | string;
     gridAutoFlow?: ICSSRule | string;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -975,6 +975,12 @@ export interface IRawStyleBase extends IRawFontStyle {
   flowFrom?: ICSSRule | string;
 
   /**
+   * The property which allows authors to opt particular elements out of forced colors mode,
+   * restoring full control over the colors to CSS. Currently it's only supported in Edge Chromium.
+   */
+  forcedColorAdjust?: 'auto' | 'none';
+
+  /**
    * Lays out one or more grid items bound by 4 grid lines. Shorthand for setting
    * grid-column-start, grid-column-end, grid-row-start, and grid-row-end in a single
    * declaration.

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,5 +1,10 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import { HighContrastSelector, getGlobalClassNames, IStyle } from '../../Styling';
+import {
+  HighContrastSelector,
+  getGlobalClassNames,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+  IStyle,
+} from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -56,6 +61,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       transitionProperty: 'border-width, border, border-color',
       transitionDuration: MS_CHECKBOX_TRANSITION_DURATION,
       transitionTimingFunction: MS_CHECKBOX_TRANSITION_TIMING,
+      selectors: {
+        [HighContrastSelector]: {
+          borderColor: 'WindowText',
+        },
+      },
     },
   ];
 
@@ -104,10 +114,6 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
                 background: checkboxBackgroundCheckedHovered,
                 borderColor: checkboxBorderColorCheckedHovered,
               },
-              [`.${classNames.checkbox}`]: {
-                background: checkboxBorderColorChecked,
-                borderColor: checkboxBorderColorChecked,
-              },
               [HighContrastSelector]: {
                 selectors: {
                   [`:hover .${classNames.checkbox}`]: {
@@ -134,6 +140,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           selectors: {
             [`:hover .${classNames.checkbox}, :hover .${classNames.checkbox}:after`]: {
               borderColor: checkboxBorderIndeterminateHoveredColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  borderColor: 'WindowText',
+                },
+              },
             },
             [`:focus .${classNames.checkbox}`]: {
               borderColor: checkboxBorderIndeterminateHoveredColor,
@@ -145,8 +156,14 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         },
         {
           selectors: {
-            [`:hover .${classNames.text}`]: { color: checkboxHoveredTextColor },
-            [`:focus .${classNames.text}`]: { color: checkboxHoveredTextColor },
+            [`:hover .${classNames.text}, :focus .${classNames.text}`]: {
+              color: checkboxHoveredTextColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  color: disabled ? 'GrayText' : 'WindowText',
+                },
+              },
+            },
           },
         },
       ],
@@ -219,6 +236,10 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         overflow: 'hidden',
         selectors: {
           ':after': indeterminate ? indeterminateDotStyles : null,
+          [HighContrastSelector]: {
+            borderColor: 'WindowText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       indeterminate && {
@@ -251,7 +272,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         borderColor: checkboxBorderColorDisabled,
         selectors: {
           [HighContrastSelector]: {
-            borderColor: 'InactiveBorder',
+            borderColor: 'GrayText',
           },
         },
       },
@@ -259,6 +280,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         disabled && {
           background: checkboxBackgroundDisabledChecked,
           borderColor: checkboxBorderColorDisabled,
+          selectors: {
+            [HighContrastSelector]: {
+              background: 'Window',
+            },
+          },
         },
     ],
     checkmark: [
@@ -268,7 +294,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         color: checkmarkFontColor,
         selectors: {
           [HighContrastSelector]: {
-            color: disabled ? 'InactiveBorder' : 'Window',
+            color: disabled ? 'GrayText' : 'Window',
             MsHighContrastAdjust: 'none',
           },
         },
@@ -280,6 +306,12 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         color: disabled ? checkboxTextColorDisabled : checkboxTextColor,
         fontSize: fonts.medium.fontSize,
         lineHeight: '20px',
+        selectors: {
+          [HighContrastSelector]: {
+            color: disabled ? 'GrayText' : 'WindowText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
       !reversed
         ? {
@@ -288,15 +320,6 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         : {
             marginRight: 4,
           },
-      disabled && {
-        selectors: {
-          [HighContrastSelector]: {
-            // backwards compat for the color of the text when the checkbox was rendered
-            // using a Button.
-            color: 'InactiveBorder',
-          },
-        },
-      },
     ],
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,10 +18,6 @@ exports[`Checkbox renders checked correctly 1`] = `
         background: #005a9e;
         border-color: #005a9e;
       }
-      & .ms-Checkbox-checkbox {
-        background: #0078d4;
-        border-color: #0078d4;
-      }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
         background: Window;
         border-color: Highlight;
@@ -41,8 +37,14 @@ exports[`Checkbox renders checked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -122,6 +124,9 @@ exports[`Checkbox renders checked correctly 1`] = `
             background: Highlight;
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -157,6 +162,12 @@ exports[`Checkbox renders checked correctly 1`] = `
             line-height: 20px;
             margin-left: 4px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Standard checkbox
     </span>
@@ -177,7 +188,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
         border-color: #005a9e;
       }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-        border-color: Highlight;
+        border-color: WindowText;
       }
       &:focus .ms-Checkbox-checkbox {
         border-color: #005a9e;
@@ -192,11 +203,20 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       &:hover .ms-Checkbox-checkbox:after {
         border-color: #005a9e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+        border-color: WindowText;
+      }
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -287,6 +307,15 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 10px;
           }
+          @media screen and (-ms-high-contrast: active){&:after {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -321,6 +350,12 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox
@@ -357,8 +392,14 @@ exports[`Checkbox renders unchecked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -432,6 +473,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 20px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -466,6 +513,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -77,8 +77,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -152,6 +158,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -186,6 +198,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -241,8 +259,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -316,6 +340,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -350,6 +380,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -405,8 +441,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -480,6 +522,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -514,6 +562,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -572,8 +626,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -647,6 +707,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -681,6 +747,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -736,8 +808,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -811,6 +889,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -845,6 +929,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -900,8 +990,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -975,6 +1071,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1009,6 +1111,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -1072,8 +1180,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1147,6 +1261,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1181,6 +1301,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -1236,8 +1362,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1311,6 +1443,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1345,6 +1483,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -1400,8 +1544,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1475,6 +1625,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1509,6 +1665,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -1567,8 +1729,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1642,6 +1810,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1676,6 +1850,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -1731,8 +1911,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1806,6 +1992,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1840,6 +2032,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -1895,8 +2093,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1970,6 +2174,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2004,6 +2214,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -2067,8 +2283,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2142,6 +2364,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2176,6 +2404,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -2231,8 +2465,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2306,6 +2546,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2340,6 +2586,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -2395,8 +2647,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -2470,6 +2728,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2504,6 +2768,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -2562,8 +2832,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2637,6 +2913,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2671,6 +2953,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -2726,8 +3014,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2801,6 +3095,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2835,6 +3135,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -2890,8 +3196,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -2965,6 +3277,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2999,6 +3317,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -31,10 +31,6 @@ Array [
             background: #005a9e;
             border-color: #005a9e;
           }
-          & .ms-Checkbox-checkbox {
-            background: #0078d4;
-            border-color: #0078d4;
-          }
           @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
             background: Window;
             border-color: Highlight;
@@ -54,8 +50,14 @@ Array [
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -135,6 +137,9 @@ Array [
                 background: Highlight;
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -169,6 +174,12 @@ Array [
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Show beak

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -49,8 +49,14 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -124,6 +130,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -159,6 +171,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Unchecked checkbox (uncontrolled)
       </span>
@@ -181,10 +199,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -204,8 +218,14 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -285,6 +305,9 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -319,6 +342,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Checked checkbox (uncontrolled)
@@ -409,7 +438,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -429,7 +461,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -447,7 +479,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled checkbox
@@ -540,7 +575,11 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              background: Window;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -560,7 +599,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -578,7 +617,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled checked checkbox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
           border-color: #005a9e;
         }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -49,11 +49,20 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -144,6 +153,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -179,6 +197,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Indeterminate checkbox (uncontrolled)
       </span>
@@ -196,8 +220,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -208,8 +238,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -300,6 +336,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -334,6 +379,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Indeterminate checkbox which defaults to true when clicked (uncontrolled)
@@ -439,8 +490,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -460,7 +517,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -478,7 +535,10 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled indeterminate checkbox
@@ -497,7 +557,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
           border-color: #005a9e;
         }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -512,11 +572,20 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -607,6 +676,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -641,6 +719,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Indeterminate checkbox (controlled)

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -39,10 +39,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -62,8 +58,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -143,6 +145,9 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -178,6 +183,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Controlled checkbox
       </span>
@@ -211,8 +222,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -288,6 +305,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -323,6 +346,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-right: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Checkbox rendered with boxSide "end"
       </span>
@@ -355,8 +384,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -430,6 +465,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -465,6 +506,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Checkbox with extra props for the input
       </span>
@@ -497,8 +544,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -571,6 +624,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-property: background, border, border-color;
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -38,8 +38,14 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -113,6 +119,12 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -147,6 +159,12 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Show beak

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -29,8 +29,14 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -104,6 +110,12 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -138,6 +150,12 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -29,8 +29,14 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -104,6 +110,12 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -138,6 +150,12 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -34,8 +34,14 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -111,6 +117,12 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -145,6 +157,12 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1124,10 +1124,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             background: #005a9e;
             border-color: #005a9e;
           }
-          & .ms-Checkbox-checkbox {
-            background: #0078d4;
-            border-color: #0078d4;
-          }
           @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
             background: Window;
             border-color: Highlight;
@@ -1147,8 +1143,14 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1228,6 +1230,9 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 background: Highlight;
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1262,6 +1267,12 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Fade In

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -30,10 +30,6 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -53,8 +49,14 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -134,6 +136,9 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -168,6 +173,12 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is marquee enabled

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -57,8 +57,14 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -133,6 +139,12 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -167,6 +179,12 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           A Checkbox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -131,8 +131,14 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -206,6 +212,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -241,6 +253,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -274,8 +292,14 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -349,6 +373,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -383,6 +413,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2082,8 +2082,14 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -2157,6 +2163,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -2192,6 +2204,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -2225,8 +2243,14 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -2300,6 +2324,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -2334,6 +2364,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -131,8 +131,14 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -206,6 +212,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -241,6 +253,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -274,8 +292,14 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -349,6 +373,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -383,6 +413,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -135,8 +135,14 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -210,6 +216,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -245,6 +257,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -278,8 +296,14 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -353,6 +377,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -387,6 +417,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -131,8 +131,14 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -206,6 +212,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -241,6 +253,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -274,8 +292,14 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -349,6 +373,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -383,6 +413,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1494,8 +1494,14 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -1569,6 +1575,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -1604,6 +1616,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -1637,8 +1655,14 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -1712,6 +1736,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -1746,6 +1776,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -131,8 +131,14 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -206,6 +212,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -241,6 +253,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -274,8 +292,14 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -349,6 +373,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -383,6 +413,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -39,10 +39,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -62,8 +58,14 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -143,6 +145,9 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -177,6 +182,12 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Include persona details

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3622,8 +3622,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -3697,6 +3703,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -3732,6 +3744,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 line-height: 20px;
                 margin-left: 4px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Enable caching
         </span>
@@ -3764,8 +3782,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -3839,6 +3863,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -3874,6 +3904,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 line-height: 20px;
                 margin-left: 4px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Set onGrowData
         </span>
@@ -3906,8 +3942,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -3981,6 +4023,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -4015,6 +4063,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Buttons checked

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -388,8 +388,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -463,6 +469,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -498,6 +510,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shadow around items
               </span>
@@ -530,8 +548,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -605,6 +629,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -639,6 +669,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Prevent item overflow
@@ -732,8 +768,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -807,6 +849,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -842,6 +890,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Wrap items
               </span>
@@ -874,8 +928,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -949,6 +1009,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -983,6 +1049,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Shrink items
@@ -3483,8 +3555,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -3558,6 +3636,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -3592,6 +3676,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             Hide empty children

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -389,8 +389,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -464,6 +470,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -499,6 +511,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shadow around items
               </span>
@@ -532,8 +550,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -607,6 +631,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -642,6 +672,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Prevent item overflow
               </span>
@@ -675,8 +711,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -750,6 +792,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -785,6 +833,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shrink items
               </span>
@@ -817,8 +871,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -892,6 +952,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -926,6 +992,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Wrap items
@@ -1208,10 +1280,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 background: #005a9e;
                 border-color: #005a9e;
               }
-              & .ms-Checkbox-checkbox {
-                background: #0078d4;
-                border-color: #0078d4;
-              }
               @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
                 background: Window;
                 border-color: Highlight;
@@ -1231,8 +1299,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1312,6 +1386,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     background: Highlight;
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1346,6 +1423,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               Automatic height (based on items)
@@ -2190,8 +2273,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   &:hover .ms-Checkbox-text {
                     color: #201f1e;
                   }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                    color: WindowText;
+                  }
                   &:focus .ms-Checkbox-text {
                     color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                    color: WindowText;
                   }
             >
               <input
@@ -2265,6 +2354,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                         width: 20px;
                       }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                 >
                   <i
                     aria-hidden={true}
@@ -2299,6 +2394,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         font-size: 14px;
                         line-height: 20px;
                         margin-left: 4px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
                       }
                 >
                   Hide empty children

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -39,8 +39,14 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -114,6 +120,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -148,6 +160,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disable Tag Picker

--- a/packages/react-next/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/react-next/src/components/Checkbox/Checkbox.styles.ts
@@ -1,5 +1,10 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import { HighContrastSelector, getGlobalClassNames, IStyle } from '../../Styling';
+import {
+  HighContrastSelector,
+  getGlobalClassNames,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+  IStyle,
+} from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -56,6 +61,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       transitionProperty: 'border-width, border, border-color',
       transitionDuration: MS_CHECKBOX_TRANSITION_DURATION,
       transitionTimingFunction: MS_CHECKBOX_TRANSITION_TIMING,
+      selectors: {
+        [HighContrastSelector]: {
+          borderColor: 'WindowText',
+        },
+      },
     },
   ];
 
@@ -104,10 +114,6 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
                 background: checkboxBackgroundCheckedHovered,
                 borderColor: checkboxBorderColorCheckedHovered,
               },
-              [`.${classNames.checkbox}`]: {
-                background: checkboxBorderColorChecked,
-                borderColor: checkboxBorderColorChecked,
-              },
               [HighContrastSelector]: {
                 selectors: {
                   [`:hover .${classNames.checkbox}`]: {
@@ -134,6 +140,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           selectors: {
             [`:hover .${classNames.checkbox}, :hover .${classNames.checkbox}:after`]: {
               borderColor: checkboxBorderIndeterminateHoveredColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  borderColor: 'WindowText',
+                },
+              },
             },
             [`:focus .${classNames.checkbox}`]: {
               borderColor: checkboxBorderIndeterminateHoveredColor,
@@ -145,8 +156,14 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         },
         {
           selectors: {
-            [`:hover .${classNames.text}`]: { color: checkboxHoveredTextColor },
-            [`:focus .${classNames.text}`]: { color: checkboxHoveredTextColor },
+            [`:hover .${classNames.text}, :focus .${classNames.text}`]: {
+              color: checkboxHoveredTextColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  color: disabled ? 'GrayText' : 'WindowText',
+                },
+              },
+            },
           },
         },
       ],
@@ -219,6 +236,10 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         overflow: 'hidden',
         selectors: {
           ':after': indeterminate ? indeterminateDotStyles : null,
+          [HighContrastSelector]: {
+            borderColor: 'WindowText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       indeterminate && {
@@ -251,7 +272,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         borderColor: checkboxBorderColorDisabled,
         selectors: {
           [HighContrastSelector]: {
-            borderColor: 'InactiveBorder',
+            borderColor: 'GrayText',
           },
         },
       },
@@ -259,6 +280,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         disabled && {
           background: checkboxBackgroundDisabledChecked,
           borderColor: checkboxBorderColorDisabled,
+          selectors: {
+            [HighContrastSelector]: {
+              background: 'Window',
+            },
+          },
         },
     ],
     checkmark: [
@@ -268,7 +294,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         color: checkmarkFontColor,
         selectors: {
           [HighContrastSelector]: {
-            color: disabled ? 'InactiveBorder' : 'Window',
+            color: disabled ? 'GrayText' : 'Window',
             MsHighContrastAdjust: 'none',
           },
         },
@@ -280,6 +306,12 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         color: disabled ? checkboxTextColorDisabled : checkboxTextColor,
         fontSize: fonts.medium.fontSize,
         lineHeight: '20px',
+        selectors: {
+          [HighContrastSelector]: {
+            color: disabled ? 'GrayText' : 'WindowText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
       !reversed
         ? {
@@ -288,15 +320,6 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         : {
             marginRight: 4,
           },
-      disabled && {
-        selectors: {
-          [HighContrastSelector]: {
-            // backwards compat for the color of the text when the checkbox was rendered
-            // using a Button.
-            color: 'InactiveBorder',
-          },
-        },
-      },
     ],
   };
 };

--- a/packages/react-next/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/react-next/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,10 +18,6 @@ exports[`Checkbox renders checked correctly 1`] = `
         background: #005a9e;
         border-color: #005a9e;
       }
-      & .ms-Checkbox-checkbox {
-        background: #0078d4;
-        border-color: #0078d4;
-      }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
         background: Window;
         border-color: Highlight;
@@ -41,8 +37,14 @@ exports[`Checkbox renders checked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -120,6 +122,9 @@ exports[`Checkbox renders checked correctly 1`] = `
             background: Highlight;
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -155,6 +160,12 @@ exports[`Checkbox renders checked correctly 1`] = `
             line-height: 20px;
             margin-left: 4px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Standard checkbox
     </span>
@@ -175,7 +186,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
         border-color: #005a9e;
       }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-        border-color: Highlight;
+        border-color: WindowText;
       }
       &:focus .ms-Checkbox-checkbox {
         border-color: #005a9e;
@@ -190,11 +201,20 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       &:hover .ms-Checkbox-checkbox:after {
         border-color: #005a9e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+        border-color: WindowText;
+      }
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -283,6 +303,15 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 10px;
           }
+          @media screen and (-ms-high-contrast: active){&:after {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -317,6 +346,12 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox
@@ -353,8 +388,14 @@ exports[`Checkbox renders unchecked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -426,6 +467,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 20px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -460,6 +507,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox

--- a/packages/react-next/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/react-next/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -77,8 +77,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -152,6 +158,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -186,6 +198,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -241,8 +259,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -316,6 +340,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -350,6 +380,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -405,8 +441,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -480,6 +522,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -514,6 +562,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -572,8 +626,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -647,6 +707,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -681,6 +747,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -736,8 +808,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -811,6 +889,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -845,6 +929,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -900,8 +990,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -975,6 +1071,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1009,6 +1111,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -1072,8 +1180,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1147,6 +1261,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1181,6 +1301,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -1236,8 +1362,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1311,6 +1443,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1345,6 +1483,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -1400,8 +1544,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1475,6 +1625,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1509,6 +1665,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -1567,8 +1729,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1642,6 +1810,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1676,6 +1850,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -1731,8 +1911,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1806,6 +1992,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1840,6 +2032,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -1895,8 +2093,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1970,6 +2174,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2004,6 +2214,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -2067,8 +2283,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2142,6 +2364,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2176,6 +2404,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -2231,8 +2465,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2306,6 +2546,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2340,6 +2586,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -2395,8 +2647,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -2470,6 +2728,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2504,6 +2768,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -2562,8 +2832,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2637,6 +2913,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2671,6 +2953,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -2726,8 +3014,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2801,6 +3095,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2835,6 +3135,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -2890,8 +3196,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -2965,6 +3277,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2999,6 +3317,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -62,6 +62,9 @@ export const DefaultFontStyles: IFontStyles;
 // @public (undocumented)
 export const DefaultPalette: IPalette;
 
+// @public (undocumented)
+export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active) and (forced-colors: active)";
+
 // @public
 export function focusClear(): IRawStyle;
 
@@ -117,6 +120,11 @@ export namespace FontWeights {
     const // (undocumented)
     bold: IFontWeight;
 }
+
+// @public
+export function getEdgeChromiumNoHighContrastAdjustSelector(): {
+    [EdgeChromiumHighContrastSelector]: IStyle;
+};
 
 // @public
 export function getFadedOverflowStyle(theme: ITheme, color?: keyof ISemanticColors | keyof IPalette, direction?: 'horizontal' | 'vertical', width?: string | number, height?: string | number): IRawStyle;

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -123,7 +123,7 @@ export namespace FontWeights {
 
 // @public
 export function getEdgeChromiumNoHighContrastAdjustSelector(): {
-    [EdgeChromiumHighContrastSelector]: IStyle;
+    [EdgeChromiumHighContrastSelector]: IRawStyle;
 };
 
 // @public

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -1,6 +1,10 @@
+import { IStyle } from '../MergeStyles';
+
 export const HighContrastSelector = '@media screen and (-ms-high-contrast: active)';
 export const HighContrastSelectorWhite = '@media screen and (-ms-high-contrast: black-on-white)';
 export const HighContrastSelectorBlack = '@media screen and (-ms-high-contrast: white-on-black)';
+export const EdgeChromiumHighContrastSelector =
+  '@media screen and (-ms-high-contrast: active) and (forced-colors: active)';
 
 export const ScreenWidthMinSmall = 320;
 export const ScreenWidthMinMedium = 480;
@@ -18,4 +22,15 @@ export const ScreenWidthMinUhfMobile = 768;
 
 export function getScreenSelector(min: number, max: number): string {
   return `@media only screen and (min-width: ${min}px) and (max-width: ${max}px)`;
+}
+
+/**
+ * The style which turns off high contrast adjustment in (only) Edge Chromium browser.
+ */
+export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
+  return {
+    [EdgeChromiumHighContrastSelector]: {
+      forcedColorAdjust: 'none',
+    },
+  };
 }

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -1,4 +1,4 @@
-import { IStyle } from '../MergeStyles';
+import { IRawStyle } from '../MergeStyles';
 
 export const HighContrastSelector = '@media screen and (-ms-high-contrast: active)';
 export const HighContrastSelectorWhite = '@media screen and (-ms-high-contrast: black-on-white)';
@@ -27,7 +27,7 @@ export function getScreenSelector(min: number, max: number): string {
 /**
  * The style which turns off high contrast adjustment in (only) Edge Chromium browser.
  */
-export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
+export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IRawStyle } {
   return {
     [EdgeChromiumHighContrastSelector]: {
       forcedColorAdjust: 'none',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Mega issue: #11742
- [X] Addresses an existing issue: Fixes #11540
- [X] Include a change request file using `$ yarn change`

#### Description of changes
**Recap of the issue:**
In old Edge, the `-ms-high-contrast` media query implies `-ms-high-contrast-adjust: none` on each property inside the media query. In new/chromium Edge, this is no longer the case and `-ms-high-contrast-adjust: none` needs to be set explicitly for the properties inside HC media query to take effect.

**Heads-up:** 
The solution to this problem is not ideal. Ideally, this can be somehow addressed/improved at browser-level. However, after talking to folks in Edge, I don't see them offering anything concrete for us any time soon.

**Principal of the fix:**
1. Increase bundle size as little as possible. Add minimal amount of new css to resolve the issue.
2. No breaking change for styles set by existing use cases: 
Turing off high contrast adjustment can be a breaking change to the styles user set today on our component. For the styles user set today which are expected to be adjusted, this change potentially turns off adjustments for those case and user will need to add styles to set colors explicitly for HC.

**The fix:**
1. Added a new css selector added which turns off the HC adjustment in new Edge, and **only** new Edge (this is ensure principal No.2 above). You can read more about `forced-color-adjust` [here](https://www.w3.org/TR/css-color-adjust-1/#forced). it serves the same purpose as `-ms-high-contrast-adjust: none` in the context of this change.
2. Applies the new css selector in places where set high contrast styles using `HighContrastSelector` so our high contrast styles work in new Edge.
3. Find places where colors were previously expected to get adjusted but no longer are. Explicitly set HC styles for those cases

**To see what's changed visually**
In new Edge, before fix: https://developer.microsoft.com/en-us/fluentui#/controls/web/checkbox
In new Edge, after fix: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/13035/merge/fabric-website-resources/dist/index.html#/examples/checkbox

New Edge + Before fix:
![image](https://user-images.githubusercontent.com/1207059/81333717-d8158700-9059-11ea-96b1-a171dffe259c.png)

New Edge + After fix:
![image](https://user-images.githubusercontent.com/1207059/81333766-e499df80-9059-11ea-9d76-56a8beaed357.png)

Old Edge + Before fix:
![image](https://user-images.githubusercontent.com/1207059/81333894-101cca00-905a-11ea-903a-0fcafc67274f.png)

Old Edge + After fix:
![image](https://user-images.githubusercontent.com/1207059/81333973-262a8a80-905a-11ea-945c-a843593cceac.png)

#### Focus areas to test
- Old Edge
- New Chromium Edge



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13035)