### PR TITLE
Adding keyboard-key to react-focus dependencies

### DIFF
--- a/change/@fluentui-react-focus-2020-05-12-14-21-32-fix-focus-deps.json
+++ b/change/@fluentui-react-focus-2020-05-12-14-21-32-fix-focus-deps.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding `@fluentui/keyboard-key` as a dependency.",
+  "packageName": "@fluentui/react-focus",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T21:21:32.375Z"
+}

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -47,6 +47,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
+    "@fluentui/keyboard-key": "^0.2.0",
     "@uifabric/merge-styles": "^7.12.0",
     "@uifabric/set-version": "^7.0.12",
     "@uifabric/styling": "^7.12.5",


### PR DESCRIPTION
Cloning a new repo, I'm getting build errors with react-focus due to this missing dependency.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13123)