### PR TITLE
FileTypeIcon: Add empty alt text to img

### DIFF
--- a/change/@uifabric-file-type-icons-2020-05-15-16-58-53-fileicon-alt.json
+++ b/change/@uifabric-file-type-icons-2020-05-15-16-58-53-fileicon-alt.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add empty alt text for filetype icon img",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "erabelle@microsoft.com",
+  "commit": "cb1f4f4575834c9467223560be33adbffef1c373",
+  "date": "2020-05-15T23:58:53.763Z"
+}

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -25,8 +25,8 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
   const fileTypeIcons: { [key: string]: JSX.Element } = {};
 
   iconTypes.forEach((type: string) => {
-    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.png' + REFRESH_STRING} />;
-    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.svg' + REFRESH_STRING} />;
+    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.png' + REFRESH_STRING} alt="" />;
+    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.svg' + REFRESH_STRING} alt="" />;
 
     // For high resolution screens, register additional versions
     // Apply height=100% and width=100% to force image to fit into containing element

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -25,8 +25,9 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
   const fileTypeIcons: { [key: string]: JSX.Element } = {};
 
   iconTypes.forEach((type: string) => {
-    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.png' + REFRESH_STRING} alt="" />;
-    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={baseUrl + size + '/' + type + '.svg' + REFRESH_STRING} alt="" />;
+    const baseUrlSizeType = baseUrl + size + '/' + type;
+    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={baseUrlSizeType + '.png' + REFRESH_STRING} alt="" />;
+    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={baseUrlSizeType + '.svg' + REFRESH_STRING} alt="" />;
 
     // For high resolution screens, register additional versions
     // Apply height=100% and width=100% to force image to fit into containing element


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add empty alt text to `<img/>` used for FileTypeIcons

#### Focus areas to test

(optional)
