### PR TITLE
compose: Adding `classes` option to compose.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "stopOnEntry": false,
       "args": ["-i", "--watch"],
       "runtimeExecutable": null,
-      "runtimeArgs": ["--nolazy", "--debug"],
+      "runtimeArgs": ["--nolazy", "--inspect"],
       "env": {
         "NODE_ENV": "development"
       },

--- a/change/@fluentui-react-compose-2020-05-11-18-24-56-feat-compose-classes.json
+++ b/change/@fluentui-react-compose-2020-05-11-18-24-56-feat-compose-classes.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding `classes` option to compose options.",
+  "packageName": "@fluentui/react-compose",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T01:24:56.658Z"
+}

--- a/packages/react-compose/config/tests.js
+++ b/packages/react-compose/config/tests.js
@@ -1,0 +1,12 @@
+/** Jest test setup file. */
+
+const { configure } = require('enzyme');
+const Adapter = require('enzyme-adapter-react-16');
+
+// Mock requestAnimationFrame for React 16+.
+global.requestAnimationFrame = callback => {
+  setTimeout(callback, 0);
+};
+
+// Configure enzyme.
+configure({ adapter: new Adapter() });

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -7,6 +7,11 @@
 import * as React from 'react';
 
 // @public (undocumented)
+export type ClassDictionary = {
+    [key: string]: string;
+};
+
+// @public (undocumented)
 export interface ComponentWithAs<E extends React.ElementType = 'div', P = {}> extends React.FunctionComponent {
     // (undocumented)
     <EE extends React.ElementType = E>(props: Omit<PropsOfElement<EE>, 'as' | keyof P> & {
@@ -35,6 +40,7 @@ export type ComposedComponent<P = {}> = React.FunctionComponent<P> & {
 // @public (undocumented)
 export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesProps = {}> = {
     className?: string;
+    classes?: ClassDictionary;
     displayName?: string;
     mapPropsToStylesProps?: (props: ParentStylesProps & InputProps) => InputStylesProps;
     handledProps?: (keyof InputProps | 'as')[];
@@ -46,6 +52,7 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
 // @public (undocumented)
 export type ComposePreparedOptions<Props = {}> = {
     className: string;
+    classes: ClassDictionary;
     displayName: string;
     displayNames: string[];
     mapPropsToStylesPropsChain: ((props: object) => object)[];

--- a/packages/react-compose/jest.config.js
+++ b/packages/react-compose/jest.config.js
@@ -1,0 +1,5 @@
+let path = require('path');
+let { createConfig, resolveMergeStylesSerializer } = require('@uifabric/build/jest/jest-resources');
+module.exports = createConfig({
+  setupFiles: [path.resolve(path.join(__dirname, 'config', 'tests.js'))],
+});

--- a/packages/react-compose/src/mergeClasses.test.ts
+++ b/packages/react-compose/src/mergeClasses.test.ts
@@ -1,0 +1,23 @@
+import { mergeClasses } from './mergeClasses';
+
+describe('mergeClasses', () => {
+  it('can merge classes', () => {
+    expect(mergeClasses({ root: 'a b c', foo: 'd e' }, { root: 'x y z', foo: 'f g' }, { root: 'm' })).toEqual({
+      root: 'a b c x y z m',
+      foo: 'd e f g',
+    });
+  });
+
+  it('can handle no input ', () => {
+    expect(mergeClasses()).toEqual({});
+  });
+
+  it('can handle falsey values', () => {
+    expect(
+      mergeClasses({ root: 'a b c', foo: 'd e' }, undefined, { root: 'x y z', foo: 'f g' }, { root: 'm' }),
+    ).toEqual({
+      root: 'a b c x y z m',
+      foo: 'd e f g',
+    });
+  });
+});

--- a/packages/react-compose/src/mergeClasses.ts
+++ b/packages/react-compose/src/mergeClasses.ts
@@ -1,0 +1,21 @@
+import cx from 'classnames';
+import { ClassDictionary } from './types';
+
+export const mergeClasses = (...classesList: (ClassDictionary | undefined)[]): ClassDictionary => {
+  const result: { [key: string]: string | string[] } = {};
+
+  for (const classes of classesList) {
+    if (classes) {
+      Object.keys(classes).forEach((key: string) => {
+        result[key] = result[key] || [];
+        (result[key] as string[]).push(classes[key]);
+      });
+    }
+  }
+
+  Object.keys(result!).forEach((key: string) => {
+    result[key] = cx(...(result[key] as string[]));
+  });
+
+  return result as ClassDictionary;
+};

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -47,6 +47,7 @@ export type ComposeRenderFunction<T extends React.ElementType = 'div', P = {}> =
 
 export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesProps = {}> = {
   className?: string;
+  classes?: ClassDictionary;
   displayName?: string;
 
   mapPropsToStylesProps?: (props: ParentStylesProps & InputProps) => InputStylesProps;
@@ -59,8 +60,13 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
   mapPropsToSlotProps?: (props: InputProps) => Record<string, object>;
 };
 
+export type ClassDictionary = {
+  [key: string]: string;
+};
+
 export type ComposePreparedOptions<Props = {}> = {
   className: string;
+  classes: ClassDictionary;
   displayName: string;
   displayNames: string[];
 

--- a/packages/react-compose/src/utils.ts
+++ b/packages/react-compose/src/utils.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 import * as ReactIs from 'react-is';
 
 import { ComposedComponent, ComposeOptions, ComposePreparedOptions, Input } from './types';
+import { mergeClasses } from './mergeClasses';
 
+/**
+ * Given input/parent options, which are both assumed to be defined and populated with
+ * displayNames array, return a string array of display names.
+ */
 function computeDisplayNames(inputOptions: ComposeOptions, parentOptions: ComposePreparedOptions): string[] {
   if (inputOptions.overrideStyles) {
     return [inputOptions.displayName].filter(Boolean) as string[];
@@ -16,6 +21,7 @@ function computeDisplayNames(inputOptions: ComposeOptions, parentOptions: Compos
 
 export const defaultComposeOptions: ComposePreparedOptions = {
   className: process.env.NODE_ENV === 'production' ? '' : 'no-classname-🙉',
+  classes: {},
   displayName: '',
   displayNames: [],
 
@@ -42,7 +48,6 @@ export function mergeComposeOptions(
     mapPropsToSlotPropsChain.reduce<Record<string, object>>((acc, definition) => {
       const nextProps = { ...definition(props) };
       const slots: string[] = [...Object.keys(acc), ...Object.keys(nextProps)];
-
       const mergedSlotProps: Record<string, object> = {};
 
       slots.forEach(slot => {
@@ -59,6 +64,8 @@ export function mergeComposeOptions(
 
   return {
     className: inputOptions.className || parentOptions.className,
+    classes: mergeClasses(parentOptions.classes, inputOptions.classes),
+
     displayName: inputOptions.displayName || parentOptions.displayName,
     displayNames: computeDisplayNames(inputOptions, parentOptions),
 


### PR DESCRIPTION
This change adds `classes` prop to `compose` so that a list of classes can be provided on options.

Quick example:

```tsx
import { ButtonBase } from '@fluentui/react';
import { compose } from '@fluentui/react-compose';
import * as classes from './MyButton.scss';

export const MyButton = compose(ButtonBase, { classes });
```

In a separate PR, I would like to add state resolving functionality here as well, rather than only accepting `ClassDictionary` types. This would require it to be resolved in `resolveSlotProps` or some identical callback which receives state (or props, if there is no state.) I'd propose we rename this callback to simply `mergeProps` and let it resolve slotProps, slots, and classes. This would enable us to resolve classes even with the current approach of resolving classes using css in js and caching on specific parts of the state:

```tsx
// Grab merge-styles or fela based css-in-js styles.
import { getStyles } from './Button.styles';

// Create a style function which will cache results based on limited inputs pulled from state.
// This means compose has no need for mapPropsToStylesProps, and that useStyles can stay
// out of the component itself and be resolved from within the class factory.
const classes = createClassFactory(getStyles, [ /* deps from state */ 'foo', 'bar', 'baz' ]);

compose(ButtonBase, { classes });
```

Feedback welcome!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13101)