### PR TITLE
DetailsList: clarify IColumn.ariaLabel docs; other doc cleanup

### DIFF
--- a/change/office-ui-fabric-react-2020-05-15-10-32-58-column-arialabel.json
+++ b/change/office-ui-fabric-react-2020-05-15-10-32-58-column-arialabel.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: clarify IColumn.ariaLabel docs; other doc cleanup",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T17:32:58.113Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -66,18 +66,14 @@ export interface IDetailsList extends IList {
  * {@docCategory DetailsList}
  */
 export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewportProps {
-  /**
-   * Theme provided by the Higher Order Component
-   */
+  /** Theme provided by a higher-order component. */
   theme?: ITheme;
 
-  /**
-   * Style function to be passed in to override the themed or default styles
-   */
+  /** Custom overrides to the themed or default styles. */
   styles?: IStyleFunctionOrObject<IDetailsListStyleProps, IDetailsListStyles>;
 
   /**
-   * Optional callback to access the IDetailsList interface. Use this instead of ref for accessing
+   * Callback to access the IDetailsList interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */
   componentRef?: IRefObject<IDetailsList>;
@@ -88,30 +84,28 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** The items to render. */
   items: any[];
 
-  /** Set this to true to indicate that the items being displayed is placeholder data. */
+  /** Set this to true to indicate that the items being displayed are placeholder data. */
   isPlaceholderData?: boolean;
 
-  /** Optional properties to pass through to the list components being rendered. */
+  /** Properties to pass through to the List components being rendered. */
   listProps?: IListProps;
 
-  /**
-   * Optional default focused index to set focus to once the items have rendered and the index exists.
-   */
+  /** Default index to set focus to once the items have rendered and the index exists. */
   initialFocusedIndex?: number;
 
-  /** Optional class name to add to the root element. */
+  /** Class name to add to the root element. */
   className?: string;
 
-  /** Optional grouping instructions. The definition for IGroup can be found under the GroupedList component. */
+  /** Grouping instructions. */
   groups?: IGroup[];
 
-  /** Optional override properties to render groups. */
+  /** Override properties to render groups. */
   groupProps?: IDetailsGroupRenderProps;
 
-  /** Optional override for the indent width used for group nesting. */
+  /** Override for the indent width used for group nesting. */
   indentWidth?: number;
 
-  /** Optional selection model to track selection state.  */
+  /** Selection model to track selection state.  */
   selection?: ISelection;
 
   /** Controls how/if the details list manages selection. Options include none, single, multiple */
@@ -125,7 +119,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   selectionPreservedOnEmptyClick?: boolean;
 
   /**
-   * Addition props to pass through to the selection zone created by default.
+   * Additional props to pass through to the SelectionZone created by default.
    */
   selectionZoneProps?: ISelectionZoneProps;
 
@@ -139,12 +133,12 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   checkboxVisibility?: CheckboxVisibility;
 
   /**
-   * Controls the visibility of the details header.
+   * Controls the visibility of the header.
    * @defaultvalue true
    */
   isHeaderVisible?: boolean;
 
-  /** Given column defitions. If none are provided, default columns will be created based on the item's properties. */
+  /** column defitions. If none are provided, default columns will be created based on the items' properties. */
   columns?: IColumn[];
 
   /** Controls how the list contrains overflow. */
@@ -153,7 +147,7 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Event names and corresponding callbacks that will be registered to rendered row elements. */
   rowElementEventMap?: { eventName: string; callback: (context: IDragDropContext, event?: any) => void }[];
 
-  /** Callback for when the details list has been updated. Useful for telemetry tracking externally. */
+  /** Callback for when the list has been updated. Useful for telemetry tracking externally. */
   onDidUpdate?: (detailsList?: DetailsListBase) => void;
 
   /**
@@ -181,24 +175,25 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
 
   /**
    * Callback for when the context menu of an item has been accessed.
-   * If undefined or false are returned, ev.preventDefault() will be called.
+   * If undefined or false is returned, `ev.preventDefault()` will be called.
    */
   onItemContextMenu?: (item?: any, index?: number, ev?: Event) => void | boolean;
 
   /**
-   *  If provided, will allow the caller to override the default row rendering.
+   * Callback to override the default row rendering.
    */
   onRenderRow?: IRenderFunction<IDetailsRowProps>;
 
   /**
    * If provided, will be the "default" item column renderer method.
    * This affects cells within the rows, not the rows themselves.
-   * If a column definition provides its own onRender method, that will be used instead of this.
+   * If a column definition provides its own `onRender` method, that will be used instead of this.
    */
   onRenderItemColumn?: (item?: any, index?: number, column?: IColumn) => React.ReactNode;
 
   /**
-   * If provided, will be the "default" item column cell value return. column getValueKey can override getCellValue.
+   * If provided, will be the "default" item column cell value return.
+   * A column's `getValueKey` can override `getCellValueKey`.
    */
   getCellValueKey?: (item?: any, index?: number, column?: IColumn) => string;
 
@@ -208,22 +203,16 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   /** Callback for what to render when the item is missing. */
   onRenderMissingItem?: (index?: number, rowProps?: IDetailsRowProps) => React.ReactNode;
 
-  /**
-   * An override to render the details header.
-   */
+  /** An override to render the details header. */
   onRenderDetailsHeader?: IRenderFunction<IDetailsHeaderProps>;
 
-  /**
-   * An override to render the details footer.
-   */
+  /** An override to render the details footer. */
   onRenderDetailsFooter?: IRenderFunction<IDetailsFooterProps>;
 
-  /**
-   * If provided, can be used to render a custom checkbox
-   */
+  /**  If provided, can be used to render a custom checkbox. */
   onRenderCheckbox?: IRenderFunction<IDetailsListCheckboxProps>;
 
-  /** Viewport, provided by the withViewport decorator. */
+  /** Viewport info, provided by the `withViewport` decorator. */
   viewport?: IViewport;
 
   /**
@@ -232,21 +221,19 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    */
   onActiveItemChanged?: (item?: any, index?: number, ev?: React.FocusEvent<HTMLElement>) => void;
 
-  /** The aria-label attribute to stamp out on the list header */
+  /** Accessible label for the list header. */
   ariaLabelForListHeader?: string;
 
-  /** The aria-label attribute to stamp out on select all checkbox for the list */
+  /** Accessible label for the select all checkbox. */
   ariaLabelForSelectAllCheckbox?: string;
 
-  /**
-   * An ARIA label for the name of the selection column, for localization.
-   */
+  /** Accessible label for the name of the selection column. */
   ariaLabelForSelectionColumn?: string;
 
   /** Callback to get the aria-label string for a given item. */
   getRowAriaLabel?: (item: any) => string;
 
-  /** Callback to get the aria-describedby IDs (space separated strings) of the elements that describe the item. */
+  /** Callback to get the aria-describedby IDs (space-separated strings) of elements that describe the item. */
   getRowAriaDescribedBy?: (item: any) => string;
 
   /**
@@ -255,16 +242,19 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    */
   getKey?: (item: any, index?: number) => string;
 
-  /** A text summary of the table set via aria-label. */
+  /** Accessible label describing or summarizing the list. */
   ariaLabel?: string;
 
-  /** Check button aria label for details list. */
+  /** Accessible label for the check button. */
   checkButtonAriaLabel?: string;
 
-  /** Aria label for grid in details list. */
+  /** Accessible label for the grid within the list. */
   ariaLabelForGrid?: string;
 
-  /** Boolean value to indicate if the role application should be applied on details list. Set to false by default */
+  /**
+   * Whether the role `application` should be applied to the list.
+   * @defaultvalue false
+   */
   shouldApplyApplicationRole?: boolean;
 
   /**
@@ -273,7 +263,10 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    */
   minimumPixelsForDrag?: number;
 
-  /** Whether the component should render in compact mode. Set to false by default */
+  /**
+   * Whether to render in compact mode.
+   * @defaultvalue false
+   */
   compact?: boolean;
 
   /**
@@ -283,36 +276,30 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
   usePageCache?: boolean;
 
   /**
-   * Optional callback to determine whether the list should be rendered in full, or virtualized.
+   * Callback to determine whether the list should be rendered in full, or virtualized.
+   *
    * Virtualization will add and remove pages of items as the user scrolls them into the visible range.
    * This benefits larger list scenarios by reducing the DOM on the screen, but can negatively affect performance
    * for smaller lists.
+   *
    * The default implementation will virtualize when this callback is not provided.
    */
   onShouldVirtualize?: (props: IListProps) => boolean;
 
-  /**
-   * Optional class name to add to the cell of a checkbox
-   */
+  /** Class name to add to the cell of a checkbox. */
   checkboxCellClassName?: string;
 
-  /**
-   * Whether or not the selection zone should enter modal state on touch.
-   */
+  /** Whether the selection zone should enter modal state on touch. */
   enterModalSelectionOnTouch?: boolean;
 
-  /**
-   * Options for column re-order using drag and drop
-   */
+  /** Options for column reordering using drag and drop. */
   columnReorderOptions?: IColumnReorderOptions;
 
-  /**
-   * Optional function to override default group height calculation used by list virtualization.
-   */
+  /** Callback to override default group height calculation used by list virtualization. */
   getGroupHeight?: IGroupedListProps['getGroupHeight'];
 
   /**
-   * Rerender DetailsRow only when props changed. Might cause regression when depending on external updates.
+   * Whether to re-render a row only when props changed. Might cause regression when depending on external updates.
    * @defaultvalue false
    */
   useReducedRowRenderer?: boolean;
@@ -323,14 +310,10 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
    */
   cellStyleProps?: ICellStyleProps;
 
-  /**
-   * Whether or not to disable the built-in SelectionZone, so the host component can provide its own.
-   */
+  /** Whether to disable the built-in SelectionZone, so the host component can provide its own. */
   disableSelectionZone?: boolean;
 
-  /**
-   * Whether to animate updates
-   */
+  /** Whether to animate updates */
   enableUpdateAnimations?: boolean;
 
   /**
@@ -345,53 +328,37 @@ export interface IDetailsListProps extends IBaseProps<IDetailsList>, IWithViewpo
  * {@docCategory DetailsList}
  */
 export interface IColumn {
-  /**
-   * A unique key for identifying the column.
-   */
+  /** A unique key for identifying the column. */
   key: string;
 
-  /**
-   * Name to render on the column header.
-   */
+  /** Name to render on the column header. */
   name: string;
 
   /**
-   * The field to pull the text value from for the column. This can be null if a custom
-   * onRender method is provided.
+   * The field to pull the text value from for the column.
+   * Can be unset if a custom `onRender` method is provided.
    */
   fieldName?: string;
 
-  /**
-   * An optional class name to stick on the column cell within each row.
-   */
+  /** Class name to apply to the column cell within each row. */
   className?: string;
 
-  /**
-   * Style function to be passed in to override the themed or default styles
-   */
+  /** Custom overrides to the themed or default styles. */
   styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
 
-  /**
-   * Minimum width for the column.
-   */
+  /** Minimum width for the column. */
   minWidth: number;
 
   /**
-   * Optional accessibility label (aria-label) attribute that will be stamped on to the element.
-   * If none is specified, the arai-label attribute will contain the column name
+   * Accessible label for the column. The column name will still be used as the primary label,
+   * but this text (if specified) will be read after the column name.
    */
   ariaLabel?: string;
 
-  /**
-   * Optional flag on whether the column is a header for the given row. There should be only one column with
-   * row header set to true.
-   * @defaultvalue false
-   */
+  /** Whether the column is a header for the given row. There should be only one column with this set to true. */
   isRowHeader?: boolean;
 
-  /**
-   * Maximum width for the column, if stretching is allowed in justified scenarios.
-   */
+  /** Maximum width for the column, if stretching is allowed in justified scenarios. */
   maxWidth?: number;
 
   /**
@@ -400,165 +367,123 @@ export interface IColumn {
    */
   columnActionsMode?: ColumnActionsMode;
 
-  /**
-   * Optional iconName to use for the column header.
-   */
+  /** Custom icon to use in the column header. */
   iconName?: string;
 
   /**
-   * Whether or not only the icon is used in the column header.
-   * Set this to true so the column name and dropdown chevron are not displayed.
+   * Whether only the icon should be displayed in the column header.
+   * If true, the column name and dropdown chevron will not be displayed.
    */
   isIconOnly?: boolean;
 
-  /**
-   * Class name to add to the Icon component.
-   */
+  /** Class name for the icon within the header. */
   iconClassName?: string;
 
   /**
-   * If specified will allow the column to be collapsed when rendered in justified layout.
+   * If true, allow the column to be collapsed when rendered in justified layout.
    * @deprecated Use `isCollapsible`
    */
   isCollapsable?: boolean;
 
-  /**
-   * If specified will allow the column to be collapsed when rendered in justified layout.
-   */
+  /** If true, allow the column to be collapsed when rendered in justified layout. */
   isCollapsible?: boolean;
 
-  /**
-   * Determines if the column is currently sorted. Renders a sort arrow in the column header.
-   */
+  /** Determines if the column is currently sorted. Renders a sort arrow in the column header. */
   isSorted?: boolean;
 
-  /**
-   * Determines if the arrow is pointed down (descending) or up.
-   */
+  /** Determines if the sort arrow is pointed down (descending) or up. */
   isSortedDescending?: boolean;
 
-  /**
-   * Determines if the column can be resized.
-   */
+  /** Determines if the column can be resized. */
   isResizable?: boolean;
 
-  /**
-   * Determines if the column can render multi-line text.
-   */
+  /** Determines if the column can render multi-line text. */
   isMultiline?: boolean;
 
-  /**
-   * If provided uses this method to render custom cell content, rather than the default text rendering.
-   */
+  /** Custom renderer for cell content, instead of the default text rendering. */
   onRender?: (item?: any, index?: number, column?: IColumn) => any;
 
-  /**
-   * If set, parent getCellValueKey will return this value.
-   */
+  /** Custom override for the parent list's `getCellValueKey`. */
   getValueKey?: (item?: any, index?: number, column?: IColumn) => string;
 
-  /**
-   * If provider, can be used to render a custom column header divider
-   */
+  /** Custom renderer for column header divider. */
   onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
 
-  /**
-   * Determines if the column is filtered, and if so shows a filter icon.
-   */
+  /** Whether the list is filtered by this column. If true, shows a filter icon next to this column's name. */
   isFiltered?: boolean;
 
-  /**
-   * If provided, will be executed when the user clicks on the column header.
-   */
+  /** Callback for when the user clicks on the column header. */
   onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void;
 
-  /**
-   * If provided, will be executed when the user accesses the contextmenu on a column header.
-   */
+  /** Callback for when the user opens the column header context menu. */
   onColumnContextMenu?: (column?: IColumn, ev?: React.MouseEvent<HTMLElement>) => void;
 
   /**
-   * If provided, will be executed when the column is resized with the column's current width.
-   * Prefer this callback over `DetailsList` `onColumnResize` if you require the `IColumn` to
-   * report its width after every resize event. Consider debouncing the callback if resize events
-   * occur frequently.
+   * Callback for when the column is resized (`width` is the current width).
+   *
+   * Prefer this over `DetailsList`'s `onColumnResize` if you require the `IColumn` to report its width
+   * after every resize event. Consider debouncing the callback if resize events occur frequently.
    */
   onColumnResize?: (width?: number) => void;
 
-  /**
-   * If set will show a grouped icon next to the column header name.
-   */
+  /** Whether the list is grouped by this column. If true, shows a grouped icon next to this column's name. */
   isGrouped?: boolean;
 
-  /**
-   * Arbitrary data passthrough which can be used by the caller.
-   */
+  /** Arbitrary data passthrough which can be used by the caller. */
   data?: any;
 
-  /**
-   * Internal only value.
-   */
+  /** Internal only value. */
   calculatedWidth?: number;
 
   /**
    * Internal only value.
-   * Remembers the actual witdh of the column on any case.
-   * On the other hand, calculatedWidth is only saved when it's defined by user, not for justified calculations.
+   * Remembers the actual width of the column in any case.
+   * `calculatedWidth` is only saved when it's defined by user, not for justified calculations.
    */
   currentWidth?: number;
 
-  /**
-   * An optional class name to stick on the column cell within each header.
-   */
+  /** Class name to apply to the column header cell. */
   headerClassName?: string;
 
-  /**
-   * If set, will add additional LTR padding-right to column and cells.
-   */
+  /** If true, add additional LTR padding-right to column and cells. */
   isPadded?: boolean;
 
   /**
-   * ARIA label for the sort order of this column when sorted ascending.
+   * Accessible label for indicating that the list is sorted by this column in ascending order.
+   * This will be read after the main column header label.
    */
   sortAscendingAriaLabel?: string;
+
   /**
-   * ARIA label for the sort order of this column when sorted descending.
+   * Accessible label for indicating that the list is sorted by this column in descending order.
+   * This will be read after the main column header label.
    */
   sortDescendingAriaLabel?: string;
-  /**
-   * ARIA label for the status of this column when grouped.
-   */
+
+  /** Accessible label for the status of this column when grouped. */
   groupAriaLabel?: string;
-  /**
-   * ARIA label for the status of this column when filtered.
-   */
+
+  /** Accessible label for the status of this column when filtered. */
   filterAriaLabel?: string;
-  /**
-   * Indicates whether a dropdown menu is open so that the appropriate ARIA attributes are rendered.
-   */
+
+  /** Whether a dropdown menu is open so that the appropriate ARIA attributes are rendered. */
   isMenuOpen?: boolean;
 }
 
 /**
- * Enum to describe how a particular column header behaves.... This enum is used to
- * to specify the property IColumn:columnActionsMode.
- * If IColumn:columnActionsMode is undefined, then it's equivalent to ColumnActionsMode.clickable
+ * Enum to describe how a particular column header behaves.
+ * This is used to to specify the property `IColumn.columnActionsMode`.
+ * If `IColumn.columnActionsMode` is undefined, it's equivalent to `ColumnActionsMode.clickable`.
  * {@docCategory DetailsList}
  */
 export enum ColumnActionsMode {
-  /**
-   * Renders the column header as disabled.
-   */
+  /** Renders the column header as disabled. */
   disabled = 0,
 
-  /**
-   * Renders the column header is clickable.
-   */
+  /** Renders the column header as clickable. Default value. */
   clickable = 1,
 
-  /**
-   * Renders the column header ias clickable and displays the dropdown cheveron.
-   */
+  /** Renders the column header as clickable and displays the dropdown chevron. */
   hasDropdown = 2,
 }
 
@@ -566,12 +491,10 @@ export enum ColumnActionsMode {
  * {@docCategory DetailsList}
  */
 export enum ConstrainMode {
-  /** If specified, lets the content grow which allows the page to manage scrolling. */
+  /** Lets the content grow which allows the page to manage scrolling. */
   unconstrained = 0,
 
-  /**
-   * If specified, constrains the list to the given layout space.
-   */
+  /** Constrains the list to the given layout space. */
   horizontalConstrained = 1,
 }
 
@@ -580,7 +503,7 @@ export enum ConstrainMode {
  */
 export interface IColumnReorderOptions {
   /**
-   * Specifies the number fixed columns from left(0th index)
+   * Specifies the number fixed columns from left
    * @defaultvalue 0
    */
   frozenColumnCountFromStart?: number;
@@ -592,27 +515,25 @@ export interface IColumnReorderOptions {
   frozenColumnCountFromEnd?: number;
 
   /**
-   * Callback to handle the column dragstart
-   * draggedStarted indicates that the column drag has been started on DetailsHeader
+   * Callback to handle when dragging on this column's DetailsHeader has started.
    */
   onColumnDragStart?: (dragStarted: boolean) => void;
 
   /**
-   * Callback to handle the column reorder
-   * draggedIndex is the source column index, that need to be placed in targetIndex
-   * Deprecated, use `onColumnDrop` instead.
+   * Callback to handle column reordering.
+   * `draggedIndex` is the source column index, which should be placed at `targetIndex`.
    * @deprecated Use `onColumnDrop` instead.
    */
   handleColumnReorder?: (draggedIndex: number, targetIndex: number) => void;
 
   /**
-   * Callback to handle the column reorder
-   * draggedIndex is the source column index, that need to be placed in targetIndex
+   * Callback to handle column reordering.
+   * `draggedIndex` is the source column index, which should be placed at `targetIndex`.
    */
   onColumnDrop?: (dragDropDetails: IColumnDragDropDetails) => void;
 
   /**
-   * Callback to handle the column reorder
+   * Callback to handle when dragging on this column's DetailsHeader has finished.
    */
   onDragEnd?: (columnDropLocationDetails: ColumnDragEndLocation) => void;
 }
@@ -639,19 +560,13 @@ export interface IColumnDragDropDetails {
  * {@docCategory DetailsList}
  */
 export enum ColumnDragEndLocation {
-  /**
-   * Drag ended outside of current list
-   */
+  /** Drag ended outside of current list */
   outside = 0,
 
-  /**
-   * Drag ended on current List
-   */
+  /** Drag ended within current list */
   surface = 1,
 
-  /**
-   * Drag ended on Header
-   */
+  /** Drag ended on header */
   header = 2,
 }
 
@@ -675,19 +590,13 @@ export enum DetailsListLayoutMode {
  * {@docCategory DetailsList}
  */
 export enum CheckboxVisibility {
-  /**
-   * Visible on hover.
-   */
+  /** Visible on hover. */
   onHover = 0,
 
-  /**
-   * Visible always.
-   */
+  /** Visible always. */
   always = 1,
 
-  /**
-   * Hide checkboxes.
-   */
+  /** Hide checkboxes. */
   hidden = 2,
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13176
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The docs for DetailsList's `IColumn.ariaLabel` were misleading, making it sound like the `ariaLabel` would be read in place of the column name, when in fact it's appended to the column name (and read after a delay). This change clarifies the wording as well as cleaning up wording on some of the other DetailsList props.