### PR TITLE
Stacked Bar chart: Fix issuefor Rounded value to 1 if less than 1% to appear in the chart

### DIFF
--- a/change/@uifabric-charting-2020-05-13-17-55-28-user-v-satgar-StackedBarChartBug.json
+++ b/change/@uifabric-charting-2020-05-13-17-55-28-user-v-satgar-StackedBarChartBug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix issue in stacked bar chart for Rounded value to 1 if less than 1% to appear in the chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-satgar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T12:25:28.773Z"
+}

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -243,9 +243,9 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         prevPosition += value;
       }
       value = (pointData / total) * 100;
-      if (value < 1) {
+      if (value < 1 && value !== 0) {
         value = 1;
-      } else if (value > 99) {
+      } else if (value > 99 && value !== 100) {
         value = 99;
       }
       startingPoint.push(prevPosition);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Stacked Bar chart: Fix issuefor Rounded value to 1 if less than 1% to appear in the chart

#### Focus areas to test

Stacked bar chart 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13141)