### PR TITLE
fix(Dropdown): Rendering no matches message when all items selected

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -824,7 +824,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       };
     }
 
-    if (items && (items.length === 0 || items.length === value.length)) {
+    if (filteredItems && filteredItems.length === 0) {
       return {
         children: () =>
           DropdownItem.create(noResultsMessage, {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -809,7 +809,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
   }
 
   renderItemsListFooter(styles: ComponentSlotStylesInput) {
-    const { loading, loadingMessage, noResultsMessage, items } = this.props;
+    const { loading, loadingMessage, noResultsMessage } = this.props;
     const { filteredItems } = this.state;
 
     if (loading) {
@@ -824,7 +824,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       };
     }
 
-    if (items && (items.length === 0 || (filteredItems && filteredItems.length === 0))) {
+    if (filteredItems && filteredItems.length === 0) {
       return {
         children: () =>
           DropdownItem.create(noResultsMessage, {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -824,7 +824,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       };
     }
 
-    if (filteredItems && filteredItems.length === 0) {
+    if (items && (items.length === 0 || (filteredItems && filteredItems.length === 0))) {
       return {
         children: () =>
           DropdownItem.create(noResultsMessage, {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -824,7 +824,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       };
     }
 
-    if ((items && items.length === 0) || items.length === value.length) {
+    if (items && (items.length === 0 || items.length === value.length)) {
       return {
         children: () =>
           DropdownItem.create(noResultsMessage, {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -810,6 +810,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
   renderItemsListFooter(styles: ComponentSlotStylesInput) {
     const { loading, loadingMessage, noResultsMessage, items } = this.props;
+    const { value } = this.state;
 
     if (loading) {
       return {
@@ -823,7 +824,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       };
     }
 
-    if (items && items.length === 0) {
+    if ((items && items.length === 0) || items.length === value.length) {
       return {
         children: () =>
           DropdownItem.create(noResultsMessage, {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -810,7 +810,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
   renderItemsListFooter(styles: ComponentSlotStylesInput) {
     const { loading, loadingMessage, noResultsMessage, items } = this.props;
-    const { value } = this.state;
+    const { filteredItems } = this.state;
 
     if (loading) {
       return {

--- a/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -783,6 +783,28 @@ describe('Dropdown', () => {
       );
     });
 
+    it('It shows no matches message when all iems are selected', () => {
+      // it will actually be the third, since one is already removed from the list due to defaultValue.
+      const noResultsMessage = 'no items';
+
+      const { clickOnItemAtIndex, clickOnToggleIndicator, itemsListNode } = renderDropdown({
+        items: ['item0', 'item1'],
+        open: true,
+        search: true,
+        multiple: true,
+        noResultsMessage,
+      });
+
+      // Select all
+      clickOnItemAtIndex(0);
+      clickOnItemAtIndex(0);
+
+      // open
+      clickOnToggleIndicator();
+
+      expect(itemsListNode.textContent).toBe(noResultsMessage);
+    });
+
     it('has onChange called with null value by hitting Escape in search input', () => {
       const onChange = jest.fn();
       const { keyDownOnSearchInput } = renderDropdown({


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Show no matches found message when all items are selected in the `Dropdown`

<img width="422" alt="Screenshot 2020-05-12 at 10 02 20" src="https://user-images.githubusercontent.com/8545105/81657278-09b29780-9438-11ea-9b18-2665b4cd8bbd.png">


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13109)