### PR TITLE
Add utility to apply default props for function components

### DIFF
--- a/change/@uifabric-utilities-2020-05-13-21-59-49-get-props-with-defaults.json
+++ b/change/@uifabric-utilities-2020-05-13-21-59-49-get-props-with-defaults.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add utility to apply default props for function components",
+  "packageName": "@uifabric/utilities",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-13T21:59:49.623Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -346,6 +346,9 @@ export function getParent(child: HTMLElement, allowVirtualParents?: boolean): HT
 export function getPreviousElement(rootElement: HTMLElement, currentElement: HTMLElement | null, checkNode?: boolean, suppressParentTraversal?: boolean, traverseChildren?: boolean, includeElementsInFocusZones?: boolean, allowFocusRoot?: boolean, tabbable?: boolean): HTMLElement | null;
 
 // @public
+export function getPropsWithDefaults<TProps extends {}>(defaultProps: Partial<TProps>, propsWithoutDefaults: TProps): TProps;
+
+// @public
 export function getRect(element: HTMLElement | Window | null): IRectangle | undefined;
 
 // @public

--- a/packages/utilities/src/getPropsWithDefaults.test.ts
+++ b/packages/utilities/src/getPropsWithDefaults.test.ts
@@ -1,0 +1,69 @@
+import { getPropsWithDefaults } from './getPropsWithDefaults';
+
+interface IProps {
+  num?: number;
+  bool?: boolean;
+  str?: string;
+  fn?: () => void;
+  nul?: string | null;
+}
+
+const defaultProps: IProps = {
+  num: 4,
+  bool: true,
+  str: 'default',
+  fn: () => {
+    console.log('default');
+  },
+  nul: 'not null',
+};
+
+describe('getPropsWithDefaults', () => {
+  it("doesn't override non-undefined specified values", () => {
+    const propsWithoutDefaults: IProps = {
+      num: 0,
+      bool: false,
+      str: '',
+      fn: jasmine.createSpy('fn'),
+      nul: null,
+    };
+
+    const props = getPropsWithDefaults(defaultProps, propsWithoutDefaults);
+
+    expect(props.num).toEqual(propsWithoutDefaults.num);
+    expect(props.bool).toEqual(propsWithoutDefaults.bool);
+    expect(props.str).toEqual(propsWithoutDefaults.str);
+    expect(props.fn).toEqual(propsWithoutDefaults.fn);
+    expect(props.nul).toEqual(propsWithoutDefaults.nul);
+  });
+
+  it('overrides specified undefined values', () => {
+    const propsWithoutDefaults: IProps = {
+      num: undefined,
+      bool: undefined,
+      str: undefined,
+      fn: undefined,
+      nul: undefined,
+    };
+
+    const props = getPropsWithDefaults(defaultProps, propsWithoutDefaults);
+
+    expect(props.num).toEqual(defaultProps.num);
+    expect(props.bool).toEqual(defaultProps.bool);
+    expect(props.str).toEqual(defaultProps.str);
+    expect(props.fn).toEqual(defaultProps.fn);
+    expect(props.nul).toEqual(defaultProps.nul);
+  });
+
+  it('overrides unspecified values', () => {
+    const propsWithoutDefaults: IProps = {};
+
+    const props = getPropsWithDefaults(defaultProps, propsWithoutDefaults);
+
+    expect(props.num).toEqual(defaultProps.num);
+    expect(props.bool).toEqual(defaultProps.bool);
+    expect(props.str).toEqual(defaultProps.str);
+    expect(props.fn).toEqual(defaultProps.fn);
+    expect(props.nul).toEqual(defaultProps.nul);
+  });
+});

--- a/packages/utilities/src/getPropsWithDefaults.ts
+++ b/packages/utilities/src/getPropsWithDefaults.ts
@@ -1,7 +1,7 @@
 /**
  * Function to apply default values to a component props object. This function is intended for function components,
  * to maintain parity with the `defaultProps` feature of class components. It accounts for properties that are
- * specified, but undefined
+ * specified, but undefined.
  * @param defaultProps- An object with default values for various properties
  * @param propsWithoutDefaults- The props object passed into the component
  */

--- a/packages/utilities/src/getPropsWithDefaults.ts
+++ b/packages/utilities/src/getPropsWithDefaults.ts
@@ -1,0 +1,20 @@
+/**
+ * Function to apply default values to a component props object. This function is intended for function components,
+ * to maintain parity with the `defaultProps` feature of class components. It accounts for properties that are
+ * specified, but undefined
+ * @param defaultProps- An object with default values for various properties
+ * @param propsWithoutDefaults- The props object passed into the component
+ */
+export function getPropsWithDefaults<TProps extends {}>(
+  defaultProps: Partial<TProps>,
+  propsWithoutDefaults: TProps,
+): TProps {
+  const props = { ...propsWithoutDefaults };
+  for (const key of Object.keys(defaultProps) as (keyof TProps)[]) {
+    if (props[key] === undefined) {
+      props[key] = defaultProps[key]!;
+    }
+  }
+
+  return props;
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -65,6 +65,7 @@ export * from './string';
 export * from './styled';
 export * from './warn';
 export * from './ie11Detector';
+export * from './getPropsWithDefaults';
 export { IStyleFunctionOrObject, Omit } from '@uifabric/merge-styles';
 export { setFocusVisibility, IsFocusVisibleClassName } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is split off from #12928. It adds a utility to provide the same sort of functionality for function components as `defaultProps` does for class components. Suggested usage pattern is:
```ts
(propsWithoutDefaults: IFooProps) => {
    const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
}
```

Alternative patterns considered and rejected:
- Parameter destructuring (`({foo, bar = ''}: IFooProps) => {}`): This prevents the ability to pass the entire props object around to hooks and the like
- In-function destructuring (`const {foo, bar = ''} = props`): This makes it easy to inadvertently dereference a non-defaulted value off of `props`, particularly if passing `props` to a hook
- Object structuring (`const props = {bar: '', ...propsWithoutDefaults}`) - This causes any property that is *specified* with an `undefined` value to remain `undefined`. This is a behavioral difference from `defaultProps` that necessitated this utility.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13152)