### PR TITLE
feat(schema): add tree item to the schema validator

### DIFF
--- a/packages/fluentui/ability-attributes/schema.json
+++ b/packages/fluentui/ability-attributes/schema.json
@@ -64,6 +64,48 @@
         }
       ]
     },
+    "$setsize": {
+      "name": "setsize",
+      "attributes": [
+        {
+          "name": "aria-setsize",
+          "constraints": [
+            {
+              "xpath": "number(@aria-setsize) = @aria-setsize",
+              "description": "aria-setsize attribute value cannot be empty"
+            }
+          ]
+        }
+      ]
+    },
+    "$posinset": {
+      "name": "posinset",
+      "attributes": [
+        {
+          "name": "aria-posinset",
+          "constraints": [
+            {
+              "xpath": "number(@aria-posinset) = @aria-posinset",
+              "description": "aria-posinset attribute value cannot be empty"
+            }
+          ]
+        }
+      ]
+    },
+    "$level": {
+      "name": "level",
+      "attributes": [
+        {
+          "name": "aria-level",
+          "constraints": [
+            {
+              "xpath": "number(@aria-level) = @aria-level",
+              "description": "aria-level attribute value cannot be empty"
+            }
+          ]
+        }
+      ]
+    },
     "$describedBy": {
       "name": "describedBy",
       "attributes": [
@@ -190,6 +232,24 @@
             {
               "parameter": false,
               "attribute": [false, "false"]
+            }
+          ]
+        }
+      ]
+    },
+    "$isSelected": {
+      "name": "isSelected",
+      "attributes": [
+        {
+          "name": "aria-selected",
+          "value": [
+            {
+              "parameter": true,
+              "attribute": "true"
+            },
+            {
+              "parameter": true,
+              "attribute": "false"
             }
           ]
         }
@@ -333,6 +393,107 @@
             {
               "name": "aria-level",
               "value": "1"
+            }
+          ]
+        }
+      }
+    },
+    "TreeItem": {
+      "constraints": [
+        {
+          "ref": "$atomic"
+        }
+      ],
+      "parameters": [
+        {
+          "ref": "$title",
+          "optional": true
+        },
+        {
+          "rel": "@tabbable"
+        },
+        {
+          "ref": "$isExpanded"
+        },
+        {
+          "ref": "$isSelected",
+          "optional": true
+        },
+        {
+          "ref": "$setsize"
+        },
+        {
+          "ref": "$posinset"
+        },
+        {
+          "ref": "$level"
+        }
+      ],
+      "tags": {
+        "<div>, <span>, <a>": {
+          "parameters": {
+            "@tabbable": {
+              "ref": "$tabbable",
+              "optional": true
+            }
+          },
+          "attributes": [
+            {
+              "name": "role",
+              "value": "treeitem",
+              "overridable": "role"
+            },
+            {
+              "ref": "$tabindex"
+            }
+          ]
+        }
+      }
+    },
+    "TreeTitle": {
+      "constraints": [
+        {
+          "ref": "$atomic"
+        }
+      ],
+      "parameters": [
+        {
+          "ref": "$title",
+          "optional": true
+        },
+        {
+          "rel": "@tabbable"
+        },
+        {
+          "ref": "$isSelected",
+          "optional": true
+        },
+        {
+          "ref": "$setsize"
+        },
+        {
+          "ref": "$posinset"
+        },
+        {
+          "ref": "$level"
+        }
+      ],
+      "tags": {
+        "<div>, <span>, <a>": {
+          "parameters": {
+            "@tabbable": {
+              "ref": "$tabbable",
+              "optional": true
+            }
+          },
+          "attributes": [
+            {
+              "name": "role",
+              "value": "treeitem",
+              "overridable": "role"
+            },
+            {
+              "ref": "$tabindex"
             }
           ]
         }

--- a/packages/fluentui/ability-attributes/schema.json
+++ b/packages/fluentui/ability-attributes/schema.json
@@ -72,7 +72,7 @@
           "constraints": [
             {
               "xpath": "number(@aria-setsize) = @aria-setsize",
-              "description": "aria-setsize attribute value cannot be empty"
+              "description": "aria-setsize attribute value should be a number"
             }
           ]
         }
@@ -86,7 +86,7 @@
           "constraints": [
             {
               "xpath": "number(@aria-posinset) = @aria-posinset",
-              "description": "aria-posinset attribute value cannot be empty"
+              "description": "aria-posinset attribute value should be a number"
             }
           ]
         }
