### PR TITLE
@fluentui/react lib exports are no longer stripped.

### DIFF
--- a/change/@fluentui-react-2020-05-12-15-40-21-fix-tsconfig.json
+++ b/change/@fluentui-react-2020-05-12-15-40-21-fix-tsconfig.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "The tsconfig paths were misconfigured, causing re-exports to fail.",
+  "comment": "Resolving tsconfig paths which were not correctly configured, causing re-exports to fail.",
   "packageName": "@fluentui/react",
   "email": "dzearing@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-2020-05-12-15-40-21-fix-tsconfig.json
+++ b/change/@fluentui-react-2020-05-12-15-40-21-fix-tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "The tsconfig paths were misconfigured, causing re-exports to fail.",
+  "packageName": "@fluentui/react",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-12T22:40:21.318Z"
+}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -20,9 +20,7 @@
     "types": ["jest", "webpack-env", "custom-global"],
     "paths": {
       "@fluentui/react/lib/*": ["./src/*"],
-      "@fluentui/react": ["./src"],
-      "office-ui-fabric-react/lib/*": ["./src/*"],
-      "office-ui-fabric-react": ["./src"]
+      "@fluentui/react": ["./src"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
Undoing a change in tsconfig causing OUFR paths to resolve incorrectly.

Fixes #13105.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13127)