### PR TITLE
Fix example-app-base demo app

### DIFF
--- a/change/@uifabric-example-app-base-2020-05-18-10-22-19-example-demo.json
+++ b/change/@uifabric-example-app-base-2020-05-18-10-22-19-example-demo.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix example-app-base demo app",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-18T17:22:19.140Z"
+}

--- a/packages/example-app-base/webpack.serve.config.js
+++ b/packages/example-app-base/webpack.serve.config.js
@@ -6,7 +6,7 @@ module.exports = resources.createServeConfig({
 
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'demo.js',
+    filename: 'demo-app.js',
   },
 
   externals: {


### PR DESCRIPTION
Change path of output file to be `demo-app.js` like all the other apps so the `index.html` works for both example-app-base and everything else.