### PR TITLE
docs(Toolbar): add SplitButton in the custom content example

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Content/ToolbarExampleCustomContent.shorthand.tsx
@@ -1,6 +1,50 @@
 import * as React from 'react';
-import { Button, Text, Toolbar } from '@fluentui/react-northstar';
+import { Button, Text, Toolbar, SplitButton } from '@fluentui/react-northstar';
 import { BoldIcon } from '@fluentui/react-icons-northstar';
+
+// used to prevent arrow navigation while SplitButton menu is open.
+function onItemKeyDown(e) {
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+    e.stopPropagation();
+  }
+}
+
+const ToolbarSplitButton = () => (
+  <>
+    <SplitButton
+      menu={[
+        {
+          key: 'group',
+          content: 'New group message',
+          onKeyDown: onItemKeyDown,
+        },
+        {
+          key: 'channel',
+          content: 'New channel message',
+          onKeyDown: onItemKeyDown,
+        },
+      ]}
+      button={{
+        content: 'New conversation',
+        'aria-roledescription': 'splitbutton',
+        'aria-describedby': 'instruction-message',
+      }}
+      toggleButton={{
+        'aria-label': 'more options',
+      }}
+      onMainButtonClick={() => alert('button was clicked')}
+    />
+    <span
+      aria-hidden="true"
+      id="instruction-message"
+      style={{
+        opacity: 0,
+      }}
+    >
+      to open menu, press Alt + Arrow Down
+    </span>
+  </>
+);
 
 const ToolbarExampleCustomContentShorthand = () => (
   <Toolbar
@@ -26,6 +70,12 @@ const ToolbarExampleCustomContentShorthand = () => (
         key: 'custom-button',
         kind: 'custom',
         content: <Button content="Button" />,
+        fitted: 'horizontally',
+      },
+      {
+        key: 'custom-split-button',
+        kind: 'custom',
+        content: <ToolbarSplitButton />,
         fitted: 'horizontally',
       },
     ]}

--- a/packages/fluentui/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Content/ToolbarExampleMenuRadioGroup.shorthand.tsx
@@ -4,7 +4,7 @@ import { MoreIcon, UnderlineIcon, FontColorIcon } from '@fluentui/react-icons-no
 
 const ToolbarExampleMenuRadioGroup = () => {
   const [activeIndex, setActiveIndex] = React.useState(0);
-  const [menuOpen, setMenuOpen] = React.useState();
+  const [menuOpen, setMenuOpen] = React.useState(false);
 
   return (
     <Toolbar


### PR DESCRIPTION
#### Description of changes

Add a SplitButton example component to the Toolbar example with custom items.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13111)