### PR TITLE
fix(Components): add Focus Zone wrapper

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))
 - Fix offset computations in `Popup` to properly position pointer @layershifter ([#13002](https://github.com/microsoft/fluentui/pull/13002))
 - Enable back focus zone in `CarouselNavigation` @kolaps33 ([#13086](https://github.com/microsoft/fluentui/pull/13086))
+- Wrapped `Alert`, `Attachment`, `Box` and `ListItem` FC with `unstable_wrapWithFocusZone` @assuncaocharles ([#13093](https://github.com/microsoft/fluentui/pull/13093))
 
 <!--------------------------------[ v0.49.0 ]------------------------------- -->
 ## [v0.49.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.49.0) (2020-05-10)

--- a/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
+++ b/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
@@ -270,7 +270,7 @@ export const Alert: React.FC<WithAsProp<AlertProps>> &
     );
   };
 
-  const element = (
+  const element = getA11yProps.unstable_wrapWithFocusZone(
     <ElementType
       {...getA11yProps('root', {
         className: classes.root,
@@ -279,7 +279,7 @@ export const Alert: React.FC<WithAsProp<AlertProps>> &
       })}
     >
       {childrenExist(children) ? children : renderContent()}
-    </ElementType>
+    </ElementType>,
   );
 
   setEnd();

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -147,7 +147,7 @@ const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps, {}, {}
       _.invoke(props, 'onClick', e, props);
     };
 
-    const element = (
+    const element = getA11Props.unstable_wrapWithFocusZone(
       <ElementType {...getA11Props('root', { className: classes.root, onClick: handleClick, ref, ...unhandledProps })}>
         {createShorthand(composeOptions.slots.icon, icon, {
           defaultProps: () => slotProps.icon,
@@ -187,7 +187,7 @@ const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps, {}, {}
           }),
         })}
         {!_.isNil(progress) && <div className="ui-attachment__progress" style={{ width: `${progress}%` }} />}
-      </ElementType>
+      </ElementType>,
     );
     setEnd();
 

--- a/packages/fluentui/react-northstar/src/components/Box/Box.tsx
+++ b/packages/fluentui/react-northstar/src/components/Box/Box.tsx
@@ -64,7 +64,7 @@ const Box = compose<'div', BoxProps, BoxStylesProps, {}, {}>(
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
     const ElementType = getElementType(props);
 
-    const result = (
+    const result = getA11yProps.unstable_wrapWithFocusZone(
       <ElementType
         {...getA11yProps('root', {
           ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
@@ -74,7 +74,7 @@ const Box = compose<'div', BoxProps, BoxStylesProps, {}, {}>(
         })}
       >
         {childrenExist(children) ? children : content}
-      </ElementType>
+      </ElementType>,
     );
 
     setEnd();

--- a/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/List/ListItem.tsx
@@ -210,7 +210,7 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
     }),
   });
 
-  const element = (
+  const element = getA11Props.unstable_wrapWithFocusZone(
     <ElementType
       {...getA11Props('root', {
         className: classes.root,
@@ -236,7 +236,7 @@ const ListItem: React.FC<WithAsProp<ListItemProps> & { index: number }> &
       </div>
 
       {endMediaElement}
-    </ElementType>
+    </ElementType>,
   );
 
   setEnd();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Some components missed the `unstable_wrapWithFocusZone` wrapper when converted to RFC. This PR adds revert that adding the wrapper in the proper components. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13093)