### PR TITLE
Copying OverflowSet to react-next, in preparation for converting to function component

### DIFF
--- a/change/@fluentui-react-next-2020-05-07-19-16-42-feat-overflow-set.json
+++ b/change/@fluentui-react-next-2020-05-07-19-16-42-feat-overflow-set.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "updates",
+  "comment": "Copying OverflowSet to react-next, in preparation for converting to function component",
   "packageName": "@fluentui/react-next",
   "email": "czearing@outlook.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-next-2020-05-07-19-16-42-feat-overflow-set.json
+++ b/change/@fluentui-react-next-2020-05-07-19-16-42-feat-overflow-set.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "updates",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-08T02:16:42.406Z"
+}

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -8,6 +8,7 @@ import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { IButtonProps as IButtonProps_2 } from 'office-ui-fabric-react/lib/components/Button/Button.types';
 import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IComponentAs } from 'office-ui-fabric-react/lib/Utilities';
+import { IFocusZoneProps } from '@fluentui/react-focus';
 import { IIconProps } from 'office-ui-fabric-react/lib/Icon';
 import { IKeytipProps } from 'office-ui-fabric-react/lib/Keytip';
 import { IRefObject } from 'office-ui-fabric-react/lib/Utilities';
@@ -221,6 +222,49 @@ export enum ImageLoadState {
     errorLoaded = 3,
     loaded = 1,
     notLoaded = 0
+}
+
+// @public (undocumented)
+export interface IOverflowSet {
+    focus(forceIntoFirstElement?: boolean): boolean;
+    focusElement(childElement?: HTMLElement): boolean;
+}
+
+// @public (undocumented)
+export interface IOverflowSetItemProps {
+    [propertyName: string]: any;
+    key: string;
+    keytipProps?: IKeytipProps;
+}
+
+// @public (undocumented)
+export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase> {
+    className?: string;
+    componentRef?: IRefObject<IOverflowSet>;
+    // @deprecated
+    doNotContainWithinFocusZone?: boolean;
+    // @deprecated
+    focusZoneProps?: IFocusZoneProps;
+    items?: IOverflowSetItemProps[];
+    itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+    keytipSequences?: string[];
+    onRenderItem: (item: IOverflowSetItemProps) => any;
+    onRenderOverflowButton: IRenderFunction<any[]>;
+    overflowItems?: IOverflowSetItemProps[];
+    overflowSide?: 'start' | 'end';
+    role?: string;
+    styles?: IStyleFunctionOrObject<IOverflowSetProps, IOverflowSetStyles>;
+    vertical?: boolean;
+}
+
+// @public
+export type IOverflowSetStyleProps = Pick<IOverflowSetProps, 'vertical' | 'className'>;
+
+// @public (undocumented)
+export interface IOverflowSetStyles {
+    item?: IStyle;
+    overflowButton?: IStyle;
+    root?: IStyle;
 }
 
 // @public (undocumented)
