### PR TITLE
DetailsList: Specifying preventDefaultWhenHandled to be false so that we don't break input navigation via keyboard

### DIFF
--- a/change/office-ui-fabric-react-2020-05-18-18-02-48-detailsListFocusZoneEventPrevention.json
+++ b/change/office-ui-fabric-react-2020-05-18-18-02-48-detailsListFocusZoneEventPrevention.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Specifying preventDefaultWhenHandled to be false so that we don't break input navigation via keyboard.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-19T01:02:48.616Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -220,6 +220,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
         data-automationid="DetailsHeader"
         style={{ minWidth: rowWidth }}
         direction={FocusZoneDirection.horizontal}
+        preventDefaultWhenHandled={false}
       >
         {showCheckbox
           ? [

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -491,6 +491,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
               shouldEnterInnerZone={this.isRightArrow}
               onActiveElementChanged={this._onActiveRowChanged}
               onBlur={this._onBlur}
+              preventDefaultWhenHandled={false}
             >
               {!this.props.disableSelectionZone ? (
                 <SelectionZone

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -283,6 +283,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         style={{ minWidth: rowWidth }}
         aria-selected={ariaSelected}
         allowFocusRoot={true}
+        preventDefaultWhenHandled={false}
       >
         {showCheckbox && (
           <div role="gridcell" aria-colindex={1} data-selection-toggle={true} className={this._classNames.checkCell}>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13210
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#12636 introduced the `preventDefaultWhenHandled` prop to `FocusZone`, which broke keyboard navigation on inputs inside of `DetailsList` due to its use of `FocusZone`. This PR fixes this problem by specifying `preventDefaultWhenHandled={false}` in all `DetailsList` related components.

#### Focus areas to test

(optional)
