### PR TITLE
feat(compose): expose __self slot

### DIFF
--- a/change/@fluentui-react-button-2020-05-19-16-52-10-feat-compose.json
+++ b/change/@fluentui-react-button-2020-05-19-16-52-10-feat-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "feat(compose): expose __self slot",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-19T14:52:10.586Z"
+}

--- a/change/@fluentui-react-compose-2020-05-12-16-54-08-feat-compose.json
+++ b/change/@fluentui-react-compose-2020-05-12-16-54-08-feat-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "feat(compose): expose __self slot",
+  "packageName": "@fluentui/react-compose",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T14:54:08.002Z"
+}

--- a/packages/fluentui/react-bindings/test/compose/compose-test.tsx
+++ b/packages/fluentui/react-bindings/test/compose/compose-test.tsx
@@ -65,7 +65,15 @@ const BaseComponent: React.FC<BaseComponentProps> = compose<
     });
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
 
-    return <button className={classes.root} onClick={() => setOpen(!open)} {...unhandledProps} ref={ref} />;
+    return (
+      <button
+        className={classes.root}
+        data-display-name={(composeOptions.slots.__self as typeof BaseComponent).displayName}
+        onClick={() => setOpen(!open)}
+        ref={ref}
+        {...unhandledProps}
+      />
+    );
   },
   {
     className: 'ui-base',
@@ -202,6 +210,12 @@ describe('useCompose', () => {
     expect(wrapper.find('#start').name()).toEqual('span');
     expect(wrapper.find('#main').name()).toEqual('b');
     expect(wrapper.find('#end').name()).toEqual('i');
+  });
+
+  it('passes component definition as "__self"', () => {
+    const wrapper = shallow(<BaseComponent />);
+
+    expect(wrapper.find('button').prop('data-display-name')).toEqual('BaseComponent');
   });
 
   it('applies mapped props to correct slots', () => {

--- a/packages/react-button/src/utils/mergeProps.ts
+++ b/packages/react-button/src/utils/mergeProps.ts
@@ -51,7 +51,7 @@ const filterProps = (props: any): any => {
 
 export interface ComponentHookResult<TState, TSlots, TSlotProps> {
   state: TState;
-  slots: Required<TSlots> & { root: React.ElementType };
+  slots: Required<TSlots> & { root: React.ElementType; __self: React.ElementType };
   slotProps: Required<TSlotProps> & { root: TState };
 }
 

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -59,7 +59,9 @@ export type ComposePreparedOptions<Props = {}> = {
     render: ComposeRenderFunction;
     handledProps: (keyof Props)[];
     overrideStyles: boolean;
-    slots: Record<string, React.ElementType>;
+    slots: Record<string, React.ElementType> & {
+        __self: React.ElementType;
+    };
     mapPropsToSlotPropsChain: ((props: Props) => Record<string, object>)[];
     resolveSlotProps: <P>(props: P) => Record<string, object>;
 };

--- a/packages/react-compose/src/compose.ts
+++ b/packages/react-compose/src/compose.ts
@@ -15,7 +15,13 @@ function compose<ElementType extends React.ElementType, InputProps, InputStylesP
 
   const Component = (React.forwardRef<ElementType, InputProps & ParentProps & { as?: React.ElementType }>(
     (props, ref) => {
-      return composeOptions.render(props, (ref as unknown) as React.Ref<HTMLDivElement>, composeOptions);
+      return composeOptions.render(props, (ref as unknown) as React.Ref<HTMLDivElement>, {
+        ...composeOptions,
+        slots: {
+          ...composeOptions.slots,
+          __self: Component,
+        },
+      });
     },
   ) as unknown) as ComponentWithAs<ElementType, InputProps & ParentProps>;
 

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -76,7 +76,7 @@ export type ComposePreparedOptions<Props = {}> = {
   handledProps: (keyof Props)[];
   overrideStyles: boolean;
 
-  slots: Record<string, React.ElementType>;
+  slots: Record<string, React.ElementType> & { __self: React.ElementType };
   mapPropsToSlotPropsChain: ((props: Props) => Record<string, object>)[];
 
   resolveSlotProps: <P>(props: P) => Record<string, object>;

--- a/packages/react-compose/src/utils.ts
+++ b/packages/react-compose/src/utils.ts
@@ -30,7 +30,7 @@ export const defaultComposeOptions: ComposePreparedOptions = {
 
   handledProps: [] as never[],
   overrideStyles: false,
-  slots: {},
+  slots: { __self: () => null },
   mapPropsToSlotPropsChain: [],
   resolveSlotProps: () => ({}),
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This adds `__self` as a slot to cover very specific scenarios related to circular references. A sample usage will be:

```tsx
const MenuItem = compose(
  (props, ref, composeOptions) => {
    return (
      <ElementType>
        {props.menu && (
          <MenuMenu>
            {props.items.map(item =>
              createShorthand(compose.options.slots.__self, item)
            )}
          </MenuMenu>
        )}
      </ElementType>
    );
  },
  { displayName: "MenuItem" }
);
```

For example `Menu` & `MenuItem`: `Menu` uses `MenuItem` as a slot in the same time `MenuItem` uses `Menu` (current approach).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13115)