### PR TITLE
SpinButton: allow empty string as value, clean up docs and tests

### DIFF
--- a/change/@fluentui-react-next-2020-05-14-14-06-04-spinbutton-emptyvalue.json
+++ b/change/@fluentui-react-next-2020-05-14-14-06-04-spinbutton-emptyvalue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Copy OUFR SpinButton changes",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-14T21:06:04.361Z"
+}

--- a/change/@fluentui-react-next-2020-05-14-14-06-04-spinbutton-emptyvalue.json
+++ b/change/@fluentui-react-next-2020-05-14-14-06-04-spinbutton-emptyvalue.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Copy OUFR SpinButton changes",
+  "comment": "SpinButton: allow empty string as value, clean up docs and tests",
   "packageName": "@fluentui/react-next",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-05-14-14-06-04-spinbutton-emptyvalue.json
+++ b/change/office-ui-fabric-react-2020-05-14-14-06-04-spinbutton-emptyvalue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: allow empty string as value, clean up docs and tests",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-14T21:05:46.623Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7124,8 +7124,6 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     labelPosition?: Position;
     max?: number;
     min?: number;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -1,628 +1,416 @@
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { SpinButton } from './SpinButton';
-import { ISpinButton } from './SpinButton.types';
+import { ReactWrapper, mount } from 'enzyme';
+import { SpinButton, ISpinButtonState } from './SpinButton';
+import { ISpinButton, ISpinButtonProps } from './SpinButton.types';
 import { KeyCodes, resetIds } from '../../Utilities';
-import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
+import { mockEvent } from '../../common/testUtilities';
 
 describe('SpinButton', () => {
+  let ref: React.RefObject<ISpinButton>;
+  let wrapper: ReactWrapper<ISpinButtonProps, ISpinButtonState, SpinButton> | undefined;
+
   beforeEach(() => {
+    ref = React.createRef<ISpinButton>();
     resetIds();
   });
 
   afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
     if ((setTimeout as any).mock) {
       jest.useRealTimers();
     }
   });
 
