### PR TITLE
fix(Types): fix ShorthandCollection Definition

### DIFF
--- a/apps/pr-deploy-site/CHANGELOG.json
+++ b/apps/pr-deploy-site/CHANGELOG.json
@@ -1,21 +1,6 @@
 {
   "name": "@uifabric/pr-deploy-site",
-  "entries": [
-    {
-      "date": "Thu, 07 May 2020 12:34:38 GMT",
-      "tag": "@uifabric/pr-deploy-site_v7.0.45",
-      "version": "7.0.45",
-      "comments": {
-        "patch": [
-          {
-            "comment": "removing more references to wrong filetype icons from a deprecated folder",
-            "author": "caperez@microsoft.com",
-            "commit": "c847450db51500f13847542b8f4c89dd277bb2bb",
-            "package": "@uifabric/pr-deploy-site"
-          }
-        ]
-      }
-    },
+  "entries": [    
     {
       "date": "Thu, 07 May 2020 01:06:55 GMT",
       "tag": "@uifabric/pr-deploy-site_v7.0.45",

--- a/apps/pr-deploy-site/CHANGELOG.json
+++ b/apps/pr-deploy-site/CHANGELOG.json
@@ -1,6 +1,6 @@
 {
   "name": "@uifabric/pr-deploy-site",
-  "entries": [    
+  "entries": [
     {
       "date": "Thu, 07 May 2020 01:06:55 GMT",
       "tag": "@uifabric/pr-deploy-site_v7.0.45",

--- a/apps/pr-deploy-site/CHANGELOG.json
+++ b/apps/pr-deploy-site/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@uifabric/pr-deploy-site",
   "entries": [
     {
+      "date": "Thu, 07 May 2020 12:34:38 GMT",
+      "tag": "@uifabric/pr-deploy-site_v7.0.45",
+      "version": "7.0.45",
+      "comments": {
+        "patch": [
+          {
+            "comment": "removing more references to wrong filetype icons from a deprecated folder",
+            "author": "caperez@microsoft.com",
+            "commit": "c847450db51500f13847542b8f4c89dd277bb2bb",
+            "package": "@uifabric/pr-deploy-site"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 07 May 2020 01:06:55 GMT",
       "tag": "@uifabric/pr-deploy-site_v7.0.45",
       "version": "7.0.45",

--- a/apps/pr-deploy-site/CHANGELOG.md
+++ b/apps/pr-deploy-site/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @uifabric/pr-deploy-site
 
-This log was last generated on Thu, 07 May 2020 01:06:55 GMT and should not be manually modified.
+This log was last generated on Thu, 07 May 2020 12:34:38 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [7.0.45](https://github.com/microsoft/fluentui/tree/@uifabric/pr-deploy-site_v7.0.45)
+
+Thu, 07 May 2020 12:34:38 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@uifabric/pr-deploy-site_v7.0.45..@uifabric/pr-deploy-site_v7.0.45)
+
+### Patches
+
+- removing more references to wrong filetype icons from a deprecated folder ([PR #12422](https://github.com/microsoft/fluentui/pull/12422) by caperez@microsoft.com)
 
 ## [7.0.45](https://github.com/microsoft/fluentui/tree/@uifabric/pr-deploy-site_v7.0.45)
 

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -34,7 +34,7 @@
     "@uifabric/set-version": "^7.0.11",
     "@uifabric/styling": "^7.12.3",
     "office-ui-fabric-react": "^7.110.5",
-    "@fluentui/react-next": "^8.0.0-alpha.12",
+    "@fluentui/react-next": "^8.0.0-alpha.13",
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",

--- a/change/@fluentui-react-next-2020-05-06-14-55-44-slider-tests-minorfix.json
+++ b/change/@fluentui-react-next-2020-05-06-14-55-44-slider-tests-minorfix.json
@@ -1,8 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Slider: Add some tests, fix minor bug for controlled component",
-  "packageName": "@fluentui/react-next",
-  "email": "joschect@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-05-06T21:55:44.105Z"
-}

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -51,6 +51,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Carousel` component which are passed to styles functions, @assuncaocharles ([#12966](https://github.com/microsoft/fluentui/pull/12966))
 - Restricted prop sets in the `Divider` component which are passed to styles functions, @assuncaocharles ([#12977](https://github.com/microsoft/fluentui/pull/12977))
 - Restricted prop sets in the `Toolbar` component which are passed to styles functions @layershifter ([#13024](https://github.com/microsoft/fluentui/pull/13024))
+- Change `AttachmentAction` to override `Button` styles and restricted props set @mnajdova ([#12913](https://github.com/microsoft/fluentui/pull/12913))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))
@@ -79,7 +80,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Converted Box, Button* and Attachment* components to use compose @layershifter @mnajdova ([#12745](https://github.com/microsoft/fluentui/pull/12745))
 - Respect `childBehaviors` for slots in `useAccessibility` hook @pompomon ([#12835](https://github.com/microsoft/fluentui/pull/12835))
 - Add `cardsContainerBehavior` for `Card`s in `Grid` navigation @mpompomon ([#12800](https://github.com/microsoft/fluentui/pull/12800))
-- Added `slots` and `mapPropsToSlotProps` in compose and added example usage in the `Button` component @mnajdova ([#12858](https://github.com/microsoft/fluentui/pull/12858))
+- Add `slots` and `mapPropsToSlotProps` in compose and added example usage in the `Button` component @mnajdova ([#12858](https://github.com/microsoft/fluentui/pull/12858))
+- Add slots support in `Attachment` @mnajdova ([#12913](https://github.com/microsoft/fluentui/pull/12913))
 
 ### Performance
 - Replace `fela-plugin-prexifer` with `stylis` @layershifter ([#12289](https://github.com/microsoft/fluentui/pull/12289))

--- a/packages/fluentui/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
+++ b/packages/fluentui/docs/src/prototypes/chatPane/services/messageFactoryMock.tsx
@@ -133,8 +133,6 @@ function createMessageContentWithAttachments(content: string, messageId: string)
 
   const action = {
     'aria-label': 'More attachment options',
-    iconOnly: true,
-    circular: true,
     icon: <MoreIcon />,
     onClick: e => e.stopPropagation(),
     onKeyDown: stopPropagationOnKeys([keyboardKey.Enter, keyboardKey.Spacebar]),

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
@@ -1,13 +1,29 @@
 import { buttonBehavior } from '@fluentui/accessibility';
+import * as customPropTypes from '@fluentui/react-proptypes';
+import * as PropTypes from 'prop-types';
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 
-import { createShorthandFactory, ShorthandFactory } from '../../utils';
+import { commonPropTypes, ShorthandConfig } from '../../utils';
 import Button, { ButtonProps, ButtonStylesProps } from '../Button/Button';
 
 interface AttachmentActionOwnProps {}
-export interface AttachmentActionProps extends AttachmentActionOwnProps, ButtonProps {}
+export interface AttachmentActionProps extends AttachmentActionOwnProps, ButtonProps {
+  text?: never;
+  iconOnly?: never;
+  circular?: never;
+  size?: never;
+  fluid?: never;
+  inverted?: never;
+}
 
-export type AttachmentActionStylesProps = never;
+export type AttachmentActionStylesProps = ButtonStylesProps & {
+  text?: never;
+  iconOnly?: never;
+  circular?: never;
+  size?: never;
+  fluid?: never;
+  inverted?: never;
+};
 export const attachmentActionClassName = 'ui-attachment__action';
 
 /**
@@ -22,16 +38,30 @@ const AttachmentAction = compose<
 >(Button, {
   className: attachmentActionClassName,
   displayName: 'AttachmentAction',
-}) as ComponentWithAs<'button', AttachmentActionProps> & { create: ShorthandFactory<any> };
+  overrideStyles: true,
+}) as ComponentWithAs<'button', AttachmentActionProps> & { shorthandConfig: ShorthandConfig<AttachmentActionProps> };
 
 AttachmentAction.defaultProps = {
   accessibility: buttonBehavior,
   as: 'button',
-  iconOnly: true,
-  text: true,
 };
-AttachmentAction.propTypes = Button.propTypes;
+AttachmentAction.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: 'shorthand',
+  }),
+  disabled: PropTypes.bool,
+  icon: customPropTypes.shorthandAllowingChildren,
+  iconPosition: PropTypes.oneOf(['before', 'after']),
+  loader: customPropTypes.itemShorthandWithoutJSX,
+  loading: PropTypes.bool,
+  onClick: PropTypes.func,
+  onFocus: PropTypes.func,
+  primary: customPropTypes.every([customPropTypes.disallow(['secondary']), PropTypes.bool]),
+  secondary: customPropTypes.every([customPropTypes.disallow(['primary']), PropTypes.bool]),
+};
 
-AttachmentAction.create = createShorthandFactory({ Component: AttachmentAction, mappedProp: 'content' });
+AttachmentAction.shorthandConfig = {
+  mappedProp: 'content',
+};
 
 export default AttachmentAction;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 
-import { commonPropTypes, createShorthandFactory, ShorthandFactory } from '../../utils';
+import { commonPropTypes, ShorthandConfig } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentBodyOwnProps {}
@@ -18,10 +18,12 @@ const AttachmentBody = compose<'div', AttachmentBodyOwnProps, AttachmentBodyStyl
     className: attachmentBodyClassName,
     displayName: 'AttachmentBody',
   },
-) as ComponentWithAs<'div', AttachmentBodyProps> & { create?: ShorthandFactory<AttachmentBodyProps> };
+) as ComponentWithAs<'div', AttachmentBodyProps> & { shorthandConfig: ShorthandConfig<AttachmentBodyProps> };
 
 AttachmentBody.propTypes = commonPropTypes.createCommon();
 
-AttachmentBody.create = createShorthandFactory({ Component: AttachmentBody, mappedProp: 'content' });
+AttachmentBody.shorthandConfig = {
+  mappedProp: 'content',
+};
 
 export default AttachmentBody;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 
-import { commonPropTypes, createShorthandFactory, ShorthandFactory } from '../../utils';
+import { commonPropTypes, ShorthandConfig } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentDescriptionOwnProps {}
@@ -23,13 +23,17 @@ const AttachmentDescription = compose<
   displayName: 'AttachmentDescription',
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', AttachmentDescriptionProps> & { create?: ShorthandFactory<AttachmentDescriptionProps> };
+}) as ComponentWithAs<'span', AttachmentDescriptionProps> & {
+  shorthandConfig: ShorthandConfig<AttachmentDescriptionProps>;
+};
 
 AttachmentDescription.defaultProps = {
   as: 'span',
 };
 AttachmentDescription.propTypes = commonPropTypes.createCommon();
 
-AttachmentDescription.create = createShorthandFactory({ Component: AttachmentDescription, mappedProp: 'content' });
+AttachmentDescription.shorthandConfig = {
+  mappedProp: 'content',
+};
 
 export default AttachmentDescription;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 
-import { commonPropTypes, createShorthandFactory, ShorthandFactory } from '../../utils';
+import { commonPropTypes, ShorthandConfig } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentHeaderOwnProps {}
@@ -24,14 +24,15 @@ const AttachmentHeader = compose<
 
   overrideStyles: true,
 }) as ComponentWithAs<'span', AttachmentHeaderProps> & {
-  create?: ShorthandFactory<AttachmentHeaderProps>;
+  shorthandConfig: ShorthandConfig<AttachmentHeaderProps>;
 };
 
 AttachmentHeader.defaultProps = {
   as: 'span',
 };
 AttachmentHeader.propTypes = commonPropTypes.createCommon();
-
-AttachmentHeader.create = createShorthandFactory({ Component: AttachmentHeader, mappedProp: 'content' });
+AttachmentHeader.shorthandConfig = {
+  mappedProp: 'content',
+};
 
 export default AttachmentHeader;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 
-import { commonPropTypes, createShorthandFactory, ShorthandFactory } from '../../utils';
+import { commonPropTypes, ShorthandConfig } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentIconOwnProps {}
@@ -20,13 +20,14 @@ const AttachmentIcon = compose<'span', AttachmentIconOwnProps, AttachmentIconSty
 
     overrideStyles: true,
   },
-) as ComponentWithAs<'span', AttachmentIconProps> & { create: ShorthandFactory<AttachmentIconProps> };
+) as ComponentWithAs<'span', AttachmentIconProps> & { shorthandConfig: ShorthandConfig<AttachmentIconProps> };
 
 AttachmentIcon.defaultProps = {
   as: 'span',
 };
 AttachmentIcon.propTypes = commonPropTypes.createCommon();
-
-AttachmentIcon.create = createShorthandFactory({ Component: AttachmentIcon, mappedProp: 'content' });
+AttachmentIcon.shorthandConfig = {
+  mappedProp: 'content',
+};
 
 export default AttachmentIcon;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -42,7 +42,7 @@ import {
   ColorComponentProps,
 } from '../../utils';
 import ToolbarCustomItem from './ToolbarCustomItem';
-import ToolbarDivider from './ToolbarDivider';
+import ToolbarDivider, { ToolbarDividerProps } from './ToolbarDivider';
 import ToolbarItem, { ToolbarItemProps } from './ToolbarItem';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarMenuDivider from './ToolbarMenuDivider';
@@ -69,7 +69,14 @@ export interface ToolbarProps
   accessibility?: Accessibility<ToolbarBehaviorProps>;
 
   /** Shorthand array of props for Toolbar. */
-  items?: ShorthandCollection<ToolbarItemProps, ToolbarItemShorthandKinds>;
+  items?: ShorthandCollection<
+    ToolbarItemProps,
+    ToolbarItemShorthandKinds,
+    {
+      item: ToolbarItemProps;
+      divider: ToolbarDividerProps;
+    }
+  >;
 
   /**
    *  Automatically move overflow items to overflow menu.

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -41,17 +41,23 @@ import {
   commonPropTypes,
   ColorComponentProps,
 } from '../../utils';
-import ToolbarCustomItem from './ToolbarCustomItem';
+import ToolbarCustomItem, { ToolbarCustomItemProps } from './ToolbarCustomItem';
 import ToolbarDivider, { ToolbarDividerProps } from './ToolbarDivider';
 import ToolbarItem, { ToolbarItemProps } from './ToolbarItem';
 import ToolbarMenu from './ToolbarMenu';
 import ToolbarMenuDivider from './ToolbarMenuDivider';
 import ToolbarMenuItem, { ToolbarMenuItemProps } from './ToolbarMenuItem';
-import ToolbarMenuRadioGroup from './ToolbarMenuRadioGroup';
+import ToolbarMenuRadioGroup, { ToolbarMenuRadioGroupProps } from './ToolbarMenuRadioGroup';
 import ToolbarRadioGroup from './ToolbarRadioGroup';
 import { ToolbarVariablesProvider } from './toolbarVariablesContext';
 
-export type ToolbarItemShorthandKinds = 'divider' | 'item' | 'group' | 'toggle' | 'custom';
+export type ToolbarItemShorthandKinds = {
+  item: ToolbarItemProps;
+  divider: ToolbarDividerProps;
+  group: ToolbarMenuRadioGroupProps;
+  toggle: ToolbarItemProps;
+  custom: ToolbarCustomItemProps;
+};
 
 type PositionOffset = {
   vertical: number;
@@ -69,14 +75,7 @@ export interface ToolbarProps
   accessibility?: Accessibility<ToolbarBehaviorProps>;
 
   /** Shorthand array of props for Toolbar. */
-  items?: ShorthandCollection<
-    ToolbarItemProps,
-    ToolbarItemShorthandKinds,
-    {
-      item: ToolbarItemProps;
-      divider: ToolbarDividerProps;
-    }
-  >;
+  items?: ShorthandCollection<ToolbarItemProps, ToolbarItemShorthandKinds>;
 
   /**
    *  Automatically move overflow items to overflow menu.
@@ -412,7 +411,6 @@ const Toolbar: React.FC<WithAsProp<ToolbarProps>> &
   };
 
   const collectOverflowItems = () => {
-    // console.log('getOverflowItems()', items.slice(lastVisibleItemIndex.current + 1))
     return getOverflowItems
       ? getOverflowItems(lastVisibleItemIndex.current + 1)
       : items.slice(lastVisibleItemIndex.current + 1);
@@ -435,7 +433,9 @@ const Toolbar: React.FC<WithAsProp<ToolbarProps>> &
 
   const renderItems = (items: ShorthandCollection<ToolbarItemProps, ToolbarItemShorthandKinds>) =>
     _.map(items, (item: ShorthandValue<ToolbarItemProps & { kind?: ToolbarItemShorthandKinds }>) => {
+      console.log(item);
       const kind = _.get(item, 'kind', 'item');
+      console.log(kind);
 
       switch (kind) {
         case 'divider':

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Attachment/attachmentActionVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Attachment/attachmentActionVariables.ts
@@ -1,7 +1,1 @@
-import { AttachmentActionVariables } from '../../../teams/components/Attachment/attachmentActionVariables';
-
-const attachmentActionVariables = (siteVariables: any): AttachmentActionVariables => ({
-  textColor: siteVariables.colors.white,
-});
-
-export default attachmentActionVariables;
+export { default } from './attachmentVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-dark/components/Attachment/attachmentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-dark/components/Attachment/attachmentVariables.ts
@@ -8,4 +8,6 @@ export default (siteVariables: any): Partial<AttachmentVariables> => ({
   backgroundColorHover: siteVariables.colors.grey[500],
   borderColor: siteVariables.colors.onyx[700],
   boxShadow: siteVariables.shadowLevel1,
+
+  actionColor: siteVariables.colors.white,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Attachment/attachmentActionVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Attachment/attachmentActionVariables.ts
@@ -1,7 +1,1 @@
-import { AttachmentActionVariables } from '../../../teams/components/Attachment/attachmentActionVariables';
-
-const attachmentActionVariables = (siteVariables: any): AttachmentActionVariables => ({
-  textColor: siteVariables.colors.white,
-});
-
-export default attachmentActionVariables;
+export { default } from './attachmentVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Attachment/attachmentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams-high-contrast/components/Attachment/attachmentVariables.ts
@@ -13,4 +13,5 @@ export default (siteVariables: any): Partial<AttachmentVariables> => ({
   boxShadow: undefined,
   progressColor: siteVariables.accessibleGreen,
   progressHeight: 6,
+  actionColor: siteVariables.colors.white,
 });

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionStyles.ts
@@ -1,38 +1,116 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { svgIconClassName } from '@fluentui/react-icons-northstar';
 
 import { AttachmentActionStylesProps } from '../../../../components/Attachment/AttachmentAction';
 import getIconFillOrOutlineStyles from '../../getIconFillOrOutlineStyles';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
-import { AttachmentActionVariables } from './attachmentActionVariables';
+import { AttachmentVariables } from './attachmentVariables';
+import { pxToRem } from '../../../../utils';
+import { loaderSlotClassNames } from '../../../../components/Loader/Loader';
 
-const attachmentActionStyles: ComponentSlotStylesPrepared<AttachmentActionStylesProps, AttachmentActionVariables> = {
-  root: ({ variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
+const attachmentActionStyles: ComponentSlotStylesPrepared<AttachmentActionStylesProps, AttachmentVariables> = {
+  root: ({ props: p, variables: v, theme }): ICSSInJSStyle => {
+    const { siteVariables } = theme;
     const iconFilledStyles = getIconFillOrOutlineStyles({ outline: false });
     const borderFocusStyles = getBorderFocusStyles({
       variables: siteVariables,
-      borderRadius: v.borderRadius,
+      borderRadius: v.actionFocusBorderRadius,
     });
 
     return {
-      [`& .${svgIconClassName}`]: {
-        color: v.textColor, // this breaks the color change on hover
-      },
+      height: v.actionHeight,
+      maxWidth: v.actionMaxWidth,
+      display: 'inline-flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      position: 'relative',
+      verticalAlign: 'middle',
+      cursor: 'pointer',
 
+      // text button defaults
+      color: v.actionColor, // textColor
+      backgroundColor: 'transparent',
+      borderColor: 'transparent',
+      padding: 0,
+
+      // by default icons should always be outline, but filled on hover/focus
       ...getIconFillOrOutlineStyles({ outline: true }),
 
-      ':hover': {
-        ...iconFilledStyles,
-        background: 'transparent',
+      ':focus': {
+        boxShadow: 'none',
+        ...borderFocusStyles[':focus'],
       },
-
-      ':focus': borderFocusStyles[':focus'],
       ':focus-visible': {
         ...iconFilledStyles,
         ...borderFocusStyles[':focus-visible'],
       },
+
+      ...(p.primary && {
+        color: v.actionPrimaryColor,
+      }),
+
+      // Overrides for "disabled" buttons
+      ...(p.disabled && {
+        cursor: 'default',
+        boxShadow: 'none',
+        pointerEvents: 'none',
+
+        color: v.actionColorDisabled,
+        backgroundColor: 'transparent',
+        ':hover': {
+          color: v.actionColorDisabled,
+        },
+      }),
+
+      minWidth: v.actionHeight,
+      ':hover': {
+        ...getIconFillOrOutlineStyles({ outline: false }),
+      },
     };
   },
+
+  icon: ({ props: p, variables: v }) => ({
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: v.actionIconSize,
+    height: v.actionIconSize,
+
+    // when loading, hide the icon
+    ...(p.loading && {
+      margin: 0,
+      opacity: 0,
+      width: 0,
+    }),
+
+    ...(p.hasContent && {
+      margin: `0 ${pxToRem(10)} 0 0`,
+      ...(p.iconPosition === 'after' && {
+        margin: `0 0 0 ${pxToRem(10)}`,
+      }),
+    }),
+  }),
+  loader: ({ props: p, variables: v }): ICSSInJSStyle => ({
+    [`& .${loaderSlotClassNames.indicator}`]: {
+      width: v.actionLoaderSize,
+      height: v.actionLoaderSize,
+    },
+    [`& .${loaderSlotClassNames.svg}`]: {
+      ':before': {
+        animationName: {
+          to: {
+            transform: `translate3d(0, ${v.actionLoaderSvgAnimationHeight}, 0)`,
+          },
+        },
+        borderWidth: v.actionLoaderBorderSize,
+        width: v.actionLoaderSize,
+        height: v.actionLoaderSvgHeight,
+      },
+    },
+
+    ...(p.hasContent && {
+      marginRight: pxToRem(4),
+    }),
+  }),
 };
 
 export default attachmentActionStyles;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentActionVariables.ts
@@ -1,11 +1,1 @@
-import { pxToRem } from '../../../../utils';
-import { ButtonVariables } from '../Button/buttonVariables';
-
-export type AttachmentActionVariables = Partial<ButtonVariables>;
-
-const attachmentActionVariables = (siteVariables: any): AttachmentActionVariables => ({
-  borderRadius: pxToRem(3),
-  textColor: siteVariables.colors.grey[750],
-});
-
-export default attachmentActionVariables;
+export { default } from './attachmentVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Attachment/attachmentVariables.ts
@@ -29,6 +29,18 @@ export type AttachmentVariables = {
   descriptionFontSize: string;
   descriptionFontWeight: number;
   descriptionLineHeight: number;
+
+  actionHeight: string;
+  actionMaxWidth: string;
+  actionColor: string;
+  actionPrimaryColor: string;
+  actionColorDisabled: string;
+  actionIconSize: string;
+  actionLoaderBorderSize: string;
+  actionLoaderSize: string;
+  actionLoaderSvgHeight: string;
+  actionLoaderSvgAnimationHeight: string;
+  actionFocusBorderRadius: string;
 };
 
 export default (siteVariables: any): AttachmentVariables => ({
@@ -59,4 +71,17 @@ export default (siteVariables: any): AttachmentVariables => ({
   descriptionFontSize: siteVariables.fontSizes.small,
   descriptionFontWeight: siteVariables.fontWeightRegular,
   descriptionLineHeight: siteVariables.lineHeightDefault,
+
+  // action variables
+  actionHeight: pxToRem(32),
+  actionMaxWidth: pxToRem(280),
+  actionColor: siteVariables.colors.grey[750],
+  actionPrimaryColor: siteVariables.colorScheme.brand.foreground,
+  actionColorDisabled: siteVariables.colorScheme.brand.foregroundDisabled1,
+  actionIconSize: pxToRem(16),
+  actionLoaderBorderSize: pxToRem(2),
+  actionLoaderSize: pxToRem(20),
+  actionLoaderSvgHeight: pxToRem(1220),
+  actionLoaderSvgAnimationHeight: pxToRem(-1200),
+  actionFocusBorderRadius: pxToRem(3),
 });

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -65,8 +65,8 @@ type ReactNode = React.ReactChild | React.ReactNodeArray | React.ReactPortal | b
 export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
-export type ShorthandCollection<P, K = never, I = { [Key in keyof K]: unknown }> = ShorthandValue<
-  P & { kind?: K } & I
+export type ShorthandCollection<P, K = never, I = { [Key in keyof K]?: unknown }> = ShorthandValue<
+  P & { kind?: K } & { [Key in keyof I]: unknown }
 >[];
 
 // ========================================================

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -65,7 +65,7 @@ type ReactNode = React.ReactChild | React.ReactNodeArray | React.ReactPortal | b
 export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
-export type ShorthandCollection<P, K = never> = ShorthandValue<P & { kind?: K }>[];
+export type ShorthandCollection<P, K = never, I = Record<keyof K, unknown>> = ShorthandValue<P & { kind?: K } & I>[];
 
 // ========================================================
 // Types for As prop support

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -65,7 +65,7 @@ type ReactNode = React.ReactChild | React.ReactNodeArray | React.ReactPortal | b
 export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
-export type ShorthandCollection<P, K = never, I = Record<keyof K, unknown> | never> = ShorthandValue<
+export type ShorthandCollection<P, K = never, I = { [Key in keyof K]: unknown }> = ShorthandValue<
   P & { kind?: K } & I
 >[];
 

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -66,7 +66,7 @@ export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
 export type ShorthandCollection<P, K = never, I = { [Key in keyof K]?: unknown }> = ShorthandValue<
-  P & { kind?: K } & { [Key in keyof I]: unknown }
+  P & { kind?: K } & { [Key in keyof I]?: unknown }
 >[];
 
 // ========================================================

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -65,7 +65,9 @@ type ReactNode = React.ReactChild | React.ReactNodeArray | React.ReactPortal | b
 export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
-export type ShorthandCollection<P, K = never, I = Record<keyof K, unknown>> = ShorthandValue<P & { kind?: K } & I>[];
+export type ShorthandCollection<P, K = never, I = Record<keyof K, unknown> | never> = ShorthandValue<
+  P & { kind?: K } & I
+>[];
 
 // ========================================================
 // Types for As prop support

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -65,9 +65,7 @@ type ReactNode = React.ReactChild | React.ReactNodeArray | React.ReactPortal | b
 export type ShorthandValue<P extends Props> =
   | ReactNode
   | (Props<P> & { children?: P['children'] | ShorthandRenderFunction<P> });
-export type ShorthandCollection<P, K = never, I = { [Key in keyof K]?: unknown }> = ShorthandValue<
-  P & { kind?: K } & { [Key in keyof I]?: unknown }
->[];
+export type ShorthandCollection<P, K = never> = ShorthandValue<P & { kind?: keyof K } & Partial<K[keyof K]>>[];
 
 // ========================================================
 // Types for As prop support

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -150,7 +150,7 @@ export function createShorthandInternal<P>({
   // ----------------------------------------
   // Build up props
   // ----------------------------------------
-  const defaultProps = options.defaultProps ? options.defaultProps() : ({} as Props<P>);
+  const defaultProps = options.defaultProps ? options.defaultProps() || ({} as Props<P>) : ({} as Props<P>);
 
   // User's props
   const usersProps =

--- a/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
+++ b/packages/fluentui/react-northstar/test/specs/commonTests/isConformant.tsx
@@ -298,7 +298,7 @@ export default function isConformant(
       expect(handledProps).toContain('variables');
     });
 
-    test('handledProps includes all handled props', () => {
+    test('handledProps includes props defined in autoControlledProps, defaultProps or propTypes', () => {
       const computedProps = _.union(
         Component.autoControlledProps,
         _.keys(Component.defaultProps),
@@ -307,17 +307,18 @@ export default function isConformant(
       const expectedProps = _.uniq(computedProps).sort();
 
       const message =
-        'Not all handled props were defined in static handledProps. Add all props defined in' +
-        ' static autoControlledProps, static defaultProps and static propTypes must be defined' +
-        ' in static handledProps.';
+        'Not all handled props were defined correctly. All props defined in handled props, must be defined' +
+        'either in static autoControlledProps, static defaultProps or static propTypes.';
 
       expect({
         message,
         handledProps: handledProps.sort(),
-      }).toEqual({
-        message,
-        handledProps: expectedProps,
-      });
+      }).toEqual(
+        expect.objectContaining({
+          message,
+          handledProps: expect.arrayContaining(expectedProps),
+        }),
+      );
     });
 
     const isClassComponent = !!Component.prototype?.isReactComponent;

--- a/packages/fluentui/react-northstar/test/specs/utils/factories-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/utils/factories-test.tsx
@@ -380,6 +380,10 @@ describe('factories', () => {
           { ...defaultPropsValue, children: 'foo' },
         );
       });
+
+      test('returns empty object if the result of the function is undefined', () => {
+        testCreateShorthand({ defaultProps: () => undefined, value: 'foo' }, { children: 'foo' });
+      });
     });
 
     describe('key', () => {

--- a/packages/react-next/CHANGELOG.json
+++ b/packages/react-next/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@fluentui/react-next",
   "entries": [
     {
+      "date": "Thu, 07 May 2020 12:34:38 GMT",
+      "tag": "@fluentui/react-next_v8.0.0-alpha.13",
+      "version": "8.0.0-alpha.13",
+      "comments": {
+        "prerelease": [
+          {
+            "comment": "Slider: Add some tests, fix minor bug for controlled component",
+            "author": "joschect@microsoft.com",
+            "commit": "31404935a5e8287ea7e5fdb491c1deb96338b710",
+            "package": "@fluentui/react-next"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 06 May 2020 12:32:22 GMT",
       "tag": "@fluentui/react-next_v8.0.0-alpha.11",
       "version": "8.0.0-alpha.11",

--- a/packages/react-next/CHANGELOG.md
+++ b/packages/react-next/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @fluentui/react-next
 
-This log was last generated on Wed, 06 May 2020 12:32:22 GMT and should not be manually modified.
+This log was last generated on Thu, 07 May 2020 12:34:38 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## [8.0.0-alpha.13](https://github.com/microsoft/fluentui/tree/@fluentui/react-next_v8.0.0-alpha.13)
+
+Thu, 07 May 2020 12:34:38 GMT 
+[Compare changes](https://github.com/microsoft/fluentui/compare/@fluentui/react-next_v8.0.0-alpha.11..@fluentui/react-next_v8.0.0-alpha.13)
+
+### Changes
+
+- Slider: Add some tests, fix minor bug for controlled component ([PR #13032](https://github.com/microsoft/fluentui/pull/13032) by joschect@microsoft.com)
 
 ## [8.0.0-alpha.11](https://github.com/microsoft/fluentui/tree/@fluentui/react-next_v8.0.0-alpha.11)
 

--- a/packages/react-next/package.json
+++ b/packages/react-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-next",
-  "version": "8.0.0-alpha.12",
+  "version": "8.0.0-alpha.13",
   "beachball": {
     "disallowedChangeTypes": [
       "patch",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In #1605 was done an update for ShorthandCollection but it was not fully complete:

```typescript
export interface ToolbarProps {
  /** Shorthand array of props for Toolbar. */
  items?: ShorthandCollection<ToolbarItemProps, ToolbarItemShorthandKinds>
}
```

It's not enough because for kind="divider" we should have ToolbarDividerProps.

This PR implements the proposed solution:

```typescript
export interface ToolbarProps {
  /** Shorthand array of props for Toolbar. */
  items?: ShorthandCollection<ToolbarItemProps, ToolbarItemShorthandKinds, {
    item: ToolbarItemProps,
    divider: ToolbarDividerProps
  }>
}
```

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13041)