### PR TITLE
Fix bundlesizecollect to work with non-oufr packages

### DIFF
--- a/scripts/tasks/bundle-size-collect.js
+++ b/scripts/tasks/bundle-size-collect.js
@@ -32,12 +32,6 @@ module.exports = function bundleSizeCollect() {
   }
 
   function getComponentName(fileName) {
-    // Special case the component names for the oufr tests.
-    if (fileName.startsWith('office-ui-fabric-react-')) {
-      return fileName.match('office-ui-fabric-react-(.*).min.js')[1];
-    }
-
-    // Assume all other tests use the basename.
     return path.basename(fileName, '.min.js');
   }
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
This change fixes size auditor for `fluent/react-next` and any non OUFR package bundles:
https://github.com/microsoft/fluentui/pull/13035#issuecomment-624978668
Notice here all `react-next` bundles have broken link to the size report due to incorrect `artifactFileName` param

Before this fix, `bundlesize.json` has:
```
{
   "sizes":{
      "fluentui-react-next-ActivityItem":67027,
      ...
      "ActivityItem":67027,
   }
}
```
After fix:
```
{
   "sizes":{
      "fluentui-react-next-ActivityItem":67027,
      ...
      "office-ui-fabric-react-ActivityItem":67027,
   }
}
```
This fix also requires change in size auditor report code: https://onedrive.visualstudio.com/DefaultCollection/OneDrive%20Service/_git/OneDrive.LightRail/pullrequest/433639?_a=overview

**Order of operations for the 2 changes:**
1. Merge and wait for size auditor worker (OneDrive repo) change to be deployed
2. Merge this change in Fluent UI repo

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13057)