### PR TITLE
chore(ReactionGroup): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Toolbar` component which are passed to styles functions @layershifter ([#13024](https://github.com/microsoft/fluentui/pull/13024))
 - Change `AttachmentAction` to override `Button` styles and restricted props set @mnajdova ([#12913](https://github.com/microsoft/fluentui/pull/12913))
 - Limit props `activeIndex` and `defaultActiveIndex` in `Carousel` to be only numbers @assuncaocharles ([#13048](https://github.com/microsoft/fluentui/pull/13048))
+- Restricted prop sets in the `ReactionGroup` component which are passed to styles functions, @assuncaocharles ([#13080](https://github.com/microsoft/fluentui/pull/13080))
 
 ### Fixes
 - Visually align checkbox and label elements in `Checkbox` component @silviuavram ([#12590](https://github.com/microsoft/fluentui/pull/12590))

--- a/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
@@ -1,10 +1,16 @@
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as React from 'react';
 import * as _ from 'lodash';
-
-import { WithAsProp, withSafeTypeForAs, ShorthandCollection } from '../../types';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 import {
-  UIComponent,
+  WithAsProp,
+  withSafeTypeForAs,
+  ShorthandCollection,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
+import {
   childrenExist,
   UIComponentProps,
   ChildrenComponentProps,
@@ -12,16 +18,16 @@ import {
   commonPropTypes,
   rtlTextContainer,
   createShorthandFactory,
-  ShorthandFactory,
 } from '../../utils';
 import { Accessibility } from '@fluentui/accessibility';
-import Reaction, { ReactionProps } from './Reaction';
+import Reaction, { ReactionProps, reactionClassName } from './Reaction';
+import { getElementType, useUnhandledProps, useAccessibility, useTelemetry, useStyles } from '@fluentui/react-bindings';
 
 export interface ReactionGroupProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<never>;
 
   /** The reactions contained inside the reaction group. */
   items?: ShorthandCollection<ReactionProps>;
@@ -29,46 +35,68 @@ export interface ReactionGroupProps extends UIComponentProps, ChildrenComponentP
 
 export const reactionGroupClassName = 'ui-reactions';
 
-class ReactionGroup extends UIComponent<WithAsProp<ReactionGroupProps>> {
-  static create: ShorthandFactory<ReactionGroupProps>;
+export type ReactionGroupStylesProps = never;
 
-  static displayName = 'ReactionGroup';
+const ReactionGroup: React.FC<WithAsProp<ReactionGroupProps>> &
+  FluentComponentStaticProps<ReactionGroupProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(ReactionGroup.displayName, context.telemetry);
+  setStart();
+  const { children, items, content, className, design, styles, variables } = props;
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(ReactionGroup.handledProps, props);
 
-  static deprecated_className = reactionGroupClassName;
+  const getA11yProps = useAccessibility<never>(props.accessibility, {
+    debugName: ReactionGroup.displayName,
+    rtl: context.rtl,
+  });
 
-  static propTypes = {
-    ...commonPropTypes.createCommon(),
-    items: customPropTypes.collectionShorthand,
-  };
+  const { classes, styles: resolvedStyles } = useStyles<ReactionGroupStylesProps>(ReactionGroup.displayName, {
+    className: reactionClassName,
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  renderComponent({ ElementType, classes, accessibility, styles, unhandledProps }): React.ReactNode {
-    const { children, items, content } = this.props;
-    if (_.isNil(items)) {
-      return (
-        <ElementType
-          {...accessibility.attributes.root}
-          {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
-          {...unhandledProps}
-          className={classes.root}
-        >
-          {childrenExist(children) ? children : content}
-        </ElementType>
-      );
-    }
-
-    return (
-      <ElementType {...unhandledProps} className={classes.root}>
-        {_.map(items, reaction =>
-          Reaction.create(reaction, {
-            defaultProps: () => ({
-              styles: styles.reaction,
-            }),
+  const element = _.isNil(items) ? (
+    <ElementType
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...unhandledProps,
+      })}
+      {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
+    >
+      {childrenExist(children) ? children : content}
+    </ElementType>
+  ) : (
+    <ElementType {...unhandledProps} className={classes.root}>
+      {_.map(items, reaction =>
+        Reaction.create(reaction, {
+          defaultProps: () => ({
+            styles: resolvedStyles.reaction,
           }),
-        )}
-      </ElementType>
-    );
-  }
-}
+        }),
+      )}
+    </ElementType>
+  );
+
+  setEnd();
+
+  return element;
+};
+
+ReactionGroup.displayName = 'ReactionGroup';
+
+ReactionGroup.propTypes = {
+  ...commonPropTypes.createCommon(),
+  items: customPropTypes.collectionShorthand,
+};
+
+ReactionGroup.handledProps = Object.keys(ReactionGroup.propTypes) as any;
 
 ReactionGroup.create = createShorthandFactory({
   Component: ReactionGroup,

--- a/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/ReactionGroup.tsx
@@ -20,7 +20,7 @@ import {
   createShorthandFactory,
 } from '../../utils';
 import { Accessibility } from '@fluentui/accessibility';
-import Reaction, { ReactionProps, reactionClassName } from './Reaction';
+import Reaction, { ReactionProps } from './Reaction';
 import { getElementType, useUnhandledProps, useAccessibility, useTelemetry, useStyles } from '@fluentui/react-bindings';
 
 export interface ReactionGroupProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -52,7 +52,7 @@ const ReactionGroup: React.FC<WithAsProp<ReactionGroupProps>> &
   });
 
   const { classes, styles: resolvedStyles } = useStyles<ReactionGroupStylesProps>(ReactionGroup.displayName, {
-    className: reactionClassName,
+    className: reactionGroupClassName,
     mapPropsToInlineStyles: () => ({
       className,
       design,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Reaction/reactionGroupStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Reaction/reactionGroupStyles.ts
@@ -1,8 +1,8 @@
 import { ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { ReactionProps } from '../../../../components/Reaction/Reaction';
+import { ReactionGroupStylesProps } from '../../../../components/Reaction/ReactionGroup';
 import { ReactionGroupVariables } from './reactionGroupVariables';
 
-const reactionStyles: ComponentSlotStylesPrepared<ReactionProps, ReactionGroupVariables> = {
+const reactionGroupStyles: ComponentSlotStylesPrepared<ReactionGroupStylesProps, ReactionGroupVariables> = {
   root: () => ({}),
   reaction: ({ variables: v }) => ({
     ':not(:last-child)': {
@@ -11,4 +11,4 @@ const reactionStyles: ComponentSlotStylesPrepared<ReactionProps, ReactionGroupVa
   }),
 };
 
-export default reactionStyles;
+export default reactionGroupStyles;

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -53,7 +53,7 @@ import { PopupContentStylesProps } from '../../components/Popup/PopupContent';
 import { PortalProps } from '../../components/Portal/Portal';
 import { RadioGroupItemProps } from '../../components/RadioGroup/RadioGroupItem';
 import { RadioGroupProps } from '../../components/RadioGroup/RadioGroup';
-import { ReactionGroupProps } from '../../components/Reaction/ReactionGroup';
+import { ReactionGroupStylesProps } from '../../components/Reaction/ReactionGroup';
 import { ReactionProps } from '../../components/Reaction/Reaction';
 import { SegmentProps } from '../../components/Segment/Segment';
 import { SliderStylesProps } from '../../components/Slider/Slider';
@@ -141,7 +141,7 @@ export type TeamsThemeStylesProps = {
   RadioGroup: RadioGroupProps;
   RadioGroupItem: RadioGroupItemProps;
   Reaction: ReactionProps;
-  ReactionGroup: ReactionGroupProps;
+  ReactionGroup: ReactionGroupStylesProps;
   Segment: SegmentProps;
   Slider: SliderStylesProps;
   SplitButton: SplitButtonStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Reaction/ReactionGroup-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Reaction/ReactionGroup-test.tsx
@@ -7,6 +7,6 @@ import implementsCollectionShorthandProp from 'test/specs/commonTests/implements
 const reactionGroupImplementsCollectionShorthandProp = implementsCollectionShorthandProp(ReactionGroup);
 
 describe('ReactionGroup', () => {
-  isConformant(ReactionGroup);
+  isConformant(ReactionGroup, { constructorName: 'ReactionGroup' });
   reactionGroupImplementsCollectionShorthandProp('items', Reaction);
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

Converting `ReactionGroup` from class component to functional. Any props are not longer passed to styles function.

Related to #12237

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13080)