### PR TITLE
Shimmer: Fix High Contrast Styles in Edge Chromium

### DIFF
--- a/change/office-ui-fabric-react-2020-05-08-15-29-47-xgao-shimmer-hc.json
+++ b/change/office-ui-fabric-react-2020-05-08-15-29-47-xgao-shimmer-hc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Shimmer: fix high contrast in new edge",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-08T22:29:47.685Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -436,6 +436,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -619,6 +622,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -804,6 +810,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -987,6 +996,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1172,6 +1184,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -1355,6 +1370,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1540,6 +1558,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -1723,6 +1744,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1908,6 +1932,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -2091,6 +2118,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -1,5 +1,11 @@
 import { IShimmerStyleProps, IShimmerStyles } from './Shimmer.types';
-import { keyframes, getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
+import {
+  keyframes,
+  getGlobalClassNames,
+  hiddenContentStyle,
+  HighContrastSelector,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+} from '../../Styling';
 import { getRTL, memoizeFunction } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -73,6 +79,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
                         0 0 / 90% 100%
                         no-repeat`,
           },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       isDataLoaded && {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -37,6 +37,9 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
                                 0 0 / 90% 100%
                                 no-repeat;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     style={
       Object {
         "width": "50%",
@@ -297,6 +300,9 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                                   transparent 100%)
                                 0 0 / 90% 100%
                                 no-repeat;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
     style={
       Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -565,6 +565,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -874,6 +877,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -1185,6 +1191,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -1494,6 +1503,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -1805,6 +1817,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -2114,6 +2129,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -2425,6 +2443,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -2734,6 +2755,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -3045,6 +3069,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -3354,6 +3381,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -69,6 +69,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": "100%",
@@ -253,6 +256,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -439,6 +445,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": "50%",
@@ -624,6 +633,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -882,6 +894,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -1518,6 +1533,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -2155,6 +2173,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -69,6 +69,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": 350,
@@ -537,6 +540,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": 550,
@@ -949,6 +955,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -193,6 +193,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": "100%",
@@ -553,6 +556,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -94,6 +94,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": "100%",
@@ -765,6 +768,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": 300,
@@ -1207,6 +1213,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": 300,
@@ -1641,192 +1650,8 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
-        style={
-          Object {
-            "width": "75%",
-          }
-        }
-      >
-        <div
-          className=
-              ms-Shimmer-shimmerGradient
-              {
-                animation-direction: normal;
-                animation-duration: 2s;
-                animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
-                animation-timing-function: ease-in-out;
-                background-color: #deecf9;
-                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-                background: #f3f2f1
-                                    linear-gradient(
-                                      to right,
-                                      #f3f2f1 0%,
-                                      #edebe9 50%,
-                                      #f3f2f1 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-                height: 100%;
-                left: 0px;
-                position: absolute;
-                top: 0px;
-                transform: translateX(-100%);
-                width: 100%;
-              }
-        />
-        <div
-          className=
-              ms-ShimmerElementsGroup-root
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                position: relative;
-              }
-          style={
-            Object {
-              "width": "auto",
-            }
-          }
-        >
-          <div
-            className=
-                ms-ShimmerLine-root
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border-bottom-style: solid;
-                  border-color: #ffffff;
-                  border-top-style: solid;
-                  border-width: 0px;
-                  box-sizing: content-box;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 16px;
-                  position: relative;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  border-color: Window;
-                }
-                @media screen and (-ms-high-contrast: active){& > * {
-                  fill: Window;
-                }
-            style={
-              Object {
-                "minWidth": "auto",
-                "width": "100%",
-              }
-            }
-          >
-            <svg
-              className=
-                  ms-ShimmerLine-topLeftCorner
-                  {
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-topRightCorner
-                  {
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomRightCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomLeftCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-Shimmer-container
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: auto;
-            position: relative;
-          }
-    >
-      <div
-        className=
-            ms-Shimmer-shimmerWrapper
-            {
-              background-color: #deecf9;
-              overflow: hidden;
-              position: relative;
-              transform: translateZ(0);
-              transition: opacity 200ms;
-            }
-            & > * {
-              transform: translateZ(0);
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: WindowText
-                                    linear-gradient(
-                                      to right,
-                                      transparent 0%,
-                                      Window 50%,
-                                      transparent 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {
@@ -2015,192 +1840,8 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
-        style={
-          Object {
-            "width": "75%",
-          }
-        }
-      >
-        <div
-          className=
-              ms-Shimmer-shimmerGradient
-              {
-                animation-direction: normal;
-                animation-duration: 2s;
-                animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
-                animation-timing-function: ease-in-out;
-                background-color: #deecf9;
-                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-                background: #f3f2f1
-                                    linear-gradient(
-                                      to right,
-                                      #f3f2f1 0%,
-                                      #edebe9 50%,
-                                      #f3f2f1 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-                height: 100%;
-                left: 0px;
-                position: absolute;
-                top: 0px;
-                transform: translateX(-100%);
-                width: 100%;
-              }
-        />
-        <div
-          className=
-              ms-ShimmerElementsGroup-root
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                position: relative;
-              }
-          style={
-            Object {
-              "width": "auto",
-            }
-          }
-        >
-          <div
-            className=
-                ms-ShimmerLine-root
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border-bottom-style: solid;
-                  border-color: #ffffff;
-                  border-top-style: solid;
-                  border-width: 0px;
-                  box-sizing: content-box;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 16px;
-                  position: relative;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  border-color: Window;
-                }
-                @media screen and (-ms-high-contrast: active){& > * {
-                  fill: Window;
-                }
-            style={
-              Object {
-                "minWidth": "auto",
-                "width": "100%",
-              }
-            }
-          >
-            <svg
-              className=
-                  ms-ShimmerLine-topLeftCorner
-                  {
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-topRightCorner
-                  {
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomRightCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomLeftCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-Shimmer-container
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: auto;
-            position: relative;
-          }
-    >
-      <div
-        className=
-            ms-Shimmer-shimmerWrapper
-            {
-              background-color: #deecf9;
-              overflow: hidden;
-              position: relative;
-              transform: translateZ(0);
-              transition: opacity 200ms;
-            }
-            & > * {
-              transform: translateZ(0);
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: WindowText
-                                    linear-gradient(
-                                      to right,
-                                      transparent 0%,
-                                      Window 50%,
-                                      transparent 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {
@@ -2388,6 +2029,389 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        style={
+          Object {
+            "width": "75%",
+          }
+        }
+      >
+        <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-direction: normal;
+                animation-duration: 2s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translateX(-100%);
+                width: 100%;
+              }
+        />
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              background-color: #deecf9;
+              overflow: hidden;
+              position: relative;
+              transform: translateZ(0);
+              transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        style={
+          Object {
+            "width": "75%",
+          }
+        }
+      >
+        <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-direction: normal;
+                animation-duration: 2s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translateX(-100%);
+                width: 100%;
+              }
+        />
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              background-color: #deecf9;
+              overflow: hidden;
+              position: relative;
+              transform: translateZ(0);
+              transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Mega issue: #11742
- [x] Addresses an existing issue: Fixes #11735
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fix Shimmer high contrast styles in Edge Chromium.

Before in new Edge:
![new_edge_before_fix](https://user-images.githubusercontent.com/1207059/81454278-a1666c00-9140-11ea-8112-8d41490a39e1.gif)

After in new Edge:
![new_edge_after_fix](https://user-images.githubusercontent.com/1207059/81454289-a75c4d00-9140-11ea-8eff-b75367f66610.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13073)