### PR TITLE
mergeStyles: addressing shallow partial issue found by TS 3.9.2

### DIFF
--- a/change/@uifabric-merge-styles-2020-05-15-10-46-03-fix-merge-styles-deep-partial.json
+++ b/change/@uifabric-merge-styles-2020-05-15-10-46-03-fix-merge-styles-deep-partial.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Addressing another typing issue found by TS 3.9.2 which is now catching scenarios which were shallow partials but should have been deep partials.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-15T17:46:03.436Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -26,7 +26,12 @@ export function concatStyleSets<TStyleSet1, TStyleSet2, TStyleSet3, TStyleSet4, 
 export function concatStyleSets(...styleSets: (IStyleSet | false | null | undefined)[]): IConcatenatedStyleSet<any>;
 
 // @public
-export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): Partial<TStyleSet>;
+export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(styleProps: TStyleProps, ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]): DeepPartial<TStyleSet>;
+
+// @public
+export type DeepPartial<T> = {
+    [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
 
 // @public
 export function fontFace(font: IFontFace): void;
@@ -391,10 +396,10 @@ export interface IStyleBaseArray extends Array<IStyle> {
 }
 
 // @public
-export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = (props: TStylesProps) => Partial<TStyleSet>;
+export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = (props: TStylesProps) => DeepPartial<TStyleSet>;
 
 // @public
-export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = IStyleFunction<TStylesProps, TStyleSet> | Partial<TStyleSet>;
+export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = IStyleFunction<TStylesProps, TStyleSet> | DeepPartial<TStyleSet>;
 
 // @public
 export type IStyleSet<TStyleSet extends IStyleSet<TStyleSet> = {

--- a/packages/merge-styles/src/DeepPartial.ts
+++ b/packages/merge-styles/src/DeepPartial.ts
@@ -1,0 +1,6 @@
+/**
+ * TypeScript type to return a deep partial object (each property can be undefined, recursively.)
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+};

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,12 +1,19 @@
 import { IStyleSet } from './IStyleSet';
 
 /**
+ * Deep partial
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+/**
  * A style function takes in styleprops and returns a partial styleset.
  * {@docCategory IStyleFunction}
  */
 export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> = (
   props: TStylesProps,
-) => Partial<TStyleSet>;
+) => DeepPartial<TStyleSet>;
 
 /**
  * Represents either a style function that takes in style props and returns a partial styleset,
@@ -15,4 +22,4 @@ export type IStyleFunction<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>>
  */
 export type IStyleFunctionOrObject<TStylesProps, TStyleSet extends IStyleSet<TStyleSet>> =
   | IStyleFunction<TStylesProps, TStyleSet>
-  | Partial<TStyleSet>;
+  | DeepPartial<TStyleSet>;

--- a/packages/merge-styles/src/IStyleFunction.ts
+++ b/packages/merge-styles/src/IStyleFunction.ts
@@ -1,11 +1,5 @@
 import { IStyleSet } from './IStyleSet';
-
-/**
- * Deep partial
- */
-export type DeepPartial<T> = {
-  [P in keyof T]?: T[P] extends (infer U)[] ? DeepPartial<U>[] : T[P] extends object ? DeepPartial<T[P]> : T[P];
-};
+import { DeepPartial } from './DeepPartial';
 
 /**
  * A style function takes in styleprops and returns a partial styleset.

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -1,6 +1,7 @@
 import { concatStyleSets } from './concatStyleSets';
 import { IStyleSet } from './IStyleSet';
-import { IStyleFunctionOrObject, DeepPartial } from './IStyleFunction';
+import { IStyleFunctionOrObject } from './IStyleFunction';
+import { DeepPartial } from './DeepPartial';
 
 /**
  * Concatenates style sets into one, but resolves functional sets using the given props.

--- a/packages/merge-styles/src/concatStyleSetsWithProps.ts
+++ b/packages/merge-styles/src/concatStyleSetsWithProps.ts
@@ -1,6 +1,6 @@
 import { concatStyleSets } from './concatStyleSets';
 import { IStyleSet } from './IStyleSet';
-import { IStyleFunctionOrObject } from './IStyleFunction';
+import { IStyleFunctionOrObject, DeepPartial } from './IStyleFunction';
 
 /**
  * Concatenates style sets into one, but resolves functional sets using the given props.
@@ -10,15 +10,15 @@ import { IStyleFunctionOrObject } from './IStyleFunction';
 export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>>(
   styleProps: TStyleProps,
   ...allStyles: (IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined)[]
-): Partial<TStyleSet> {
-  const result: Partial<TStyleSet>[] = [];
+): DeepPartial<TStyleSet> {
+  const result: DeepPartial<TStyleSet>[] = [];
   for (const styles of allStyles) {
     if (styles) {
       result.push(typeof styles === 'function' ? styles(styleProps) : styles);
     }
   }
   if (result.length === 1) {
-    return result[0] as Partial<TStyleSet>;
+    return result[0] as DeepPartial<TStyleSet>;
   } else if (result.length) {
     // cliffkoh: I cannot figure out how to avoid the cast to any here.
     // It is something to do with the use of Omit in IStyleSet.
@@ -27,5 +27,6 @@ export function concatStyleSetsWithProps<TStyleProps, TStyleSet extends IStyleSe
     // tslint:disable-next-line:no-any
     return concatStyleSets(...(result as any)) as any;
   }
+
   return {};
 }

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -1,6 +1,6 @@
 export { IRawStyle, IStyle, IStyleBase, IStyleBaseArray } from './IStyle';
 
-export { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
+export { DeepPartial, IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
 
 export { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, Omit } from './IStyleSet';
 

--- a/packages/merge-styles/src/index.ts
+++ b/packages/merge-styles/src/index.ts
@@ -1,6 +1,8 @@
 export { IRawStyle, IStyle, IStyleBase, IStyleBaseArray } from './IStyle';
 
-export { DeepPartial, IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
+export { IStyleFunction, IStyleFunctionOrObject } from './IStyleFunction';
+
+export { DeepPartial } from './DeepPartial';
 
 export { IConcatenatedStyleSet, IProcessedStyleSet, IStyleSet, Omit } from './IStyleSet';
 


### PR DESCRIPTION
We were still seeing some scenarios where typings would not work with TS 3.9.2, due to the increase in type checking. 

The problem being reported was that subComponentStyles would require EVERY sub component in partial results. This should be address in this PR which correctly applies a deep partial typing.
