### PR TITLE
fix(mixed): use useRef() hook in functional components

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Enable back focus zone in `CarouselNavigation` @kolaps33 ([#13086](https://github.com/microsoft/fluentui/pull/13086))
 - Update examples to focus on internal input when Tab is pressed in `RadioGroupItem` @assuncaocharles ([#13110](https://github.com/microsoft/fluentui/pull/13110))
 - Wrapped `Alert`, `Attachment`, `Box` and `ListItem` FC with `unstable_wrapWithFocusZone` @assuncaocharles ([#13093](https://github.com/microsoft/fluentui/pull/13093))
+- Fix to use `useRef()` hook in functional components @layershifter ([#13228](https://github.com/microsoft/fluentui/pull/13228))
 
 ### Features
 - Added icons: `TranscriptIcon`, `FilesGenericColoredIcon`, `FilesHtmlColoredIcon`, `FilesPdfColoredIcon`, `FilesPictureColoredIcon`, `FilesTextColoredIcon`, `PopupIcon`, `ShareGenericIcon`, `ComposeIcon`, `SpotlightStopIcon`, `TenantWorkIcon`, `TenantPersonalIcon`, `WorkOrSchoolIcon`, `EmailWithDotIcon`. Modified: `ShareLocationIcon`, `SpotlightIcon`. @TanelVari ([#12872](https://github.com/microsoft/fluentui/pull/12872))

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -220,8 +220,8 @@ export const Carousel: React.FC<WithAsProp<CarouselProps>> &
     rtl: context.rtl,
   });
 
-  const paddleNextRef = React.createRef<HTMLElement>(); // TODO
-  const paddlePreviousRef = React.createRef<HTMLElement>(); // TODO
+  const paddleNextRef = React.useRef<HTMLElement>();
+  const paddlePreviousRef = React.useRef<HTMLElement>();
 
   const focusItemAtIndex = _.debounce((index: number) => {
     itemRefs[index].current?.focus();

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -220,8 +220,8 @@ export const Carousel: React.FC<WithAsProp<CarouselProps>> &
     rtl: context.rtl,
   });
 
-  const paddleNextRef = React.createRef<HTMLElement>();
-  const paddlePreviousRef = React.createRef<HTMLElement>();
+  const paddleNextRef = React.createRef<HTMLElement>(); // TODO
+  const paddlePreviousRef = React.createRef<HTMLElement>(); // TODO
 
   const focusItemAtIndex = _.debounce((index: number) => {
     itemRefs[index].current?.focus();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -82,9 +82,12 @@ const DropdownSelectedItem: React.FC<WithAsProp<DropdownSelectedItemProps>> &
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DropdownSelectedItem.displayName, context.telemetry);
   setStart();
+
   const { active, header, icon, image, className, design, styles, variables } = props;
-  const itemRef = React.createRef<HTMLElement>(); // TODO
+
+  const itemRef = React.useRef<HTMLElement>();
   const unhandledProps = useUnhandledProps(DropdownSelectedItem.handledProps, props);
+
   React.useEffect(() => {
     if (active) {
       itemRef.current.focus();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -83,7 +83,7 @@ const DropdownSelectedItem: React.FC<WithAsProp<DropdownSelectedItemProps>> &
   const { setStart, setEnd } = useTelemetry(DropdownSelectedItem.displayName, context.telemetry);
   setStart();
   const { active, header, icon, image, className, design, styles, variables } = props;
-  const itemRef = React.createRef<HTMLElement>();
+  const itemRef = React.createRef<HTMLElement>(); // TODO
   const unhandledProps = useUnhandledProps(DropdownSelectedItem.handledProps, props);
   React.useEffect(() => {
     if (active) {

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -148,7 +148,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> & FluentComponentStaticProps = p
     vertical,
     disabled,
   } = props;
-  const inputRef = React.createRef<HTMLElement>(); // TODO
+  const inputRef = React.useRef<HTMLElement>();
 
   const { state, actions } = useStateManager(createSliderManager, {
     mapPropsToInitialState: () => ({

--- a/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Slider/Slider.tsx
@@ -148,7 +148,7 @@ const Slider: React.FC<WithAsProp<SliderProps>> & FluentComponentStaticProps = p
     vertical,
     disabled,
   } = props;
-  const inputRef = React.createRef<HTMLElement>();
+  const inputRef = React.createRef<HTMLElement>(); // TODO
 
   const { state, actions } = useStateManager(createSliderManager, {
     mapPropsToInitialState: () => ({

--- a/packages/fluentui/react-northstar/src/components/Video/Video.tsx
+++ b/packages/fluentui/react-northstar/src/components/Video/Video.tsx
@@ -44,7 +44,7 @@ export const Video: React.FC<WithAsProp<VideoProps>> & FluentComponentStaticProp
   setStart();
   const { controls, autoPlay, loop, poster, src, muted, variables, className, design, styles } = props;
   const ElementType = getElementType(props);
-  const videoRef = React.createRef<HTMLVideoElement>();
+  const videoRef = React.createRef<HTMLVideoElement>(); // TODO
   const unhandledProps = useUnhandledProps(Video.handledProps, props);
   const getA11yProps = useAccessibility(props.accessibility, {
     debugName: Video.displayName,

--- a/packages/fluentui/react-northstar/src/components/Video/Video.tsx
+++ b/packages/fluentui/react-northstar/src/components/Video/Video.tsx
@@ -42,10 +42,13 @@ export const Video: React.FC<WithAsProp<VideoProps>> & FluentComponentStaticProp
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Video.displayName, context.telemetry);
   setStart();
+
   const { controls, autoPlay, loop, poster, src, muted, variables, className, design, styles } = props;
+  const videoRef = React.useRef<HTMLVideoElement>();
+
   const ElementType = getElementType(props);
-  const videoRef = React.createRef<HTMLVideoElement>(); // TODO
   const unhandledProps = useUnhandledProps(Video.handledProps, props);
+
   const getA11yProps = useAccessibility(props.accessibility, {
     debugName: Video.displayName,
   });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue with usage of `.createRef()` instead of `useRef()` hook in recently converted components.

#### Focus areas to test

(optional)
