### PR TITLE
chore(FormField): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Stop propagadion in `Dropdown` for `keypress` of `ArrowRight`, `ArrowLeft`, `Esc` and `Backspace` @assuncaocharles ([#13088](https://github.com/microsoft/fluentui/pull/13088))
 - Restricted prop sets in the `Menu` component which are passed to styles functions @assuncaocharles ([#13040](https://github.com/microsoft/fluentui/pull/13040))
 - Renamed `Survey20pxIcon` to `ApprovalsAppbarIcon` @TanelVari ([#12872](https://github.com/microsoft/fluentui/pull/12872))
+- Restricted prop sets in the `FormField` component which are passed to styles functions, @assuncaocharles ([#13181](https://github.com/microsoft/fluentui/pull/13181))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,7 +27,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `FormField` component which are passed to styles functions, @assuncaocharles ([#13181](https://github.com/microsoft/fluentui/pull/13181))
 - Restricted prop sets in the `DropdownSelectedItem` component which are passed to styles functions, @assuncaocharles ([#13179](https://github.com/microsoft/fluentui/pull/13179))
 
-
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))
 - Fix offset computations in `Popup` to properly position pointer @layershifter ([#13002](https://github.com/microsoft/fluentui/pull/13002))

--- a/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
@@ -4,25 +4,31 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
 import {
-  UIComponent,
   childrenExist,
   createShorthandFactory,
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
-  ShorthandFactory,
 } from '../../utils';
-
-import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types';
+import {
+  WithAsProp,
+  ShorthandValue,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
 import Text, { TextProps } from '../Text/Text';
 import Input from '../Input/Input';
 import Box, { BoxProps } from '../Box/Box';
+import { getElementType, useUnhandledProps, useTelemetry, useStyles, useAccessibility } from '@fluentui/react-bindings';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 
 export interface FormFieldProps extends UIComponentProps, ChildrenComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<never>;
 
   /** A control for the form field. */
   control?: ShorthandValue<BoxProps>;
@@ -51,74 +57,121 @@ export interface FormFieldProps extends UIComponentProps, ChildrenComponentProps
 
 export const formFieldClassName = 'ui-form__field';
 
-class FormField extends UIComponent<WithAsProp<FormFieldProps>, any> {
-  static displayName = 'FormField';
+export type FormFieldStylesProps = Required<Pick<FormFieldProps, 'type' | 'inline' | 'required'>>;
 
-  static deprecated_className = formFieldClassName;
+const FormField: React.FC<WithAsProp<FormFieldProps>> & FluentComponentStaticProps<FormFieldProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(FormField.displayName, context.telemetry);
+  setStart();
 
-  static create: ShorthandFactory<FormFieldProps>;
+  const {
+    children,
+    control,
+    id,
+    label,
+    message,
+    name,
+    required,
+    type,
+    className,
+    design,
+    styles,
+    variables,
+    inline,
+  } = props;
 
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false,
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(FormField.handledProps, props);
+
+  const getA11yProps = useAccessibility<never>(props.accessibility, {
+    debugName: FormField.displayName,
+    rtl: context.rtl,
+  });
+
+  const { classes, styles: resolvedStyles } = useStyles<FormFieldStylesProps>(FormField.displayName, {
+    className: formFieldClassName,
+    mapPropsToStyles: () => ({
+      type,
+      inline,
+      required,
     }),
-    control: customPropTypes.itemShorthand,
-    id: PropTypes.string,
-    inline: PropTypes.bool,
-    label: customPropTypes.itemShorthand,
-    message: customPropTypes.itemShorthand,
-    name: PropTypes.string,
-    required: PropTypes.bool,
-    type: PropTypes.string,
-  };
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  static defaultProps = {
-    as: 'div',
-    control: { as: Input },
-  };
+  const labelElement = Text.create(label, {
+    defaultProps: () => ({
+      as: 'label',
+      htmlFor: id,
+      styles: resolvedStyles.label,
+    }),
+  });
 
-  renderComponent({ ElementType, classes, accessibility, styles, unhandledProps }): React.ReactNode {
-    const { children, control, id, label, message, name, required, type } = this.props;
+  const messageElement = Text.create(message, {
+    defaultProps: () => ({
+      styles: resolvedStyles.message,
+    }),
+  });
 
-    const labelElement = Text.create(label, {
-      defaultProps: () => ({
-        as: 'label',
-        htmlFor: id,
-        styles: styles.label,
-      }),
-    });
+  const controlElement = Box.create(control || {}, {
+    defaultProps: () => ({ required, id, name, type, styles: resolvedStyles.control }),
+  });
 
-    const messageElement = Text.create(message, {
-      defaultProps: () => ({
-        styles: styles.message,
-      }),
-    });
-
-    const controlElement = Box.create(control || {}, {
-      defaultProps: () => ({ required, id, name, type, styles: styles.control }),
-    });
-
-    const content = (
-      <>
-        {this.shouldControlAppearFirst() && controlElement}
-        {labelElement}
-        {!this.shouldControlAppearFirst() && controlElement}
-        {messageElement}
-      </>
-    );
-
-    return (
-      <ElementType className={classes.root} {...accessibility.attributes.root} {...unhandledProps}>
-        {childrenExist(children) ? children : content}
-      </ElementType>
-    );
-  }
-
-  shouldControlAppearFirst = () => {
-    const { type } = this.props;
+  const shouldControlAppearFirst = () => {
+    const { type } = props;
     return type && (type === 'checkbox' || type === 'radio');
   };
-}
+
+  const content = (
+    <>
+      {shouldControlAppearFirst() && controlElement}
+      {labelElement}
+      {!shouldControlAppearFirst() && controlElement}
+      {messageElement}
+    </>
+  );
+
+  const element = (
+    <ElementType
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...unhandledProps,
+      })}
+    >
+      {childrenExist(children) ? children : content}
+    </ElementType>
+  );
+  setEnd();
+  return element;
+};
+
+FormField.displayName = 'FormField';
+
+FormField.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false,
+  }),
+  control: customPropTypes.itemShorthand,
+  id: PropTypes.string,
+  inline: PropTypes.bool,
+  label: customPropTypes.itemShorthand,
+  message: customPropTypes.itemShorthand,
+  name: PropTypes.string,
+  required: PropTypes.bool,
+  type: PropTypes.string,
+};
+
+FormField.handledProps = Object.keys(FormField.propTypes) as any;
+
+FormField.defaultProps = {
+  as: 'div',
+  control: { as: Input },
+};
 
 FormField.create = createShorthandFactory({ Component: FormField, mappedProp: 'label' });
 

--- a/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormField.tsx
@@ -123,7 +123,6 @@ const FormField: React.FC<WithAsProp<FormFieldProps>> & FluentComponentStaticPro
   });
 
   const shouldControlAppearFirst = () => {
-    const { type } = props;
     return type && (type === 'checkbox' || type === 'radio');
   };
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Form/formFieldStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Form/formFieldStyles.ts
@@ -1,8 +1,8 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { FormFieldProps } from '../../../../components/Form/FormField';
+import { FormFieldStylesProps } from '../../../../components/Form/FormField';
 import { pxToRem } from '../../../../utils';
 
-const formFieldStyles: ComponentSlotStylesPrepared<FormFieldProps> = {
+const formFieldStyles: ComponentSlotStylesPrepared<FormFieldStylesProps> = {
   root: ({ props, variables }): ICSSInJSStyle => ({}),
   label: ({ props }): ICSSInJSStyle => {
     const { type, inline, required } = props;

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -34,7 +34,7 @@ import { DropdownSearchInputStylesProps } from '../../components/Dropdown/Dropdo
 import { EmbedStylesProps } from '../../components/Embed/Embed';
 import { FlexItemStylesProps } from '../../components/Flex/FlexItem';
 import { FlexStylesProps } from '../../components/Flex/Flex';
-import { FormFieldProps } from '../../components/Form/FormField';
+import { FormFieldStylesProps } from '../../components/Form/FormField';
 import { FormProps } from '../../components/Form/Form';
 import { GridProps } from '../../components/Grid/Grid';
 import { HeaderDescriptionProps } from '../../components/Header/HeaderDescription';
@@ -122,7 +122,7 @@ export type TeamsThemeStylesProps = {
   Flex: FlexStylesProps;
   FlexItem: FlexItemStylesProps;
   Form: FormProps;
-  FormField: FormFieldProps;
+  FormField: FormFieldStylesProps;
   Grid: GridProps;
   Header: HeaderProps;
   HeaderDescription: HeaderDescriptionProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Form/FormField-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Form/FormField-test.tsx
@@ -15,7 +15,7 @@ const getFormField = (control: React.ComponentType<any> | string) =>
   mountWithProvider(<FormField control={{ as: control }} name="firstName" />).find('FormField');
 
 describe('FormField', () => {
-  isConformant(FormField);
+  isConformant(FormField, { constructorName: 'FormField' });
   formFieldImplementsShorthandProp('label', Text);
   formFieldImplementsShorthandProp('message', Text);
   formFieldImplementsShorthandProp('control', Box, { mapsValueToProp: 'children' });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `FormField` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `FormField`    |
| --------- |
| `type` |
| `inline` |
| `required` |

#### Focus areas to test

(optional)