@@ -642,6 +686,26 @@ export const MeasuredContext: React.Context<{
 // @public (undocumented)
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
 
+// @public (undocumented)
+export const OverflowSet: React.FunctionComponent<IOverflowSetProps>;
+
+// @public (undocumented)
+export class OverflowSetBase extends React.Component<IOverflowSetProps, {}> implements IOverflowSet {
+    constructor(props: IOverflowSetProps);
+    // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
+    componentDidUpdate(): void;
+    // (undocumented)
+    componentWillUnmount(): void;
+    focus(forceIntoFirstElement?: boolean): boolean;
+    focusElement(childElement?: HTMLElement): boolean;
+    // (undocumented)
+    render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(): void;
+}
+
 // @public
 export const Pivot: React.FunctionComponent<IPivotProps>;
 
@@ -800,7 +864,6 @@ export * from "office-ui-fabric-react/lib/MarqueeSelection";
 export * from "office-ui-fabric-react/lib/MessageBar";
 export * from "office-ui-fabric-react/lib/Modal";
 export * from "office-ui-fabric-react/lib/Nav";
-export * from "office-ui-fabric-react/lib/OverflowSet";
 export * from "office-ui-fabric-react/lib/Overlay";
 export * from "office-ui-fabric-react/lib/Panel";
 export * from "office-ui-fabric-react/lib/Persona";

--- a/packages/react-next/src/OverflowSet.ts
+++ b/packages/react-next/src/OverflowSet.ts
@@ -1,1 +1,1 @@
-export * from 'office-ui-fabric-react/lib/OverflowSet';
+export * from './components/OverflowSet/index';

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
@@ -1,0 +1,257 @@
+import * as React from 'react';
+
+import { FocusZone, FocusZoneDirection, IFocusZone } from '@fluentui/react-focus';
+import { IKeytipProps } from '../../Keytip';
+import {
+  initializeComponentRef,
+  classNamesFunction,
+  divProperties,
+  elementContains,
+  focusFirstChild,
+  getNativeProps,
+  warnMutuallyExclusive,
+} from '../../Utilities';
+import { IProcessedStyleSet } from '../../Styling';
+import { KeytipManager } from '../../utilities/keytips/KeytipManager';
+import {
+  IOverflowSet,
+  IOverflowSetItemProps,
+  IOverflowSetProps,
+  IOverflowSetStyles,
+  IOverflowSetStyleProps,
+} from './OverflowSet.types';
+
+const getClassNames = classNamesFunction<IOverflowSetStyleProps, IOverflowSetStyles>();
+const COMPONENT_NAME = 'OverflowSet';
+
+export class OverflowSetBase extends React.Component<IOverflowSetProps, {}> implements IOverflowSet {
+  private _focusZone = React.createRef<IFocusZone>();
+  private _persistedKeytips: { [uniqueID: string]: IKeytipProps } = {};
+  private _keytipManager: KeytipManager = KeytipManager.getInstance();
+  private _divContainer = React.createRef<HTMLDivElement>();
+  private _classNames: IProcessedStyleSet<IOverflowSetStyles>;
+
+  constructor(props: IOverflowSetProps) {
+    super(props);
+
+    initializeComponentRef(this);
+    warnMutuallyExclusive(COMPONENT_NAME, props, {
+      doNotContainWithinFocusZone: 'focusZoneProps',
+    });
+  }
+
+  public render(): JSX.Element {
+    const {
+      items,
+      overflowItems,
+      className,
+      // tslint:disable-next-line:deprecation
+      focusZoneProps,
+      styles,
+      vertical,
+      // tslint:disable-next-line:deprecation
+      doNotContainWithinFocusZone,
+      role,
+      overflowSide = 'end',
+    } = this.props;
+
+    this._classNames = getClassNames(styles, { className, vertical });
+
+    let Tag;
+    let uniqueComponentProps;
+
+    if (doNotContainWithinFocusZone) {
+      Tag = 'div';
+      uniqueComponentProps = {
+        ...getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties),
+        ref: this._divContainer,
+      };
+    } else {
+      Tag = FocusZone;
+      uniqueComponentProps = {
+        ...getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties),
+        ...focusZoneProps,
+        componentRef: this._focusZone,
+        direction: vertical ? FocusZoneDirection.vertical : FocusZoneDirection.horizontal,
+      };
+    }
+
+    const showOverflow = overflowItems && overflowItems.length > 0;
+
+    return (
+      <Tag
+        role={role || 'group'}
+        aria-orientation={role === 'menubar' ? (vertical === true ? 'vertical' : 'horizontal') : undefined}
+        {...uniqueComponentProps}
+        className={this._classNames.root}
+      >
+        {overflowSide === 'start' && showOverflow && this._onRenderOverflowButtonWrapper(overflowItems!)}
+        {items && this._onRenderItems(items)}
+        {overflowSide === 'end' && showOverflow && this._onRenderOverflowButtonWrapper(overflowItems!)}
+      </Tag>
+    );
+  }
+
+  /**
+   * Sets focus to the first tabbable item in the OverflowSet.
+   * @param forceIntoFirstElement - If true, focus will be forced into the first element,
+   * even if focus is already in theOverflowSet
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  public focus(forceIntoFirstElement?: boolean): boolean {
+    let focusSucceeded = false;
+
+    // tslint:disable-next-line:deprecation
+    if (this.props.doNotContainWithinFocusZone) {
+      if (this._divContainer.current) {
+        focusSucceeded = focusFirstChild(this._divContainer.current);
+      }
+    } else if (this._focusZone.current) {
+      focusSucceeded = this._focusZone.current.focus(forceIntoFirstElement);
+    }
+
+    return focusSucceeded;
+  }
+
+  /**
+   * Sets focus to a specific child element within the OverflowSet.
+   * @param childElement - The child element within the zone to focus.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  public focusElement(childElement?: HTMLElement): boolean {
+    let focusSucceeded = false;
+
+    if (!childElement) {
+      return false;
+    }
+
+    // tslint:disable-next-line:deprecation
+    if (this.props.doNotContainWithinFocusZone) {
+      if (this._divContainer.current && elementContains(this._divContainer.current, childElement)) {
+        childElement.focus();
+        focusSucceeded = document.activeElement === childElement;
+      }
+    } else if (this._focusZone.current) {
+      focusSucceeded = this._focusZone.current.focusElement(childElement);
+    }
+
+    return focusSucceeded;
+  }
+
+  // Add keytip register/unregister handlers to lifecycle functions to correctly manage persisted keytips
+  public componentDidMount() {
+    this._registerPersistedKeytips();
+  }
+
+  public componentWillUnmount() {
+    this._unregisterPersistedKeytips();
+  }
+
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate() {
+    this._unregisterPersistedKeytips();
+  }
+
+  public componentDidUpdate() {
+    this._registerPersistedKeytips();
+  }
+
+  private _registerPersistedKeytips() {
+    Object.keys(this._persistedKeytips).forEach((key: string) => {
+      const keytip = this._persistedKeytips[key];
+      const uniqueID = this._keytipManager.register(keytip, true);
+      // Update map
+      this._persistedKeytips[uniqueID] = keytip;
+      delete this._persistedKeytips[key];
+    });
+  }
+
+  private _unregisterPersistedKeytips() {
+    // Delete all persisted keytips saved
+    Object.keys(this._persistedKeytips).forEach((uniqueID: string) => {
+      this._keytipManager.unregister(this._persistedKeytips[uniqueID], uniqueID, true);
+    });
+    this._persistedKeytips = {};
+  }
+
+  private _onRenderItems = (items: IOverflowSetItemProps[]): JSX.Element[] => {
+    return items.map((item, i) => {
+      return (
+        <div key={item.key} className={this._classNames.item}>
+          {this.props.onRenderItem(item)}
+        </div>
+      );
+    });
+  };
+
+  private _onRenderOverflowButtonWrapper = (items: any[]): JSX.Element => {
+    const wrapperDivProps: React.HTMLProps<HTMLDivElement> = {
+      className: this._classNames.overflowButton,
+    };
+
+    const overflowKeytipSequences = this.props.keytipSequences;
+    let newOverflowItems: any[] = [];
+
+    if (overflowKeytipSequences) {
+      items.forEach(overflowItem => {
+        const keytip = (overflowItem as IOverflowSetItemProps).keytipProps;
+        if (keytip) {
+          // Create persisted keytip
+          const persistedKeytip: IKeytipProps = {
+            content: keytip.content,
+            keySequences: keytip.keySequences,
+            disabled: keytip.disabled || !!(overflowItem.disabled || overflowItem.isDisabled),
+            hasDynamicChildren: keytip.hasDynamicChildren,
+            hasMenu: keytip.hasMenu,
+          };
+
+          if (keytip.hasDynamicChildren || this._getSubMenuForItem(overflowItem)) {
+            // If the keytip has a submenu or children nodes, change onExecute to persistedKeytipExecute
+            persistedKeytip.onExecute = this._keytipManager.menuExecute.bind(
+              this._keytipManager,
+              overflowKeytipSequences,
+              overflowItem.keytipProps.keySequences,
+            );
+          } else {
+            // If the keytip doesn't have a submenu, just execute the original function
+            persistedKeytip.onExecute = keytip.onExecute;
+          }
+
+          // Add this persisted keytip to our internal list, use a temporary uniqueID (its content)
+          // uniqueID will get updated on register
+          this._persistedKeytips[persistedKeytip.content] = persistedKeytip;
+
+          // Add the overflow sequence to this item
+          const newOverflowItem = {
+            ...overflowItem,
+            keytipProps: {
+              ...keytip,
+              overflowSetSequence: overflowKeytipSequences,
+            },
+          };
+          newOverflowItems.push(newOverflowItem);
+        } else {
+          // Nothing to change, add overflowItem to list
+          newOverflowItems.push(overflowItem);
+        }
+      });
+    } else {
+      newOverflowItems = items;
+    }
+    return <div {...wrapperDivProps}>{this.props.onRenderOverflowButton(newOverflowItems)}</div>;
+  };
+
+  /**
+   * Gets the subMenu for an overflow item
+   * Checks if itemSubMenuProvider has been defined, if not defaults to subMenuProps
+   */
+  private _getSubMenuForItem(item: any): any[] | undefined {
+    if (this.props.itemSubMenuProvider) {
+      return this.props.itemSubMenuProvider(item);
+    }
+    if (item.subMenuProps) {
+      return item.subMenuProps.items;
+    }
+    return undefined;
+  }
+}

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import { FocusZone, FocusZoneDirection, IFocusZone } from '@fluentui/react-focus';
 import { IKeytipProps } from '../../Keytip';
 import {
@@ -12,7 +11,7 @@ import {
   warnMutuallyExclusive,
 } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
-import { KeytipManager } from '../../utilities/keytips/KeytipManager';
+import { KeytipManager } from 'office-ui-fabric-react/lib/utilities/keytips/KeytipManager';
 import {
   IOverflowSet,
   IOverflowSetItemProps,

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.doc.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.doc.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { OverflowSetCustomExample } from './examples/OverflowSet.Custom.Example';
+
+import { IDocPageProps } from '../../common/DocPage.types';
+import { OverflowSetBasicExample } from './examples/OverflowSet.Basic.Example';
+import { OverflowSetVerticalExample } from './examples/OverflowSet.Vertical.Example';
+import { OverflowSetBasicReversedExample } from './examples/OverflowSet.BasicReversed.Example';
+
+const OverflowSetCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx') as string;
+const OverflowSetBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx') as string;
+const OverflowSetVerticalExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Vertical.Example.tsx') as string;
+const OverflowSetBasicReversedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.BasicReversed.Example.tsx') as string;
+
+export const OverflowSetPageProps: IDocPageProps = {
+  title: 'OverflowSet',
+  componentName: 'OverflowSet',
+  componentUrl:
+    'https://github.com/microsoft/fluentui/tree/master/packages/office-ui-fabric-react/src/components/OverflowSet',
+  examples: [
+    {
+      title: 'OverflowSet Basic Example',
+      code: OverflowSetBasicExampleCode,
+      view: <OverflowSetBasicExample />,
+    },
+    {
+      title: 'OverflowSet Vertical Example',
+      code: OverflowSetVerticalExampleCode,
+      view: <OverflowSetVerticalExample />,
+    },
+    {
+      title: 'OverflowSet Custom Example',
+      code: OverflowSetCustomExampleCode,
+      view: <OverflowSetCustomExample />,
+    },
+    {
+      title: 'OverflowSet Reversed Example',
+      code: OverflowSetBasicReversedExampleCode,
+      view: <OverflowSetBasicReversedExample />,
+    },
+  ],
+  overview: require<
+    string
+  >('!raw-loader!office-ui-fabric-react/src/components/OverflowSet/docs/OverflowSetOverview.md'),
+  bestPractices: '',
+  dos: '',
+  donts: '',
+  isHeaderVisible: true,
+  isFeedbackVisible: true,
+  allowNativeProps: true,
+};

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.scss
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.scss
@@ -1,0 +1,16 @@
+@import '../../common/common';
+
+.root {
+  position: relative;
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+.rootVertical {
+  flex-direction: column;
+}
+
+.item {
+  flex-shrink: 0;
+  display: inherit;
+}

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.styles.ts
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.styles.ts
@@ -1,0 +1,26 @@
+import { IOverflowSetStyles, IOverflowSetStyleProps } from './OverflowSet.types';
+import { IStyleFunction } from '../../Utilities';
+import { IStyle } from '../../Styling';
+
+const overflowItemStyle: IStyle = {
+  flexShrink: 0,
+  display: 'inherit',
+};
+
+export const getStyles: IStyleFunction<IOverflowSetStyleProps, IOverflowSetStyles> = props => {
+  const { className, vertical } = props;
+  return {
+    root: [
+      'ms-OverflowSet',
+      {
+        position: 'relative',
+        display: 'flex',
+        flexWrap: 'nowrap',
+      },
+      vertical && { flexDirection: 'column' },
+      className,
+    ],
+    item: ['ms-OverflowSet-item', overflowItemStyle],
+    overflowButton: ['ms-OverflowSet-overflowButton', overflowItemStyle],
+  };
+};

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
@@ -1,0 +1,698 @@
+import { shallow } from 'enzyme';
+import { ReactWrapper, mount } from 'enzyme';
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import * as sinon from 'sinon';
+
+import { CommandBarButton } from '../../Button';
+import { IKeytipProps } from '../../Keytip';
+import { KeytipLayer, KeytipLayerBase } from '../../KeytipLayer';
+import { arraysEqual, find } from '../../Utilities';
+import { IUniqueKeytip, KeytipManager, ktpTargetFromId } from '../../utilities/keytips/index';
+import { OverflowSet } from './OverflowSet';
+import { IOverflowSetItemProps } from './OverflowSet.types';
+
+function getKeytip(keytipManager: KeytipManager, keySequences: string[]): IKeytipProps | undefined {
+  const ktp = find(
+    Object.keys(keytipManager.keytips).map(key => keytipManager.keytips[key]),
+    (uniqueKeytip: IUniqueKeytip) => {
+      return arraysEqual(uniqueKeytip.keytip.keySequences, keySequences);
+    },
+  );
+  return ktp ? ktp.keytip : undefined;
+}
+
+function getPersistedKeytip(keytipManager: KeytipManager, keySequences: string[]): IKeytipProps | undefined {
+  const ktp = find(
+    Object.keys(keytipManager.persistedKeytips).map(key => keytipManager.persistedKeytips[key]),
+    (uniqueKeytip: IUniqueKeytip) => {
+      return arraysEqual(uniqueKeytip.keytip.keySequences, keySequences);
+    },
+  );
+  return ktp ? ktp.keytip : undefined;
+}
+
+describe('OverflowSet', () => {
+  describe('snapshot tests', () => {
+    test('basicSnapshot', () => {
+      const onRenderItem = sinon.spy();
+      const onRenderOverflowButton = sinon.spy();
+      const component = renderer.create(
+        <OverflowSet onRenderItem={onRenderItem} onRenderOverflowButton={onRenderOverflowButton} />,
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    test('snapshot with classname', () => {
+      const onRenderItem = sinon.spy();
+      const onRenderOverflowButton = sinon.spy();
+      const component = renderer.create(
+        <OverflowSet className="foobar" onRenderItem={onRenderItem} onRenderOverflowButton={onRenderOverflowButton} />,
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    test('snapshot with classname and vertical layout', () => {
+      const onRenderItem = sinon.spy();
+      const onRenderOverflowButton = sinon.spy();
+      const component = renderer.create(
+        <OverflowSet
+          className="foobar"
+          vertical={true}
+          onRenderItem={onRenderItem}
+          onRenderOverflowButton={onRenderOverflowButton}
+        />,
+      );
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  it('does not render overflow when there are no overflow items', () => {
+    const onRenderItem = sinon.spy();
+    const onRenderOverflowButton = sinon.spy();
+    shallow(<OverflowSet onRenderItem={onRenderItem} onRenderOverflowButton={onRenderOverflowButton} />);
+
+    expect(onRenderOverflowButton.called).toEqual(false);
+  });
+
+  it('does not render overflow when overflow items is an empty array', () => {
+    const onRenderItem = sinon.spy();
+    const onRenderOverflowButton = sinon.spy();
+    shallow(
+      <OverflowSet onRenderItem={onRenderItem} onRenderOverflowButton={onRenderOverflowButton} overflowItems={[]} />,
+    );
+
+    expect(onRenderOverflowButton.called).toEqual(false);
+  });
+
+  describe('keytip tests', () => {
+    let overflowSet: ReactWrapper;
+    let overflowKeytips: any;
+    let items: IOverflowSetItemProps[];
+    let overflowItems: IOverflowSetItemProps[];
+    const layerRef = React.createRef<KeytipLayerBase>();
+
+    const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
+      return (
+        <CommandBarButton {...item} menuProps={item.subMenuProps}>
+          {item.name}
+        </CommandBarButton>
+      );
+    };
+
+    const onRenderOverflowButton = (overflowElements: any[] | undefined): JSX.Element => {
+      return (
+        <CommandBarButton
+          menuIconProps={{ iconName: 'More' }}
+          menuProps={{ items: overflowElements! }}
+          keytipProps={overflowKeytips.overflowButtonKeytip}
+        />
+      );
+    };
+
+    const keytipManager = KeytipManager.getInstance();
+
+    beforeEach(() => {
+      overflowKeytips = {
+        overflowItemKeytip1: {
+          content: 'A',
+          keySequences: ['a'],
+          onExecute: jest.fn(),
+        },
+        overflowItemKeytip2: {
+          content: 'B',
+          keySequences: ['b'],
+          onExecute: jest.fn(),
+        },
+        overflowItemKeytip3: {
+          content: 'C',
+          keySequences: ['c'],
+          onExecute: jest.fn(),
+        },
+        overflowItemKeytip4: {
+          content: 'D',
+          keySequences: ['d'],
+          onExecute: jest.fn(),
+        },
+        overflowItemKeytip5: {
+          content: 'E',
+          keySequences: ['d', 'e'],
+          onExecute: jest.fn(),
+        },
+        overflowItemKeytip6: {
+          content: 'F',
+          keySequences: ['d', 'f'],
+          onExecute: jest.fn(),
+        },
+        overflowButtonKeytip: {
+          // Overflow button
+          content: 'X',
+          keySequences: ['x'],
+          onExecute: (el: HTMLElement) => {
+            // Find the overflow button and manually click it to open the overflow menu
+            overflowSet.find(ktpTargetFromId('ktp-x')).simulate('click');
+          },
+        },
+      };
+
+      items = [
+        {
+          key: 'item1',
+          name: 'Item 1',
+          keytipProps: overflowKeytips.overflowItemKeytip1,
+        },
+        {
+          key: 'item2',
+          name: 'Item 2',
+          keytipProps: overflowKeytips.overflowItemKeytip2,
+        },
+      ];
+
+      overflowItems = [
+        {
+          key: 'item3',
+          name: 'Item 3',
+          keytipProps: overflowKeytips.overflowItemKeytip3,
+        },
+        {
+          key: 'item4',
+          name: 'Item 4',
+          keytipProps: overflowKeytips.overflowItemKeytip4,
+        },
+      ];
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+
+      // Clean up the keytip items
+      keytipManager.keytips = {};
+      keytipManager.persistedKeytips = {};
+      keytipManager.inKeytipMode = false;
+
+      // Manually unmount to clean up listeners
+      if (overflowSet) {
+        overflowSet.unmount();
+      }
+
+      // Cleanup ContextualMenus that were created
+      for (let i = 0; i < document.body.children.length; i++) {
+        if (document.body.children[i].tagName === 'DIV') {
+          document.body.removeChild(document.body.children[i]);
+          i--;
+        }
+      }
+    });
+
+    describe('without submenus', () => {
+      it('should register regular and persisted keytips', () => {
+        overflowSet = mount(
+          <OverflowSet
+            onRenderItem={onRenderItem}
+            onRenderOverflowButton={onRenderOverflowButton}
+            items={items}
+            overflowItems={overflowItems}
+            keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+          />,
+        );
+        // Persisted keytips will have the original key sequence of the items in the overflow
+        // Regular keytips
+        expect(getKeytip(keytipManager, overflowKeytips.overflowItemKeytip1.keySequences)).toBeDefined();
+        expect(getKeytip(keytipManager, overflowKeytips.overflowItemKeytip2.keySequences)).toBeDefined();
+        // Persisted keytips
+        expect(getPersistedKeytip(keytipManager, overflowKeytips.overflowItemKeytip3.keySequences)).toBeDefined();
+        expect(getPersistedKeytip(keytipManager, overflowKeytips.overflowItemKeytip4.keySequences)).toBeDefined();
+        // Overflow button keytip
+        expect(getKeytip(keytipManager, overflowKeytips.overflowButtonKeytip.keySequences)).toBeDefined();
+      });
+
+      it('should properly register and unregister keytips when items are moved to the overflow and back', () => {
+        overflowSet = mount(
+          <OverflowSet
+            onRenderItem={onRenderItem}
+            onRenderOverflowButton={onRenderOverflowButton}
+            items={items}
+            overflowItems={overflowItems}
+            keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+          />,
+        );
+
+        // Add the first overflow item to 'items'
+        overflowSet.setProps({
+          items: items.concat(overflowItems.slice(0, 1)),
+          overflowItems: overflowItems.slice(1, 2),
+        });
+
+        // Regular keytips
+        expect(getKeytip(keytipManager, overflowKeytips.overflowItemKeytip1.keySequences)).toBeDefined();
+        expect(getKeytip(keytipManager, overflowKeytips.overflowItemKeytip2.keySequences)).toBeDefined();
+        expect(getKeytip(keytipManager, overflowKeytips.overflowItemKeytip3.keySequences)).toBeDefined();
+        // Persisted keytips
+        expect(getPersistedKeytip(keytipManager, overflowKeytips.overflowItemKeytip4.keySequences)).toBeDefined();
+        // Overflow button keytip
+        expect(getKeytip(keytipManager, overflowKeytips.overflowButtonKeytip.keySequences)).toBeDefined();
+      });
+
+      it('registers menu item keytips with modified sequents when overflow button is triggered', () => {
+        jest.useFakeTimers();
+
+        // enable keytip mode to update the KeytipTree
+        keytipManager.inKeytipMode = true;
+
+        overflowSet = mount(
+          <div>
+            <OverflowSet
+              onRenderItem={onRenderItem}
+              onRenderOverflowButton={onRenderOverflowButton}
+              items={items}
+              overflowItems={overflowItems}
+              keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+            />
+            <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+          </div>,
+        );
+
+        // Set current keytip at root, like we've entered keytip mode
+        const keytipTree = layerRef.current!.getKeytipTree();
+        keytipTree.currentKeytip = keytipTree.root;
+        // Open the overflow menu
+        layerRef.current!.processInput('x');
+        jest.runAllTimers();
+
+        // Opening the submenu should register the two keytips for those items
+        const keytip3 = getKeytip(keytipManager, ['c']);
+        expect(keytip3).toBeDefined();
+        expect(keytip3!.overflowSetSequence).toBeDefined();
+        expect(keytip3!.overflowSetSequence![0]).toEqual('x');
+        const keytip4 = getKeytip(keytipManager, ['d']);
+        expect(keytip4).toBeDefined();
+        expect(keytip4!.overflowSetSequence).toBeDefined();
+        expect(keytip4!.overflowSetSequence![0]).toEqual('x');
+
+        // Those two keytips should now be visible in the Layer
+        layerRef.current!.state.keytips;
+        const visibleKeytips = layerRef.current!.state.visibleKeytips;
+        expect(visibleKeytips).toHaveLength(2);
+      });
+
+      it('overflowSetSequence gets set correctly on overflowItems keytipProps when the overflow menu is opened', () => {
+        jest.useFakeTimers();
+        keytipManager.inKeytipMode = true;
+
+        // Set current keytip at root, like we've entered keytip mode
+        overflowSet = mount(
+          <div>
+            <OverflowSet
+              onRenderItem={onRenderItem}
+              onRenderOverflowButton={onRenderOverflowButton}
+              items={items}
+              overflowItems={overflowItems}
+              keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+            />
+            <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+          </div>,
+        );
+
+        // Set current keytip at root, like we've entered keytip mode
+        const keytipTree = layerRef.current!.getKeytipTree();
+        keytipTree.currentKeytip = keytipTree.root;
+        // Open the overflow menu
+        layerRef.current!.processInput('x');
+        jest.runAllTimers();
+
+        // item3
+        const item3Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip3.keySequences);
+        expect(
+          arraysEqual(item3Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
+        ).toEqual(true);
+        // item4
+        const item4Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip4.keySequences);
+        expect(
+          arraysEqual(item4Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
+        ).toEqual(true);
+      });
+
+      it("correctly picks up a disabled keytip and doesn't call it", () => {
+        overflowItems = [
+          {
+            key: 'item3',
+            name: 'Item 3',
+            disabled: true,
+            keytipProps: overflowKeytips.overflowItemKeytip3,
+          },
+          {
+            key: 'item4',
+            name: 'Item 4',
+            keytipProps: overflowKeytips.overflowItemKeytip4,
+          },
+        ];
+        overflowSet = mount(
+          <div>
+            <OverflowSet
+              onRenderItem={onRenderItem}
+              onRenderOverflowButton={onRenderOverflowButton}
+              items={items}
+              overflowItems={overflowItems}
+              keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+            />
+            <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+          </div>,
+        );
+
+        // Set current keytip at root, like we've entered keytip mode
+        const keytipTree = layerRef.current!.getKeytipTree();
+        keytipTree.currentKeytip = keytipTree.root;
+        // Open the overflow menu
+        layerRef.current!.processInput('c');
+        // Nothing should happen, the current keytip should still be the root
+        expect(keytipTree.currentKeytip).toEqual(keytipTree.root);
+        expect(overflowKeytips.overflowItemKeytip3.onExecute).not.toBeCalled();
+      });
+    });
+
+    describe('with submenus', () => {
+      let item3: any;
+      beforeEach(() => {
+        item3 = { ...overflowItems[0] };
+      });
+
+      describe('without children keytips', () => {
+        it('should not exit keytip mode after being triggered', () => {
+          // Insert a submenu into one of the overflow items
+          const overflowItemsWithSubMenu = [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+              },
+              subMenuProps: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                  },
+                ],
+              },
+            },
+          ];
+
+          overflowSet = mount(
+            <div>
+              <OverflowSet
+                onRenderItem={onRenderItem}
+                onRenderOverflowButton={onRenderOverflowButton}
+                items={items}
+                overflowItems={overflowItemsWithSubMenu}
+                keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+              />
+              <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+            </div>,
+          );
+
+          // Set current keytip at root, like we've entered keytip mode
+          const keytipTree = layerRef.current!.getKeytipTree();
+          keytipTree.currentKeytip = keytipTree.root;
+          // Open d's submenu
+          layerRef.current!.processInput('d');
+
+          expect(keytipTree.currentKeytip).toBeDefined();
+        });
+      });
+
+      describe('with children keytips', () => {
+        it('should open the overflow and submenu when the persisted keytip is triggered', () => {
+          jest.useFakeTimers();
+          keytipManager.inKeytipMode = true;
+          const overflowItemsWithSubMenuAndKeytips = [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+              },
+              subMenuProps: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                    keytipProps: overflowKeytips.overflowItemKeytip5,
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                    keytipProps: overflowKeytips.overflowItemKeytip6,
+                    subMenuProps: {
+                      items: [
+                        {
+                          key: 'item7',
+                          name: 'Item 7',
+                          keytipProps: {
+                            content: 'X',
+                            keySequences: ['d', 'f', 'x'],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ];
+
+          overflowSet = mount(
+            <div>
+              <OverflowSet
+                onRenderItem={onRenderItem}
+                onRenderOverflowButton={onRenderOverflowButton}
+                items={items}
+                overflowItems={overflowItemsWithSubMenuAndKeytips}
+                keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+              />
+              <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+            </div>,
+          );
+
+          // Set current keytip at root, like we've entered keytip mode
+          const keytipTree = layerRef.current!.getKeytipTree();
+          keytipTree.currentKeytip = keytipTree.root;
+          layerRef.current!.processInput('d');
+
+          // The two submenu keytips should be registered with their modified sequence in the manager
+          const modifiedKeytip5Sequence = ['d', 'e'];
+          const modifiedKeytip6Sequence = ['d', 'f'];
+          const subMenu5Keytip = getKeytip(keytipManager, modifiedKeytip5Sequence);
+          expect(subMenu5Keytip).toBeDefined();
+          expect(subMenu5Keytip!.overflowSetSequence![0]).toEqual('x');
+          const subMenu6Keytip = getKeytip(keytipManager, modifiedKeytip6Sequence);
+          expect(subMenu6Keytip).toBeDefined();
+          expect(subMenu6Keytip!.overflowSetSequence![0]).toEqual('x');
+          jest.runAllTimers();
+
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(
+              arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
+            ).toEqual(true);
+          });
+        });
+
+        it('should behave correctly when the persisted keytip execute is delayed', () => {
+          jest.useFakeTimers();
+
+          const overflowItemsWithSubMenuAndKeytips = [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+                hasMenu: true,
+              },
+              subMenuProps: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                    keytipProps: overflowKeytips.overflowItemKeytip5,
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                    keytipProps: overflowKeytips.overflowItemKeytip6,
+                    subMenuProps: {
+                      items: [
+                        {
+                          key: 'item7',
+                          name: 'Item 7',
+                          keytipProps: {
+                            content: 'X',
+                            keySequences: ['d', 'f', 'x'],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ];
+
+          const delayedOverflowButton = (overflowElements: any[] | undefined): JSX.Element => {
+            // Overflow button which delays 2s before opening the menu
+            // This simulates latency when opening the menu
+            // (note that we'll actually skip through this latency with jest.runAllTimers())
+            return (
+              <CommandBarButton
+                menuIconProps={{ iconName: 'More' }}
+                menuProps={{ items: overflowElements! }}
+                keytipProps={{
+                  content: 'X',
+                  keySequences: ['x'],
+                  onExecute: (el: HTMLElement) => {
+                    setTimeout(() => {
+                      // Find the overflow button and manually click it to open the overflow menu
+                      overflowSet.find(ktpTargetFromId('ktp-x')).simulate('click');
+                    }, 2000);
+                  },
+                }}
+              />
+            );
+          };
+
+          overflowSet = mount(
+            <div>
+              <OverflowSet
+                onRenderItem={onRenderItem}
+                onRenderOverflowButton={delayedOverflowButton}
+                items={items}
+                overflowItems={overflowItemsWithSubMenuAndKeytips}
+                keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+              />
+              <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+            </div>,
+          );
+
+          // Set current keytip at root, like we've entered keytip mode
+          const keytipTree = layerRef.current!.getKeytipTree();
+          keytipTree.currentKeytip = keytipTree.root;
+          layerRef.current!.processInput('d');
+          // Wait for the menu to open
+          jest.runAllTimers();
+
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(
+              arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
+            ).toEqual(true);
+          });
+        });
+      });
+
+      describe('with non-standard children keytips', () => {
+        it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
+          const overflowItemsWithSubMenuAndKeytips = [
+            item3,
+            {
+              key: 'item4',
+              name: 'Item 4',
+              keytipProps: {
+                ...overflowKeytips.overflowItemKeytip4,
+                onExecute: (el: HTMLElement) => {
+                  el.click();
+                },
+              },
+              customSubMenu: {
+                items: [
+                  {
+                    key: 'item5',
+                    name: 'Item 5',
+                    keytipProps: overflowKeytips.overflowItemKeytip5,
+                  },
+                  {
+                    key: 'item6',
+                    name: 'Item 6',
+                    keytipProps: overflowKeytips.overflowItemKeytip6,
+                    customSubMenu: {
+                      items: [
+                        {
+                          key: 'item7',
+                          name: 'Item 7',
+                          keytipProps: {
+                            content: 'X',
+                            keySequences: ['d', 'f', 'x'],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          ];
+
+          const itemSubMenuProvider = (item: IOverflowSetItemProps) => {
+            if (item.customSubMenu) {
+              return item.customSubMenu.items;
+            }
+            return undefined;
+          };
+
+          overflowSet = mount(
+            <div>
+              <OverflowSet
+                onRenderItem={onRenderItem}
+                onRenderOverflowButton={onRenderOverflowButton}
+                items={items}
+                overflowItems={overflowItemsWithSubMenuAndKeytips}
+                keytipSequences={overflowKeytips.overflowButtonKeytip.keySequences}
+                itemSubMenuProvider={itemSubMenuProvider}
+              />
+              <KeytipLayer content={'Alt Windows'} componentRef={layerRef} />
+            </div>,
+          );
+
+          // Set current keytip at root, like we've entered keytip mode
+          const keytipTree = layerRef.current!.getKeytipTree();
+          keytipTree.currentKeytip = keytipTree.root;
+
+          layerRef.current!.processInput('d');
+          jest.runAllTimers();
+
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(
+              arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences),
+            ).toEqual(true);
+          });
+        });
+      });
+    });
+  });
+});

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
@@ -3,12 +3,11 @@ import { ReactWrapper, mount } from 'enzyme';
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import * as sinon from 'sinon';
-
 import { CommandBarButton } from '../../Button';
 import { IKeytipProps } from '../../Keytip';
 import { KeytipLayer, KeytipLayerBase } from '../../KeytipLayer';
 import { arraysEqual, find } from '../../Utilities';
-import { IUniqueKeytip, KeytipManager, ktpTargetFromId } from '../../utilities/keytips/index';
+import { IUniqueKeytip, KeytipManager, ktpTargetFromId } from 'office-ui-fabric-react/lib/utilities/keytips/index';
 import { OverflowSet } from './OverflowSet';
 import { IOverflowSetItemProps } from './OverflowSet.types';
 

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.ts
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { styled } from '../../Utilities';
+import { OverflowSetBase } from './OverflowSet.base';
+import { getStyles } from './OverflowSet.styles';
+import { IOverflowSetProps } from './OverflowSet.types';
+
+export const OverflowSet: React.FunctionComponent<IOverflowSetProps> = styled(OverflowSetBase, getStyles, undefined, {
+  scope: 'OverflowSet',
+});

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.types.ts
@@ -1,0 +1,158 @@
+import * as React from 'react';
+
+import { IFocusZoneProps } from '@fluentui/react-focus';
+import { IKeytipProps } from '../../Keytip';
+import { IStyle } from '../../Styling';
+import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
+import { OverflowSetBase } from './OverflowSet.base';
+
+/**
+ * {@docCategory OverflowSet}
+ */
+export interface IOverflowSet {
+  /**
+   * Sets focus to the first tabbable item in the zone.
+   * @param forceIntoFirstElement - If true, focus will be forced into the first element, even if
+   * focus is already in the focus zone.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  focus(forceIntoFirstElement?: boolean): boolean;
+
+  /**
+   * Sets focus to a specific child element within the zone. This can be used in conjunction with
+   * shouldReceiveFocus to created delayed focus scenarios (like animate the scroll position to the correct
+   * location and then focus.)
+   * @param childElement - The child element within the zone to focus.
+   * @returns True if focus could be set to an active element, false if no operation was taken.
+   */
+  focusElement(childElement?: HTMLElement): boolean;
+}
+
+/**
+ * {@docCategory OverflowSet}
+ */
+export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase> {
+  /**
+   * Gets the component ref.
+   */
+  componentRef?: IRefObject<IOverflowSet>;
+
+  /**
+   * Class name
+   */
+  className?: string;
+
+  /**
+   * An array of items to be rendered by your onRenderItem function in the primary content area
+   */
+  items?: IOverflowSetItemProps[];
+
+  /**
+   * Change item layout direction to vertical/stacked.
+   * If role is set to `menubar`, `vertical={true}` will also add proper `aria-orientation`.
+   * @defaultvalue false
+   */
+  vertical?: boolean;
+
+  /**
+   * Controls wether or not the overflow button is placed at the start or end of the items.
+   * This gives a reveresed visual behavior but maintains correct keyboard navigation.
+   * @defaultValue 'end'
+   */
+  overflowSide?: 'start' | 'end';
+
+  /**
+   * An array of items to be passed to overflow contextual menu
+   */
+  overflowItems?: IOverflowSetItemProps[];
+
+  /**
+   * Method to call when trying to render an item.
+   */
+  onRenderItem: (item: IOverflowSetItemProps) => any;
+
+  /**
+   * Rendering method for overflow button and contextual menu. The argument to the function is
+   * the overflowItems passed in as props to this function.
+   */
+  onRenderOverflowButton: IRenderFunction<any[]>;
+
+  /**
+   * Custom properties for OverflowSet's FocusZone.
+   * If doNotContainWithinFocusZone is set to true focusZoneProps will be ignored.
+   * Use one or the other.
+   * @deprecated In 8.0 the OverflowSet will no longer be wrapped in a FocusZone
+   */
+  focusZoneProps?: IFocusZoneProps;
+
+  /**
+   * If true do not contain the OverflowSet inside of a FocusZone,
+   * otherwise the OverflowSet will contain a FocusZone.
+   * If this is set to true focusZoneProps will be ignored.
+   * Use one or the other.
+   * @deprecated In 8.0 the OverflowSet will no longer be wrapped in a FocusZone
+   */
+  doNotContainWithinFocusZone?: boolean;
+
+  /**
+   * The role for the OverflowSet.
+   * @defaultvalue 'group'
+   */
+  role?: string;
+
+  /**
+   * Optional full keytip sequence for the overflow button, if it will have a keytip.
+   */
+  keytipSequences?: string[];
+
+  /**
+   * Function that will take in an IOverflowSetItemProps and return the subMenu for that item.
+   * If not provided, will use 'item.subMenuProps.items' by default.
+   * This is only used if your overflow set has keytips.
+   */
+  itemSubMenuProvider?: (item: IOverflowSetItemProps) => any[] | undefined;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules.
+   */
+  styles?: IStyleFunctionOrObject<IOverflowSetProps, IOverflowSetStyles>;
+}
+
+/**
+ * {@docCategory OverflowSet}
+ */
+export interface IOverflowSetStyles {
+  /** The style that is layered onto the root element of OverflowSet. */
+  root?: IStyle;
+  /** The style that is layered onto each individual item in the overflow set. */
+  item?: IStyle;
+  /** The style that is layered onto the overflow button for the overflow set. */
+  overflowButton?: IStyle;
+}
+
+/**
+ * The props needed to construct styles.
+ * This represents the simplified set of immutable things which control the class names.
+ * {@docCategory OverflowSet}
+ */
+export type IOverflowSetStyleProps = Pick<IOverflowSetProps, 'vertical' | 'className'>;
+
+/**
+ * {@docCategory OverflowSet}
+ */
+export interface IOverflowSetItemProps {
+  /**
+   * Unique id to identify the item.
+   */
+  key: string;
+
+  /**
+   * Optional keytip for the overflowSetItem.
+   */
+  keytipProps?: IKeytipProps;
+
+  /**
+   * Any additional properties to use when custom rendering menu items.
+   */
+  [propertyName: string]: any;
+}

--- a/packages/react-next/src/components/OverflowSet/__snapshots__/OverflowSet.test.tsx.snap
+++ b/packages/react-next/src/components/OverflowSet/__snapshots__/OverflowSet.test.tsx.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OverflowSet snapshot tests basicSnapshot 1`] = `
+<div
+  className=
+      ms-FocusZone
+      ms-OverflowSet
+      &:focus {
+        outline: none;
+      }
+      {
+        display: flex;
+        flex-wrap: nowrap;
+        position: relative;
+      }
+  data-focuszone-id="FocusZone0"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+  role="group"
+/>
+`;
+
+exports[`OverflowSet snapshot tests snapshot with classname 1`] = `
+<div
+  className=
+      ms-FocusZone
+      ms-OverflowSet
+      foobar
+      &:focus {
+        outline: none;
+      }
+      {
+        display: flex;
+        flex-wrap: nowrap;
+        position: relative;
+      }
+  data-focuszone-id="FocusZone1"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+  role="group"
+/>
+`;
+
+exports[`OverflowSet snapshot tests snapshot with classname and vertical layout 1`] = `
+<div
+  className=
+      ms-FocusZone
+      ms-OverflowSet
+      foobar
+      &:focus {
+        outline: none;
+      }
+      {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        position: relative;
+      }
+  data-focuszone-id="FocusZone2"
+  onFocus={[Function]}
+  onKeyDown={[Function]}
+  onMouseDownCapture={[Function]}
+  role="group"
+/>
+`;

--- a/packages/react-next/src/components/OverflowSet/docs/OverflowSetOverview.md
+++ b/packages/react-next/src/components/OverflowSet/docs/OverflowSetOverview.md
@@ -1,0 +1,5 @@
+The OverflowSet is a flexible container component that is useful for displaying a primary set of content with additional content in an overflow callout. Note that the example below is only an example of how to render the component, not a specific use case.
+
+### Accessibility
+
+By default, the OverflowSet is simply `role=group`. If you used as a menu, you will need to add `role="menubar"` and add proper aria roles to each rendered item (`menuitem`, `menuitemcheckbox`, `menuitemradio`)

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { IconButton, IButtonStyles } from '@fluentui/react-next/lib/Button';
+import { Link } from '@fluentui/react-next/lib/Link';
+import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
+
+const noOp = () => undefined;
+
+const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
+  return (
+    <Link role="menuitem" styles={{ root: { marginRight: 10 } }} onClick={item.onClick}>
+      {item.name}
+    </Link>
+  );
+};
+
+const onRenderOverflowButton = (overflowItems: any[] | undefined): JSX.Element => {
+  const buttonStyles: Partial<IButtonStyles> = {
+    root: {
+      minWidth: 0,
+      padding: '0 4px',
+      alignSelf: 'stretch',
+      height: 'auto',
+    },
+  };
+  return (
+    <IconButton
+      role="menuitem"
+      title="More options"
+      styles={buttonStyles}
+      menuIconProps={{ iconName: 'More' }}
+      menuProps={{ items: overflowItems! }}
+    />
+  );
+};
+
+export const OverflowSetBasicExample: React.FunctionComponent = () => (
+  <OverflowSet
+    aria-label="Basic Menu Example"
+    role="menubar"
+    items={[
+      {
+        key: 'item1',
+        name: 'Link 1',
+        onClick: noOp,
+      },
+      {
+        key: 'item2',
+        name: 'Link 2',
+        onClick: noOp,
+      },
+      {
+        key: 'item3',
+        name: 'Link 3',
+        onClick: noOp,
+      },
+    ]}
+    overflowItems={[
+      {
+        key: 'item4',
+        name: 'Overflow Link 1',
+        onClick: noOp,
+      },
+      {
+        key: 'item5',
+        name: 'Overflow Link 2',
+        onClick: noOp,
+      },
+    ]}
+    onRenderOverflowButton={onRenderOverflowButton}
+    onRenderItem={onRenderItem}
+  />
+);

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.BasicReversed.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.BasicReversed.Example.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { IconButton, IButtonStyles } from '@fluentui/react-next/lib/Button';
+import { Link } from '@fluentui/react-next/lib/Link';
+import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
+
+const noOp = () => undefined;
+
+const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
+  return (
+    <Link role="menuitem" styles={{ root: { marginRight: 10 } }} onClick={item.onClick}>
+      {item.name}
+    </Link>
+  );
+};
+
+const onRenderOverflowButton = (overflowItems: any[] | undefined): JSX.Element => {
+  const buttonStyles: Partial<IButtonStyles> = {
+    root: {
+      minWidth: 0,
+      padding: '0 4px',
+      alignSelf: 'stretch',
+      height: 'auto',
+    },
+  };
+  return (
+    <IconButton
+      role="menuitem"
+      title="More options"
+      styles={buttonStyles}
+      menuIconProps={{ iconName: 'More' }}
+      menuProps={{ items: overflowItems! }}
+    />
+  );
+};
+
+export const OverflowSetBasicReversedExample: React.FunctionComponent = () => (
+  <OverflowSet
+    aria-label="Basic Menu Example"
+    role="menubar"
+    items={[
+      {
+        key: 'item3',
+        name: 'Link 3',
+        onClick: noOp,
+      },
+      {
+        key: 'item2',
+        name: 'Link 2',
+        onClick: noOp,
+      },
+      {
+        key: 'item1',
+        name: 'Link 1',
+        onClick: noOp,
+      },
+    ]}
+    overflowItems={[
+      {
+        key: 'item4',
+        name: 'Overflow Link 1',
+        onClick: noOp,
+      },
+      {
+        key: 'item5',
+        name: 'Overflow Link 2',
+        onClick: noOp,
+      },
+    ]}
+    onRenderOverflowButton={onRenderOverflowButton}
+    onRenderItem={onRenderItem}
+    overflowSide={'start'}
+  />
+);

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { CommandBarButton, IButtonStyles, IOverflowSetItemProps, OverflowSet, Checkbox } from '@fluentui/react-next';
+
+const noOp = () => undefined;
+
+const checkboxStyles = {
+  root: {
+    marginRight: 5,
+  },
+};
+
+const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
+  if (item.onRender) {
+    return item.onRender(item);
+  }
+  return (
+    <CommandBarButton
+      role="menuitem"
+      iconProps={{ iconName: item.icon }}
+      menuProps={item.subMenuProps}
+      text={item.name}
+    />
+  );
+};
+
+const onRenderOverflowButton = (overflowItems: any[] | undefined): JSX.Element => {
+  const buttonStyles: Partial<IButtonStyles> = {
+    root: {
+      minWidth: 0,
+      padding: '0 4px',
+      alignSelf: 'stretch',
+      height: 'auto',
+    },
+  };
+  return (
+    <CommandBarButton
+      ariaLabel="More items"
+      role="menuitem"
+      styles={buttonStyles}
+      menuIconProps={{ iconName: 'More' }}
+      menuProps={{ items: overflowItems! }}
+    />
+  );
+};
+
+export const OverflowSetCustomExample: React.FunctionComponent = () => (
+  <OverflowSet
+    aria-label="Custom Example"
+    role="menubar"
+    items={[
+      {
+        key: 'checkbox',
+        onRender: () => {
+          return <Checkbox inputProps={{ role: 'menuitemcheckbox' }} label="A Checkbox" styles={checkboxStyles} />;
+        },
+      },
+      {
+        key: 'newItem',
+        name: 'New',
+        icon: 'Add',
+        ariaLabel: 'New. Use left and right arrow keys to navigate',
+        onClick: noOp,
+        subMenuProps: {
+          items: [
+            {
+              key: 'emailMessage',
+              name: 'Email message',
+              icon: 'Mail',
+            },
+            {
+              key: 'calendarEvent',
+              name: 'Calendar event',
+              icon: 'Calendar',
+            },
+          ],
+        },
+      },
+      {
+        key: 'upload',
+        name: 'Upload',
+        icon: 'Upload',
+        onClick: noOp,
+      },
+      {
+        key: 'share',
+        name: 'Share',
+        icon: 'Share',
+        onClick: noOp,
+      },
+    ]}
+    overflowItems={[
+      {
+        key: 'move',
+        name: 'Move to...',
+        icon: 'MoveToFolder',
+        onClick: noOp,
+      },
+      {
+        key: 'copy',
+        name: 'Copy to...',
+        icon: 'Copy',
+        onClick: noOp,
+      },
+      {
+        key: 'rename',
+        name: 'Rename...',
+        icon: 'Edit',
+        onClick: noOp,
+      },
+      {
+        key: 'disabled',
+        name: 'Disabled...',
+        icon: 'Cancel',
+        disabled: true,
+        onClick: noOp,
+      },
+    ]}
+    onRenderOverflowButton={onRenderOverflowButton}
+    onRenderItem={onRenderItem}
+  />
+);

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Vertical.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Vertical.Example.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { CommandBarButton } from '@fluentui/react-next/lib/Button';
+import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
+
+const noOp = () => undefined;
+
+const onRenderItemStyles = {
+  root: { padding: '10px' },
+};
+const onRenderOverflowButtonStyles = {
+  root: { padding: '10px' },
+  menuIcon: { fontSize: '16px' },
+};
+
+const onRenderItem = (item: IOverflowSetItemProps): JSX.Element => {
+  return (
+    <CommandBarButton
+      role="menuitem"
+      aria-label={item.name}
+      styles={onRenderItemStyles}
+      iconProps={{ iconName: item.icon }}
+      onClick={item.onClick}
+    />
+  );
+};
+
+const onRenderOverflowButton = (overflowItems: any[] | undefined): JSX.Element => {
+  return (
+    <CommandBarButton
+      role="menuitem"
+      title="More items"
+      styles={onRenderOverflowButtonStyles}
+      menuIconProps={{ iconName: 'More' }}
+      menuProps={{ items: overflowItems! }}
+    />
+  );
+};
+
+export const OverflowSetVerticalExample: React.FunctionComponent = () => (
+  <OverflowSet
+    aria-label="Vertical Example"
+    role="menubar"
+    vertical
+    items={[
+      {
+        key: 'item1',
+        icon: 'Add',
+        name: 'Link 1',
+        ariaLabel: 'New. Use left and right arrow keys to navigate',
+        onClick: noOp,
+      },
+      {
+        key: 'item2',
+        icon: 'Upload',
+        name: 'Link 2',
+        onClick: noOp,
+      },
+      {
+        key: 'item3',
+        icon: 'Share',
+        name: 'Link 3',
+        onClick: noOp,
+      },
+    ]}
+    overflowItems={[
+      {
+        key: 'item4',
+        icon: 'Mail',
+        name: 'Overflow Link 1',
+        onClick: noOp,
+      },
+      {
+        key: 'item5',
+        icon: 'Calendar',
+        name: 'Overflow Link 2',
+        onClick: noOp,
+      },
+    ]}
+    onRenderOverflowButton={onRenderOverflowButton}
+    onRenderItem={onRenderItem}
+  />
+);

--- a/packages/react-next/src/components/OverflowSet/index.ts
+++ b/packages/react-next/src/components/OverflowSet/index.ts
@@ -1,0 +1,3 @@
+export * from './OverflowSet';
+export * from './OverflowSet.base';
+export * from './OverflowSet.types';


### PR DESCRIPTION
#### Pull request checklist
This change does not modify `OverflowSet`; it simply moves it to react-next for better diffing in the actual conversion PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13059)