### PR TITLE
Fix aka.ms/fabricdemo

### DIFF
--- a/change/@uifabric-example-app-base-2020-05-17-19-19-42-fix-demo.json
+++ b/change/@uifabric-example-app-base-2020-05-17-19-19-42-fix-demo.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix demo app",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-18T02:19:42.489Z"
+}

--- a/packages/example-app-base/index.html
+++ b/packages/example-app-base/index.html
@@ -46,9 +46,9 @@
       }
 
       if (useMinified) {
-        scripts.push('demo.min.js');
+        scripts.push('demo-app.min.js');
       } else {
-        scripts.push('demo.js');
+        scripts.push('demo-app.js');
       }
 
       loadScript(scripts);


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

For some reason the demo app URL in the `index.html` used for aka.ms/fabricdemo (and packages in the PR deploy site) was changed from `demo-app.js` to `demo.js` in #12482, despite all the webpack configs still generating `demo-app.js`. This changes it back.