### PR TITLE
Bug fix to handle removal of duplicates in UnifiedPicker (SelectedItemsList)

### DIFF
--- a/change/@uifabric-experiments-2020-05-11-18-37-37-u-nebhatna-uppsb.json
+++ b/change/@uifabric-experiments-2020-05-11-18-37-37-u-nebhatna-uppsb.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "fixing removing of duplicate entries at once",
+  "packageName": "@uifabric/experiments",
+  "email": "nebhatna@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T01:37:37.630Z"
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
@@ -29,7 +29,7 @@ export class FloatingSuggestionPage extends React.Component<IComponentDemoPagePr
         dos={
           <div>
             <ul>
-              <li>Use them to display a list of people suggetions</li>
+              <li>Use them to display a list of people suggestions</li>
             </ul>
           </div>
         }

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -13,7 +13,7 @@ import { IRenderFunction, IRefObject } from '@uifabric/utilities';
  */
 export interface IBaseFloatingSuggestionsProps<T> {
   /**
-   * Component reference incase needed to focus FlaotingSuggestions
+   * Component reference in case needed to focus FloatingSuggestions
    */
   componentRef?: IRefObject<HTMLDivElement>;
   /**

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -14,7 +14,14 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   }, [props.selectedItems]);
 
   const removeItems = (itemsToRemove: TItem[]): void => {
-    updateItems(items.filter(item => itemsToRemove.indexOf(item) === -1));
+    // Intentionally not using .filter here as we want to only remove a specific
+    // item in case of duplicates of same item.
+    const updatedItems: TItem[] = [...items];
+    itemsToRemove.forEach(item => {
+      const index: number = updatedItems.indexOf(item);
+      updatedItems.splice(index, 1);
+    });
+    updateItems(updatedItems);
     props.onItemsRemoved ? props.onItemsRemoved(itemsToRemove) : null;
   };
 
@@ -47,6 +54,8 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
           <SelectedItem
             item={item}
             index={index}
+            // To keep react from complaining for duplicate elements with the same key
+            // we will append the index to the key so that we have unique key for each item
             key={item.key !== undefined ? item.key + '_' + index : index}
             selected={props.focusedItemIndices?.includes(index)}
             removeButtonAriaLabel={props.removeButtonAriaLabel}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -14,7 +14,12 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   }, [props.selectedItems]);
 
   const removeItems = (itemsToRemove: TItem[]): void => {
-    updateItems(items.filter(item => itemsToRemove.indexOf(item) === -1));
+    const updatedItems: TItem[] = [...items];
+    itemsToRemove.forEach(item => {
+      const index: number = updatedItems.indexOf(item);
+      updatedItems.splice(index, 1);
+    });
+    updateItems(updatedItems);
     props.onItemsRemoved ? props.onItemsRemoved(itemsToRemove) : null;
   };
 

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -14,12 +14,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   }, [props.selectedItems]);
 
   const removeItems = (itemsToRemove: TItem[]): void => {
-    const updatedItems: TItem[] = [...items];
-    itemsToRemove.forEach(item => {
-      const index: number = updatedItems.indexOf(item);
-      updatedItems.splice(index, 1);
-    });
-    updateItems(updatedItems);
+    updateItems(items.filter(item => itemsToRemove.indexOf(item) === -1));
     props.onItemsRemoved ? props.onItemsRemoved(itemsToRemove) : null;
   };
 
@@ -52,7 +47,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
           <SelectedItem
             item={item}
             index={index}
-            key={item.key !== undefined ? item.key : index}
+            key={item.key !== undefined ? item.key + '_' + index : index}
             selected={props.focusedItemIndices?.includes(index)}
             removeButtonAriaLabel={props.removeButtonAriaLabel}
             onRemoveItem={onRemoveItemCallbacks[index]}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -84,7 +84,7 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
   removeButtonAriaLabel?: string;
 
   /**
-   * A callback when and item or items are removed
+   * A callback when an item or items are removed
    */
   onItemsRemoved?: (removedItems: T[]) => void;
 

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -14,7 +14,6 @@ export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Eleme
 
   // }, [props.floatingSuggestionProps.suggestions]);
 
-  console.log('something');
   const renderSelectedItems = (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {
     return <SelectedPeopleList {...selectedPeopleListProps} ref={null} />;
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -22,7 +22,7 @@ export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Eleme
       <UnifiedPicker
         {...props}
         onRenderSelectedItems={renderSelectedItems}
-        onRederFloatingSuggestions={FloatingPeopleSuggestions}
+        onRenderFloatingSuggestions={FloatingPeopleSuggestions}
       />
     </>
   );

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -14,6 +14,7 @@ export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Eleme
 
   // }, [props.floatingSuggestionProps.suggestions]);
 
+  console.log('something');
   const renderSelectedItems = (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {
     return <SelectedPeopleList {...selectedPeopleListProps} ref={null} />;
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.types.ts
@@ -4,5 +4,5 @@ import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 
 export type IUnifiedPeoplePickerProps = Omit<
   IUnifiedPickerProps<IPersonaProps>,
-  'onRenderSelectedItems' | 'onRederFloatingSuggestions'
+  'onRenderSelectedItems' | 'onRenderFloatingSuggestions'
 >;

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -98,7 +98,6 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
   };
 
   const _onInputChange = (filterText: string): void => {
-    console.log(people[40]);
     const allPeople = people;
     const suggestions = allPeople.filter((item: IPersonaProps) => _startsWith(item.text || '', filterText));
     const suggestionList = suggestions.map(item => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -52,7 +52,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     inputProps,
     onRenderSelectedItems,
     selectedItemsListProps,
-    onRederFloatingSuggestions,
+    onRenderFloatingSuggestions,
     floatingSuggestionProps,
     headerComponent,
     onInputChange,
@@ -185,7 +185,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     removeItems(itemsToRemove);
   };
   const _renderFloatingPicker = () =>
-    onRederFloatingSuggestions({
+    onRenderFloatingSuggestions({
       ...floatingSuggestionProps,
       targetElement: input.current?.inputElement,
       isSuggestionsVisible: isSuggestionsShown,

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
@@ -6,7 +6,7 @@ import { IFocusZoneProps, IInputProps, Autofill } from 'office-ui-fabric-react';
 
 export interface IUnifiedPickerProps<T> {
   /**
-   * Ref of teh component
+   * Ref of the component
    */
   componentRef?: IRefObject<any>;
 
@@ -30,7 +30,7 @@ export interface IUnifiedPickerProps<T> {
    * Component to render floating suggestions
    * floatingSuggestionProps will be passed as props to this component
    */
-  onRederFloatingSuggestions: (props: IBaseFloatingSuggestionsProps<T>) => JSX.Element;
+  onRenderFloatingSuggestions: (props: IBaseFloatingSuggestionsProps<T>) => JSX.Element;
 
   /**
    * Props to pass to floating suggestions component

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -55,11 +55,14 @@ export const useSelectedItems = <T extends {}>(
   };
 
   const removeItems = (itemsToRemove: any[]): void => {
-    const currentitems: T[] = [...items];
-    const updatedItems: T[] = currentitems.filter(item => itemsToRemove.indexOf(item) === -1);
-
-    setSelectedItems(updatedItems);
-    selection.setItems(updatedItems);
+    const currentItems: T[] = [...items];
+    const updatedItems: T[] = currentItems;
+    itemsToRemove.forEach(item => {
+      const index: number = currentItems.indexOf(item);
+      updatedItems.splice(index, 1);
+      setSelectedItems(updatedItems);
+      selection.setItems(updatedItems);
+    });
   };
 
   const removeSelectedItems = (): void => {

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -55,8 +55,14 @@ export const useSelectedItems = <T extends {}>(
   };
 
   const removeItems = (itemsToRemove: any[]): void => {
-    const currentitems: T[] = [...items];
-    const updatedItems: T[] = currentitems.filter(item => itemsToRemove.indexOf(item) === -1);
+    const currentItems: T[] = [...items];
+    const updatedItems: T[] = currentItems;
+    // Intentionally not using .filter here as we want to only remove a specific
+    // item in case of duplicates of same item.
+    itemsToRemove.forEach(item => {
+      const index: number = updatedItems.indexOf(item);
+      updatedItems.splice(index, 1);
+    });
     setSelectedItems(updatedItems);
     selection.setItems(updatedItems);
   };

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -58,11 +58,11 @@ export const useSelectedItems = <T extends {}>(
     const currentItems: T[] = [...items];
     const updatedItems: T[] = currentItems;
     itemsToRemove.forEach(item => {
-      const index: number = currentItems.indexOf(item);
+      const index: number = updatedItems.indexOf(item);
       updatedItems.splice(index, 1);
-      setSelectedItems(updatedItems);
-      selection.setItems(updatedItems);
     });
+    setSelectedItems(updatedItems);
+    selection.setItems(updatedItems);
   };
 
   const removeSelectedItems = (): void => {

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -55,12 +55,8 @@ export const useSelectedItems = <T extends {}>(
   };
 
   const removeItems = (itemsToRemove: any[]): void => {
-    const currentItems: T[] = [...items];
-    const updatedItems: T[] = currentItems;
-    itemsToRemove.forEach(item => {
-      const index: number = updatedItems.indexOf(item);
-      updatedItems.splice(index, 1);
-    });
+    const currentitems: T[] = [...items];
+    const updatedItems: T[] = currentitems.filter(item => itemsToRemove.indexOf(item) === -1);
     setSelectedItems(updatedItems);
     selection.setItems(updatedItems);
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Updating the logic to remove selected items by not using .filter, as we end up removing all the duplicate items whereas we want to just remove that specific item. Updated the key in SelectedItemsList to be unique to handle duplicates for UnifiedPicker (selecteditemslist). And fixing minor typos
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13102)