### PR TITLE
Enabling option to not select anything in a Nav component.

### DIFF
--- a/change/office-ui-fabric-react-2020-05-12-18-05-43-master.json
+++ b/change/office-ui-fabric-react-2020-05-12-18-05-43-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Enabling option to not select anything in a Nav component.",
+  "packageName": "office-ui-fabric-react",
+  "email": "heath@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T01:05:43.830Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5687,7 +5687,7 @@ export interface IModalStyles {
 // @public (undocumented)
 export interface INav {
     focus(forceIntoFirstElement?: boolean): boolean;
-    selectedKey: string | undefined;
+    selectedKey: string | null | undefined;
 }
 
 // @public (undocumented)
@@ -5748,7 +5748,7 @@ export interface INavProps {
     onRenderLink?: IRenderFunction<INavLink>;
     // @deprecated
     selectedAriaLabel?: string;
-    selectedKey?: string;
+    selectedKey?: string | null;
     styles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;
     theme?: ITheme;
 }
@@ -5762,7 +5762,7 @@ export interface INavState {
     // (undocumented)
     isLinkExpandStateChanged?: boolean;
     // (undocumented)
-    selectedKey?: string;
+    selectedKey?: string | null;
 }
 
 // @public (undocumented)
@@ -8308,7 +8308,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     // (undocumented)
     render(): JSX.Element | null;
     // (undocumented)
-    readonly selectedKey: string | undefined;
+    readonly selectedKey: string | null | undefined;
     }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -26,7 +26,7 @@ const getClassNames = classNamesFunction<INavStyleProps, INavStyles>();
 export interface INavState {
   isGroupCollapsed: { [key: string]: boolean };
   isLinkExpandStateChanged?: boolean;
-  selectedKey?: string;
+  selectedKey?: string | null;
 }
 
 export class NavBase extends React.Component<INavProps, INavState> implements INav {
@@ -65,8 +65,9 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     );
   }
 
-  public get selectedKey(): string | undefined {
-    return this.state.selectedKey;
+  public get selectedKey(): string | null | undefined {
+    const { selectedKey = this.state.selectedKey } = this.props;
+    return selectedKey;
   }
 
   /**
@@ -308,18 +309,8 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   }
 
   private _isLinkSelected(link: INavLink): boolean {
-    // if caller passes in selectedKey, use it as first choice or
-    // if current state.selectedKey (from addressbar) is match to the link or
-    // check if URL is matching location.href (if link.url exists)
-    if ('selectedKey' in this.props) {
-      if (this.props.selectedKey !== undefined) {
-        return link.key === this.props.selectedKey;
-      } else {
-        // Allow an explicitly specified "undefined" value for selectedKey to mean that nothing is selected
-        return false;
-      }
-    } else if (this.state.selectedKey !== undefined) {
-      return link.key === this.state.selectedKey;
+    if (this.selectedKey !== undefined) {
+      return link.key === this.selectedKey;
     } else if (typeof getWindow() === 'undefined' || !link.url) {
       // resolve is not supported for ssr
       return false;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -311,8 +311,13 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     // if caller passes in selectedKey, use it as first choice or
     // if current state.selectedKey (from addressbar) is match to the link or
     // check if URL is matching location.href (if link.url exists)
-    if (this.props.selectedKey !== undefined) {
-      return link.key === this.props.selectedKey;
+    if ('selectedKey' in this.props) {
+      if (this.props.selectedKey !== undefined) {
+        return link.key === this.props.selectedKey;
+      } else {
+        // Allow an explicitly specified "undefined" value for selectedKey to mean that nothing is selected
+        return false;
+      }
     } else if (this.state.selectedKey !== undefined) {
       return link.key === this.state.selectedKey;
     } else if (typeof getWindow() === 'undefined' || !link.url) {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -14,7 +14,7 @@ export interface INav {
    * that in order for Nav to properly understand which key is selected all NavItems in
    * all groups of the Nav must have populated key properties.
    */
-  selectedKey: string | undefined;
+  selectedKey: string | null | undefined;
   /**
    * Sets focus to the first tabbable item in the zone.
    * @param forceIntoFirstElement - If true, focus will be forced into the first element, even
@@ -96,7 +96,7 @@ export interface INavProps {
   /**
    * (Optional) The key of the nav item selected by caller.
    */
-  selectedKey?: string;
+  selectedKey?: string | null;
 
   /**
    * (Optional) The nav container aria label.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13129
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This checks whether the value of `selectedKey` was explicitly set to `undefined`. If so, nothing will be shown as selected. If `selectedKey` was not set at all, it will still respect the previous functionality.

#### Focus areas to test

--


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13130)