### PR TITLE
Document card click can open in new tab

### DIFF
--- a/change/office-ui-fabric-react-2020-05-11-12-07-43-master.json
+++ b/change/office-ui-fabric-react-2020-05-11-12-07-43-master.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Clicking DocumentCard always opens the link in the same page. I have a requirement where I prefer to load it in a new tab.",
+  "comment": "DocumentCard: add prop to open link in a new tab.",
   "packageName": "office-ui-fabric-react",
   "email": "mahesh8488@gmail.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-05-11-12-07-43-master.json
+++ b/change/office-ui-fabric-react-2020-05-11-12-07-43-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Clicking DocumentCard always opens the link in the same page. I have a requirement where I prefer to load it in a new tab.",
+  "packageName": "office-ui-fabric-react",
+  "email": "mahesh8488@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-11T19:07:43.504Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4207,6 +4207,7 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
     componentRef?: IRefObject<IDocumentCard>;
     onClick?: (ev?: React.SyntheticEvent<HTMLElement>) => void;
     onClickHref?: string;
+    onClickTarget?: string;
     role?: string;
     styles?: IStyleFunctionOrObject<IDocumentCardStyleProps, IDocumentCardStyles>;
     theme?: ITheme;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -104,13 +104,18 @@ export class DocumentCardBase extends React.Component<IDocumentCardProps, any> i
   };
 
   private _onAction = (ev: React.SyntheticEvent<HTMLElement>): void => {
-    const { onClick, onClickHref } = this.props;
+    const { onClick, onClickHref, openLinkInNewTab } = this.props;
 
     if (onClick) {
       onClick(ev);
     } else if (!onClick && onClickHref) {
       // If no onClick Function was provided and we do have an onClickHref, redirect to the onClickHref
-      window.location.href = onClickHref;
+      if (openLinkInNewTab) {
+        window.open(onClickHref, '_blank');
+      } else {
+        window.location.href = onClickHref;
+      }
+
       ev.preventDefault();
       ev.stopPropagation();
     }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.base.tsx
@@ -104,14 +104,14 @@ export class DocumentCardBase extends React.Component<IDocumentCardProps, any> i
   };
 
   private _onAction = (ev: React.SyntheticEvent<HTMLElement>): void => {
-    const { onClick, onClickHref, openLinkInNewTab } = this.props;
+    const { onClick, onClickHref, onClickTarget } = this.props;
 
     if (onClick) {
       onClick(ev);
     } else if (!onClick && onClickHref) {
       // If no onClick Function was provided and we do have an onClickHref, redirect to the onClickHref
-      if (openLinkInNewTab) {
-        window.open(onClickHref, '_blank');
+      if (onClickTarget) {
+        window.open(onClickHref, onClickTarget, 'noreferrer noopener nofollow');
       } else {
         window.location.href = onClickHref;
       }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -40,7 +40,7 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
   onClickHref?: string;
 
   /**
-   * A target browser context for opening the link.
+   * A target browser context for opening the link. If not specified, will open in the same tab/window.
    */
   onClickTarget?: string;
 

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -40,6 +40,11 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
   onClickHref?: string;
 
   /**
+   * A boolean which indicates whether the link has to be opened in a new tab.
+   */
+  openLinkInNewTab?: boolean;
+
+  /**
    * Aria role assigned to the documentCard (Eg. button, link).
    * Use this to override the default assignment.
    * @defaultvalue When `onClick` is provided, default role will be 'button'.

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.types.ts
@@ -40,9 +40,9 @@ export interface IDocumentCardProps extends IBaseProps<IDocumentCard>, React.HTM
   onClickHref?: string;
 
   /**
-   * A boolean which indicates whether the link has to be opened in a new tab.
+   * A target browser context for opening the link.
    */
-  openLinkInNewTab?: boolean;
+  onClickTarget?: string;
 
   /**
    * Aria role assigned to the documentCard (Eg. button, link).


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Clicking DocumentCard always opens the link in the same page. I have a requirement where I prefer to load it in a new tab.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13076)