@@ -100,7 +100,7 @@
           "constraints": [
             {
               "xpath": "number(@aria-level) = @aria-level",
-              "description": "aria-level attribute value cannot be empty"
+              "description": "aria-level attribute value should be a number"
             }
           ]
         }

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeItemAsListItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeItemAsListItemBehavior.ts
@@ -9,7 +9,8 @@ import treeTitleAsListItemTitleBehavior from './treeTitleAsListItemTitleBehavior
  */
 const treeItemAsListItemBehavior: Accessibility<TreeItemBehaviorProps> = props => {
   const behavior = treeItemBehavior(props);
-  return _.merge(behavior, {
+
+  const definition = _.merge(behavior, {
     attributes: {
       root: {
         ...(props.hasSubtree && {
@@ -21,6 +22,13 @@ const treeItemAsListItemBehavior: Accessibility<TreeItemBehaviorProps> = props =
       title: treeTitleAsListItemTitleBehavior,
     },
   });
+
+  if (process.env.NODE_ENV !== 'production' && props.hasSubtree) {
+    // Override the default trigger's accessibility schema class.
+    definition.attributes.root['data-aa-class'] = 'TreeItemList';
+  }
+
+  return definition;
 };
 
 export type TreeItemBehaviorProps = {

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
@@ -1,5 +1,5 @@
 import * as keyboardKey from 'keyboard-key';
-import { Accessibility } from '../../types';
+import { Accessibility, AriaRole } from '../../types';
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import treeTitleBehavior from './treeTitleBehavior';
@@ -22,64 +22,73 @@ import treeTitleBehavior from './treeTitleBehavior';
  * Triggers 'expand' action with 'ArrowRight' on 'root', when has a closed subtree.
  * Triggers 'focusFirstChild' action with 'ArrowRight' on 'root', when has an opened subtree.
  */
-const treeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => ({
-  attributes: {
-    root: {
-      role: 'none',
-      ...(props.hasSubtree && {
-        'aria-expanded': props.expanded,
-        'aria-selected': props.selectable ? props.selected || false : undefined,
-        tabIndex: -1,
-        [IS_FOCUSABLE_ATTRIBUTE]: true,
-        role: 'treeitem',
-        'aria-setsize': props.treeSize,
-        'aria-posinset': props.index,
-        'aria-level': props.level,
-      }),
-    },
-  },
-  keyActions: {
-    root: {
-      performClick: {
-        keyCombinations: [{ keyCode: keyboardKey.Enter }, { keyCode: keyboardKey.Spacebar }],
+const treeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => {
+  const definition = {
+    attributes: {
+      root: {
+        role: 'none',
+        ...(props.hasSubtree && {
+          'aria-expanded': props.expanded,
+          'aria-selected': props.selectable ? props.selected || false : undefined,
+          tabIndex: -1,
+          [IS_FOCUSABLE_ATTRIBUTE]: true,
+          role: 'treeitem' as AriaRole,
+          'aria-setsize': props.treeSize,
+          'aria-posinset': props.index,
+          'aria-level': props.level,
+        }),
       },
-      ...(isSubtreeExpanded(props) && {
-        collapse: {
-          keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+    },
+    keyActions: {
+      root: {
+        performClick: {
+          keyCombinations: [{ keyCode: keyboardKey.Enter }, { keyCode: keyboardKey.Spacebar }],
         },
-        focusFirstChild: {
-          keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
-        },
-        focusParent: {
-          keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
-        },
-      }),
-      ...(!isSubtreeExpanded(props) &&
-        props.hasSubtree && {
-          expand: {
+        ...(isSubtreeExpanded(props) && {
+          collapse: {
+            keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+          },
+          focusFirstChild: {
             keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
           },
           focusParent: {
             keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
           },
         }),
-      expandSiblings: {
-        keyCombinations: [{ keyCode: keyboardKey['*'] }],
+        ...(!isSubtreeExpanded(props) &&
+          props.hasSubtree && {
+            expand: {
+              keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+            },
+            focusParent: {
+              keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+            },
+          }),
+        expandSiblings: {
+          keyCombinations: [{ keyCode: keyboardKey['*'] }],
+        },
+        ...(props.selectable && {
+          performClick: {
+            keyCombinations: props.hasSubtree ? [{ keyCode: keyboardKey.Enter }] : [{ keyCode: keyboardKey.Spacebar }],
+          },
+          performSelection: {
+            keyCombinations: [{ keyCode: keyboardKey.Spacebar }],
+          },
+        }),
       },
-      ...(props.selectable && {
-        performClick: {
-          keyCombinations: props.hasSubtree ? [{ keyCode: keyboardKey.Enter }] : [{ keyCode: keyboardKey.Spacebar }],
-        },
-        performSelection: {
-          keyCombinations: [{ keyCode: keyboardKey.Spacebar }],
-        },
-      }),
     },
-  },
-  childBehaviors: {
-    title: treeTitleBehavior,
-  },
-});
+    childBehaviors: {
+      title: treeTitleBehavior,
+    },
+  };
+
+  if (process.env.NODE_ENV !== 'production' && !props.hasSubtree) {
+    // Override the default trigger's accessibility schema class.
+    definition.attributes.root['data-aa-class'] = 'SingleTreeItem';
+  }
+
+  return definition;
+};
 
 export type TreeItemBehaviorProps = {
   /** If item is a subtree, it indicates if it's expanded. */

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleAsListItemTitleBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleAsListItemTitleBehavior.ts
@@ -9,7 +9,8 @@ import treeTitleBehavior from './treeTitleBehavior';
  */
 const treeTitleAsListItemTitleBehavior: Accessibility<TreeTitleBehavior> = props => {
   const behavior = treeTitleBehavior(props);
-  return _.merge(behavior, {
+
+  const definition = _.merge(behavior, {
     attributes: {
       root: {
         ...(!props.hasSubtree && {
@@ -18,6 +19,13 @@ const treeTitleAsListItemTitleBehavior: Accessibility<TreeTitleBehavior> = props
       },
     },
   });
+
+  if (process.env.NODE_ENV !== 'production' && props.hasSubtree) {
+    // Override the default trigger's accessibility schema class.
+    definition.attributes.root['data-aa-class'] = 'TreeTitleList';
+  }
+
+  return definition;
 };
 
 export default treeTitleAsListItemTitleBehavior;

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleBehavior.ts
@@ -1,7 +1,7 @@
 import * as keyboardKey from 'keyboard-key';
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
-import { Accessibility } from '../../types';
+import { Accessibility, AriaRole } from '../../types';
 
 /**
  * @description
@@ -15,28 +15,37 @@ import { Accessibility } from '../../types';
  * Adds attribute 'aria-level=1' based on the property 'level' if the component has 'hasSubtree' property false or undefined. Does not set anything if true..
  * Triggers 'performClick' action with 'Spacebar' on 'root'.
  */
-const treeTitleBehavior: Accessibility<TreeTitleBehaviorProps> = props => ({
-  attributes: {
-    root: {
-      ...(!props.hasSubtree && {
-        tabIndex: -1,
-        [IS_FOCUSABLE_ATTRIBUTE]: true,
-        role: 'treeitem',
-        'aria-setsize': props.treeSize,
-        'aria-posinset': props.index,
-        'aria-level': props.level,
-        'aria-selected': props.selectable ? props.selected || false : undefined,
-      }),
-    },
-  },
-  keyActions: {
-    root: {
-      performClick: {
-        keyCombinations: [{ keyCode: keyboardKey.Spacebar }],
+const treeTitleBehavior: Accessibility<TreeTitleBehaviorProps> = props => {
+  const definition = {
+    attributes: {
+      root: {
+        ...(!props.hasSubtree && {
+          tabIndex: -1,
+          [IS_FOCUSABLE_ATTRIBUTE]: true,
+          role: 'treeitem' as AriaRole,
+          'aria-setsize': props.treeSize,
+          'aria-posinset': props.index,
+          'aria-level': props.level,
+          'aria-selected': props.selectable ? props.selected || false : undefined,
+        }),
       },
     },
-  },
-});
+    keyActions: {
+      root: {
+        performClick: {
+          keyCombinations: [{ keyCode: keyboardKey.Spacebar }],
+        },
+      },
+    },
+  };
+
+  if (process.env.NODE_ENV !== 'production' && props.hasSubtree) {
+    // Override the default trigger's accessibility schema class.
+    definition.attributes.root['data-aa-class'] = 'ExpandableTreeTitle';
+  }
+
+  return definition;
+};
 
 export default treeTitleBehavior;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `TreeItem` to the schema validation adding on it atomic attributes to throw errors in some cases as for example if it has other focusable element inside:

<img width="1765" alt="Screenshot 2020-05-14 at 13 21 19" src="https://user-images.githubusercontent.com/8545105/81928946-6358c480-95e6-11ea-8e2c-04920e5b9436.png">


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13159)