### PR TITLE
PivotItem: Expanding types of headerButtonProps to include IButtonProps

### DIFF
--- a/change/@fluentui-react-next-2020-05-12-17-39-32-pivotItemHeaderButtonPropsType.json
+++ b/change/@fluentui-react-next-2020-05-12-17-39-32-pivotItemHeaderButtonPropsType.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "PivotItem: Expanding types of headerButtonProps to include IButtonProps.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T00:39:32.179Z"
+}

--- a/change/office-ui-fabric-react-2020-05-12-17-39-32-pivotItemHeaderButtonPropsType.json
+++ b/change/office-ui-fabric-react-2020-05-12-17-39-32-pivotItemHeaderButtonPropsType.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "PivotItem: Expanding types of headerButtonProps to include IButtonProps.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T00:39:26.435Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6271,7 +6271,7 @@ export interface IPivot {
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
-    headerButtonProps?: {
+    headerButtonProps?: IButtonProps & {
         [key: string]: string | number | boolean;
     };
     headerText?: string;

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { IRefObject, IRenderFunction } from '../../Utilities';
+import { IButtonProps } from '../../Button';
 import { IKeytipProps } from '../../Keytip';
+import { IRefObject, IRenderFunction } from '../../Utilities';
 
 /**
  * {@docCategory Pivot}
@@ -26,7 +27,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Props for the header command button. This provides a way to pass in native props, such as data-* and aria-*,
    * for each pivot header/link element.
    */
-  headerButtonProps?: { [key: string]: string | number | boolean };
+  headerButtonProps?: IButtonProps & { [key: string]: string | number | boolean };
 
   /**
    * An required key to uniquely identify a pivot item.

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -349,7 +349,7 @@ export interface IPivot {
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
-    headerButtonProps?: {
+    headerButtonProps?: IButtonProps & {
         [key: string]: string | number | boolean;
     };
     headerText?: string;

--- a/packages/react-next/src/components/Pivot/PivotItem.types.ts
+++ b/packages/react-next/src/components/Pivot/PivotItem.types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { IButtonProps } from '../../Button';
 import { IRefObject, IRenderFunction } from '../../Utilities';
 import { IKeytipProps } from '../../Keytip';
 
@@ -26,7 +27,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Props for the header command button. This provides a way to pass in native props, such as data-* and aria-*,
    * for each pivot header/link element.
    */
-  headerButtonProps?: { [key: string]: string | number | boolean };
+  headerButtonProps?: IButtonProps & { [key: string]: string | number | boolean };
 
   /**
    * An required key to uniquely identify a pivot item.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `headerButtonProps` prop in `PivotItem` was just accepting `string` keys with `string`, `number` and `boolean` values. This PR increases the scope of the prop to also accept `IButtonProps`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13128)