### PR TITLE
Pin TS version used by test:projects:typings

### DIFF
--- a/scripts/gulp/tasks/test-projects.ts
+++ b/scripts/gulp/tasks/test-projects.ts
@@ -265,7 +265,9 @@ task('test:projects:typings', async () => {
 
   logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
 
-  const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', 'typescript'].join(' ');
+  // Install dependencies, ensuring we specify the same TS version as our projects use
+  const tsVersion = fs.readJSONSync(paths.base('scripts', 'package.json')).devDependencies.typescript;
+  const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', `typescript@${tsVersion}`].join(' ');
   await sh(`yarn add ${dependencies}`, tmpDirectory);
   logger(`✔️ Dependencies were installed`);
 


### PR DESCRIPTION
Pin TS version used by test:projects:typings to the same one we use locally. This works around the merge-styles build errors in TS 3.9.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13133)