### PR TITLE
Copy update to Cross platform Getting Started

### DIFF
--- a/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/cross/GetStartedOverview.md
+++ b/apps/fabric-website/src/pages/Overviews/GetStartedPage/docs/cross/GetStartedOverview.md
@@ -4,7 +4,7 @@ Fluent UI React Native is an [open-source](https://github.com/microsoft/fluentui
 
 Fluent UI React Native includes an expanding library of controls written in JavaScript. These controls implement the Fluent Design language and provide consistency across Microsoft experiences.
 
-Documentation for the controls is a work in progress. Some controls can be found in the <a href="#/controls/crossplatform">Controls section</a> of the site. To view the full list, see the [Fluent UI React Native Github source folder](https://github.com/microsoft/fluentui-react-native/tree/master/packages/components).
+Fluent UI React Native is still in the early stages of development, and currently only supports Windows and macOS components, with iOS and Android component support coming soon. Documentation for the controls is a work in progress. Some controls can be found in the <a href="#/controls/crossplatform">Controls section</a> of the site. To view the full list, see the [Fluent UI React Native Github source folder](https://github.com/microsoft/fluentui-react-native/tree/master/packages/components).
 
 ### Start developing
 

--- a/change/@uifabric-fabric-website-2020-05-18-14-18-14-ej-website.json
+++ b/change/@uifabric-fabric-website-2020-05-18-14-18-14-ej-website.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "added blurb on the Cross platform Getting Started page that FURN controls only support Windows and Mac atm",
+  "packageName": "@uifabric/fabric-website",
+  "email": "ejlayne@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-18T21:18:14.041Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Added blurb on the Cross platform Getting Started page that FURN controls only support Windows and Mac atm.

"Fluent UI React Native is still in the early stages of development, and currently only supports Windows and macOS components, with iOS and Android component support coming soon."

#### Focus areas to test

This page: https://developer.microsoft.com/en-us/fluentui#/get-started/crossplatform
