### PR TITLE
chore(Toolbar): use compose()

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleCompose.shorthand.tsx
@@ -1,0 +1,119 @@
+import { compose } from '@fluentui/react-bindings';
+import {
+  Provider,
+  Toolbar,
+  ToolbarItem,
+  ToolbarItemProps,
+  ToolbarItemStylesProps,
+  ToolbarMenu,
+  ToolbarMenuItem,
+  ToolbarMenuItemProps,
+  ToolbarMenuItemStylesProps,
+  ToolbarMenuProps,
+  ToolbarMenuStylesProps,
+  ToolbarProps,
+  ToolbarStylesProps,
+} from '@fluentui/react-northstar';
+import * as React from 'react';
+import { MoreIcon, PauseIcon, PlayIcon, BoldIcon, UnderlineIcon } from '@fluentui/react-icons-northstar';
+
+const CustomToolbarMenuItem = compose<'button', {}, {}, ToolbarMenuItemProps, ToolbarMenuItemStylesProps>(
+  ToolbarMenuItem,
+  {
+    displayName: 'CustomToolbarMenuItem',
+    slots: {
+      // menu: CustomToolbarMenu /* WELCOME TO CIRCULAR REFERENCES */,
+    },
+    // Option 1: to potentially avoid circulars we can use callbacks
+    // Option 2: assign non-existant slots on parent and pass them down
+    // Option 3: break circular references somehow
+  },
+);
+const CustomToolbarMenu = compose<'ul', {}, {}, ToolbarMenuProps, ToolbarMenuStylesProps>(ToolbarMenu, {
+  displayName: 'CustomToolbarMenu',
+  slots: {
+    item: CustomToolbarMenuItem,
+  },
+});
+const CustomToolbarItem = compose<'button', {}, {}, ToolbarItemProps, ToolbarItemStylesProps>(ToolbarItem, {
+  displayName: 'CustomToolbarItem',
+  slots: {
+    menu: CustomToolbarMenu,
+  },
+});
+const CustomToolbar = compose<'div', {}, {}, ToolbarProps, ToolbarStylesProps>(Toolbar, {
+  displayName: 'CustomToolbar',
+  slots: {
+    item: CustomToolbarItem,
+  },
+});
+
+const customTheme = {
+  componentStyles: {
+    CustomToolbar: {
+      root: () => ({ border: '1px solid red' }),
+    },
+    CustomToolbarItem: {
+      root: () => ({ background: 'green' }),
+    },
+    CustomToolbarMenu: {
+      root: () => ({ background: 'orange' }),
+    },
+    CustomToolbarMenuItem: {
+      root: () => ({ background: 'blue' }),
+    },
+  },
+};
+
+const ToolbarExampleCompose = () => {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [subMenuOpen, setSubMenuOpen] = React.useState(false);
+
+  return (
+    <Provider theme={customTheme}>
+      <CustomToolbar
+        aria-label="A Toolbar that uses compose()"
+        items={[
+          {
+            key: 'bold',
+            content: 'bold',
+            icon: <BoldIcon />,
+            title: 'Bold',
+          },
+          {
+            key: 'underline',
+            content: 'underline',
+            icon: <UnderlineIcon />,
+            title: 'Underline',
+          },
+
+          {
+            icon: <MoreIcon />,
+            key: 'more',
+            active: menuOpen,
+            title: 'More',
+            menu: {
+              items: [
+                {
+                  key: 'play',
+                  content: 'Play',
+                  icon: <PlayIcon />,
+                  menu: ['One', 'Two', 'Three'],
+                  menuOpen: subMenuOpen,
+                  onMenuOpenChange: (e, data) => setSubMenuOpen(data.menuOpen),
+                },
+                { key: 'pause', content: 'Pause', icon: <PauseIcon /> },
+                { key: 'divider', kind: 'divider' },
+                'Without icon',
+              ],
+            },
+            menuOpen,
+            onMenuOpenChange: (e, data) => setMenuOpen(data.menuOpen),
+          },
+        ]}
+      />
+    </Provider>
+  );
+};
+
+export default ToolbarExampleCompose;

--- a/packages/fluentui/react-northstar/src/components/Box/Box.tsx
+++ b/packages/fluentui/react-northstar/src/components/Box/Box.tsx
@@ -28,7 +28,7 @@ export interface BoxProps extends UIComponentProps<BoxProps>, ContentComponentPr
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<never>;
 }
