### PR TITLE
CommandBar: Add optional role prop

### DIFF
--- a/change/office-ui-fabric-react-2020-05-15-16-48-05-commandbar-role.json
+++ b/change/office-ui-fabric-react-2020-05-15-16-48-05-commandbar-role.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "CommandBar: Add optional aria role prop",
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com",
+  "commit": "e788a5dfe348f03d21a453d789bd811f25e740ca",
+  "date": "2020-05-15T23:48:05.673Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2863,6 +2863,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
     overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowButtonProps?: IButtonProps;
     overflowItems?: ICommandBarItemProps[];
+    role?: string;
     shiftOnReduce?: boolean;
     styles?: IStyleFunctionOrObject<ICommandBarStyleProps, ICommandBarStyles>;
     theme?: ITheme;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -100,7 +100,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       <FocusZone
         className={css(this._classNames.root)}
         direction={FocusZoneDirection.horizontal}
-        role={'menubar'}
+        role={this.props.role || 'menubar'}
         aria-label={this.props.ariaLabel}
       >
         {/*Primary Items*/}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -119,6 +119,11 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Theme provided by HOC.
    */
   theme?: ITheme;
+
+  /**
+   * Aria role assigned to the CommandBar. Default role is 'menubar'.
+   */
+  role?: string;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add optional `role` prop to `CommandBar` to override the default role of `menubar`. 

#### Focus areas to test

(optional)