-  it('renders SpinButton correctly', () => {
+  it('renders correctly', () => {
     const component = renderer.create(<SpinButton label="label" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('SpinButton allows value updates when no props are defined', () => {
-    const ref = React.createRef<ISpinButton>();
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" componentRef={ref} />);
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-    expect(inputDOM.value).toEqual('1');
-    expect(ref.current!.value).toEqual('1');
-  });
-
-  it('renders SpinButton correctly with values that the user passes in', () => {
+  it('renders correctly with user-provided values', () => {
     const component = renderer.create(
-      <SpinButton label="label" value={'0'} ariaValueNow={0} ariaValueText={'0 pt'} data-test="test" />,
+      <SpinButton label="label" value="0" ariaValueNow={0} ariaValueText="0 pt" data-test="test" />,
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render a spinner with the default value on the input element', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects label', () => {
+    wrapper = mount(<SpinButton label="my label" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const labelDOM = wrapper.getDOMNode().querySelector('label')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const labelDOM: HTMLLabelElement = renderedDOM.getElementsByTagName('label')[0];
-
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
-    expect(inputDOM.getAttribute('aria-labelledby')).toEqual(labelDOM.id);
-
-    // Assert on the label element.
-    expect(labelDOM.textContent).toEqual(exampleLabelValue);
-    expect(labelDOM.htmlFor).toEqual(inputDOM.id);
+    expect(labelDOM.textContent).toBe('my label');
+    expect(labelDOM.htmlFor).toBe(inputDOM.id);
+    expect(inputDOM.getAttribute('aria-labelledby')).toBe(labelDOM.id);
   });
 
-  it('should increment the value in the spin button via the up button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('uses default min and max', () => {
+    wrapper = mount(<SpinButton />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
-
-    expect(buttonDOM.tagName).toEqual('BUTTON');
-
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    ReactTestUtils.Simulate.mouseUp(buttonDOM, {
-      type: 'mouseup',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    expect(inputDOM.value).toEqual('13');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('13');
+    expect(inputDOM.getAttribute('aria-valuemin')).toBe(String(SpinButton.defaultProps.min));
+    expect(inputDOM.getAttribute('aria-valuemax')).toBe(String(SpinButton.defaultProps.max));
   });
 
-  it('should decrement the value in the spin button by the down button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects min and max in DOM', () => {
+    wrapper = mount(<SpinButton min={2} max={22} />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-DownButton')[0];
-
-    expect(buttonDOM.tagName).toEqual('BUTTON');
-
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    ReactTestUtils.Simulate.mouseUp(buttonDOM, {
-      type: 'mouseup',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    expect(inputDOM.value).toEqual('11');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('11');
+    expect(inputDOM.getAttribute('aria-valuemin')).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuemax')).toBe('22');
   });
 
-  it('should increment the value in the spin button by the up arrow', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('12');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    expect(inputDOM.value).toEqual('13');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('13');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
   });
 
-  it('should decrement the value in the spin button by the down arrow', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects empty defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    expect(inputDOM.value).toEqual('11');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('11');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('');
   });
 
-  it('should increment the value in the spin button by a step value of 2', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  // This is probably a behavior we should get rid of in the future (replace with custom rendering
+  // or something), but documenting it for now...
+  it('respects non-numeric defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12 pt" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={2}
-      />,
-    );
+    expect(ref.current!.value).toBe('12 pt');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    expect(inputDOM.value).toEqual('14');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('14');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12 pt');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('12 pt');
   });
 
-  it('should decrement the value in the spin button by a step value of 2', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('ignores updates to defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="3" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={2}
-      />,
-    );
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    wrapper.setProps({ defaultValue: '4' });
+    wrapper.update();
 
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    expect(inputDOM.value).toEqual('10');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('10');
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
   });
 
-  it('should set the value of the spin button by manual entry', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '21';
+  it('respects value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="3" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('3');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('3');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('3');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('respects updates to value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="3" />);
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
+
+    wrapper.setProps({ value: '4' });
+    wrapper.update();
+
+    expect(ref.current!.value).toBe('4');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('4');
+  });
+
+  // This is probably a behavior we should get rid of in the future (replace with custom rendering
+  // or something), but documenting it for now...
+  it('respects non-numeric value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="12 pt" />);
+
+    expect(ref.current!.value).toBe('12 pt');
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12 pt');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('12 pt');
+  });
+
+  it('respects empty value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="" />);
+
+    expect(ref.current!.value).toBe('');
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('');
+  });
+
+  it('uses min as default if neither value nor defaultValue is provided', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    expect(ref.current!.value).toBe('2');
+    expect(inputDOM.value).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('uses 0 as default if neither value, defaultValue nor min is provided', () => {
+    wrapper = mount(<SpinButton componentRef={ref} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    expect(ref.current!.value).toBe('0');
+    expect(inputDOM.value).toBe('0');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('0');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('increments value when up button is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
+
+    expect(buttonDOM.tagName).toBe('BUTTON');
+
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
+    ReactTestUtils.Simulate.mouseUp(buttonDOM, { type: 'mouseup', clientX: 0, clientY: 0 });
+
+    expect(ref.current!.value).toBe('13');
+    expect(inputDOM.value).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('decrements value when down button is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-DownButton')[0];
+
+    expect(buttonDOM.tagName).toBe('BUTTON');
+
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
+    ReactTestUtils.Simulate.mouseUp(buttonDOM, { type: 'mouseup', clientX: 0, clientY: 0 });
+
+    expect(ref.current!.value).toBe('11');
+    expect(inputDOM.value).toBe('11');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('11');
+  });
+
+  it('increments value when up arrow key is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.up });
+
+    expect(ref.current!.value).toBe('13');
+    expect(inputDOM.value).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('13');
+  });
+
+  it('decrements value when down arrow key is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.down });
+
+    expect(ref.current!.value).toBe('11');
+    expect(inputDOM.value).toBe('11');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('11');
+  });
+
+  it('respects step when incrementing value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" step={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.up });
+
+    expect(ref.current!.value).toBe('14');
+    expect(inputDOM.value).toBe('14');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('14');
+  });
+
+  it('respects step when decrementing value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" step={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.down });
+
+    expect(ref.current!.value).toBe('10');
+    expect(inputDOM.value).toBe('10');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('10');
+  });
+
+  it('allows value updates when no props are defined', () => {
+    wrapper = mount(<SpinButton componentRef={ref} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    expect(inputDOM.value).toBe('1');
+    expect(ref.current!.value).toBe('1');
+  });
+
+  it('accepts user-entered values', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleNewValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
   });
 
-  it('should reset the value of the spin button with invalid manual entry', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = 'garbage';
+  it('resets value when user entry is invalid', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('garbage'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should reset the value of the spin button when input value is cleared (empty)', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('resets value when input is cleared (empty)', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
     ReactTestUtils.Simulate.input(inputDOM, mockEvent());
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should revert to max value when input value is higher than the max of the spin button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '23';
+  it('resets to max when user-entered value is too high', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} max={22} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('23'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMaxValue));
+    expect(ref.current!.value).toBe('22');
+    expect(inputDOM.value).toBe('22');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('22');
   });
 
-  it('should revert existing value when input value is lower than the min of the spin button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '0';
+  it('resets to min when user-entered value is too low', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} max={22} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('0'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMinValue));
+    expect(ref.current!.value).toBe('2');
+    expect(inputDOM.value).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('2');
   });
 
-  it('should use validator passed to the spin button (with valid input)', () => {
-    const errorMessage = 'The value is invalid';
-    const exampleLabelValue = 'SpinButton';
+  it('uses onValidate prop (with valid input)', () => {
     const exampleMinValue = 2;
     const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '21';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
+    wrapper = mount(
       <SpinButton
-        label={exampleLabelValue}
+        componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
+        defaultValue="12"
         // tslint:disable-next-line:jsx-no-lambda
-        onValidate={(newValue: string): string => {
+        onValidate={(newValue: string): string | void => {
           const numberValue: number = +newValue;
-          return !isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue
-            ? newValue
-            : errorMessage;
+          if (!isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue) {
+            return newValue;
+          }
         }}
       />,
     );
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
   });
 
-  it('should use validator passed to the spin button', () => {
-    const errorMessage = 'The value is invalid';
-    const exampleLabelValue = 'SpinButton';
+  it('uses onValidate prop', () => {
     const exampleMinValue = 2;
     const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '100';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
+    wrapper = mount(
       <SpinButton
-        label={exampleLabelValue}
+        componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        value={exampleDefaultValue}
+        value="12"
         // tslint:disable-next-line:jsx-no-lambda
-        onValidate={(newValue: string): string => {
+        onValidate={(newValue: string): string | void => {
           const numberValue: number = Number(newValue);
-          return !isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue
-            ? newValue
-            : errorMessage;
+          if (!isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue) {
+            return newValue;
+          }
         }}
       />,
     );
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('100'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(errorMessage));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toBeFalsy();
-    expect(inputDOM.getAttribute('aria-valuetext')).toEqual(errorMessage);
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should have correct value after increment and using defaultValue', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleStepValue = 2;
-    const exampleNewValue: string = String(Number(exampleDefaultValue) + exampleStepValue);
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={exampleStepValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const upButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-UpButton')[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(upButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(upButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
-  });
-
-  it('should have correct value after decrement and using defaultValue', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleStepValue = 2;
-    const exampleNewValue: string = String(Number(exampleDefaultValue) - exampleStepValue);
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={exampleStepValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const downButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName(
-      'ms-DownButton',
-    )[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(downButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(downButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
-  });
-
-  it('should use min as defaultvalue if neither value nor defaultValue are passed', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleStepValue = 2;
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton label={exampleLabelValue} min={exampleMinValue} max={exampleMaxValue} step={exampleStepValue} />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    expect(inputDOM.value).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMinValue));
-  });
-
-  it('should use 0 as defaultvalue if neither value, defaultValue nor min are passed', () => {
-    const exampleLabelValue = 'SpinButton';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label={exampleLabelValue} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    expect(inputDOM.value).toEqual(String(0));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(0));
-  });
-
-  it('uses the default onIncrement function when no value, defaultValue nor onIncrement function is passed', () => {
-    const exampleLabelValue = 'SpinButton';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label={exampleLabelValue} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const upButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-UpButton')[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(upButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(upButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(1));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(1));
-  });
-
-  it('should stop spinning if text field is focused while actively spinning', () => {
+  it('stops spinning if text field is focused while actively spinning', () => {
     jest.useFakeTimers();
 
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+    wrapper = mount(<SpinButton defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
 
     expect(buttonDOM).toBeTruthy();
 
     // start spinning
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
     // spin again
     jest.runOnlyPendingTimers();
     // spin again
@@ -632,108 +420,78 @@ describe('SpinButton', () => {
     jest.runAllTimers();
 
     const currentValue = inputDOM.value;
-    expect(currentValue).not.toEqual('2');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(currentValue);
-
-    const newCurrentValue = inputDOM.value;
-    expect(currentValue).toEqual(newCurrentValue);
+    expect(currentValue).not.toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(currentValue);
   });
 
-  it('should fire custom onIncrement handler (with minimal properties)', () => {
+  it('uses custom onIncrement handler', () => {
     const onIncrement: jest.Mock = jest.fn();
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onIncrement={onIncrement} />);
+    wrapper = mount(<SpinButton onIncrement={onIncrement} />);
 
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
 
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
 
     expect(onIncrement).toBeCalled();
   });
 
-  it('should fire custom onDecrement handler (with minimal properties)', () => {
+  it('uses custom onDecrement handler', () => {
     const onDecrement: jest.Mock = jest.fn();
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onDecrement={onDecrement} />);
+    wrapper = mount(<SpinButton onDecrement={onDecrement} />);
 
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-DownButton')[0];
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-DownButton')[0];
 
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
 
     expect(onDecrement).toBeCalled();
   });
 
-  it('should fire custom onValidate handler (with minimal properties)', () => {
-    const onValidate: jest.Mock = jest.fn();
-    const exampleNewValue = '99';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
-    ReactTestUtils.Simulate.blur(inputDOM);
-
-    expect(onValidate).toBeCalled();
-  });
-
-  it(`should pass KeyCode ${KeyCodes.enter} to onValidate handler`, () => {
-    let keyCode;
-    const onValidate: jest.Mock = jest.fn((value, event) => {
-      keyCode = event.which;
+  it(`passes KeyCode ${KeyCodes.enter} to onValidate handler`, () => {
+    let keyCode: number | undefined;
+    const onValidate: jest.Mock = jest.fn((value: string, event?: React.SyntheticEvent) => {
+      keyCode = (event as React.KeyboardEvent).which;
       return value;
     });
-    const exampleNewValue = '99';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+    wrapper = mount(<SpinButton onValidate={onValidate} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
     ReactTestUtils.Simulate.focus(inputDOM);
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('99'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
-    expect(keyCode).toEqual(KeyCodes.enter);
+    expect(keyCode).toBe(KeyCodes.enter);
     expect(onValidate).toBeCalled();
     ReactTestUtils.Simulate.blur(inputDOM);
     expect(onValidate).toHaveBeenCalledTimes(1);
   });
 
-  it('onValidate is not called again on enter key press until the input changes', () => {
-    const onValidate: jest.Mock = jest.fn((value, event) => {
-      return value;
-    });
-    const exampleNewValue = '99';
-    const exampleChangedValue = '10';
+  it('does not call onValidate again on enter key press until the input changes', () => {
+    const onValidate = jest.fn((value: string) => value);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+    wrapper = mount(<SpinButton onValidate={onValidate} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('99'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(1);
+
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(1);
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleChangedValue)));
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('10'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(2);
   });
 
-  it('allows adding a custom aria-describedby id to the input', () => {
+  it('respects custom ariaDescribedBby id to the input', () => {
     const customId = 'customAriaDescriptionId';
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" ariaDescribedBy={customId} />);
+    wrapper = mount(<SpinButton label="label" ariaDescribedBy={customId} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
     const ariaDescribedByAttribute = inputDOM.getAttribute('aria-describedby');
-    expect(ariaDescribedByAttribute).toMatch(new RegExp('\\b' + customId + '\\b'));
+    expect(ariaDescribedByAttribute).toBe(customId);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -219,7 +219,13 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
                     ? Number(value)
                     : undefined
                 }
-                aria-valuetext={ariaValueText || (!value || isNaN(Number(value)) ? value : undefined)}
+                aria-valuetext={
+                  typeof ariaValueText === 'string'
+                    ? ariaValueText
+                    : !value || isNaN(Number(value)) // Number('') is 0 which may not be desirable
+                    ? value
+                    : undefined
+                }
                 aria-valuemin={min}
                 aria-valuemax={max}
                 aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -14,13 +14,12 @@ import { IButtonProps } from '../Button/Button.types';
  */
 export interface ISpinButton {
   /**
-   * The value of the SpinButton. Use this if you intend to pass in a new value as a result of onChange events.
-   * This value is mutually exclusive to defaultValue. Use one or the other.
+   * Current value of the control.
    */
   value?: string;
 
   /**
-   * Sets focus to the spin button.
+   * Sets focus to the control.
    */
   focus: () => void;
 }
@@ -35,128 +34,130 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   componentRef?: IRefObject<ISpinButton>;
 
   /**
-   * The initial value of the SpinButton. Use this if you intend for the SpinButton to be an uncontrolled component.
-   * This value is mutually exclusive to value. Use one or the other.
+   * Initial value of the control. Updates to this prop will not be respected.
+   *
+   * Use this if you intend for the SpinButton to be an uncontrolled component.
+   * Mutually exclusive with `value`.
    * @defaultvalue 0
    */
   defaultValue?: string;
 
   /**
-   * The value of the SpinButton. Use this if you intend to pass in a new value as a result of onChange events.
-   * This value is mutually exclusive to defaultValue. Use one or the other.
+   * Current value of the control.
+   *
+   * Use this if you intend to pass in a new value as a result of change events.
+   * Mutually exclusive with `defaultValue`.
    */
   value?: string;
 
   /**
-   * The min value of the SpinButton.
+   * Min value of the control.
    * @defaultvalue 0
    */
   min?: number;
 
   /**
-   * The max value of the SpinButton.
+   * Max value of the control.
    * @defaultvalue 100
    */
   max?: number;
 
   /**
-   * The difference between the two adjacent values of the SpinButton.
-   * This value is sued to calculate the precision of the input if no
-   * precision is given. The precision calculated this way will always
-   * be \>= 0.
+   * Difference between two adjacent values of the control.
+   * This value is used to calculate the precision of the input if no `precision` is given.
+   * The precision calculated this way will always be \>= 0.
    * @defaultvalue 1
    */
   step?: number;
 
   /**
-   * A description of the SpinButton for the benefit of screen readers.
+   * A description of the control for the benefit of screen reader users.
    */
   ariaLabel?: string;
 
   /**
-   * Optional prop to add a string id that can be referenced inside the aria-describedby attribute
+   * ID of a label which describes the control, if not using the default label.
    */
   ariaDescribedBy?: string;
 
   /**
-   * A title for the SpinButton used for a more descriptive name that's also visible on its tooltip.
+   * A more descriptive title for the control, visible on its tooltip.
    */
   title?: string;
 
   /**
-   * Whether or not the SpinButton is disabled.
+   * Whether or not the control is disabled.
    */
   disabled?: boolean;
 
   /**
-   * Optional className for SpinButton.
+   * Custom className for the control.
    */
   className?: string;
 
   /**
-   * Descriptive label for the SpinButton.
+   * Descriptive label for the control.
    */
   label?: string;
 
   /**
+   * Where to position the control's label.
    * @defaultvalue Left
    */
   labelPosition?: Position;
 
   /**
-   * Icon that goes along with the label for the whole SpinButton
+   * Props for an icon to display alongside the control's label.
    */
   iconProps?: IIconProps;
 
   /**
-   * This callback is triggered when the value inside the SpinButton should be validated.
-   * @param value - The value entered in the SpinButton to validate
-   * @param event - The event that triggered this validate, if any. (For accessibility)
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the entered value should be validated.
+   * @param value - The entered value to validate
+   * @param event - The event that triggered this validate, if any (for accessibility)
+   * @returns If a string is returned, it will be used as the new value
    */
   onValidate?: (value: string, event?: React.SyntheticEvent<HTMLElement>) => string | void;
 
   /**
-   * This callback is triggered when the increment button is pressed or if the user presses up arrow
-   * with focus on the input of the spinButton
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the increment button or up arrow key is pressed.
+   * @returns If a string is returned, it will be used as the new value
    */
   onIncrement?: (value: string) => string | void;
 
   /**
-   * This callback is triggered when the decrement button is pressed or if the user presses down arrow
-   * with focus on the input of the spinButton
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the decrement button or down arrow key is pressed.
+   * @returns If a string is returned, it will be used as the new value
    */
   onDecrement?: (value: string) => string | void;
 
   /**
-   * A callback for when the user put focus on the picker
+   * Callback for when the user focuses the control.
    */
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
 
   /**
-   * A callback for when the user moves the focus away from the picker
+   * Callback for when the control loses focus.
    */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
 
   /**
-   * Icon for the increment button of the spinButton
+   * Custom props for the increment button.
    */
   incrementButtonIcon?: IIconProps;
 
   /**
-   * Icon for the decrement button of the spinButton
+   * Custom props for the decrement button.
    */
   decrementButtonIcon?: IIconProps;
 
   /**
-   * Custom styling for individual elements within the button DOM.
+   * Custom styling for individual elements within the control.
    */
   styles?: Partial<ISpinButtonStyles>;
 
   /**
-   * Custom function for providing the classNames for the spinbutton. Can be used to provide
+   * Custom function for providing the classNames for the SpinButton. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
   getClassNames?: (
@@ -169,20 +170,18 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   ) => ISpinButtonClassNames;
 
   /**
-   * Custom styles for the upArrow button.
+   * Custom styles for the up arrow button.
    *
-   * Note: The buttons are in a checked state when arrow keys are used to
-   * incremenent/decrement the spinButton. Use rootChecked instead of rootPressed
-   * for styling when that is the case.
+   * Note: The buttons are in a checked state when arrow keys are used to incremenent/decrement
+   * the SpinButton. Use `rootChecked` instead of `rootPressed` for styling when that is the case.
    */
   upArrowButtonStyles?: Partial<IButtonStyles>;
 
   /**
-   * Custom styles for the downArrow button.
+   * Custom styles for the down arrow button.
    *
-   * Note: The buttons are in a checked state when arrow keys are used to
-   * incremenent/decrement the spinButton. Use rootChecked instead of rootPressed
-   * for styling when that is the case.
+   * Note: The buttons are in a checked state when arrow keys are used to incremenent/decrement
+   * the SpinButton. Use `rootChecked` instead of `rootPressed` for styling when that is the case.
    */
   downArrowButtonStyles?: Partial<IButtonStyles>;
 
@@ -192,57 +191,57 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: ITheme;
 
   /**
-   * Accessibile label text for the increment button for the benefit of the screen reader.
+   * Accessibile label text for the increment button (for screen reader users).
    */
   incrementButtonAriaLabel?: string;
 
   /**
-   * Accessibile label text for the decrement button for the benefit of the screen reader.
+   * Accessibile label text for the decrement button (for screen reader users).
    */
   decrementButtonAriaLabel?: string;
 
   /**
    * How many decimal places the value should be rounded to.
+   *
    * The default is calculated based on the precision of `step`: i.e. if step = 1, precision = 0.
    * step = 0.0089, precision = 4. step = 300, precision = 2. step = 23.00, precision = 2.
    */
   precision?: number;
 
   /**
-   * The position in the parent set (if in a set) for aria-posinset.
+   * The position in the parent set (if in a set).
    */
   ariaPositionInSet?: number;
 
   /**
-   * The total size of the parent set (if in a set) for aria-setsize.
+   * The total size of the parent set (if in a set).
    */
   ariaSetSize?: number;
 
   /**
-   * Sets the aria-valuenow of the spin button. The component must be
-   * controlled by the creator who controls the value externally.
-   * ariaValueNow would be the numeric form of value.
+   * Sets the control's aria-valuenow. This is the numeric form of `value`.
+   * Providing this only makes sense when using the SpinButton as a controlled component.
    */
   ariaValueNow?: number;
 
   /*
-   * Sets the aria-valuetext of the spin button. The component must be
-   * controlled by the creator who controls the values externally.
+   * Sets the control's aria-valuetext.
+   * Providing this only makes sense when using the SpinButton as a controlled component.
    */
   ariaValueText?: string;
 
   /**
-   * Optional keytip for this spin button
+   * Keytip for this SpinButton
    */
   keytipProps?: IKeytipProps;
 
   /**
-   * Optional input props on spin button
+   * Additional props for the input field.
    */
   inputProps?: React.InputHTMLAttributes<HTMLElement | HTMLInputElement>;
 
   /**
-   * Optional iconButton props on spin button
+   * Additional props for the up and down arrow buttons.
    */
   iconButtonProps?: IButtonProps;
 }
@@ -252,13 +251,12 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export interface ISpinButtonStyles {
   /**
-   * Styles for the root of the spin button component.
+   * Styles for the root of the component.
    */
   root: IStyle;
 
   /**
-   * Style for the label wrapper element of the component.
-   * The label wrapper contains the icon and the label.
+   * Style for the label wrapper element, which contains the icon and label.
    */
   labelWrapper: IStyle;
 
@@ -288,23 +286,23 @@ export interface ISpinButtonStyles {
   icon: IStyle;
 
   /**
-   * Style for the icon.
+   * Style for the icon when the control is disabled.
    */
   iconDisabled: IStyle;
 
   /**
-   * Style for the label text
+   * Style for the label text.
    */
   label: IStyle;
 
   /**
-   * Style for the label text
+   * Style for the label text when the control is disabled.
    * @deprecated Disabled styles taken care by `Label` component.
    */
   labelDisabled: IStyle;
 
   /**
-   * Style for spinButtonWrapper when enabled.
+   * Style for the wrapper element of the input field and arrow buttons.
    */
   spinButtonWrapper: IStyle;
 
@@ -314,17 +312,17 @@ export interface ISpinButtonStyles {
   spinButtonWrapperTopBottom: IStyle;
 
   /**
-   * Style override when spinButton is enabled/hovered.
+   * Style override when control is enabled/hovered.
    */
   spinButtonWrapperHovered: IStyle;
 
   /**
-   * Style override when spinButton is enabled/focused.
+   * Style override when SpinButton is enabled/focused.
    */
   spinButtonWrapperFocused: IStyle;
 
   /**
-   * Style override when spinButton is disabled.
+   * Style override when control is disabled.
    */
   spinButtonWrapperDisabled: IStyle;
 
@@ -339,7 +337,7 @@ export interface ISpinButtonStyles {
   inputTextSelected: IStyle;
 
   /**
-   * Style override when spinButton is disabled.
+   * Style override when control is disabled.
    */
   inputDisabled: IStyle;
 
@@ -349,7 +347,7 @@ export interface ISpinButtonStyles {
   arrowButtonsContainer: IStyle;
 
   /**
-   * Style override for the arrowButtonsContainer when spin button is disabled.
+   * Style override for the arrowButtonsContainer when control is disabled.
    */
   arrowButtonsContainerDisabled: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -36,7 +36,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Initial value of the control. Updates to this prop will not be respected.
    *
-   * Use this if you intend for the SpinButton to be an uncontrolled component.
+   * Use this if you intend for the SpinButton to be an uncontrolled component which maintains its own value.
    * Mutually exclusive with `value`.
    * @defaultvalue 0
    */
@@ -157,7 +157,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   styles?: Partial<ISpinButtonStyles>;
 
   /**
-   * Custom function for providing the classNames for the SpinButton. Can be used to provide
+   * Custom function for providing the classNames for the control. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
   getClassNames?: (
@@ -191,12 +191,12 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: ITheme;
 
   /**
-   * Accessibile label text for the increment button (for screen reader users).
+   * Accessible label text for the increment button (for screen reader users).
    */
   incrementButtonAriaLabel?: string;
 
   /**
-   * Accessibile label text for the decrement button (for screen reader users).
+   * Accessible label text for the decrement button (for screen reader users).
    */
   decrementButtonAriaLabel?: string;
 
@@ -220,18 +220,18 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
 
   /**
    * Sets the control's aria-valuenow. This is the numeric form of `value`.
-   * Providing this only makes sense when using the SpinButton as a controlled component.
+   * Providing this only makes sense when using as a controlled component.
    */
   ariaValueNow?: number;
 
   /*
    * Sets the control's aria-valuetext.
-   * Providing this only makes sense when using the SpinButton as a controlled component.
+   * Providing this only makes sense when using as a controlled component.
    */
   ariaValueText?: string;
 
   /**
-   * Keytip for this SpinButton
+   * Keytip for the control.
    */
   keytipProps?: IKeytipProps;
 

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SpinButton renders SpinButton correctly 1`] = `
+exports[`SpinButton renders correctly 1`] = `
 <div
   className=
 
@@ -438,7 +438,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
 </div>
 `;
 
-exports[`SpinButton renders SpinButton correctly with values that the user passes in 1`] = `
+exports[`SpinButton renders correctly with user-provided values 1`] = `
 <div
   className=
 

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -634,7 +634,6 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
     inputProps?: React.InputHTMLAttributes<HTMLElement | HTMLInputElement>;
     keytipProps?: IKeytipProps;
     label?: string;
-    // (undocumented)
     labelPosition?: Position;
     max?: number;
     min?: number;

--- a/packages/react-next/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.test.tsx
@@ -1,628 +1,416 @@
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
-import { SpinButton } from './SpinButton';
-import { ISpinButton } from './SpinButton.types';
+import { ReactWrapper, mount } from 'enzyme';
+import { SpinButton, ISpinButtonState } from './SpinButton';
+import { ISpinButton, ISpinButtonProps } from './SpinButton.types';
 import { KeyCodes, resetIds } from '../../Utilities';
-import { mockEvent, renderIntoDocument } from 'office-ui-fabric-react/lib/common/testUtilities';
+import { mockEvent } from 'office-ui-fabric-react/lib/common/testUtilities';
 
 describe('SpinButton', () => {
+  let ref: React.RefObject<ISpinButton>;
+  let wrapper: ReactWrapper<ISpinButtonProps, ISpinButtonState, SpinButton> | undefined;
+
   beforeEach(() => {
+    ref = React.createRef<ISpinButton>();
     resetIds();
   });
 
   afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
     if ((setTimeout as any).mock) {
       jest.useRealTimers();
     }
   });
 
-  it('renders SpinButton correctly', () => {
+  it('renders correctly', () => {
     const component = renderer.create(<SpinButton label="label" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('SpinButton allows value updates when no props are defined', () => {
-    const ref = React.createRef<ISpinButton>();
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" componentRef={ref} />);
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-    expect(inputDOM.value).toEqual('1');
-    expect(ref.current!.value).toEqual('1');
-  });
-
-  it('renders SpinButton correctly with values that the user passes in', () => {
+  it('renders correctly with user-provided values', () => {
     const component = renderer.create(
-      <SpinButton label="label" value={'0'} ariaValueNow={0} ariaValueText={'0 pt'} data-test="test" />,
+      <SpinButton label="label" value="0" ariaValueNow={0} ariaValueText="0 pt" data-test="test" />,
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('should render a spinner with the default value on the input element', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects label', () => {
+    wrapper = mount(<SpinButton label="my label" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const labelDOM = wrapper.getDOMNode().querySelector('label')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const labelDOM: HTMLLabelElement = renderedDOM.getElementsByTagName('label')[0];
-
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
-    expect(inputDOM.getAttribute('aria-labelledby')).toEqual(labelDOM.id);
-
-    // Assert on the label element.
-    expect(labelDOM.textContent).toEqual(exampleLabelValue);
-    expect(labelDOM.htmlFor).toEqual(inputDOM.id);
+    expect(labelDOM.textContent).toBe('my label');
+    expect(labelDOM.htmlFor).toBe(inputDOM.id);
+    expect(inputDOM.getAttribute('aria-labelledby')).toBe(labelDOM.id);
   });
 
-  it('should increment the value in the spin button via the up button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('uses default min and max', () => {
+    wrapper = mount(<SpinButton />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
-
-    expect(buttonDOM.tagName).toEqual('BUTTON');
-
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    ReactTestUtils.Simulate.mouseUp(buttonDOM, {
-      type: 'mouseup',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    expect(inputDOM.value).toEqual('13');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('13');
+    expect(inputDOM.getAttribute('aria-valuemin')).toBe(String(SpinButton.defaultProps.min));
+    expect(inputDOM.getAttribute('aria-valuemax')).toBe(String(SpinButton.defaultProps.max));
   });
 
-  it('should decrement the value in the spin button by the down button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects min and max in DOM', () => {
+    wrapper = mount(<SpinButton min={2} max={22} />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-DownButton')[0];
-
-    expect(buttonDOM.tagName).toEqual('BUTTON');
-
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    ReactTestUtils.Simulate.mouseUp(buttonDOM, {
-      type: 'mouseup',
-      clientX: 0,
-      clientY: 0,
-    });
-
-    expect(inputDOM.value).toEqual('11');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('11');
+    expect(inputDOM.getAttribute('aria-valuemin')).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuemax')).toBe('22');
   });
 
-  it('should increment the value in the spin button by the up arrow', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('12');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    expect(inputDOM.value).toEqual('13');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('13');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
   });
 
-  it('should decrement the value in the spin button by the down arrow', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('respects empty defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    expect(inputDOM.value).toEqual('11');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('11');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('');
   });
 
-  it('should increment the value in the spin button by a step value of 2', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  // This is probably a behavior we should get rid of in the future (replace with custom rendering
+  // or something), but documenting it for now...
+  it('respects non-numeric defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12 pt" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={2}
-      />,
-    );
+    expect(ref.current!.value).toBe('12 pt');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.up,
-    });
-
-    expect(inputDOM.value).toEqual('14');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('14');
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12 pt');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('12 pt');
   });
 
-  it('should decrement the value in the spin button by a step value of 2', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('ignores updates to defaultValue', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="3" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={2}
-      />,
-    );
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    wrapper.setProps({ defaultValue: '4' });
+    wrapper.update();
 
-    ReactTestUtils.Simulate.keyDown(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    ReactTestUtils.Simulate.keyUp(inputDOM, {
-      which: KeyCodes.down,
-    });
-
-    expect(inputDOM.value).toEqual('10');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual('10');
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
   });
 
-  it('should set the value of the spin button by manual entry', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '21';
+  it('respects value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="3" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
+    expect(ref.current!.value).toBe('3');
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('3');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('3');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('respects updates to value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="3" />);
+    expect(ref.current!.value).toBe('3');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('3');
+
+    wrapper.setProps({ value: '4' });
+    wrapper.update();
+
+    expect(ref.current!.value).toBe('4');
+    expect((wrapper.find('input').getDOMNode() as HTMLInputElement).value).toBe('4');
+  });
+
+  // This is probably a behavior we should get rid of in the future (replace with custom rendering
+  // or something), but documenting it for now...
+  it('respects non-numeric value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="12 pt" />);
+
+    expect(ref.current!.value).toBe('12 pt');
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('12 pt');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('12 pt');
+  });
+
+  it('respects empty value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="" />);
+
+    expect(ref.current!.value).toBe('');
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    expect(inputDOM.value).toBe('');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(null);
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe('');
+  });
+
+  it('uses min as default if neither value nor defaultValue is provided', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    expect(ref.current!.value).toBe('2');
+    expect(inputDOM.value).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('uses 0 as default if neither value, defaultValue nor min is provided', () => {
+    wrapper = mount(<SpinButton componentRef={ref} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    expect(ref.current!.value).toBe('0');
+    expect(inputDOM.value).toBe('0');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('0');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('increments value when up button is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
+
+    expect(buttonDOM.tagName).toBe('BUTTON');
+
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
+    ReactTestUtils.Simulate.mouseUp(buttonDOM, { type: 'mouseup', clientX: 0, clientY: 0 });
+
+    expect(ref.current!.value).toBe('13');
+    expect(inputDOM.value).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuetext')).toBe(null);
+  });
+
+  it('decrements value when down button is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-DownButton')[0];
+
+    expect(buttonDOM.tagName).toBe('BUTTON');
+
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
+    ReactTestUtils.Simulate.mouseUp(buttonDOM, { type: 'mouseup', clientX: 0, clientY: 0 });
+
+    expect(ref.current!.value).toBe('11');
+    expect(inputDOM.value).toBe('11');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('11');
+  });
+
+  it('increments value when up arrow key is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.up });
+
+    expect(ref.current!.value).toBe('13');
+    expect(inputDOM.value).toBe('13');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('13');
+  });
+
+  it('decrements value when down arrow key is pressed', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.down });
+
+    expect(ref.current!.value).toBe('11');
+    expect(inputDOM.value).toBe('11');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('11');
+  });
+
+  it('respects step when incrementing value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" step={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.up });
+
+    expect(ref.current!.value).toBe('14');
+    expect(inputDOM.value).toBe('14');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('14');
+  });
+
+  it('respects step when decrementing value', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" step={2} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.down });
+    ReactTestUtils.Simulate.keyUp(inputDOM, { which: KeyCodes.down });
+
+    expect(ref.current!.value).toBe('10');
+    expect(inputDOM.value).toBe('10');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('10');
+  });
+
+  it('allows value updates when no props are defined', () => {
+    wrapper = mount(<SpinButton componentRef={ref} />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+
+    ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.up });
+    expect(inputDOM.value).toBe('1');
+    expect(ref.current!.value).toBe('1');
+  });
+
+  it('accepts user-entered values', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleNewValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
   });
 
-  it('should reset the value of the spin button with invalid manual entry', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = 'garbage';
+  it('resets value when user entry is invalid', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('garbage'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should reset the value of the spin button when input value is cleared (empty)', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+  it('resets value when input is cleared (empty)', () => {
+    wrapper = mount(<SpinButton componentRef={ref} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
     ReactTestUtils.Simulate.input(inputDOM, mockEvent());
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(exampleDefaultValue);
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleDefaultValue));
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should revert to max value when input value is higher than the max of the spin button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '23';
+  it('resets to max when user-entered value is too high', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} max={22} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(exampleNewValue));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('23'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMaxValue));
+    expect(ref.current!.value).toBe('22');
+    expect(inputDOM.value).toBe('22');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('22');
   });
 
-  it('should revert existing value when input value is lower than the min of the spin button', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '0';
+  it('resets to min when user-entered value is too low', () => {
+    wrapper = mount(<SpinButton componentRef={ref} min={2} max={22} defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('0'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMinValue));
+    expect(ref.current!.value).toBe('2');
+    expect(inputDOM.value).toBe('2');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('2');
   });
 
-  it('should use validator passed to the spin button (with valid input)', () => {
-    const errorMessage = 'The value is invalid';
-    const exampleLabelValue = 'SpinButton';
+  it('uses onValidate prop (with valid input)', () => {
     const exampleMinValue = 2;
     const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '21';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
+    wrapper = mount(
       <SpinButton
-        label={exampleLabelValue}
+        componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
+        defaultValue="12"
         // tslint:disable-next-line:jsx-no-lambda
-        onValidate={(newValue: string): string => {
+        onValidate={(newValue: string): string | void => {
           const numberValue: number = +newValue;
-          return !isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue
-            ? newValue
-            : errorMessage;
+          if (!isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue) {
+            return newValue;
+          }
         }}
       />,
     );
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
   });
 
-  it('should use validator passed to the spin button', () => {
-    const errorMessage = 'The value is invalid';
-    const exampleLabelValue = 'SpinButton';
+  it('uses onValidate prop', () => {
     const exampleMinValue = 2;
     const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleNewValue = '100';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
+    wrapper = mount(
       <SpinButton
-        label={exampleLabelValue}
+        componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        value={exampleDefaultValue}
+        value="12"
         // tslint:disable-next-line:jsx-no-lambda
-        onValidate={(newValue: string): string => {
+        onValidate={(newValue: string): string | void => {
           const numberValue: number = Number(newValue);
-          return !isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue
-            ? newValue
-            : errorMessage;
+          if (!isNaN(numberValue) && numberValue >= exampleMinValue && numberValue <= exampleMaxValue) {
+            return newValue;
+          }
         }}
       />,
     );
 
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('100'));
     ReactTestUtils.Simulate.blur(inputDOM);
 
-    expect(inputDOM.value).toEqual(String(errorMessage));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toBeFalsy();
-    expect(inputDOM.getAttribute('aria-valuetext')).toEqual(errorMessage);
+    expect(ref.current!.value).toBe('12');
+    expect(inputDOM.value).toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('12');
   });
 
-  it('should have correct value after increment and using defaultValue', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleStepValue = 2;
-    const exampleNewValue: string = String(Number(exampleDefaultValue) + exampleStepValue);
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={exampleStepValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const upButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-UpButton')[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(upButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(upButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
-  });
-
-  it('should have correct value after decrement and using defaultValue', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
-    const exampleStepValue = 2;
-    const exampleNewValue: string = String(Number(exampleDefaultValue) - exampleStepValue);
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-        step={exampleStepValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const downButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName(
-      'ms-DownButton',
-    )[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(downButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(downButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(exampleNewValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleNewValue));
-  });
-
-  it('should use min as defaultvalue if neither value nor defaultValue are passed', () => {
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleStepValue = 2;
-
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton label={exampleLabelValue} min={exampleMinValue} max={exampleMaxValue} step={exampleStepValue} />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    expect(inputDOM.value).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(exampleMinValue));
-  });
-
-  it('should use 0 as defaultvalue if neither value, defaultValue nor min are passed', () => {
-    const exampleLabelValue = 'SpinButton';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label={exampleLabelValue} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-
-    expect(inputDOM.value).toEqual(String(0));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(0));
-  });
-
-  it('uses the default onIncrement function when no value, defaultValue nor onIncrement function is passed', () => {
-    const exampleLabelValue = 'SpinButton';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label={exampleLabelValue} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const upButtonDOM: HTMLButtonElement = renderedDOM.getElementsByClassName('ms-UpButton')[0] as HTMLButtonElement;
-    ReactTestUtils.Simulate.mouseDown(upButtonDOM);
-    ReactTestUtils.Simulate.mouseUp(upButtonDOM);
-
-    expect(inputDOM.value).toEqual(String(1));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(String(1));
-  });
-
-  it('should stop spinning if text field is focused while actively spinning', () => {
+  it('stops spinning if text field is focused while actively spinning', () => {
     jest.useFakeTimers();
 
-    const exampleLabelValue = 'SpinButton';
-    const exampleMinValue = 2;
-    const exampleMaxValue = 22;
-    const exampleDefaultValue = '12';
+    wrapper = mount(<SpinButton defaultValue="12" />);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(
-      <SpinButton
-        label={exampleLabelValue}
-        min={exampleMinValue}
-        max={exampleMaxValue}
-        defaultValue={exampleDefaultValue}
-      />,
-    );
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
 
     expect(buttonDOM).toBeTruthy();
 
     // start spinning
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
     // spin again
     jest.runOnlyPendingTimers();
     // spin again
@@ -632,108 +420,78 @@ describe('SpinButton', () => {
     jest.runAllTimers();
 
     const currentValue = inputDOM.value;
-    expect(currentValue).not.toEqual('2');
-    expect(inputDOM.getAttribute('aria-valuemin')).toEqual(String(exampleMinValue));
-    expect(inputDOM.getAttribute('aria-valuemax')).toEqual(String(exampleMaxValue));
-    expect(inputDOM.getAttribute('aria-valuenow')).toEqual(currentValue);
-
-    const newCurrentValue = inputDOM.value;
-    expect(currentValue).toEqual(newCurrentValue);
+    expect(currentValue).not.toBe('12');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe(currentValue);
   });
 
-  it('should fire custom onIncrement handler (with minimal properties)', () => {
+  it('uses custom onIncrement handler', () => {
     const onIncrement: jest.Mock = jest.fn();
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onIncrement={onIncrement} />);
+    wrapper = mount(<SpinButton onIncrement={onIncrement} />);
 
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-UpButton')[0];
 
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
 
     expect(onIncrement).toBeCalled();
   });
 
-  it('should fire custom onDecrement handler (with minimal properties)', () => {
+  it('uses custom onDecrement handler', () => {
     const onDecrement: jest.Mock = jest.fn();
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onDecrement={onDecrement} />);
+    wrapper = mount(<SpinButton onDecrement={onDecrement} />);
 
-    const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-DownButton')[0];
+    const buttonDOM = wrapper.getDOMNode().getElementsByClassName('ms-DownButton')[0];
 
-    ReactTestUtils.Simulate.mouseDown(buttonDOM, {
-      type: 'mousedown',
-      clientX: 0,
-      clientY: 0,
-    });
+    ReactTestUtils.Simulate.mouseDown(buttonDOM, { type: 'mousedown', clientX: 0, clientY: 0 });
 
     expect(onDecrement).toBeCalled();
   });
 
-  it('should fire custom onValidate handler (with minimal properties)', () => {
-    const onValidate: jest.Mock = jest.fn();
-    const exampleNewValue = '99';
-
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
-
-    // Assert on the input element.
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
-    ReactTestUtils.Simulate.blur(inputDOM);
-
-    expect(onValidate).toBeCalled();
-  });
-
-  it(`should pass KeyCode ${KeyCodes.enter} to onValidate handler`, () => {
-    let keyCode;
-    const onValidate: jest.Mock = jest.fn((value, event) => {
-      keyCode = event.which;
+  it(`passes KeyCode ${KeyCodes.enter} to onValidate handler`, () => {
+    let keyCode: number | undefined;
+    const onValidate: jest.Mock = jest.fn((value: string, event?: React.SyntheticEvent) => {
+      keyCode = (event as React.KeyboardEvent).which;
       return value;
     });
-    const exampleNewValue = '99';
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+    wrapper = mount(<SpinButton onValidate={onValidate} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
     ReactTestUtils.Simulate.focus(inputDOM);
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('99'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
-    expect(keyCode).toEqual(KeyCodes.enter);
+    expect(keyCode).toBe(KeyCodes.enter);
     expect(onValidate).toBeCalled();
     ReactTestUtils.Simulate.blur(inputDOM);
     expect(onValidate).toHaveBeenCalledTimes(1);
   });
 
-  it('onValidate is not called again on enter key press until the input changes', () => {
-    const onValidate: jest.Mock = jest.fn((value, event) => {
-      return value;
-    });
-    const exampleNewValue = '99';
-    const exampleChangedValue = '10';
+  it('does not call onValidate again on enter key press until the input changes', () => {
+    const onValidate = jest.fn((value: string) => value);
 
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" onValidate={onValidate} />);
+    wrapper = mount(<SpinButton onValidate={onValidate} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleNewValue)));
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('99'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(1);
+
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(1);
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(String(exampleChangedValue)));
+
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('10'));
     ReactTestUtils.Simulate.keyDown(inputDOM, { which: KeyCodes.enter });
     expect(onValidate).toHaveBeenCalledTimes(2);
   });
 
-  it('allows adding a custom aria-describedby id to the input', () => {
+  it('respects custom ariaDescribedBby id to the input', () => {
     const customId = 'customAriaDescriptionId';
-    const renderedDOM: HTMLElement = renderIntoDocument(<SpinButton label="label" ariaDescribedBy={customId} />);
+    wrapper = mount(<SpinButton label="label" ariaDescribedBy={customId} />);
 
-    const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
 
     const ariaDescribedByAttribute = inputDOM.getAttribute('aria-describedby');
-    expect(ariaDescribedByAttribute).toMatch(new RegExp('\\b' + customId + '\\b'));
+    expect(ariaDescribedByAttribute).toBe(customId);
   });
 });

--- a/packages/react-next/src/components/SpinButton/SpinButton.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.tsx
@@ -219,7 +219,13 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
                     ? Number(value)
                     : undefined
                 }
-                aria-valuetext={ariaValueText || (!value || isNaN(Number(value)) ? value : undefined)}
+                aria-valuetext={
+                  typeof ariaValueText === 'string'
+                    ? ariaValueText
+                    : !value || isNaN(Number(value)) // Number('') is 0 which may not be desirable
+                    ? value
+                    : undefined
+                }
                 aria-valuemin={min}
                 aria-valuemax={max}
                 aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}

--- a/packages/react-next/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-next/src/components/SpinButton/SpinButton.types.ts
@@ -14,13 +14,12 @@ import { IButtonProps } from 'office-ui-fabric-react/lib/components/Button/Butto
  */
 export interface ISpinButton {
   /**
-   * The value of the SpinButton. Use this if you intend to pass in a new value as a result of onChange events.
-   * This value is mutually exclusive to defaultValue. Use one or the other.
+   * Current value of the control.
    */
   value?: string;
 
   /**
-   * Sets focus to the spin button.
+   * Sets focus to the control.
    */
   focus: () => void;
 }
@@ -35,128 +34,130 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   componentRef?: IRefObject<ISpinButton>;
 
   /**
-   * The initial value of the SpinButton. Use this if you intend for the SpinButton to be an uncontrolled component.
-   * This value is mutually exclusive to value. Use one or the other.
+   * Initial value of the control. Updates to this prop will not be respected.
+   *
+   * Use this if you intend for the SpinButton to be an uncontrolled component.
+   * Mutually exclusive with `value`.
    * @defaultvalue 0
    */
   defaultValue?: string;
 
   /**
-   * The value of the SpinButton. Use this if you intend to pass in a new value as a result of onChange events.
-   * This value is mutually exclusive to defaultValue. Use one or the other.
+   * Current value of the control.
+   *
+   * Use this if you intend to pass in a new value as a result of change events.
+   * Mutually exclusive with `defaultValue`.
    */
   value?: string;
 
   /**
-   * The min value of the SpinButton.
+   * Min value of the control.
    * @defaultvalue 0
    */
   min?: number;
 
   /**
-   * The max value of the SpinButton.
+   * Max value of the control.
    * @defaultvalue 100
    */
   max?: number;
 
   /**
-   * The difference between the two adjacent values of the SpinButton.
-   * This value is sued to calculate the precision of the input if no
-   * precision is given. The precision calculated this way will always
-   * be \>= 0.
+   * Difference between two adjacent values of the control.
+   * This value is used to calculate the precision of the input if no `precision` is given.
+   * The precision calculated this way will always be \>= 0.
    * @defaultvalue 1
    */
   step?: number;
 
   /**
-   * A description of the SpinButton for the benefit of screen readers.
+   * A description of the control for the benefit of screen reader users.
    */
   ariaLabel?: string;
 
   /**
-   * Optional prop to add a string id that can be referenced inside the aria-describedby attribute
+   * ID of a label which describes the control, if not using the default label.
    */
   ariaDescribedBy?: string;
 
   /**
-   * A title for the SpinButton used for a more descriptive name that's also visible on its tooltip.
+   * A more descriptive title for the control, visible on its tooltip.
    */
   title?: string;
 
   /**
-   * Whether or not the SpinButton is disabled.
+   * Whether or not the control is disabled.
    */
   disabled?: boolean;
 
   /**
-   * Optional className for SpinButton.
+   * Custom className for the control.
    */
   className?: string;
 
   /**
-   * Descriptive label for the SpinButton.
+   * Descriptive label for the control.
    */
   label?: string;
 
   /**
+   * Where to position the control's label.
    * @defaultvalue Left
    */
   labelPosition?: Position;
 
   /**
-   * Icon that goes along with the label for the whole SpinButton
+   * Props for an icon to display alongside the control's label.
    */
   iconProps?: IIconProps;
 
   /**
-   * This callback is triggered when the value inside the SpinButton should be validated.
-   * @param value - The value entered in the SpinButton to validate
-   * @param event - The event that triggered this validate, if any. (For accessibility)
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the entered value should be validated.
+   * @param value - The entered value to validate
+   * @param event - The event that triggered this validate, if any (for accessibility)
+   * @returns If a string is returned, it will be used as the new value
    */
   onValidate?: (value: string, event?: React.SyntheticEvent<HTMLElement>) => string | void;
 
   /**
-   * This callback is triggered when the increment button is pressed or if the user presses up arrow
-   * with focus on the input of the spinButton
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the increment button or up arrow key is pressed.
+   * @returns If a string is returned, it will be used as the new value
    */
   onIncrement?: (value: string) => string | void;
 
   /**
-   * This callback is triggered when the decrement button is pressed or if the user presses down arrow
-   * with focus on the input of the spinButton
-   * @returns If a string is returned, it will be used as the value of the SpinButton.
+   * Callback for when the decrement button or down arrow key is pressed.
+   * @returns If a string is returned, it will be used as the new value
    */
   onDecrement?: (value: string) => string | void;
 
   /**
-   * A callback for when the user put focus on the picker
+   * Callback for when the user focuses the control.
    */
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
 
   /**
-   * A callback for when the user moves the focus away from the picker
+   * Callback for when the control loses focus.
    */
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
 
   /**
-   * Icon for the increment button of the spinButton
+   * Custom props for the increment button.
    */
   incrementButtonIcon?: IIconProps;
 
   /**
-   * Icon for the decrement button of the spinButton
+   * Custom props for the decrement button.
    */
   decrementButtonIcon?: IIconProps;
 
   /**
-   * Custom styling for individual elements within the button DOM.
+   * Custom styling for individual elements within the control.
    */
   styles?: Partial<ISpinButtonStyles>;
 
   /**
-   * Custom function for providing the classNames for the spinbutton. Can be used to provide
+   * Custom function for providing the classNames for the SpinButton. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
   getClassNames?: (
@@ -169,20 +170,18 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   ) => ISpinButtonClassNames;
 
   /**
-   * Custom styles for the upArrow button.
+   * Custom styles for the up arrow button.
    *
-   * Note: The buttons are in a checked state when arrow keys are used to
-   * incremenent/decrement the spinButton. Use rootChecked instead of rootPressed
-   * for styling when that is the case.
+   * Note: The buttons are in a checked state when arrow keys are used to incremenent/decrement
+   * the SpinButton. Use `rootChecked` instead of `rootPressed` for styling when that is the case.
    */
   upArrowButtonStyles?: Partial<IButtonStyles>;
 
   /**
-   * Custom styles for the downArrow button.
+   * Custom styles for the down arrow button.
    *
-   * Note: The buttons are in a checked state when arrow keys are used to
-   * incremenent/decrement the spinButton. Use rootChecked instead of rootPressed
-   * for styling when that is the case.
+   * Note: The buttons are in a checked state when arrow keys are used to incremenent/decrement
+   * the SpinButton. Use `rootChecked` instead of `rootPressed` for styling when that is the case.
    */
   downArrowButtonStyles?: Partial<IButtonStyles>;
 
@@ -192,57 +191,57 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: ITheme;
 
   /**
-   * Accessibile label text for the increment button for the benefit of the screen reader.
+   * Accessibile label text for the increment button (for screen reader users).
    */
   incrementButtonAriaLabel?: string;
 
   /**
-   * Accessibile label text for the decrement button for the benefit of the screen reader.
+   * Accessibile label text for the decrement button (for screen reader users).
    */
   decrementButtonAriaLabel?: string;
 
   /**
    * How many decimal places the value should be rounded to.
+   *
    * The default is calculated based on the precision of `step`: i.e. if step = 1, precision = 0.
    * step = 0.0089, precision = 4. step = 300, precision = 2. step = 23.00, precision = 2.
    */
   precision?: number;
 
   /**
-   * The position in the parent set (if in a set) for aria-posinset.
+   * The position in the parent set (if in a set).
    */
   ariaPositionInSet?: number;
 
   /**
-   * The total size of the parent set (if in a set) for aria-setsize.
+   * The total size of the parent set (if in a set).
    */
   ariaSetSize?: number;
 
   /**
-   * Sets the aria-valuenow of the spin button. The component must be
-   * controlled by the creator who controls the value externally.
-   * ariaValueNow would be the numeric form of value.
+   * Sets the control's aria-valuenow. This is the numeric form of `value`.
+   * Providing this only makes sense when using the SpinButton as a controlled component.
    */
   ariaValueNow?: number;
 
   /*
-   * Sets the aria-valuetext of the spin button. The component must be
-   * controlled by the creator who controls the values externally.
+   * Sets the control's aria-valuetext.
+   * Providing this only makes sense when using the SpinButton as a controlled component.
    */
   ariaValueText?: string;
 
   /**
-   * Optional keytip for this spin button
+   * Keytip for this SpinButton
    */
   keytipProps?: IKeytipProps;
 
   /**
-   * Optional input props on spin button
+   * Additional props for the input field.
    */
   inputProps?: React.InputHTMLAttributes<HTMLElement | HTMLInputElement>;
 
   /**
-   * Optional iconButton props on spin button
+   * Additional props for the up and down arrow buttons.
    */
   iconButtonProps?: IButtonProps;
 }
@@ -252,13 +251,12 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 export interface ISpinButtonStyles {
   /**
-   * Styles for the root of the spin button component.
+   * Styles for the root of the component.
    */
   root: IStyle;
 
   /**
-   * Style for the label wrapper element of the component.
-   * The label wrapper contains the icon and the label.
+   * Style for the label wrapper element, which contains the icon and label.
    */
   labelWrapper: IStyle;
 
@@ -288,23 +286,23 @@ export interface ISpinButtonStyles {
   icon: IStyle;
 
   /**
-   * Style for the icon.
+   * Style for the icon when the control is disabled.
    */
   iconDisabled: IStyle;
 
   /**
-   * Style for the label text
+   * Style for the label text.
    */
   label: IStyle;
 
   /**
-   * Style for the label text
+   * Style for the label text when the control is disabled.
    * @deprecated Disabled styles taken care by `Label` component.
    */
   labelDisabled: IStyle;
 
   /**
-   * Style for spinButtonWrapper when enabled.
+   * Style for the wrapper element of the input field and arrow buttons.
    */
   spinButtonWrapper: IStyle;
 
@@ -314,17 +312,17 @@ export interface ISpinButtonStyles {
   spinButtonWrapperTopBottom: IStyle;
 
   /**
-   * Style override when spinButton is enabled/hovered.
+   * Style override when control is enabled/hovered.
    */
   spinButtonWrapperHovered: IStyle;
 
   /**
-   * Style override when spinButton is enabled/focused.
+   * Style override when SpinButton is enabled/focused.
    */
   spinButtonWrapperFocused: IStyle;
 
   /**
-   * Style override when spinButton is disabled.
+   * Style override when control is disabled.
    */
   spinButtonWrapperDisabled: IStyle;
 
@@ -339,7 +337,7 @@ export interface ISpinButtonStyles {
   inputTextSelected: IStyle;
 
   /**
-   * Style override when spinButton is disabled.
+   * Style override when control is disabled.
    */
   inputDisabled: IStyle;
 
@@ -349,7 +347,7 @@ export interface ISpinButtonStyles {
   arrowButtonsContainer: IStyle;
 
   /**
-   * Style override for the arrowButtonsContainer when spin button is disabled.
+   * Style override for the arrowButtonsContainer when control is disabled.
    */
   arrowButtonsContainerDisabled: IStyle;
 }

--- a/packages/react-next/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-next/src/components/SpinButton/SpinButton.types.ts
@@ -36,7 +36,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Initial value of the control. Updates to this prop will not be respected.
    *
-   * Use this if you intend for the SpinButton to be an uncontrolled component.
+   * Use this if you intend for the SpinButton to be an uncontrolled component which maintains its own value.
    * Mutually exclusive with `value`.
    * @defaultvalue 0
    */
@@ -157,7 +157,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   styles?: Partial<ISpinButtonStyles>;
 
   /**
-   * Custom function for providing the classNames for the SpinButton. Can be used to provide
+   * Custom function for providing the classNames for the control. Can be used to provide
    * all styles for the component instead of applying them on top of the default styles.
    */
   getClassNames?: (
@@ -191,12 +191,12 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   theme?: ITheme;
 
   /**
-   * Accessibile label text for the increment button (for screen reader users).
+   * Accessible label text for the increment button (for screen reader users).
    */
   incrementButtonAriaLabel?: string;
 
   /**
-   * Accessibile label text for the decrement button (for screen reader users).
+   * Accessible label text for the decrement button (for screen reader users).
    */
   decrementButtonAriaLabel?: string;
 
@@ -220,18 +220,18 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
 
   /**
    * Sets the control's aria-valuenow. This is the numeric form of `value`.
-   * Providing this only makes sense when using the SpinButton as a controlled component.
+   * Providing this only makes sense when using as a controlled component.
    */
   ariaValueNow?: number;
 
   /*
    * Sets the control's aria-valuetext.
-   * Providing this only makes sense when using the SpinButton as a controlled component.
+   * Providing this only makes sense when using as a controlled component.
    */
   ariaValueText?: string;
 
   /**
-   * Keytip for this SpinButton
+   * Keytip for the control.
    */
   keytipProps?: IKeytipProps;
 

--- a/packages/react-next/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/react-next/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SpinButton renders SpinButton correctly 1`] = `
+exports[`SpinButton renders correctly 1`] = `
 <div
   className=
 
@@ -438,7 +438,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
 </div>
 `;
 
-exports[`SpinButton renders SpinButton correctly with values that the user passes in 1`] = `
+exports[`SpinButton renders correctly with user-provided values 1`] = `
 <div
   className=
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13119
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Allow setting an empty value in the SpinButton (needed for a user scenario) and clean up some logic.

Also clean up doc comments on SpinButton props, and clean up tests:
- Add tests for a few more scenarios, including the one fixed in this PR (symmetrical for `value` and `defaultValue`)
- Reorder tests so the simplest ones are first (this makes the diff messy, sorry)
- Use `enzyme.mount` instead of `renderIntoDocument`
- Remove props that are irrelevant to the thing being tested, adding separate tests when appropriate (min and max should be tested on their own, not with every single other test)
- Remove redundant tests (there were 2 sets of tests for up/down buttons)

react-next changes are exactly the same as OUFR changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/microsoft/fluentui/pull/13174)