-export type BoxStylesProps = never;
+export type BoxStylesProps = {};
 
 export const boxClassName = 'ui-box';
 

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -6,6 +6,8 @@ import {
   IS_FOCUSABLE_ATTRIBUTE,
 } from '@fluentui/accessibility';
 import {
+  ComponentWithAs,
+  compose,
   getElementType,
   getFirstFocusable,
   useAccessibility,
@@ -14,7 +16,7 @@ import {
   useUnhandledProps,
 } from '@fluentui/react-bindings';
 import { EventListener } from '@fluentui/react-component-event-listener';
-import { Ref } from '@fluentui/react-component-ref';
+import { handleRef, Ref } from '@fluentui/react-component-ref';
 import { MoreIcon } from '@fluentui/react-icons-northstar';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
@@ -23,18 +25,10 @@ import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import {
-  ComponentEventHandler,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-  ShorthandCollection,
-  ShorthandValue,
-  WithAsProp,
-  withSafeTypeForAs,
-} from '../../types';
+import { ComponentEventHandler, ProviderContextPrepared, ShorthandCollection, ShorthandValue } from '../../types';
 import {
   childrenExist,
-  createShorthandFactory,
+  createShorthand,
   UIComponentProps,
   ContentComponentProps,
   ChildrenComponentProps,
@@ -118,412 +112,472 @@ export type ToolbarStylesProps = never;
 
 export const toolbarClassName = 'ui-toolbar';
 
-const Toolbar: React.FC<WithAsProp<ToolbarProps>> &
-  FluentComponentStaticProps<ToolbarProps> & {
-    CustomItem: typeof ToolbarCustomItem;
-    Divider: typeof ToolbarDivider;
-    Item: typeof ToolbarItem;
-    Menu: typeof ToolbarMenu;
-    MenuDivider: typeof ToolbarMenuDivider;
-    MenuItem: typeof ToolbarMenuItem;
-    MenuRadioGroup: typeof ToolbarMenuRadioGroup;
-    RadioGroup: typeof ToolbarRadioGroup;
-  } = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(Toolbar.displayName, context.telemetry);
-  setStart();
+/**
+ * A Toolbar is a container for grouping a set of controls, often action controls (e.g. buttons) or input controls (e.g. checkboxes).
+ *
+ * @accessibility
+ *  * Implements [ARIA Toolbar](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) design pattern.
+ * @accessibilityIssues
+ * [Issue 988424: VoiceOver narrates selected for button in toolbar](https://bugs.chromium.org/p/chromium/issues/detail?id=988424)
+ */
+const Toolbar = compose<'div', ToolbarProps, ToolbarStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const {
-    accessibility,
-    className,
-    children,
-    design,
-    getOverflowItems,
-    items,
-    overflow,
-    overflowItem,
-    overflowOpen,
-    styles,
-    variables,
-  } = props;
-
-  const overflowContainerRef = React.useRef<HTMLDivElement>();
-  const overflowItemRef = React.useRef<HTMLElement>();
-  const offsetMeasureRef = React.useRef<HTMLDivElement>();
-  const containerRef = React.useRef<HTMLElement>();
-
-  // index of the last visible item in Toolbar, the rest goes to overflow menu
-  const lastVisibleItemIndex = React.useRef<number>();
-  const animationFrameId = React.useRef<number>();
-
-  const getA11Props = useAccessibility(accessibility, {
-    debugName: Toolbar.displayName,
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarStylesProps>(Toolbar.displayName, {
-    className: toolbarClassName,
-    mapPropsToInlineStyles: () => ({
+    const {
+      accessibility,
       className,
+      children,
       design,
+      getOverflowItems,
+      items,
+      overflow,
+      overflowItem,
+      overflowOpen,
       styles,
       variables,
-    }),
-    rtl: context.rtl,
-  });
+    } = props;
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(Toolbar.handledProps, props);
+    const overflowContainerRef = React.useRef<HTMLDivElement>();
+    const overflowItemRef = React.useRef<HTMLElement>();
+    const offsetMeasureRef = React.useRef<HTMLDivElement>();
+    const containerRef = React.useRef<HTMLElement>();
 
-  const hide = (el: HTMLElement) => {
-    if (el.style.visibility === 'hidden') {
-      return;
-    }
+    // index of the last visible item in Toolbar, the rest goes to overflow menu
+    const lastVisibleItemIndex = React.useRef<number>();
+    const animationFrameId = React.useRef<number>();
 
-    if (context.target.activeElement === el || el.contains(context.target.activeElement)) {
-      if (containerRef.current) {
-        const firstFocusableItem = getFirstFocusable(
-          containerRef.current,
-          containerRef.current.firstElementChild as HTMLElement,
-        );
+    const getA11Props = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarStylesProps>(composeOptions.displayName, {
+      className: toolbarClassName,
+      composeOptions,
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables,
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
 
-        if (firstFocusableItem) {
-          firstFocusableItem.focus();
+    const ElementType = getElementType(props);
+    const slotProps = composeOptions.resolveSlotProps<ToolbarProps>(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const hide = (el: HTMLElement) => {
+      if (el.style.visibility === 'hidden') {
+        return;
+      }
+
+      if (context.target.activeElement === el || el.contains(context.target.activeElement)) {
+        if (containerRef.current) {
+          const firstFocusableItem = getFirstFocusable(
+            containerRef.current,
+            containerRef.current.firstElementChild as HTMLElement,
+          );
+
+          if (firstFocusableItem) {
+            firstFocusableItem.focus();
+          }
         }
       }
-    }
 
-    el.style.visibility = 'hidden';
-    const wasFocusable = el.getAttribute(IS_FOCUSABLE_ATTRIBUTE);
-    if (wasFocusable) {
-      el.setAttribute(WAS_FOCUSABLE_ATTRIBUTE, wasFocusable);
-    }
-    el.setAttribute(IS_FOCUSABLE_ATTRIBUTE, 'false');
-  };
-
-  const show = (el: HTMLElement) => {
-    if (el.style.visibility !== 'hidden') {
-      return false;
-    }
-
-    el.style.visibility = null;
-    const wasFocusable = el.getAttribute(WAS_FOCUSABLE_ATTRIBUTE);
-    if (wasFocusable) {
-      el.setAttribute(IS_FOCUSABLE_ATTRIBUTE, wasFocusable);
-      el.removeAttribute(WAS_FOCUSABLE_ATTRIBUTE);
-    } else {
-      el.removeAttribute(IS_FOCUSABLE_ATTRIBUTE);
-    }
-
-    return true;
-  };
-
-  /**
-   * Checks if `item` overflows a `container`.
-   * TODO: check and fix all margin combination
-   */
-  const isItemOverflowing = (itemBoundingRect: ClientRect, containerBoundingRect: ClientRect) => {
-    return itemBoundingRect.right > containerBoundingRect.right || itemBoundingRect.left < containerBoundingRect.left;
-  };
-
-  /**
-   * Checks if `item` would collide with eventual position of `overflowItem`.
-   */
-  const wouldItemCollide = (
-    $item: Element,
-    itemBoundingRect: ClientRect,
-    overflowItemBoundingRect: ClientRect,
-    containerBoundingRect: ClientRect,
-  ) => {
-    const actualWindow: Window = context.target.defaultView;
-    let wouldCollide;
-
-    if (context.rtl) {
-      const itemLeftMargin = parseFloat(actualWindow.getComputedStyle($item).marginLeft) || 0;
-      wouldCollide =
-        itemBoundingRect.left - overflowItemBoundingRect.width - itemLeftMargin < containerBoundingRect.left;
-
-      // console.log('Collision [RTL]', {
-      //   wouldCollide,
-      //   'itemBoundingRect.left': itemBoundingRect.left,
-      //   'overflowItemBoundingRect.width': overflowItemBoundingRect.width,
-      //   itemRightMargin: itemLeftMargin,
-      //   sum: itemBoundingRect.left - overflowItemBoundingRect.width - itemLeftMargin,
-      //   'overflowContainerBoundingRect.left': containerBoundingRect.left,
-      // })
-    } else {
-      const itemRightMargin = parseFloat(actualWindow.getComputedStyle($item).marginRight) || 0;
-      wouldCollide =
-        itemBoundingRect.right + overflowItemBoundingRect.width + itemRightMargin > containerBoundingRect.right;
-
-      // console.log('Collision', {
-      //   wouldCollide,
-      //   'itemBoundingRect.right': itemBoundingRect.right,
-      //   'overflowItemBoundingRect.width': overflowItemBoundingRect.width,
-      //   itemRightMargin,
-      //   sum: itemBoundingRect.right + overflowItemBoundingRect.width + itemRightMargin,
-      //   'overflowContainerBoundingRect.right': containerBoundingRect.right,
-      // })
-    }
-
-    return wouldCollide;
-  };
-
-  /**
-   * Positions overflowItem next to lastVisible item
-   * TODO: consider overflowItem margin
-   */
-  const setOverflowPosition = (
-    $overflowItem: HTMLElement,
-    $lastVisibleItem: HTMLElement | undefined,
-    lastVisibleItemRect: ClientRect | undefined,
-    containerBoundingRect: ClientRect,
-    absolutePositioningOffset: PositionOffset,
-  ) => {
-    const actualWindow: Window = context.target.defaultView;
-
-    if ($lastVisibleItem) {
-      if (context.rtl) {
-        const lastVisibleItemMarginLeft = parseFloat(actualWindow.getComputedStyle($lastVisibleItem).marginLeft) || 0;
-
-        $overflowItem.style.right = `${containerBoundingRect.right -
-          lastVisibleItemRect.left +
-          lastVisibleItemMarginLeft +
-          absolutePositioningOffset.horizontal}px`;
-      } else {
-        const lastVisibleItemRightMargin = parseFloat(actualWindow.getComputedStyle($lastVisibleItem).marginRight) || 0;
-
-        $overflowItem.style.left = `${lastVisibleItemRect.right -
-          containerBoundingRect.left +
-          lastVisibleItemRightMargin +
-          absolutePositioningOffset.horizontal}px`;
+      el.style.visibility = 'hidden';
+      const wasFocusable = el.getAttribute(IS_FOCUSABLE_ATTRIBUTE);
+      if (wasFocusable) {
+        el.setAttribute(WAS_FOCUSABLE_ATTRIBUTE, wasFocusable);
       }
-    } else {
-      // there is no last visible item -> position the overflow as the first item
-      lastVisibleItemIndex.current = -1;
-      if (context.rtl) {
-        $overflowItem.style.right = `${absolutePositioningOffset.horizontal}px`;
-      } else {
-        $overflowItem.style.left = `${absolutePositioningOffset.horizontal}px`;
-      }
-    }
-  };
-
-  const hideOverflowItems = () => {
-    const $overflowContainer = overflowContainerRef.current;
-    const $overflowItem = overflowItemRef.current;
-    const $offsetMeasure = offsetMeasureRef.current;
-    if (!$overflowContainer || !$overflowItem || !$offsetMeasure) {
-      return;
-    }
-
-    // workaround: when resizing window with popup opened the container contents scroll for some reason
-    if (context.rtl) {
-      $overflowContainer.scrollTo(Number.MAX_SAFE_INTEGER, 0);
-    } else {
-      $overflowContainer.scrollTo(0, 0);
-    }
-
-    const $items = $overflowContainer.children;
-
-    const overflowContainerBoundingRect = $overflowContainer.getBoundingClientRect();
-    const overflowItemBoundingRect = $overflowItem.getBoundingClientRect();
-    const offsetMeasureBoundingRect = $offsetMeasure.getBoundingClientRect();
-
-    // Absolute positioning offset
-    // Overflow menu is absolutely positioned relative to root slot
-    // If there is padding set on the root slot boundingClientRect computations use inner content box,
-    // but absolute position is relative to root slot's PADDING box.
-    // We compute absolute positioning offset
-    // By measuring position of an offsetMeasure element absolutely positioned to 0,0.
-    // TODO: replace by getComputedStyle('padding')
-    const absolutePositioningOffset: PositionOffset = {
-      horizontal: context.rtl
-        ? offsetMeasureBoundingRect.right - overflowContainerBoundingRect.right
-        : overflowContainerBoundingRect.left - offsetMeasureBoundingRect.left,
-      vertical: overflowContainerBoundingRect.top - offsetMeasureBoundingRect.top,
+      el.setAttribute(IS_FOCUSABLE_ATTRIBUTE, 'false');
     };
 
-    let isOverflowing = false;
-    let $lastVisibleItem;
-    let lastVisibleItemRect;
-
-    // check all items from the last one back
-    _.forEachRight($items, ($item: HTMLElement, i: number) => {
-      if ($item === $overflowItem) {
-        return true;
+    const show = (el: HTMLElement) => {
+      if (el.style.visibility !== 'hidden') {
+        return false;
       }
 
-      const itemBoundingRect = $item.getBoundingClientRect();
+      el.style.visibility = null;
+      const wasFocusable = el.getAttribute(WAS_FOCUSABLE_ATTRIBUTE);
+      if (wasFocusable) {
+        el.setAttribute(IS_FOCUSABLE_ATTRIBUTE, wasFocusable);
+        el.removeAttribute(WAS_FOCUSABLE_ATTRIBUTE);
+      } else {
+        el.removeAttribute(IS_FOCUSABLE_ATTRIBUTE);
+      }
 
-      // if the item is out of the crop rectangle, hide it
-      if (isItemOverflowing(itemBoundingRect, overflowContainerBoundingRect)) {
-        isOverflowing = true;
-        // console.log('Overflow', i, {
-        //   item: [itemBoundingRect.left, itemBoundingRect.right],
-        //   crop: [
-        //     overflowContainerBoundingRect.left,
-        //     overflowContainerBoundingRect.right,
-        //     overflowContainerBoundingRect.width,
-        //   ],
-        //   container: $overflowContainer,
+      return true;
+    };
+
+    /**
+     * Checks if `item` overflows a `container`.
+     * TODO: check and fix all margin combination
+     */
+    const isItemOverflowing = (itemBoundingRect: ClientRect, containerBoundingRect: ClientRect) => {
+      return itemBoundingRect.right > containerBoundingRect.right || itemBoundingRect.left < containerBoundingRect.left;
+    };
+
+    /**
+     * Checks if `item` would collide with eventual position of `overflowItem`.
+     */
+    const wouldItemCollide = (
+      $item: Element,
+      itemBoundingRect: ClientRect,
+      overflowItemBoundingRect: ClientRect,
+      containerBoundingRect: ClientRect,
+    ) => {
+      const actualWindow: Window = context.target.defaultView;
+      let wouldCollide;
+
+      if (context.rtl) {
+        const itemLeftMargin = parseFloat(actualWindow.getComputedStyle($item).marginLeft) || 0;
+        wouldCollide =
+          itemBoundingRect.left - overflowItemBoundingRect.width - itemLeftMargin < containerBoundingRect.left;
+
+        // console.log('Collision [RTL]', {
+        //   wouldCollide,
+        //   'itemBoundingRect.left': itemBoundingRect.left,
+        //   'overflowItemBoundingRect.width': overflowItemBoundingRect.width,
+        //   itemRightMargin: itemLeftMargin,
+        //   sum: itemBoundingRect.left - overflowItemBoundingRect.width - itemLeftMargin,
+        //   'overflowContainerBoundingRect.left': containerBoundingRect.left,
         // })
-        hide($item);
-        return true;
+      } else {
+        const itemRightMargin = parseFloat(actualWindow.getComputedStyle($item).marginRight) || 0;
+        wouldCollide =
+          itemBoundingRect.right + overflowItemBoundingRect.width + itemRightMargin > containerBoundingRect.right;
+
+        // console.log('Collision', {
+        //   wouldCollide,
+        //   'itemBoundingRect.right': itemBoundingRect.right,
+        //   'overflowItemBoundingRect.width': overflowItemBoundingRect.width,
+        //   itemRightMargin,
+        //   sum: itemBoundingRect.right + overflowItemBoundingRect.width + itemRightMargin,
+        //   'overflowContainerBoundingRect.right': containerBoundingRect.right,
+        // })
       }
 
-      // if there is an overflow, check collision of remaining items with eventual overflow position
-      if (
-        isOverflowing &&
-        !$lastVisibleItem &&
-        wouldItemCollide($item, itemBoundingRect, overflowItemBoundingRect, overflowContainerBoundingRect)
-      ) {
-        hide($item);
-        return true;
-      }
+      return wouldCollide;
+    };
 
-      // Remember the last visible item
-      if (!$lastVisibleItem) {
-        $lastVisibleItem = $item;
-        lastVisibleItemRect = itemBoundingRect;
-        lastVisibleItemIndex.current = i;
-      }
+    /**
+     * Positions overflowItem next to lastVisible item
+     * TODO: consider overflowItem margin
+     */
+    const setOverflowPosition = (
+      $overflowItem: HTMLElement,
+      $lastVisibleItem: HTMLElement | undefined,
+      lastVisibleItemRect: ClientRect | undefined,
+      containerBoundingRect: ClientRect,
+      absolutePositioningOffset: PositionOffset,
+    ) => {
+      const actualWindow: Window = context.target.defaultView;
 
-      return show($item); // exit the loop when first visible item is found
-    });
+      if ($lastVisibleItem) {
+        if (context.rtl) {
+          const lastVisibleItemMarginLeft = parseFloat(actualWindow.getComputedStyle($lastVisibleItem).marginLeft) || 0;
 
-    // if there is an overflow,  position and show overflow item, otherwise hide it
-    if (isOverflowing || overflowOpen) {
-      $overflowItem.style.position = 'absolute';
-      setOverflowPosition(
-        $overflowItem,
-        $lastVisibleItem,
-        lastVisibleItemRect,
-        overflowContainerBoundingRect,
-        absolutePositioningOffset,
-      );
-      show($overflowItem);
-    } else {
-      lastVisibleItemIndex.current = items.length - 1;
-      hide($overflowItem);
-    }
+          $overflowItem.style.right = `${containerBoundingRect.right -
+            lastVisibleItemRect.left +
+            lastVisibleItemMarginLeft +
+            absolutePositioningOffset.horizontal}px`;
+        } else {
+          const lastVisibleItemRightMargin =
+            parseFloat(actualWindow.getComputedStyle($lastVisibleItem).marginRight) || 0;
 
-    _.invoke(props, 'onOverflow', lastVisibleItemIndex.current + 1);
-  };
-
-  const collectOverflowItems = (): ToolbarItemProps['menu'] => {
-    return getOverflowItems
-      ? getOverflowItems(lastVisibleItemIndex.current + 1)
-      : items.slice(lastVisibleItemIndex.current + 1);
-  };
-
-  const getVisibleItems = () => {
-    // console.log('allItems()', items)
-    const end = overflowOpen ? lastVisibleItemIndex.current + 1 : items.length;
-    // console.log('getVisibleItems()', items.slice(0, end))
-    return items.slice(0, end);
-  };
-
-  const handleWindowResize = _.debounce((e: UIEvent) => {
-    hideOverflowItems();
-
-    if (overflowOpen) {
-      _.invoke(props, 'onOverflowOpenChange', e, { ...props, overflowOpen: false });
-    }
-  }, 16);
-
-  const renderItems = (items: ToolbarProps['items']) =>
-    _.map(items, item => {
-      const kind = _.get(item, 'kind', 'item');
-
-      switch (kind) {
-        case 'divider':
-          return ToolbarDivider.create(item);
-        case 'group':
-          return ToolbarRadioGroup.create(item);
-        case 'toggle':
-          return ToolbarItem.create(item, {
-            defaultProps: () => ({ accessibility: toggleButtonBehavior }),
-          });
-        case 'custom':
-          return ToolbarCustomItem.create(item);
-        default:
-          return ToolbarItem.create(item);
-      }
-    });
-
-  const renderOverflowItem = overflowItem => {
-    return (
-      <Ref innerRef={overflowItemRef}>
-        {ToolbarItem.create(overflowItem, {
-          defaultProps: () => ({
-            icon: <MoreIcon outline />,
-          }),
-          overrideProps: {
-            menu: {
-              items: overflowOpen ? (collectOverflowItems() as ToolbarMenuProps['items']) : [],
-              popper: { positionFixed: true },
-            },
-            menuOpen: overflowOpen,
-            onMenuOpenChange: (e, { menuOpen }) => {
-              _.invoke(props, 'onOverflowOpenChange', e, { ...props, overflowOpen: menuOpen });
-            },
-          },
-        })}
-      </Ref>
-    );
-  };
-
-  React.useEffect(() => {
-    const actualWindow: Window = context.target.defaultView;
-
-    actualWindow.cancelAnimationFrame(animationFrameId.current);
-    // Heads up! There are cases (like opening a portal and rendering the Toolbar there immediately) when rAF is necessary
-    animationFrameId.current = actualWindow.requestAnimationFrame(() => {
-      hideOverflowItems();
-    });
-
-    return () => {
-      if (animationFrameId.current !== undefined) {
-        context.target.defaultView.cancelAnimationFrame(animationFrameId.current);
-        animationFrameId.current = undefined;
+          $overflowItem.style.left = `${lastVisibleItemRect.right -
+            containerBoundingRect.left +
+            lastVisibleItemRightMargin +
+            absolutePositioningOffset.horizontal}px`;
+        }
+      } else {
+        // there is no last visible item -> position the overflow as the first item
+        lastVisibleItemIndex.current = -1;
+        if (context.rtl) {
+          $overflowItem.style.right = `${absolutePositioningOffset.horizontal}px`;
+        } else {
+          $overflowItem.style.left = `${absolutePositioningOffset.horizontal}px`;
+        }
       }
     };
-  });
 
-  const element = overflow ? (
-    <>
-      <Ref innerRef={containerRef}>
+    const hideOverflowItems = () => {
+      const $overflowContainer = overflowContainerRef.current;
+      const $overflowItem = overflowItemRef.current;
+      const $offsetMeasure = offsetMeasureRef.current;
+      if (!$overflowContainer || !$overflowItem || !$offsetMeasure) {
+        return;
+      }
+
+      // workaround: when resizing window with popup opened the container contents scroll for some reason
+      if (context.rtl) {
+        $overflowContainer.scrollTo(Number.MAX_SAFE_INTEGER, 0);
+      } else {
+        $overflowContainer.scrollTo(0, 0);
+      }
+
+      const $items = $overflowContainer.children;
+
+      const overflowContainerBoundingRect = $overflowContainer.getBoundingClientRect();
+      const overflowItemBoundingRect = $overflowItem.getBoundingClientRect();
+      const offsetMeasureBoundingRect = $offsetMeasure.getBoundingClientRect();
+
+      // Absolute positioning offset
+      // Overflow menu is absolutely positioned relative to root slot
+      // If there is padding set on the root slot boundingClientRect computations use inner content box,
+      // but absolute position is relative to root slot's PADDING box.
+      // We compute absolute positioning offset
+      // By measuring position of an offsetMeasure element absolutely positioned to 0,0.
+      // TODO: replace by getComputedStyle('padding')
+      const absolutePositioningOffset: PositionOffset = {
+        horizontal: context.rtl
+          ? offsetMeasureBoundingRect.right - overflowContainerBoundingRect.right
+          : overflowContainerBoundingRect.left - offsetMeasureBoundingRect.left,
+        vertical: overflowContainerBoundingRect.top - offsetMeasureBoundingRect.top,
+      };
+
+      let isOverflowing = false;
+      let $lastVisibleItem;
+      let lastVisibleItemRect;
+
+      // check all items from the last one back
+      _.forEachRight($items, ($item: HTMLElement, i: number) => {
+        if ($item === $overflowItem) {
+          return true;
+        }
+
+        const itemBoundingRect = $item.getBoundingClientRect();
+
+        // if the item is out of the crop rectangle, hide it
+        if (isItemOverflowing(itemBoundingRect, overflowContainerBoundingRect)) {
+          isOverflowing = true;
+          // console.log('Overflow', i, {
+          //   item: [itemBoundingRect.left, itemBoundingRect.right],
+          //   crop: [
+          //     overflowContainerBoundingRect.left,
+          //     overflowContainerBoundingRect.right,
+          //     overflowContainerBoundingRect.width,
+          //   ],
+          //   container: $overflowContainer,
+          // })
+          hide($item);
+          return true;
+        }
+
+        // if there is an overflow, check collision of remaining items with eventual overflow position
+        if (
+          isOverflowing &&
+          !$lastVisibleItem &&
+          wouldItemCollide($item, itemBoundingRect, overflowItemBoundingRect, overflowContainerBoundingRect)
+        ) {
+          hide($item);
+          return true;
+        }
+
+        // Remember the last visible item
+        if (!$lastVisibleItem) {
+          $lastVisibleItem = $item;
+          lastVisibleItemRect = itemBoundingRect;
+          lastVisibleItemIndex.current = i;
+        }
+
+        return show($item); // exit the loop when first visible item is found
+      });
+
+      // if there is an overflow,  position and show overflow item, otherwise hide it
+      if (isOverflowing || overflowOpen) {
+        $overflowItem.style.position = 'absolute';
+        setOverflowPosition(
+          $overflowItem,
+          $lastVisibleItem,
+          lastVisibleItemRect,
+          overflowContainerBoundingRect,
+          absolutePositioningOffset,
+        );
+        show($overflowItem);
+      } else {
+        lastVisibleItemIndex.current = items.length - 1;
+        hide($overflowItem);
+      }
+
+      _.invoke(props, 'onOverflow', lastVisibleItemIndex.current + 1);
+    };
+
+    const collectOverflowItems = (): ToolbarItemProps['menu'] => {
+      // console.log('getOverflowItems()', items.slice(lastVisibleItemIndex.current + 1))
+      return getOverflowItems
+        ? getOverflowItems(lastVisibleItemIndex.current + 1)
+        : items.slice(lastVisibleItemIndex.current + 1);
+    };
+
+    const getVisibleItems = () => {
+      // console.log('allItems()', items)
+      const end = overflowOpen ? lastVisibleItemIndex.current + 1 : items.length;
+      // console.log('getVisibleItems()', items.slice(0, end))
+      return items.slice(0, end);
+    };
+
+    const handleWindowResize = _.debounce((e: UIEvent) => {
+      hideOverflowItems();
+
+      if (overflowOpen) {
+        _.invoke(props, 'onOverflowOpenChange', e, { ...props, overflowOpen: false });
+      }
+    }, 16);
+
+    const renderItems = (items: ToolbarProps['items']) =>
+      _.map(items, item => {
+        const kind = _.get(item, 'kind', 'item');
+
+        switch (kind) {
+          case 'divider':
+            return createShorthand(composeOptions.slots.divider, item, {
+              defaultProps: () => slotProps.divider,
+            });
+          case 'group':
+            return createShorthand(ToolbarRadioGroup, item);
+          case 'toggle':
+            return createShorthand(composeOptions.slots.item, item, {
+              defaultProps: () => ({
+                accessibility: toggleButtonBehavior,
+                ...slotProps.item,
+              }),
+            });
+          case 'custom':
+            return createShorthand(composeOptions.slots.customItem, item, {
+              defaultProps: () => slotProps.customItem,
+            });
+          default:
+            return createShorthand(composeOptions.slots.item, item, {
+              defaultProps: () => slotProps.item,
+            });
+        }
+      });
+
+    const renderOverflowItem = overflowItem => {
+      return (
+        <Ref innerRef={overflowItemRef}>
+          {createShorthand(ToolbarItem, overflowItem, {
+            defaultProps: () => ({
+              icon: <MoreIcon outline />,
+            }),
+            overrideProps: {
+              menu: {
+                items: overflowOpen ? (collectOverflowItems() as ToolbarMenuProps['items']) : [],
+                popper: { positionFixed: true },
+              },
+              menuOpen: overflowOpen,
+              onMenuOpenChange: (e, { menuOpen }) => {
+                _.invoke(props, 'onOverflowOpenChange', e, { ...props, overflowOpen: menuOpen });
+              },
+            },
+          })}
+        </Ref>
+      );
+    };
+
+    React.useEffect(() => {
+      const actualWindow: Window = context.target.defaultView;
+
+      actualWindow.cancelAnimationFrame(animationFrameId.current);
+      // Heads up! There are cases (like opening a portal and rendering the Toolbar there immediately) when rAF is necessary
+      animationFrameId.current = actualWindow.requestAnimationFrame(() => {
+        hideOverflowItems();
+      });
+
+      return () => {
+        if (animationFrameId.current !== undefined) {
+          context.target.defaultView.cancelAnimationFrame(animationFrameId.current);
+          animationFrameId.current = undefined;
+        }
+      };
+    });
+
+    const element = overflow ? (
+      <>
+        <Ref
+          innerRef={(node: HTMLDivElement) => {
+            containerRef.current = node;
+            handleRef(ref, node as any /*TODO: fix me */);
+          }}
+        >
+          {getA11Props.unstable_wrapWithFocusZone(
+            <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>
+              <div className={classes.overflowContainer} ref={overflowContainerRef}>
+                <ToolbarVariablesProvider value={variables}>
+                  {childrenExist(children) ? children : renderItems(getVisibleItems())}
+                  {renderOverflowItem(overflowItem)}
+                </ToolbarVariablesProvider>
+              </div>
+              <div className={classes.offsetMeasure} ref={offsetMeasureRef} />
+            </ElementType>,
+          )}
+        </Ref>
+        <EventListener listener={handleWindowResize} target={context.target.defaultView} type="resize" />
+      </>
+    ) : (
+      <Ref
+        innerRef={(node: HTMLDivElement) => {
+          containerRef.current = node;
+          handleRef(ref, node as any /*TODO: fix me */);
+        }}
+      >
         {getA11Props.unstable_wrapWithFocusZone(
           <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>
-            <div className={classes.overflowContainer} ref={overflowContainerRef}>
-              <ToolbarVariablesProvider value={variables}>
-                {childrenExist(children) ? children : renderItems(getVisibleItems())}
-                {renderOverflowItem(overflowItem)}
-              </ToolbarVariablesProvider>
-            </div>
-            <div className={classes.offsetMeasure} ref={offsetMeasureRef} />
+            <ToolbarVariablesProvider value={variables}>
+              {childrenExist(children) ? children : renderItems(items)}
+            </ToolbarVariablesProvider>
           </ElementType>,
         )}
       </Ref>
-      <EventListener listener={handleWindowResize} target={context.target.defaultView} type="resize" />
-    </>
-  ) : (
-    <Ref innerRef={containerRef}>
-      {getA11Props.unstable_wrapWithFocusZone(
-        <ElementType {...getA11Props('root', { className: classes.root, ...unhandledProps })}>
-          <ToolbarVariablesProvider value={variables}>
-            {childrenExist(children) ? children : renderItems(items)}
-          </ToolbarVariablesProvider>
-        </ElementType>,
-      )}
-    </Ref>
-  );
-  setEnd();
+    );
+    setEnd();
 
-  return element;
+    return element;
+  },
+  {
+    className: toolbarClassName,
+    displayName: 'Toolbar',
+
+    slots: {
+      customItem: ToolbarCustomItem,
+      divider: ToolbarDivider,
+      item: ToolbarItem,
+    },
+
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'getOverflowItems',
+      'items',
+      'onOverflow',
+      'onOverflowOpenChange',
+      'overflow',
+      'overflowItem',
+      'overflowOpen',
+      'styles',
+      'variables',
+    ],
+  },
+) as ComponentWithAs<'div', ToolbarProps> & {
+  CustomItem: typeof ToolbarCustomItem;
+  Divider: typeof ToolbarDivider;
+  Item: typeof ToolbarItem;
+  Menu: typeof ToolbarMenu;
+  MenuDivider: typeof ToolbarMenuDivider;
+  MenuItem: typeof ToolbarMenuItem;
+  MenuRadioGroup: typeof ToolbarMenuRadioGroup;
+  RadioGroup: typeof ToolbarRadioGroup;
 };
-
-Toolbar.displayName = 'Toolbar';
 
 Toolbar.propTypes = {
   ...commonPropTypes.createCommon(),
@@ -540,7 +594,6 @@ Toolbar.defaultProps = {
   items: [],
   overflowItem: {},
 };
-Toolbar.handledProps = Object.keys(Toolbar.propTypes) as any;
 
 Toolbar.CustomItem = ToolbarCustomItem;
 Toolbar.Divider = ToolbarDivider;
@@ -551,14 +604,4 @@ Toolbar.MenuItem = ToolbarMenuItem;
 Toolbar.MenuRadioGroup = ToolbarMenuRadioGroup;
 Toolbar.RadioGroup = ToolbarRadioGroup;
 
-Toolbar.create = createShorthandFactory({ Component: Toolbar, mappedProp: 'content' });
-
-/**
- * A Toolbar is a container for grouping a set of controls, often action controls (e.g. buttons) or input controls (e.g. checkboxes).
- *
- * @accessibility
- *  * Implements [ARIA Toolbar](https://www.w3.org/TR/wai-aria-practices-1.1/#toolbar) design pattern.
- * @accessibilityIssues
- * [Issue 988424: VoiceOver narrates selected for button in toolbar](https://bugs.chromium.org/p/chromium/issues/detail?id=988424)
- */
-export default withSafeTypeForAs<typeof Toolbar, ToolbarProps>(Toolbar);
+export default Toolbar;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarCustomItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarCustomItem.tsx
@@ -1,5 +1,12 @@
 import { Accessibility, IS_FOCUSABLE_ATTRIBUTE } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  compose,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
 import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
@@ -7,17 +14,10 @@ import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import {
-  ComponentEventHandler,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-  WithAsProp,
-  withSafeTypeForAs,
-} from '../../types';
+import { ComponentEventHandler, ProviderContextPrepared } from '../../types';
 import {
   ChildrenComponentProps,
   ContentComponentProps,
-  createShorthandFactory,
   UIComponentProps,
   childrenExist,
   commonPropTypes,
@@ -57,64 +57,90 @@ export interface ToolbarCustomItemProps extends UIComponentProps, ChildrenCompon
 export type ToolbarCustomItemStylesProps = Required<Pick<ToolbarCustomItemProps, 'fitted'>>;
 export const toolbarCustomItemClassName = 'ui-toolbar__customitem';
 
-const ToolbarCustomItem: React.FC<WithAsProp<ToolbarCustomItemProps>> & FluentComponentStaticProps = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarCustomItem.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarCustomItem renders Toolbar item as a non-actionable `div` with custom content inside.
+ */
+const ToolbarCustomItem = compose<'div', ToolbarCustomItemProps, ToolbarCustomItemStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const { accessibility, children, className, content, design, fitted, focusable, styles, variables } = props;
-  const parentVariables = React.useContext(ToolbarVariablesContext);
+    const { accessibility, children, className, content, design, fitted, focusable, styles, variables } = props;
+    const parentVariables = React.useContext(ToolbarVariablesContext);
 
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarCustomItem.displayName,
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarCustomItemStylesProps>(ToolbarCustomItem.displayName, {
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarCustomItemStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      composeOptions,
+      mapPropsToStyles: () => ({ fitted }),
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables: mergeComponentVariables(parentVariables, variables),
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
+
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const handleBlur = (e: React.SyntheticEvent) => {
+      if (focusable) {
+        _.invoke(props, 'onBlur', e, props);
+      }
+    };
+
+    const handleFocus = (e: React.SyntheticEvent) => {
+      if (focusable) {
+        _.invoke(props, 'onFocus', e, props);
+      }
+    };
+
+    const element = (
+      <ElementType
+        {...getA11yProps('root', {
+          [IS_FOCUSABLE_ATTRIBUTE]: focusable,
+          ...unhandledProps,
+          className: classes.root,
+          onBlur: handleBlur,
+          onFocus: handleFocus,
+          ref,
+        })}
+      >
+        {childrenExist(children) ? children : content}
+      </ElementType>
+    );
+    setEnd();
+
+    return element;
+  },
+  {
     className: toolbarCustomItemClassName,
-    mapPropsToStyles: () => ({ fitted }),
-    mapPropsToInlineStyles: () => ({
-      className,
-      design,
-      styles,
-      variables: mergeComponentVariables(parentVariables, variables),
-    }),
-    rtl: context.rtl,
-  });
+    displayName: 'ToolbarCustomItem',
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarCustomItem.handledProps, props);
-
-  const handleBlur = (e: React.SyntheticEvent) => {
-    if (focusable) {
-      _.invoke(props, 'onBlur', e, props);
-    }
-  };
-
-  const handleFocus = (e: React.SyntheticEvent) => {
-    if (focusable) {
-      _.invoke(props, 'onFocus', e, props);
-    }
-  };
-
-  const element = (
-    <ElementType
-      {...getA11yProps('root', {
-        [IS_FOCUSABLE_ATTRIBUTE]: focusable,
-        ...unhandledProps,
-        className: classes.root,
-        onBlur: handleBlur,
-        onFocus: handleFocus,
-      })}
-    >
-      {childrenExist(children) ? children : content}
-    </ElementType>
-  );
-  setEnd();
-
-  return element;
-};
-
-ToolbarCustomItem.displayName = 'ToolbarCustomItem';
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'fitted',
+      'focusable',
+      'onBlur',
+      'onFocus',
+      'styles',
+      'variables',
+    ],
+  },
+);
 
 ToolbarCustomItem.propTypes = {
   ...commonPropTypes.createCommon(),
@@ -126,14 +152,8 @@ ToolbarCustomItem.propTypes = {
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
 };
-ToolbarCustomItem.handledProps = Object.keys(ToolbarCustomItem.propTypes) as any;
-
-ToolbarCustomItem.create = createShorthandFactory({
-  Component: ToolbarCustomItem,
-  mappedProp: 'content',
-});
 
 /**
  * A ToolbarCustomItem renders Toolbar item as a non-actionable `div` with custom content inside.
  */
-export default withSafeTypeForAs<typeof ToolbarCustomItem, ToolbarCustomItemProps>(ToolbarCustomItem);
+export default ToolbarCustomItem;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -1,6 +1,13 @@
 import { Accessibility, toolbarItemBehavior, ToolbarItemBehaviorProps } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
-import { Ref } from '@fluentui/react-component-ref';
+import {
+  compose,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
+import { handleRef, Ref } from '@fluentui/react-component-ref';
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
 import * as customPropTypes from '@fluentui/react-proptypes';
@@ -13,7 +20,7 @@ import * as React from 'react';
 import { ThemeContext } from 'react-fela';
 
 import {
-  createShorthandFactory,
+  createShorthand,
   doesNodeContainClick,
   UIComponentProps,
   ChildrenComponentProps,
@@ -21,16 +28,7 @@ import {
   commonPropTypes,
   childrenExist,
 } from '../../utils';
-import {
-  ComponentEventHandler,
-  ShorthandValue,
-  WithAsProp,
-  withSafeTypeForAs,
-  Omit,
-  ShorthandCollection,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-} from '../../types';
+import { ComponentEventHandler, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
 import { getPopperPropsFromShorthand, Popper, PopperShorthandProps } from '../../utils/positioner';
 
 import ToolbarMenu, { ToolbarMenuProps } from './ToolbarMenu';
@@ -116,244 +114,293 @@ export const toolbarItemSlotClassNames: ToolbarItemSlotClassNames = {
   wrapper: `${toolbarItemClassName}__wrapper`,
 };
 
-const ToolbarItem: React.FC<WithAsProp<ToolbarItemProps>> & FluentComponentStaticProps<ToolbarItemProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarItem.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarItem renders Toolbar item as a button with an icon.
+ */
+const ToolbarItem = compose<'button', ToolbarItemProps, ToolbarItemStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const {
-    accessibility,
-    active,
-    className,
-    design,
-    icon,
-    children,
-    disabled,
-    popup,
-    menu,
-    menuOpen,
-    wrapper,
-    styles,
-    variables,
-  } = props;
-
-  const itemRef = React.useRef<HTMLElement>();
-  const menuRef = React.useRef<HTMLElement>();
-
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
-
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarItem.displayName,
-    actionHandlers: {
-      performClick: event => {
-        event.preventDefault();
-        handleClick(event);
-      },
-      performWrapperClick: event => {
-        handleWrapperClick(event);
-      },
-      closeMenuAndFocusTrigger: event => {
-        trySetMenuOpen(false, event);
-        _.invoke(itemRef.current, 'focus');
-      },
-      doNotNavigateNextToolbarItem: event => {
-        event.stopPropagation();
-      },
-    },
-    mapPropsToBehavior: () => ({
-      as: String(props.as),
-      disabled,
-      hasMenu: !!menu,
-      hasPopup: !!popup,
-      menuOpen,
+    const {
+      accessibility,
       active,
-    }),
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarItemStylesProps>(ToolbarItem.displayName, {
-    className: toolbarItemClassName,
-    mapPropsToStyles: () => ({ active, disabled }),
-    mapPropsToInlineStyles: () => ({
       className,
       design,
+      icon,
+      children,
+      disabled,
+      popup,
+      menu,
+      menuOpen,
+      wrapper,
       styles,
-      variables: mergedVariables,
-    }),
-    rtl: context.rtl,
-  });
+      variables,
+    } = props;
 
-  const handleBlur = (e: React.SyntheticEvent) => {
-    _.invoke(props, 'onBlur', e, props);
-  };
+    const itemRef = React.useRef<HTMLElement>();
+    const menuRef = React.useRef<HTMLElement>();
 
-  const handleFocus = (e: React.SyntheticEvent) => {
-    _.invoke(props, 'onFocus', e, props);
-  };
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
 
-  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
-
-    if (menu) {
-      trySetMenuOpen(!menuOpen, e);
-    }
-
-    _.invoke(props, 'onClick', e, props);
-  };
-
-  const handleWrapperClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    if (menu) {
-      if (doesNodeContainClick(menuRef.current, e.nativeEvent as MouseEvent, context.target)) {
-        trySetMenuOpen(false, e);
-      }
-    }
-  };
-
-  const handleOutsideClick = (getRefs: GetRefs) => (e: MouseEvent) => {
-    const isItemClick = doesNodeContainClick(itemRef.current, e, context.target);
-    const isNestedClick = _.some(getRefs(), (childRef: NodeRef) => {
-      return doesNodeContainClick(childRef.current as HTMLElement, e, context.target);
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      actionHandlers: {
+        performClick: event => {
+          event.preventDefault();
+          handleClick(event);
+        },
+        performWrapperClick: event => {
+          handleWrapperClick(event);
+        },
+        closeMenuAndFocusTrigger: event => {
+          trySetMenuOpen(false, event);
+          _.invoke(itemRef.current, 'focus');
+        },
+        doNotNavigateNextToolbarItem: event => {
+          event.stopPropagation();
+        },
+      },
+      mapPropsToBehavior: () => ({
+        as: String(props.as),
+        disabled,
+        hasMenu: !!menu,
+        hasPopup: !!popup,
+        menuOpen,
+        active,
+      }),
+      rtl: context.rtl,
     });
-    const isInside = isItemClick || isNestedClick;
+    const { classes } = useStyles<ToolbarItemStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      composeOptions,
+      mapPropsToStyles: () => ({ active, disabled }),
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables: mergedVariables,
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
 
-    if (!isInside) {
-      trySetMenuOpen(false, e);
-    }
-  };
+    const handleBlur = (e: React.SyntheticEvent) => {
+      _.invoke(props, 'onBlur', e, props);
+    };
 
-  const trySetMenuOpen = (newValue: boolean, e: Event | React.SyntheticEvent) => {
-    _.invoke(props, 'onMenuOpenChange', e, { ...props, menuOpen: newValue });
-  };
+    const handleFocus = (e: React.SyntheticEvent) => {
+      _.invoke(props, 'onFocus', e, props);
+    };
 
-  const handleMenuOverrides = (getRefs: GetRefs) => (predefinedProps: ToolbarMenuProps) => ({
-    onBlur: (e: React.FocusEvent) => {
-      const isInsideOrMenuTrigger = _.some(getRefs(), (childRef: NodeRef) => {
-        return (
-          childRef.current.contains(e.relatedTarget as HTMLElement) ||
-          itemRef.current.contains(e.relatedTarget as HTMLElement)
-        );
-      });
-
-      if (!isInsideOrMenuTrigger) {
-        trySetMenuOpen(false, e);
-      }
-    },
-    onItemClick: (e, itemProps: ToolbarMenuItemProps) => {
-      const { popup, menuOpen } = itemProps;
-      _.invoke(predefinedProps, 'onItemClick', e, itemProps);
-      if (popup) {
+    const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+      if (disabled) {
+        e.preventDefault();
         return;
       }
-      // TODO: should we pass toolbarMenuItem to the user callback so he can decide if he wants to close the menu?
-      trySetMenuOpen(menuOpen, e);
-    },
-  });
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarItem.handledProps, props);
+      if (menu) {
+        trySetMenuOpen(!menuOpen, e);
+      }
 
-  const itemElement = (
-    <ElementType
-      {...getA11yProps('root', {
-        ...unhandledProps,
-        disabled,
-        className: classes.root,
-        onBlur: handleBlur,
-        onFocus: handleFocus,
-        onClick: handleClick,
-      })}
-    >
-      {childrenExist(children) ? children : Box.create(icon)}
-    </ElementType>
-  );
+      _.invoke(props, 'onClick', e, props);
+    };
 
-  const submenuElement = menuOpen ? (
-    <Unstable_NestingAuto>
-      {(getRefs, nestingRef) => (
-        <>
-          <Ref
-            innerRef={(node: HTMLElement) => {
-              nestingRef.current = node;
-              menuRef.current = node;
-            }}
-          >
-            <Popper align="start" position="above" targetRef={itemRef} {...getPopperPropsFromShorthand(menu)}>
-              <ToolbarVariablesProvider value={mergedVariables}>
-                {ToolbarMenu.create(menu, {
-                  overrideProps: handleMenuOverrides(getRefs),
-                })}
-              </ToolbarVariablesProvider>
-            </Popper>
-          </Ref>
-          <EventListener listener={handleOutsideClick(getRefs)} target={context.target} type="click" capture />
-        </>
-      )}
-    </Unstable_NestingAuto>
-  ) : null;
+    const handleWrapperClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+      if (menu) {
+        if (doesNodeContainClick(menuRef.current, e.nativeEvent as MouseEvent, context.target)) {
+          trySetMenuOpen(false, e);
+        }
+      }
+    };
 
-  if (popup) {
-    const popupElement = Popup.create(popup, {
-      defaultProps: () => ({
-        trapFocus: true,
-      }),
-      overrideProps: {
-        trigger: itemElement,
-        children: undefined, // force-reset `children` defined for `Popup` as it collides with the `trigger`
+    const handleOutsideClick = (getRefs: GetRefs) => (e: MouseEvent) => {
+      const isItemClick = doesNodeContainClick(itemRef.current, e, context.target);
+      const isNestedClick = _.some(getRefs(), (childRef: NodeRef) => {
+        return doesNodeContainClick(childRef.current as HTMLElement, e, context.target);
+      });
+      const isInside = isItemClick || isNestedClick;
+
+      if (!isInside) {
+        trySetMenuOpen(false, e);
+      }
+    };
+
+    const trySetMenuOpen = (newValue: boolean, e: Event | React.SyntheticEvent) => {
+      _.invoke(props, 'onMenuOpenChange', e, { ...props, menuOpen: newValue });
+    };
+
+    const handleMenuOverrides = (getRefs: GetRefs) => (predefinedProps: ToolbarMenuProps) => ({
+      onBlur: (e: React.FocusEvent) => {
+        const isInsideOrMenuTrigger = _.some(getRefs(), (childRef: NodeRef) => {
+          return (
+            childRef.current.contains(e.relatedTarget as HTMLElement) ||
+            itemRef.current.contains(e.relatedTarget as HTMLElement)
+          );
+        });
+
+        if (!isInsideOrMenuTrigger) {
+          trySetMenuOpen(false, e);
+        }
+      },
+      onItemClick: (e, itemProps: ToolbarMenuItemProps) => {
+        const { popup, menuOpen } = itemProps;
+        _.invoke(predefinedProps, 'onItemClick', e, itemProps);
+        if (popup) {
+          return;
+        }
+        // TODO: should we pass toolbarMenuItem to the user callback so he can decide if he wants to close the menu?
+        trySetMenuOpen(menuOpen, e);
       },
     });
-    setEnd();
 
-    return popupElement;
-  }
+    const ElementType = getElementType(props);
+    const slotProps = composeOptions.resolveSlotProps<ToolbarItemProps>(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
 
-  // wrap the item if it has menu (even if it is closed = not rendered)
-  if (menu) {
-    const contentElement = (
-      <>
-        <Ref innerRef={itemRef}>{itemElement}</Ref>
-        {submenuElement}
-      </>
+    const itemElement = (
+      <ElementType
+        {...getA11yProps('root', {
+          ...unhandledProps,
+          disabled,
+          className: classes.root,
+          onBlur: handleBlur,
+          onFocus: handleFocus,
+          onClick: handleClick,
+        })}
+      >
+        {childrenExist(children) ? children : Box.create(icon)}
+      </ElementType>
     );
 
-    if (wrapper) {
-      const wrapperElement = Box.create(wrapper, {
-        defaultProps: () =>
-          getA11yProps('wrapper', {
-            className: cx(toolbarItemSlotClassNames.wrapper, classes.wrapper),
-          }),
-        overrideProps: predefinedProps => ({
-          children: contentElement,
-          onClick: e => {
-            handleWrapperClick(e);
-            _.invoke(predefinedProps, 'onClick', e);
-          },
+    const submenuElement = menuOpen ? (
+      <Unstable_NestingAuto>
+        {(getRefs, nestingRef) => (
+          <>
+            <Ref
+              innerRef={(node: HTMLElement) => {
+                nestingRef.current = node;
+                menuRef.current = node;
+              }}
+            >
+              <Popper align="start" position="above" targetRef={itemRef} {...getPopperPropsFromShorthand(menu)}>
+                <ToolbarVariablesProvider value={mergedVariables}>
+                  {createShorthand(composeOptions.slots.menu, menu, {
+                    defaultProps: () => slotProps.menu,
+                    overrideProps: handleMenuOverrides(getRefs),
+                  })}
+                </ToolbarVariablesProvider>
+              </Popper>
+            </Ref>
+            <EventListener listener={handleOutsideClick(getRefs)} target={context.target} type="click" capture />
+          </>
+        )}
+      </Unstable_NestingAuto>
+    ) : null;
+
+    if (popup) {
+      const popupElement = Popup.create(popup, {
+        defaultProps: () => ({
+          trapFocus: true,
         }),
+        overrideProps: {
+          trigger: itemElement,
+          children: undefined, // force-reset `children` defined for `Popup` as it collides with the `trigger`
+        },
       });
       setEnd();
 
-      return wrapperElement;
+      return popupElement;
     }
 
+    // wrap the item if it has menu (even if it is closed = not rendered)
+    if (menu) {
+      const contentElement = (
+        <>
+          <Ref
+            innerRef={node => {
+              itemRef.current = node;
+              handleRef(ref, node as any /* TODO: fix me in compose() */);
+            }}
+          >
+            {itemElement}
+          </Ref>
+          {submenuElement}
+        </>
+      );
+
+      if (wrapper) {
+        const wrapperElement = Box.create(wrapper, {
+          defaultProps: () =>
+            getA11yProps('wrapper', {
+              className: cx(toolbarItemSlotClassNames.wrapper, classes.wrapper),
+            }),
+          overrideProps: predefinedProps => ({
+            children: contentElement,
+            onClick: e => {
+              handleWrapperClick(e);
+              _.invoke(predefinedProps, 'onClick', e);
+            },
+          }),
+        });
+        setEnd();
+
+        return wrapperElement;
+      }
+
+      setEnd();
+      return contentElement;
+    }
+
+    const refElement = (
+      <Ref
+        innerRef={node => {
+          itemRef.current = node;
+          handleRef(ref, node as any /* TODO: fix me in compose() */);
+        }}
+      >
+        {itemElement}
+      </Ref>
+    );
     setEnd();
-    return contentElement;
-  }
 
-  const refElement = <Ref innerRef={itemRef}>{itemElement}</Ref>;
-  setEnd();
+    return refElement;
+  },
+  {
+    className: toolbarItemClassName,
+    displayName: 'ToolbarItem',
 
-  return refElement;
-};
+    slots: {
+      menu: ToolbarMenu,
+    },
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'styles',
+      'variables',
 
-ToolbarItem.displayName = 'ToolbarItem';
+      'active',
+      'disabled',
+      'icon',
+      'menu',
+      'menuOpen',
+      'onMenuOpenChange',
+      'onClick',
+      'onFocus',
+      'onBlur',
+      'popup',
+      'wrapper',
+    ],
+  },
+);
 
-ToolbarItem.defaultProps = {
-  as: 'button',
-  accessibility: toolbarItemBehavior,
-  wrapper: {},
-};
 ToolbarItem.propTypes = {
   ...commonPropTypes.createCommon(),
   active: PropTypes.bool,
@@ -378,11 +425,10 @@ ToolbarItem.propTypes = {
   ]),
   wrapper: customPropTypes.shorthandAllowingChildren,
 };
-ToolbarItem.handledProps = Object.keys(ToolbarItem.propTypes) as any;
+ToolbarItem.defaultProps = {
+  as: 'button',
+  accessibility: toolbarItemBehavior,
+  wrapper: {},
+};
 
-ToolbarItem.create = createShorthandFactory({ Component: ToolbarItem, mappedProp: 'content' });
-
-/**
- * A ToolbarItem renders Toolbar item as a button with an icon.
- */
-export default withSafeTypeForAs<typeof ToolbarItem, ToolbarItemProps, 'button'>(ToolbarItem);
+export default ToolbarItem;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -5,6 +5,8 @@ import {
   ToolbarMenuBehaviorProps,
 } from '@fluentui/accessibility';
 import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-compose';
+import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
@@ -14,7 +16,7 @@ import * as React from 'react';
 import { ThemeContext } from 'react-fela';
 
 import {
-  createShorthandFactory,
+  createShorthand,
   commonPropTypes,
   childrenExist,
   UIComponentProps,
@@ -22,15 +24,7 @@ import {
   ContentComponentProps,
 } from '../../utils';
 
-import {
-  ComponentEventHandler,
-  ShorthandCollection,
-  withSafeTypeForAs,
-  ShorthandValue,
-  WithAsProp,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-} from '../../types';
+import { ComponentEventHandler, ShorthandCollection, ShorthandValue, ProviderContextPrepared } from '../../types';
 
 import ToolbarMenuRadioGroup, { ToolbarMenuRadioGroupProps } from './ToolbarMenuRadioGroup';
 import ToolbarMenuDivider from './ToolbarMenuDivider';
@@ -73,103 +67,137 @@ export interface ToolbarMenuProps extends UIComponentProps, ChildrenComponentPro
 export type ToolbarMenuStylesProps = never;
 export const toolbarMenuClassName = 'ui-toolbar__menu';
 
-const ToolbarMenu: React.FC<WithAsProp<ToolbarMenuProps>> & FluentComponentStaticProps = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarMenu.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarMenu creates a pop-up menu attached to a ToolbarItem.
+ *
+ * @accessibility
+ * Implements pop-up menu (submenu) behavior of [ARIA Menu](https://www.w3.org/TR/wai-aria-practices-1.1/#menu) design pattern.
+ */
+const ToolbarMenu = compose<'ul', ToolbarMenuProps, ToolbarMenuStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const { accessibility, className, children, design, items, submenu, submenuIndicator, styles, variables } = props;
+    const { accessibility, className, children, design, items, submenu, submenuIndicator, styles, variables } = props;
 
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const slotProps = composeOptions.resolveSlotProps<ToolbarMenuProps>(props);
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
 
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarMenu.displayName,
-    actionHandlers: {
-      performClick: e => {
-        _.invoke(props, 'onClick', e, props);
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      actionHandlers: {
+        performClick: e => {
+          _.invoke(props, 'onClick', e, props);
+        },
       },
-    },
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarMenuStylesProps>(ToolbarMenu.displayName, {
-    className: toolbarMenuClassName,
-    mapPropsToInlineStyles: () => ({
-      className,
-      design,
-      styles,
-      variables: mergedVariables,
-    }),
-    rtl: context.rtl,
-  });
-
-  const handleItemOverrides = predefinedProps => ({
-    onClick: (e, itemProps) => {
-      _.invoke(predefinedProps, 'onClick', e, itemProps);
-      _.invoke(props, 'onItemClick', e, {
-        ...itemProps,
-        menuOpen: !!itemProps.menu,
-      });
-    },
-  });
-
-  const handleRadioGroupOverrides = (predefinedProps: ToolbarMenuRadioGroupProps) => ({
-    onItemClick: (e, itemProps) => {
-      _.invoke(predefinedProps, 'onItemClick', e, itemProps);
-      _.invoke(props, 'onItemClick', e, itemProps);
-    },
-  });
-
-  const renderItems = () => {
-    return _.map(items, item => {
-      const kind = _.get(item, 'kind', 'item');
-
-      switch (kind) {
-        case 'divider':
-          return ToolbarMenuDivider.create(item);
-
-        case 'group':
-          return ToolbarMenuRadioGroup.create(item, { overrideProps: handleRadioGroupOverrides });
-
-        case 'toggle':
-          return ToolbarMenuItem.create(item, {
-            defaultProps: () => ({ accessibility: toolbarMenuItemCheckboxBehavior }),
-            overrideProps: handleItemOverrides,
-          });
-
-        default:
-          return ToolbarMenuItem.create(item, {
-            defaultProps: () => ({
-              submenuIndicator,
-              inSubmenu: submenu,
-            }),
-            overrideProps: handleItemOverrides,
-          });
-      }
+      rtl: context.rtl,
     });
-  };
+    const { classes } = useStyles<ToolbarMenuStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      composeOptions,
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables: mergedVariables,
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarMenu.handledProps, props);
+    const handleItemOverrides = predefinedProps => ({
+      onClick: (e, itemProps) => {
+        _.invoke(predefinedProps, 'onClick', e, itemProps);
+        _.invoke(props, 'onItemClick', e, {
+          ...itemProps,
+          menuOpen: !!itemProps.menu,
+        });
+      },
+    });
 
-  const element = getA11yProps.unstable_wrapWithFocusZone(
-    <ElementType
-      {...getA11yProps('root', {
-        ...unhandledProps,
-        className: classes.root,
-      })}
-    >
-      <ToolbarVariablesProvider value={mergedVariables}>
-        {childrenExist(children) ? children : renderItems()}
-      </ToolbarVariablesProvider>
-    </ElementType>,
-  );
-  setEnd();
+    const handleRadioGroupOverrides = (predefinedProps: ToolbarMenuRadioGroupProps) => ({
+      onItemClick: (e, itemProps) => {
+        _.invoke(predefinedProps, 'onItemClick', e, itemProps);
+        _.invoke(props, 'onItemClick', e, itemProps);
+      },
+    });
 
-  return element;
-};
+    const renderItems = () => {
+      return _.map(items, item => {
+        const kind = _.get(item, 'kind', 'item');
 
-ToolbarMenu.displayName = 'ToolbarMenu';
+        switch (kind) {
+          case 'divider':
+            return createShorthand(composeOptions.slots.divider, item, {
+              defaultProps: () => slotProps.divider,
+            });
+
+          case 'group':
+            return createShorthand(ToolbarMenuRadioGroup, item, { overrideProps: handleRadioGroupOverrides });
+
+          case 'toggle':
+            return createShorthand(composeOptions.slots.item || ToolbarMenuItem, item, {
+              defaultProps: () => ({ accessibility: toolbarMenuItemCheckboxBehavior }),
+              overrideProps: handleItemOverrides,
+            });
+
+          default:
+            return createShorthand(composeOptions.slots.item || ToolbarMenuItem, item, {
+              defaultProps: () => ({
+                submenuIndicator,
+                inSubmenu: submenu,
+              }),
+              overrideProps: handleItemOverrides,
+            });
+        }
+      });
+    };
+
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const element = getA11yProps.unstable_wrapWithFocusZone(
+      <ElementType {...getA11yProps('root', { ...unhandledProps, className: classes.root })}>
+        <ToolbarVariablesProvider value={mergedVariables}>
+          {childrenExist(children) ? children : renderItems()}
+        </ToolbarVariablesProvider>
+      </ElementType>,
+    );
+    setEnd();
+
+    // TODO: As ElementType is wrapped with FocusZone which doesn't ref forwarding we have to use Ref
+    return ref ? <Ref innerRef={(ref as unknown) as React.Ref<HTMLElement>}>{element}</Ref> : element;
+  },
+  {
+    displayName: 'ToolbarMenu',
+    className: toolbarMenuClassName,
+
+    shorthandConfig: {
+      mappedArrayProp: 'items',
+    },
+    slots: {
+      divider: ToolbarMenuDivider,
+      // item: ToolbarMenuItem,
+    },
+
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'items',
+      'onItemClick',
+      'styles',
+      'submenu',
+      'submenuIndicator',
+      'variables',
+    ],
+  },
+);
 
 ToolbarMenu.propTypes = {
   ...commonPropTypes.createCommon(),
@@ -178,19 +206,9 @@ ToolbarMenu.propTypes = {
   submenu: PropTypes.bool,
   submenuIndicator: customPropTypes.shorthandAllowingChildren,
 };
-ToolbarMenu.handledProps = Object.keys(ToolbarMenu.propTypes) as any;
-
 ToolbarMenu.defaultProps = {
   accessibility: toolbarMenuBehavior,
   as: 'ul',
 };
 
-ToolbarMenu.create = createShorthandFactory({ Component: ToolbarMenu, mappedArrayProp: 'items' });
-
-/**
- * A ToolbarMenu creates a pop-up menu attached to a ToolbarItem.
- *
- * @accessibility
- * Implements pop-up menu (submenu) behavior of [ARIA Menu](https://www.w3.org/TR/wai-aria-practices-1.1/#menu) design pattern.
- */
-export default withSafeTypeForAs<typeof ToolbarMenu, ToolbarMenuProps, 'ul'>(ToolbarMenu);
+export default ToolbarMenu;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -1,18 +1,19 @@
 import { Accessibility } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+  compose,
+} from '@fluentui/react-bindings';
 import { mergeComponentVariables } from '@fluentui/styles';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import {
-  ChildrenComponentProps,
-  ContentComponentProps,
-  createShorthandFactory,
-  UIComponentProps,
-  commonPropTypes,
-} from '../../utils';
-import { FluentComponentStaticProps, ProviderContextPrepared, WithAsProp, withSafeTypeForAs } from '../../types';
+import { ChildrenComponentProps, ContentComponentProps, UIComponentProps, commonPropTypes } from '../../utils';
+import { ProviderContextPrepared } from '../../types';
 import { ToolbarVariablesContext } from './toolbarVariablesContext';
 
 export interface ToolbarMenuDividerProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -25,53 +26,55 @@ export interface ToolbarMenuDividerProps extends UIComponentProps, ChildrenCompo
 export type ToolbarMenuDividerStylesProps = never;
 export const toolbarMenuDividerClassName = 'ui-toolbar__menudivider';
 
-const ToolbarMenuDivider: React.FC<WithAsProp<ToolbarMenuDividerProps>> &
-  FluentComponentStaticProps<ToolbarMenuDividerProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarMenuDivider.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarMenuDivider adds non-actionable separator between items of ToolbarMenu.
+ */
+const ToolbarMenuDivider = compose<'li', ToolbarMenuDividerProps, ToolbarMenuDividerStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const { accessibility, className, design, styles, variables } = props;
-  const parentVariables = React.useContext(ToolbarVariablesContext);
+    const { accessibility, className, design, styles, variables } = props;
+    const parentVariables = React.useContext(ToolbarVariablesContext);
 
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarMenuDivider.displayName,
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarMenuDividerStylesProps>(ToolbarMenuDivider.displayName, {
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarMenuDividerStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      composeOptions,
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables: mergeComponentVariables(parentVariables, variables),
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
+
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const element = <ElementType {...getA11yProps('root', { ...unhandledProps, className: classes.root, ref })} />;
+    setEnd();
+
+    return element;
+  },
+  {
     className: toolbarMenuDividerClassName,
-    mapPropsToInlineStyles: () => ({
-      className,
-      design,
-      styles,
-      variables: mergeComponentVariables(parentVariables, variables),
-    }),
-    rtl: context.rtl,
-  });
+    displayName: 'ToolbarMenuDivider',
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarMenuDivider.handledProps, props);
-
-  const element = <ElementType {...getA11yProps('root', { ...unhandledProps, className: classes.root })} />;
-  setEnd();
-
-  return element;
-};
-
-ToolbarMenuDivider.displayName = 'ToolbarMenuDivider';
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables'],
+  },
+);
 
 ToolbarMenuDivider.propTypes = commonPropTypes.createCommon();
 ToolbarMenuDivider.defaultProps = {
   as: 'li',
 };
-ToolbarMenuDivider.handledProps = Object.keys(ToolbarMenuDivider.propTypes) as any;
 
-ToolbarMenuDivider.create = createShorthandFactory({
-  Component: ToolbarMenuDivider,
-  mappedProp: 'content',
-});
-
-/**
- * A ToolbarMenuDivider adds non-actionable separator between items of ToolbarMenu.
- */
-export default withSafeTypeForAs<typeof ToolbarMenuDivider, ToolbarMenuDividerProps, 'li'>(ToolbarMenuDivider);
+export default ToolbarMenuDivider;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -13,6 +13,7 @@ import { EventListener } from '@fluentui/react-component-event-listener';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import {
+  compose,
   focusAsync,
   useTelemetry,
   useStyles,
@@ -27,29 +28,21 @@ import { ThemeContext } from 'react-fela';
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
 
 import {
+  createShorthand,
   ChildrenComponentProps,
   commonPropTypes,
   ContentComponentProps,
   UIComponentProps,
-  createShorthandFactory,
   childrenExist,
   doesNodeContainClick,
 } from '../../utils';
-import {
-  ComponentEventHandler,
-  ShorthandValue,
-  WithAsProp,
-  withSafeTypeForAs,
-  Omit,
-  ShorthandCollection,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-} from '../../types';
+import { ComponentEventHandler, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
 import { getPopperPropsFromShorthand, Popper, PopperShorthandProps } from '../../utils/positioner';
 
 import Box, { BoxProps } from '../Box/Box';
 import Popup, { PopupProps } from '../Popup/Popup';
 import ToolbarMenu, { ToolbarMenuProps, ToolbarMenuItemShorthandKinds } from './ToolbarMenu';
+import ToolbarMenuItemIcon, { ToolbarMenuItemIconProps } from './ToolbarMenuItemIcon';
 import { ToolbarVariablesContext, ToolbarVariablesProvider } from './toolbarVariablesContext';
 
 export interface ToolbarMenuItemProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -68,7 +61,7 @@ export interface ToolbarMenuItemProps extends UIComponentProps, ChildrenComponen
   disabled?: boolean;
 
   /** Name or shorthand for Toolbar Item Icon */
-  icon?: ShorthandValue<BoxProps>;
+  icon?: ShorthandValue<ToolbarMenuItemIconProps>;
 
   /** ToolbarMenuItem index inside ToolbarMenu. */
   index?: number;
@@ -134,315 +127,356 @@ export const toolbarMenuItemSlotClassNames: ToolbarMenuItemSlotClassNames = {
   submenuIndicator: `${toolbarMenuItemClassName}__submenuIndicator`,
 };
 
-const ToolbarMenuItem: React.FC<WithAsProp<ToolbarMenuItemProps>> &
-  FluentComponentStaticProps<ToolbarMenuItemProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarMenuItem.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarMenuItem renders ToolbarMenu item as button.
+ */
+const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMenuItemStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const {
-    active,
-    activeIndicator,
-    children,
-    content,
-    disabled,
-    submenuIndicator,
-    icon,
-    menu,
-    popup,
-    wrapper,
-    inSubmenu,
-    className,
-    design,
-    styles,
-    variables,
-  } = props;
-
-  const [menuOpen, setMenuOpen] = useAutoControlled({
-    defaultValue: props.defaultMenuOpen,
-    value: props.menuOpen,
-    initialValue: false,
-  });
-
-  const itemRef = React.useRef<HTMLElement>();
-  const menuRef = React.useRef<HTMLElement>();
-
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
-
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarMenuItem.handledProps, props);
-
-  const getA11yProps = useAccessibility(props.accessibility, {
-    debugName: ToolbarMenuItem.displayName,
-    mapPropsToBehavior: () => ({
-      menu,
+    const {
       active,
-      menuOpen,
+      activeIndicator,
+      children,
+      content,
       disabled,
-      'aria-label': props['aria-label'],
-      'aria-labelledby': props['aria-labelledby'],
-      'aria-describedby': props['aria-describedby'],
-    }),
-    actionHandlers: {
-      performClick: event => {
-        event.preventDefault();
-        handleClick(event);
-      },
-      openMenu: event => openMenu(event),
-      closeAllMenusAndFocusNextParentItem: event => closeAllMenus(event),
-      closeMenu: event => closeMenu(event),
-      closeMenuAndFocusTrigger: event => closeMenu(event),
-      doNotNavigateNextParentItem: event => {
-        event.stopPropagation();
-      },
-      closeAllMenus: event => closeAllMenus(event),
-    },
-    rtl: context.rtl,
-  });
-
-  const { classes, styles: resolvedStyles } = useStyles<ToolbarMenuItemStylesProps>(ToolbarMenuItem.displayName, {
-    className: toolbarMenuItemClassName,
-    mapPropsToStyles: () => ({
-      disabled,
-      hasContent: !!content,
-    }),
-    mapPropsToInlineStyles: () => ({
+      submenuIndicator,
+      icon,
+      menu,
+      popup,
+      wrapper,
+      inSubmenu,
       className,
       design,
       styles,
-      variables: mergedVariables,
-    }),
-    rtl: context.rtl,
-  });
+      variables,
+    } = props;
 
-  const openMenu = (e: React.KeyboardEvent) => {
-    if (menu && !menuOpen) {
-      trySetMenuOpen(true, e);
-      e.stopPropagation();
-      e.preventDefault();
-    }
-  };
-
-  const closeMenu = (e: React.KeyboardEvent) => {
-    if (!isSubmenuOpen()) {
-      return;
-    }
-
-    trySetMenuOpen(false, e, () => {
-      focusAsync(itemRef.current);
+    const [menuOpen, setMenuOpen] = useAutoControlled({
+      defaultValue: props.defaultMenuOpen,
+      value: props.menuOpen,
+      initialValue: false,
     });
 
-    e.stopPropagation();
-  };
+    const itemRef = React.useRef<HTMLElement>();
+    const menuRef = React.useRef<HTMLElement>();
 
-  const closeAllMenus = (e: React.KeyboardEvent) => {
-    if (!isSubmenuOpen()) {
-      return;
-    }
-    trySetMenuOpen(false, e, () => {
-      if (!inSubmenu) {
-        focusAsync(itemRef.current);
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+
+    const ElementType = getElementType(props);
+    const slotProps = composeOptions.resolveSlotProps<ToolbarMenuItemProps>(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const getA11yProps = useAccessibility(props.accessibility, {
+      debugName: composeOptions.displayName,
+      mapPropsToBehavior: () => ({
+        menu,
+        active,
+        menuOpen,
+        disabled,
+        'aria-label': props['aria-label'],
+        'aria-labelledby': props['aria-labelledby'],
+        'aria-describedby': props['aria-describedby'],
+      }),
+      actionHandlers: {
+        performClick: event => {
+          event.preventDefault();
+          handleClick(event);
+        },
+        openMenu: event => openMenu(event),
+        closeAllMenusAndFocusNextParentItem: event => closeAllMenus(event),
+        closeMenu: event => closeMenu(event),
+        closeMenuAndFocusTrigger: event => closeMenu(event),
+        doNotNavigateNextParentItem: event => {
+          event.stopPropagation();
+        },
+        closeAllMenus: event => closeAllMenus(event),
+      },
+      rtl: context.rtl,
+    });
+
+    const { classes, styles: resolvedStyles } = useStyles<ToolbarMenuItemStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      composeOptions,
+      mapPropsToStyles: () => ({
+        disabled,
+        hasContent: !!content,
+      }),
+      mapPropsToInlineStyles: () => ({
+        className,
+        design,
+        styles,
+        variables: mergedVariables,
+      }),
+      rtl: context.rtl,
+      unstable_props: props,
+    });
+
+    const openMenu = (e: React.KeyboardEvent) => {
+      if (menu && !menuOpen) {
+        trySetMenuOpen(true, e);
+        e.stopPropagation();
+        e.preventDefault();
       }
-    });
+    };
 
-    // avoid spacebar scrolling the page
-    if (!inSubmenu) {
-      e.preventDefault();
-    }
-  };
-
-  const isSubmenuOpen = (): boolean => {
-    return !!(menu && menuOpen);
-  };
-
-  const trySetMenuOpen = (newValue: boolean, e: Event | React.SyntheticEvent, onStateChanged?: any) => {
-    setMenuOpen(newValue);
-    // The reason why post-effect is not passed as callback to trySetState method
-    // is that in 'controlled' mode the post-effect is applied before final re-rendering
-    // which cause a broken behavior: for e.g. when it is needed to focus submenu trigger on ESC.
-    // TODO: all DOM post-effects should be applied at componentDidMount & componentDidUpdated stages.
-    onStateChanged && onStateChanged();
-    _.invoke(props, 'onMenuOpenChange', e, {
-      ...props,
-      menuOpen: newValue,
-    });
-  };
-
-  const outsideClickHandler = (getRefs: GetRefs) => (e: MouseEvent) => {
-    const isItemClick = doesNodeContainClick(itemRef.current, e, context.target);
-    const isNestedClick = _.some(getRefs(), (childRef: NodeRef) => {
-      return doesNodeContainClick(childRef.current as HTMLElement, e, context.target);
-    });
-    const isInside = isItemClick || isNestedClick;
-
-    if (!isInside) {
-      trySetMenuOpen(false, e);
-    }
-  };
-
-  const handleMenuOverrides = (predefinedProps: ToolbarMenuProps) => ({
-    onItemClick: (e, itemProps: ToolbarMenuItemProps) => {
-      const { popup, menuOpen } = itemProps;
-      _.invoke(predefinedProps, 'onItemClick', e, itemProps);
-      if (popup) {
+    const closeMenu = (e: React.KeyboardEvent) => {
+      if (!isSubmenuOpen()) {
         return;
       }
 
-      trySetMenuOpen(menuOpen, e);
-      if (!menuOpen) {
-        _.invoke(itemRef.current, 'focus');
+      trySetMenuOpen(false, e, () => {
+        focusAsync(itemRef.current);
+      });
+
+      e.stopPropagation();
+    };
+
+    const closeAllMenus = (e: React.KeyboardEvent) => {
+      if (!isSubmenuOpen()) {
+        return;
       }
-    },
-  });
+      trySetMenuOpen(false, e, () => {
+        if (!inSubmenu) {
+          focusAsync(itemRef.current);
+        }
+      });
 
-  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
+      // avoid spacebar scrolling the page
+      if (!inSubmenu) {
+        e.preventDefault();
+      }
+    };
 
-    if (menu) {
-      // the menuItem element was clicked => toggle the open/close and stop propagation
-      trySetMenuOpen(!menuOpen, e);
-      e.stopPropagation();
-      e.preventDefault();
-    }
+    const isSubmenuOpen = (): boolean => {
+      return !!(menu && menuOpen);
+    };
 
-    if (popup) {
-      e.stopPropagation();
-      e.preventDefault();
-      return;
-    }
+    const trySetMenuOpen = (newValue: boolean, e: Event | React.SyntheticEvent, onStateChanged?: any) => {
+      setMenuOpen(newValue);
+      // The reason why post-effect is not passed as callback to trySetState method
+      // is that in 'controlled' mode the post-effect is applied before final re-rendering
+      // which cause a broken behavior: for e.g. when it is needed to focus submenu trigger on ESC.
+      // TODO: all DOM post-effects should be applied at componentDidMount & componentDidUpdated stages.
+      onStateChanged && onStateChanged();
+      _.invoke(props, 'onMenuOpenChange', e, {
+        ...props,
+        menuOpen: newValue,
+      });
+    };
 
-    _.invoke(props, 'onClick', e, props);
-  };
+    const outsideClickHandler = (getRefs: GetRefs) => (e: MouseEvent) => {
+      const isItemClick = doesNodeContainClick(itemRef.current, e, context.target);
+      const isNestedClick = _.some(getRefs(), (childRef: NodeRef) => {
+        return doesNodeContainClick(childRef.current as HTMLElement, e, context.target);
+      });
+      const isInside = isItemClick || isNestedClick;
 
-  const element = (
-    <ElementType
-      {...getA11yProps('root', {
-        className: classes.root,
-        onClick: handleClick,
-        disabled,
-        ...unhandledProps,
-      })}
-    >
-      {childrenExist(children) ? (
-        children
-      ) : (
-        <>
-          {Box.create(icon, {
-            defaultProps: () => ({
-              styles: resolvedStyles.icon,
-            }),
-          })}
-          {content}
-          {active &&
-            Box.create(activeIndicator, {
-              defaultProps: () => ({
-                as: 'span',
-                className: toolbarMenuItemSlotClassNames.activeIndicator,
-                styles: resolvedStyles.activeIndicator,
-                accessibility: indicatorBehavior,
-              }),
-            })}
-          {menu &&
-            Box.create(submenuIndicator, {
-              defaultProps: () => ({
-                as: 'span',
-                className: toolbarMenuItemSlotClassNames.submenuIndicator,
-                styles: resolvedStyles.submenuIndicator,
-                accessibility: indicatorBehavior,
-              }),
-            })}
-        </>
-      )}
-    </ElementType>
-  );
+      if (!isInside) {
+        trySetMenuOpen(false, e);
+      }
+    };
 
-  const hasChildren = childrenExist(children);
+    const handleMenuOverrides = (predefinedProps: ToolbarMenuProps) => ({
+      onItemClick: (e, itemProps: ToolbarMenuItemProps) => {
+        const { popup, menuOpen } = itemProps;
+        _.invoke(predefinedProps, 'onItemClick', e, itemProps);
+        if (popup) {
+          return;
+        }
 
-  if (popup && !hasChildren) {
-    const popupElement = Popup.create(popup, {
-      defaultProps: () => ({
-        trapFocus: true,
-        onOpenChange: e => {
-          e.stopPropagation();
-        },
-      }),
-      overrideProps: {
-        trigger: element,
-        children: undefined, // force-reset `children` defined for `Popup` as it collides with the `trigger`
+        trySetMenuOpen(menuOpen, e);
+        if (!menuOpen) {
+          _.invoke(itemRef.current, 'focus');
+        }
       },
+    });
+
+    const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+
+      if (menu) {
+        // the menuItem element was clicked => toggle the open/close and stop propagation
+        trySetMenuOpen(!menuOpen, e);
+        e.stopPropagation();
+        e.preventDefault();
+      }
+
+      if (popup) {
+        e.stopPropagation();
+        e.preventDefault();
+        return;
+      }
+
+      _.invoke(props, 'onClick', e, props);
+    };
+
+    const element = (
+      <ElementType
+        {...getA11yProps('root', {
+          className: classes.root,
+          onClick: handleClick,
+          disabled,
+          ref,
+          ...unhandledProps,
+        })}
+      >
+        {childrenExist(children) ? (
+          children
+        ) : (
+          <>
+            {createShorthand(composeOptions.slots.icon, icon, { defaultProps: () => slotProps.icon })}
+            {content}
+            {active &&
+              Box.create(activeIndicator, {
+                defaultProps: () => ({
+                  as: 'span',
+                  className: toolbarMenuItemSlotClassNames.activeIndicator,
+                  styles: resolvedStyles.activeIndicator,
+                  accessibility: indicatorBehavior,
+                }),
+              })}
+            {menu &&
+              Box.create(submenuIndicator, {
+                defaultProps: () => ({
+                  as: 'span',
+                  className: toolbarMenuItemSlotClassNames.submenuIndicator,
+                  styles: resolvedStyles.submenuIndicator,
+                  accessibility: indicatorBehavior,
+                }),
+              })}
+          </>
+        )}
+      </ElementType>
+    );
+
+    const hasChildren = childrenExist(children);
+
+    if (popup && !hasChildren) {
+      const popupElement = Popup.create(popup, {
+        defaultProps: () => ({
+          trapFocus: true,
+          onOpenChange: e => {
+            e.stopPropagation();
+          },
+        }),
+        overrideProps: {
+          trigger: element,
+          children: undefined, // force-reset `children` defined for `Popup` as it collides with the `trigger`
+        },
+      });
+      setEnd();
+
+      return popupElement;
+    }
+
+    const menuItemInner = hasChildren ? (children as React.ReactElement) : <Ref innerRef={itemRef}>{element}</Ref>;
+
+    const maybeSubmenu =
+      menu && menuOpen ? (
+        <Unstable_NestingAuto>
+          {(getRefs, nestingRef) => (
+            <>
+              <Ref
+                innerRef={(node: HTMLElement) => {
+                  nestingRef.current = node;
+                  menuRef.current = node;
+                }}
+              >
+                <Popper
+                  align="top"
+                  position={context.rtl ? 'before' : 'after'}
+                  targetRef={itemRef}
+                  {...getPopperPropsFromShorthand(menu)}
+                >
+                  <ToolbarVariablesProvider value={mergedVariables}>
+                    {createShorthand(composeOptions.slots.menu || ToolbarMenu, menu, {
+                      defaultProps: () => ({
+                        className: toolbarMenuItemSlotClassNames.submenu,
+                        styles: resolvedStyles.menu,
+                        submenu: true,
+                        submenuIndicator,
+                        ...slotProps.menu,
+                      }),
+                      overrideProps: handleMenuOverrides,
+                    })}
+                  </ToolbarVariablesProvider>
+                </Popper>
+              </Ref>
+              <EventListener listener={outsideClickHandler(getRefs)} target={context.target} type="click" />
+            </>
+          )}
+        </Unstable_NestingAuto>
+      ) : null;
+
+    if (!wrapper) {
+      setEnd();
+      return menuItemInner;
+    }
+
+    const wrapperElement = Box.create(wrapper, {
+      defaultProps: () =>
+        getA11yProps('wrapper', {
+          className: cx(toolbarMenuItemSlotClassNames.wrapper, classes.wrapper),
+        }),
+      overrideProps: () => ({
+        children: (
+          <>
+            {menuItemInner}
+            {maybeSubmenu}
+          </>
+        ),
+      }),
     });
     setEnd();
 
-    return popupElement;
-  }
+    return wrapperElement;
+  },
+  {
+    className: toolbarMenuItemClassName,
+    displayName: 'ToolbarMenuItem',
 
-  const menuItemInner = hasChildren ? (children as React.ReactElement) : <Ref innerRef={itemRef}>{element}</Ref>;
+    slots: {
+      icon: ToolbarMenuItemIcon,
+      // menu: ToolbarMenu,
+    },
 
-  const maybeSubmenu =
-    menu && menuOpen ? (
-      <Unstable_NestingAuto>
-        {(getRefs, nestingRef) => (
-          <>
-            <Ref
-              innerRef={(node: HTMLElement) => {
-                nestingRef.current = node;
-                menuRef.current = node;
-              }}
-            >
-              <Popper
-                align="top"
-                position={context.rtl ? 'before' : 'after'}
-                targetRef={itemRef}
-                {...getPopperPropsFromShorthand(menu)}
-              >
-                <ToolbarVariablesProvider value={mergedVariables}>
-                  {ToolbarMenu.create(menu, {
-                    defaultProps: () => ({
-                      className: toolbarMenuItemSlotClassNames.submenu,
-                      styles: resolvedStyles.menu,
-                      submenu: true,
-                      submenuIndicator,
-                    }),
-                    overrideProps: handleMenuOverrides,
-                  })}
-                </ToolbarVariablesProvider>
-              </Popper>
-            </Ref>
-            <EventListener listener={outsideClickHandler(getRefs)} target={context.target} type="click" />
-          </>
-        )}
-      </Unstable_NestingAuto>
-    ) : null;
+    shorthandConfig: {
+      mappedProp: 'content',
+    },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'styles',
+      'variables',
 
-  if (!wrapper) {
-    setEnd();
-    return menuItemInner;
-  }
-
-  const wrapperElement = Box.create(wrapper, {
-    defaultProps: () =>
-      getA11yProps('wrapper', {
-        className: cx(toolbarMenuItemSlotClassNames.wrapper, classes.wrapper),
-      }),
-    overrideProps: () => ({
-      children: (
-        <>
-          {menuItemInner}
-          {maybeSubmenu}
-        </>
-      ),
-    }),
-  });
-  setEnd();
-
-  return wrapperElement;
-};
-
-ToolbarMenuItem.displayName = 'ToolbarMenuItem';
+      'active',
+      'activeIndicator',
+      'defaultMenuOpen',
+      'disabled',
+      'icon',
+      'index',
+      'submenuIndicator',
+      'inSubmenu',
+      'menu',
+      'menuOpen',
+      'onClick',
+      'onMenuOpenChange',
+      'popup',
+      'wrapper',
+    ],
+  },
+);
 
 ToolbarMenuItem.propTypes = {
   ...commonPropTypes.createCommon(),
@@ -468,23 +502,12 @@ ToolbarMenuItem.propTypes = {
   ]),
   wrapper: customPropTypes.itemShorthand,
 };
-
-ToolbarMenuItem.handledProps = Object.keys(ToolbarMenuItem.propTypes) as any;
-
 ToolbarMenuItem.defaultProps = {
   as: 'button',
   accessibility: toolbarMenuItemBehavior,
-  wrapper: { as: 'li' },
   activeIndicator: {},
   submenuIndicator: {},
+  wrapper: { as: 'li' },
 };
 
-ToolbarMenuItem.create = createShorthandFactory({
-  Component: ToolbarMenuItem,
-  mappedProp: 'content',
-});
-
-/**
- * A ToolbarMenuItem renders ToolbarMenu item as button.
- */
-export default withSafeTypeForAs<typeof ToolbarMenuItem, ToolbarMenuItemProps, 'button'>(ToolbarMenuItem);
+export default ToolbarMenuItem;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItemIcon.tsx
@@ -1,0 +1,39 @@
+import { compose } from '@fluentui/react-bindings';
+
+import { commonPropTypes } from '../../utils';
+import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
+
+interface ToolbarMenuItemIconOwnProps {}
+export interface ToolbarMenuItemIconProps extends ToolbarMenuItemIconOwnProps, BoxProps {}
+
+export type ToolbarMenuItemIconStylesProps = { hasContent: boolean };
+export const toolbarMenuItemIconClassName = 'ui-toolbar__menuitem__active-icon';
+
+/**
+ * TODO
+ */
+const ToolbarMenuItemIcon = compose<
+  'span',
+  ToolbarMenuItemIconOwnProps,
+  ToolbarMenuItemIconStylesProps,
+  BoxProps,
+  BoxStylesProps
+>(Box, {
+  className: toolbarMenuItemIconClassName,
+  displayName: 'ToolbarMenuItemIcon',
+
+  mapPropsToStylesProps: props => ({
+    hasContent: props.content,
+  }),
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+  overrideStyles: true,
+});
+
+ToolbarMenuItemIcon.defaultProps = {
+  as: 'span',
+};
+ToolbarMenuItemIcon.propTypes = commonPropTypes.createCommon();
+
+export default ToolbarMenuItemIcon;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -4,7 +4,14 @@ import {
   toolbarRadioGroupItemBehavior,
   ToolbarRadioGroupBehaviorProps,
 } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  compose,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import { mergeComponentVariables } from '@fluentui/styles';
@@ -17,18 +24,12 @@ import { ThemeContext } from 'react-fela';
 import {
   ChildrenComponentProps,
   ContentComponentProps,
-  createShorthandFactory,
+  createShorthand,
   UIComponentProps,
   childrenExist,
   commonPropTypes,
 } from '../../utils';
-import {
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-  ShorthandCollection,
-  WithAsProp,
-  withSafeTypeForAs,
-} from '../../types';
+import { ProviderContextPrepared, ShorthandCollection } from '../../types';
 import ToolbarDivider, { ToolbarDividerProps } from './ToolbarDivider';
 import ToolbarItem, { ToolbarItemProps } from './ToolbarItem';
 import { ToolbarVariablesContext, ToolbarVariablesProvider } from './toolbarVariablesContext';
@@ -54,131 +55,6 @@ export interface ToolbarRadioGroupProps extends UIComponentProps, ChildrenCompon
 export type ToolbarRadioGroupStylesProps = never;
 export const toolbarRadioGroupClassName = 'ui-toolbars'; // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
-const ToolbarRadioGroup: React.FC<WithAsProp<ToolbarRadioGroupProps>> &
-  FluentComponentStaticProps<ToolbarRadioGroupProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarRadioGroup.displayName, context.telemetry);
-  setStart();
-
-  const { accessibility, activeIndex, children, className, design, items, variables, styles } = props;
-  const itemRefs: React.RefObject<HTMLElement>[] = [];
-
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
-
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarRadioGroup.displayName,
-    actionHandlers: {
-      nextItem: event => setFocusedItem(event, 1),
-      prevItem: event => setFocusedItem(event, -1),
-    },
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarRadioGroupStylesProps>(ToolbarRadioGroup.displayName, {
-    className: toolbarRadioGroupClassName,
-    mapPropsToInlineStyles: () => ({ className, design, styles, variables: mergedVariables }),
-    rtl: context.rtl,
-  });
-
-  const setFocusedItem = (event: React.KeyboardEvent, direction) => {
-    // filter items which are not disabled
-    const filteredRadioItems: React.RefObject<HTMLElement>[] = _.filter(itemRefs, (item, index) => {
-      const currentItem = items[index] as ToolbarItemProps;
-      return currentItem && !currentItem.disabled;
-    });
-
-    // get the index of currently focused element (w/ tabindex = 0) or the first one as default
-    const currentFocusedIndex =
-      _.findIndex(filteredRadioItems, (item: React.RefObject<HTMLElement>) => {
-        return item.current.tabIndex === 0;
-      }) || 0;
-
-    const itemsLength = filteredRadioItems.length;
-    let nextIndex = currentFocusedIndex + direction;
-
-    if (nextIndex >= itemsLength) {
-      nextIndex = 0;
-    }
-
-    if (nextIndex < 0) {
-      nextIndex = itemsLength - 1;
-    }
-
-    const nextItemToFocus = filteredRadioItems[nextIndex].current;
-    if (nextItemToFocus) {
-      nextItemToFocus.focus();
-    }
-
-    if (context.target.activeElement === nextItemToFocus) {
-      event.stopPropagation();
-    }
-    event.preventDefault();
-  };
-
-  const renderItems = () => {
-    return _.map(items, (item, index) => {
-      const kind = _.get(item, 'kind', 'item');
-
-      const ref = React.createRef<HTMLElement>();
-      itemRefs[index] = ref;
-
-      if (kind === 'divider') {
-        return ToolbarDivider.create(item);
-      }
-
-      const toolbarItem = ToolbarItem.create(item, {
-        defaultProps: () => ({
-          accessibility: toolbarRadioGroupItemBehavior,
-          active: activeIndex === index,
-        }),
-      });
-
-      return (
-        <Ref innerRef={ref} key={toolbarItem.key}>
-          {toolbarItem}
-        </Ref>
-      );
-    });
-  };
-
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarRadioGroup.handledProps, props);
-
-  const element = (
-    <ElementType
-      {...getA11yProps('root', {
-        ...unhandledProps,
-        className: classes.root,
-      })}
-    >
-      <ToolbarVariablesProvider value={mergedVariables}>
-        {childrenExist(children) ? children : renderItems()}
-      </ToolbarVariablesProvider>
-    </ElementType>
-  );
-  setEnd();
-
-  return element;
-};
-
-ToolbarRadioGroup.displayName = 'ToolbarRadioGroup';
-
-ToolbarRadioGroup.propTypes = {
-  ...commonPropTypes.createCommon(),
-  activeIndex: PropTypes.number,
-  items: customPropTypes.collectionShorthandWithKindProp(['divider', 'item']),
-};
-ToolbarRadioGroup.handledProps = Object.keys(ToolbarRadioGroup.propTypes) as any;
-
-ToolbarRadioGroup.defaultProps = {
-  accessibility: toolbarRadioGroupBehavior,
-};
-
-ToolbarRadioGroup.create = createShorthandFactory({
-  Component: ToolbarRadioGroup,
-  mappedProp: 'content',
-});
-
 /**
  * A ToolbarRadioGroup renders Toolbar item as a group of mutually exclusive options.
  * Component doesn't implement mutual exclusiveness, it just serves accessibility purposes.
@@ -186,4 +62,141 @@ ToolbarRadioGroup.create = createShorthandFactory({
  * @accessibility
  * Implements [ARIA RadioGroup](https://www.w3.org/TR/wai-aria-practices/#radiobutton) design pattern.
  */
-export default withSafeTypeForAs<typeof ToolbarRadioGroup, ToolbarRadioGroupProps>(ToolbarRadioGroup);
+const ToolbarRadioGroup = compose<'div', ToolbarRadioGroupProps, ToolbarRadioGroupStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
+
+    const { accessibility, activeIndex, children, className, design, items, variables, styles } = props;
+    const itemRefs: React.RefObject<HTMLElement>[] = [];
+
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      actionHandlers: {
+        nextItem: event => setFocusedItem(event, 1),
+        prevItem: event => setFocusedItem(event, -1),
+      },
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarRadioGroupStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      mapPropsToInlineStyles: () => ({ className, design, styles, variables: mergedVariables }),
+      rtl: context.rtl,
+    });
+
+    const setFocusedItem = (event: React.KeyboardEvent, direction) => {
+      // filter items which are not disabled
+      const filteredRadioItems: React.RefObject<HTMLElement>[] = _.filter(itemRefs, (item, index) => {
+        const currentItem = items[index] as ToolbarItemProps;
+        return currentItem && !currentItem.disabled;
+      });
+
+      // get the index of currently focused element (w/ tabindex = 0) or the first one as default
+      const currentFocusedIndex =
+        _.findIndex(filteredRadioItems, (item: React.RefObject<HTMLElement>) => {
+          return item.current.tabIndex === 0;
+        }) || 0;
+
+      const itemsLength = filteredRadioItems.length;
+      let nextIndex = currentFocusedIndex + direction;
+
+      if (nextIndex >= itemsLength) {
+        nextIndex = 0;
+      }
+
+      if (nextIndex < 0) {
+        nextIndex = itemsLength - 1;
+      }
+
+      const nextItemToFocus = filteredRadioItems[nextIndex].current;
+      if (nextItemToFocus) {
+        nextItemToFocus.focus();
+      }
+
+      if (context.target.activeElement === nextItemToFocus) {
+        event.stopPropagation();
+      }
+      event.preventDefault();
+    };
+
+    const renderItems = () => {
+      return _.map(items, (item, index) => {
+        const kind = _.get(item, 'kind', 'item');
+
+        const ref = React.createRef<HTMLElement>();
+        itemRefs[index] = ref;
+
+        if (kind === 'divider') {
+          return ToolbarDivider.create(item);
+        }
+
+        const toolbarItem = createShorthand(ToolbarItem, item, {
+          defaultProps: () => ({
+            accessibility: toolbarRadioGroupItemBehavior,
+            active: activeIndex === index,
+          }),
+        });
+
+        return (
+          <Ref innerRef={ref} key={toolbarItem.key}>
+            {toolbarItem}
+          </Ref>
+        );
+      });
+    };
+
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const element = (
+      <ElementType
+        {...getA11yProps('root', {
+          ...unhandledProps,
+          className: classes.root,
+          ref,
+        })}
+      >
+        <ToolbarVariablesProvider value={mergedVariables}>
+          {childrenExist(children) ? children : renderItems()}
+        </ToolbarVariablesProvider>
+      </ElementType>
+    );
+    setEnd();
+
+    return element;
+  },
+  {
+    className: toolbarRadioGroupClassName,
+    displayName: 'ToolbarRadioGroup',
+
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'styles',
+      'variables',
+
+      'activeIndex',
+      'items',
+    ],
+  },
+);
+
+ToolbarRadioGroup.propTypes = {
+  ...commonPropTypes.createCommon(),
+  activeIndex: PropTypes.number,
+  items: customPropTypes.collectionShorthandWithKindProp(['divider', 'item']),
+};
+ToolbarRadioGroup.defaultProps = {
+  accessibility: toolbarRadioGroupBehavior,
+};
+
+export default ToolbarRadioGroup;

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -108,6 +108,7 @@ export { default as ToolbarItem } from './components/Toolbar/toolbarItemStyles';
 export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuStyles';
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerStyles';
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemStyles';
+export { default as ToolbarMenuItemIcon } from './components/Toolbar/toolbarMenuItemIconStyles';
 export { default as ToolbarMenuRadioGroup } from './components/Toolbar/toolbarMenuRadioGroupStyles';
 
 export { default as Tree } from './components/Tree/treeStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
@@ -94,6 +94,7 @@ export { default as ToolbarDivider } from './components/Toolbar/toolbarDividerVa
 export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuVariables';
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerVariables';
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemVariables';
+export { default as ToolbarMenuItemIcon } from './components/Toolbar/toolbarMenuItemIconVariables';
 export { default as ToolbarMenuRadioGroup } from './components/Toolbar/toolbarMenuRadioGroupVariables';
 
 export { default as TreeTitle } from './components/Tree/treeTitleVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemIconStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemIconStyles.ts
@@ -1,0 +1,15 @@
+import { ComponentSlotStylesPrepared } from '@fluentui/styles';
+
+import { pxToRem } from '../../../../utils';
+import { ToolbarMenuItemIconStylesProps } from '../../../../components/Toolbar/ToolbarMenuItemIcon';
+import { ToolbarVariables } from './toolbarVariables';
+
+const toolbarMenuItemIconStyles: ComponentSlotStylesPrepared<ToolbarMenuItemIconStylesProps, ToolbarVariables> = {
+  root: ({ props: p }) => ({
+    ...(p.hasContent && {
+      marginRight: pxToRem(10),
+    }),
+  }),
+};
+
+export default toolbarMenuItemIconStyles;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemIconVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemIconVariables.ts
@@ -1,0 +1,1 @@
+export { default } from './toolbarVariables';

--- a/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuItemIcon-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuItemIcon-test.ts
@@ -1,0 +1,6 @@
+import ToolbarMenuItemIcon from 'src/components/Toolbar/ToolbarMenuItemIcon';
+import { isConformant } from 'test/specs/commonTests';
+
+describe('ToolbarMenuItemIcon', () => {
+  isConformant(ToolbarMenuItemIcon, { constructorName: 'ToolbarMenuItemIcon' });
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

### Findings:

- [ ] `mapPropsToStylesProps()` - we need to have there `ParentProps`, see `ToolbarMenuItemIcon.ts`
- [ ] `ref` has a wrong type (for example it's `button`, but should be `HTMLButtonElement`), see `Toolbar.tsx`
- [ ] `mapPropsToStylesProps()` - should allow only primitive types
- [ ] add dev check to `useStyles` to check `mapPropsToStylesProps` for primitive types

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13047)