### PR TITLE
feat(compose): add shorthandConfig to options

### DIFF
--- a/change/@fluentui-react-compose-2020-05-20-10-55-51-feat-add-shorthand-config-compose.json
+++ b/change/@fluentui-react-compose-2020-05-20-10-55-51-feat-add-shorthand-config-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add shorthand config",
+  "packageName": "@fluentui/react-compose",
+  "email": "mnajdova@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-20T08:55:51.131Z"
+}

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `menuItemSlotClassNames.indicator` and `menuItemSlotClassNames.wrapper` were removed, `menuItemIndicatorClassName` and `menuItemWrapperClassName` should be used instead @mnajdova ([#13117](https://github.com/microsoft/fluentui/pull/13117))
 - Move `MenuItem`'s slots styles to dedicated components @mnajdova ([#13117](https://github.com/microsoft/fluentui/pull/13117))
 - Move `divider`'s slots styles to `MenuDivider` component @mnajdova @layershifter ([#13207](https://github.com/microsoft/fluentui/pull/13207))
+- Move `shorthandConfig` to `compose`'s options @mnajdova ([#13240](https://github.com/microsoft/fluentui/pull/13240))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   Menu,
   MenuItem,
+  MenuProps,
   compose,
   Provider,
   MenuItemIcon,
@@ -9,6 +10,7 @@ import {
   MenuItemIndicator,
   MenuItemWrapper,
   BookmarkIcon,
+  MenuStylesProps,
 } from '@fluentui/react-northstar';
 
 const MenuItemWrapperDashed = compose(MenuItemWrapper, {
@@ -19,8 +21,8 @@ const MenuItemIconGreen = compose(MenuItemIcon, {
   displayName: 'MenuItemIconGreen',
 });
 
-const MenuItemContentPink = compose(MenuItemContent, {
-  displayName: 'MenuItemContentPink',
+const MenuItemContentPurple = compose(MenuItemContent, {
+  displayName: 'MenuItemContentPurple',
 });
 
 const MenuitemIndicatorSaturated = compose(MenuItemIndicator, {
@@ -31,9 +33,16 @@ const MenuItemBlue = compose(MenuItem, {
   displayName: 'MenuItemBlue',
   slots: {
     icon: MenuItemIconGreen,
-    content: MenuItemContentPink,
+    content: MenuItemContentPurple,
     indicator: MenuitemIndicatorSaturated,
     wrapper: MenuItemWrapperDashed,
+  },
+});
+
+const MenuCoral = compose<'ul', MenuProps, MenuStylesProps, MenuProps, MenuStylesProps>(Menu, {
+  displayName: 'MenuCoral',
+  slots: {
+    item: MenuItemBlue,
   },
 });
 
@@ -42,9 +51,16 @@ const items = [
     key: 'editorials',
     content: 'Editorials',
     icon: <BookmarkIcon />,
-    menu: ['One', 'Two', 'Three'],
-    // TODO: remove once compose is implemented for the hierarchical structure
-    children: (C, p) => <MenuItemBlue {...p} />,
+    menuOpen: true,
+    menu: [
+      {
+        key: 'One',
+        content: 'One',
+        menu: ['Four', { content: 'Five' }],
+      },
+      'Two',
+      'Three',
+    ],
   },
   { key: 'review', content: 'Reviews' },
   { key: 'events', content: 'Upcoming Events' },
@@ -62,9 +78,9 @@ const themeOverrides = {
         color: 'lightgreen',
       },
     },
-    MenuItemContentPink: {
+    MenuItemContentPurple: {
       root: {
-        color: 'pink',
+        color: 'purple',
       },
     },
     MenuitemIndicatorSaturated: {
@@ -79,12 +95,17 @@ const themeOverrides = {
         border: '1px dashed lightgreen',
       },
     },
+    MenuCoral: {
+      root: {
+        background: 'coral',
+      },
+    },
   },
 };
 
 const MenuExampleCompose = () => (
   <Provider theme={themeOverrides}>
-    <Menu defaultActiveIndex={0} items={items} />
+    <MenuCoral defaultActiveIndex={0} items={items} />
   </Provider>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   Menu,
   MenuItem,
-  MenuProps,
   compose,
   Provider,
   MenuItemIcon,
@@ -10,7 +9,6 @@ import {
   MenuItemIndicator,
   MenuItemWrapper,
   BookmarkIcon,
-  MenuStylesProps,
 } from '@fluentui/react-northstar';
 
 const MenuItemWrapperDashed = compose(MenuItemWrapper, {
@@ -21,8 +19,8 @@ const MenuItemIconGreen = compose(MenuItemIcon, {
   displayName: 'MenuItemIconGreen',
 });
 
-const MenuItemContentPurple = compose(MenuItemContent, {
-  displayName: 'MenuItemContentPurple',
+const MenuItemContentPink = compose(MenuItemContent, {
+  displayName: 'MenuItemContentPink',
 });
 
 const MenuitemIndicatorSaturated = compose(MenuItemIndicator, {
@@ -33,16 +31,9 @@ const MenuItemBlue = compose(MenuItem, {
   displayName: 'MenuItemBlue',
   slots: {
     icon: MenuItemIconGreen,
-    content: MenuItemContentPurple,
+    content: MenuItemContentPink,
     indicator: MenuitemIndicatorSaturated,
     wrapper: MenuItemWrapperDashed,
-  },
-});
-
-const MenuCoral = compose<'ul', MenuProps, MenuStylesProps, MenuProps, MenuStylesProps>(Menu, {
-  displayName: 'MenuCoral',
-  slots: {
-    item: MenuItemBlue,
   },
 });
 
@@ -51,16 +42,9 @@ const items = [
     key: 'editorials',
     content: 'Editorials',
     icon: <BookmarkIcon />,
-    menuOpen: true,
-    menu: [
-      {
-        key: 'One',
-        content: 'One',
-        menu: ['Four', { content: 'Five' }],
-      },
-      'Two',
-      'Three',
-    ],
+    menu: ['One', 'Two', 'Three'],
+    // TODO: remove once compose is implemented for the hierarchical structure
+    children: (C, p) => <MenuItemBlue {...p} />,
   },
   { key: 'review', content: 'Reviews' },
   { key: 'events', content: 'Upcoming Events' },
@@ -78,9 +62,9 @@ const themeOverrides = {
         color: 'lightgreen',
       },
     },
-    MenuItemContentPurple: {
+    MenuItemContentPink: {
       root: {
-        color: 'purple',
+        color: 'pink',
       },
     },
     MenuitemIndicatorSaturated: {
@@ -95,17 +79,12 @@ const themeOverrides = {
         border: '1px dashed lightgreen',
       },
     },
-    MenuCoral: {
-      root: {
-        background: 'coral',
-      },
-    },
   },
 };
 
 const MenuExampleCompose = () => (
   <Provider theme={themeOverrides}>
-    <MenuCoral defaultActiveIndex={0} items={items} />
+    <Menu defaultActiveIndex={0} items={items} />
   </Provider>
 );
 

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
@@ -1,8 +1,7 @@
 import { buttonBehavior } from '@fluentui/accessibility';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Button, { ButtonProps, ButtonStylesProps } from '../Button/Button';
 

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
@@ -2,8 +2,8 @@ import { buttonBehavior } from '@fluentui/accessibility';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes } from '../../utils';
 import Button, { ButtonProps, ButtonStylesProps } from '../Button/Button';
 
 interface AttachmentActionOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
@@ -1,6 +1,7 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { ShorthandConfig } from '@fluentui/react-compose';
 
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentBodyOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentDescriptionOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentHeaderOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
@@ -1,6 +1,6 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface AttachmentIconOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -14,7 +14,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-
+import { ShorthandConfig } from '@fluentui/react-compose';
 import {
   childrenExist,
   createShorthandFactory,
@@ -25,7 +25,6 @@ import {
   rtlTextContainer,
   SizeValue,
   ShorthandFactory,
-  ShorthandConfig,
   createShorthand,
 } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -7,6 +7,7 @@ import {
   useStyles,
   useTelemetry,
   useUnhandledProps,
+  ShorthandConfig,
 } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
@@ -14,7 +15,6 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import {
   childrenExist,
   createShorthandFactory,

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -1,7 +1,7 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
-
-import { commonPropTypes, ShorthandConfig, SizeValue } from '../../utils';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes, SizeValue } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
 interface ButtonContentOwnProps {

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -1,6 +1,5 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import { commonPropTypes, SizeValue } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
@@ -1,5 +1,5 @@
-import { ComponentWithAs, compose } from '@fluentui/react-compose';
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { ComponentWithAs, compose, ShorthandConfig } from '@fluentui/react-compose';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
 interface CardExpandableBoxOwnProps {}

--- a/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
@@ -1,4 +1,4 @@
-import { ComponentWithAs, compose, ShorthandConfig } from '@fluentui/react-compose';
+import { ComponentWithAs, compose, ShorthandConfig } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
@@ -1,6 +1,6 @@
 import { Accessibility, loaderBehavior } from '@fluentui/accessibility';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { ShorthandConfig } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import {

--- a/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
@@ -1,8 +1,8 @@
 import { Accessibility, loaderBehavior } from '@fluentui/accessibility';
 import * as customPropTypes from '@fluentui/react-proptypes';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-
 import {
   UIComponent,
   createShorthandFactory,
@@ -11,7 +11,6 @@ import {
   SizeValue,
   ShorthandFactory,
   getOrGenerateIdFromShorthand,
-  ShorthandConfig,
 } from '../../utils';
 import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -8,6 +8,7 @@ import {
   useStyles,
   useTelemetry,
   useUnhandledProps,
+  ShorthandConfig,
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
@@ -17,7 +18,6 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import { ShorthandCollection, ShorthandValue, ComponentEventHandler, ProviderContextPrepared } from '../../types';
 import {
   childrenExist,

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -17,7 +17,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-
+import { ShorthandConfig } from '@fluentui/react-compose';
 import { ShorthandCollection, ShorthandValue, ComponentEventHandler, ProviderContextPrepared } from '../../types';
 import {
   childrenExist,
@@ -29,7 +29,6 @@ import {
   getKindProp,
   rtlTextContainer,
   ShorthandFactory,
-  ShorthandConfig,
 } from '../../utils';
 import MenuItem, { MenuItemProps } from './MenuItem';
 import MenuDivider from './MenuDivider';
@@ -329,6 +328,9 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
       'submenu',
       'indicator',
     ],
+    shorthandConfig: {
+      mappedArrayProp: 'items',
+    },
   },
 ) as ComponentWithAs<'ul', MenuProps> & {
   create: ShorthandFactory<MenuProps>;
@@ -375,6 +377,5 @@ Menu.ItemIndicator = MenuItemIndicator;
 Menu.Divider = MenuDivider;
 
 Menu.create = createShorthandFactory({ Component: Menu, mappedArrayProp: 'items' });
-Menu.shorthandConfig = { mappedArrayProp: 'items' };
 
 export default Menu;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -8,11 +8,11 @@ import {
   useStyles,
   useUnhandledProps,
 } from '@fluentui/react-bindings';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-
 import {
   createShorthandFactory,
   UIComponentProps,
@@ -22,7 +22,6 @@ import {
   ContentComponentProps,
   rtlTextContainer,
   ShorthandFactory,
-  ShorthandConfig,
 } from '../../utils';
 import { ProviderContextPrepared } from '../../types';
 

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -7,8 +7,8 @@ import {
   useTelemetry,
   useStyles,
   useUnhandledProps,
+  ShorthandConfig,
 } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -9,11 +9,11 @@ import {
   useAccessibility,
   useStyles,
   ComponentWithAs,
+  ShorthandConfig,
 } from '@fluentui/react-bindings';
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { Ref, handleRef } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -13,6 +13,7 @@ import {
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { Ref, handleRef } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -25,7 +26,6 @@ import {
   ContentComponentProps,
   commonPropTypes,
   isFromKeyboard as isEventFromKeyboard,
-  ShorthandConfig,
 } from '../../utils';
 import Menu, { MenuProps, MenuShorthandKinds } from './Menu';
 import MenuItemIcon, { MenuItemIconProps } from './MenuItemIcon';
@@ -545,6 +545,9 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       'styles',
       'variables',
     ],
+    shorthandConfig: {
+      mappedProp: 'content',
+    },
   },
 ) as ComponentWithAs<'a', MenuItemProps> & {
   shorthandConfig: ShorthandConfig<MenuItemProps>;
@@ -585,10 +588,6 @@ MenuItem.defaultProps = {
   accessibility: menuItemBehavior as Accessibility,
   wrapper: {},
   indicator: {},
-};
-
-MenuItem.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default MenuItem;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
@@ -1,7 +1,7 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
 interface MenuItemContentOwnProps {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
@@ -1,5 +1,4 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
-import { ShorthandConfig } from '@fluentui/react-compose';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
@@ -1,7 +1,7 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
 interface MenuItemIconOwnProps {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
@@ -1,7 +1,6 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import { indicatorBehavior } from '@fluentui/accessibility';
 import * as PropTypes from 'prop-types';
-import { ShorthandConfig } from '@fluentui/react-compose';
 
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
@@ -1,8 +1,9 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 import { indicatorBehavior } from '@fluentui/accessibility';
 import * as PropTypes from 'prop-types';
+import { ShorthandConfig } from '@fluentui/react-compose';
 
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
 interface MenuItemIndicatorOwnProps {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
@@ -1,6 +1,5 @@
-import { compose, ComponentWithAs } from '@fluentui/react-bindings';
+import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
@@ -1,8 +1,8 @@
 import { compose, ComponentWithAs } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as PropTypes from 'prop-types';
-
-import { commonPropTypes, ShorthandConfig } from '../../utils';
+import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
 interface MenuItemWrapperOwnProps {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
@@ -7,11 +7,11 @@ import {
   useTelemetry,
   compose,
   ComponentWithAs,
+  ShorthandConfig,
 } from '@fluentui/react-bindings';
 import { mergeComponentVariables } from '@fluentui/styles';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import * as React from 'react';
 import { ProviderContextPrepared } from '../../types';
 import {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
@@ -11,7 +11,7 @@ import {
 import { mergeComponentVariables } from '@fluentui/styles';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
-
+import { ShorthandConfig } from '@fluentui/react-compose';
 import * as React from 'react';
 import { ProviderContextPrepared } from '../../types';
 import {
@@ -21,7 +21,6 @@ import {
   UIComponentProps,
   commonPropTypes,
   ShorthandFactory,
-  ShorthandConfig,
 } from '../../utils';
 import { ToolbarVariablesContext } from './toolbarVariablesContext';
 

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -1,6 +1,5 @@
-import { StylesContextInputValue, StylesContextValue, Telemetry } from '@fluentui/react-bindings';
+import { StylesContextInputValue, StylesContextValue, Telemetry, ShorthandConfig } from '@fluentui/react-bindings';
 import * as React from 'react';
-import { ShorthandConfig } from '@fluentui/react-compose';
 import { ShorthandFactory } from './utils/factories';
 
 // Temporary workaround for @lodash dependency

--- a/packages/fluentui/react-northstar/src/types.ts
+++ b/packages/fluentui/react-northstar/src/types.ts
@@ -1,7 +1,7 @@
 import { StylesContextInputValue, StylesContextValue, Telemetry } from '@fluentui/react-bindings';
 import * as React from 'react';
-
-import { ShorthandConfig, ShorthandFactory } from './utils/factories';
+import { ShorthandConfig } from '@fluentui/react-compose';
+import { ShorthandFactory } from './utils/factories';
 
 // Temporary workaround for @lodash dependency
 

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -1,12 +1,11 @@
 import { mergeStyles } from '@fluentui/styles';
-import { ComponentWithAs } from '@fluentui/react-compose';
+import { ComponentWithAs, ComposePreparedOptions } from '@fluentui/react-compose';
 import cx from 'classnames';
 import * as _ from 'lodash';
 import * as React from 'react';
 import * as ReactIs from 'react-is';
 
 import { ShorthandValue, Props, PropsOf, ShorthandRenderFunction } from '../types';
-import { ComposePreparedOptions } from '@fluentui/react-compose/dist/src';
 
 type HTMLTag = 'iframe' | 'img' | 'input';
 type ShorthandProp = 'children' | 'src' | 'type';

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -1,5 +1,5 @@
 import { mergeStyles } from '@fluentui/styles';
-import { ComponentWithAs, ComposePreparedOptions } from '@fluentui/react-compose';
+import { ComponentWithAs, ComposePreparedOptions } from '@fluentui/react-bindings';
 import cx from 'classnames';
 import * as _ from 'lodash';
 import * as React from 'react';

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -261,7 +261,7 @@ export function createShorthand<TElementType extends React.ElementType>(
 ): React.ReactElement;
 export function createShorthand<P>(Component, value?, options?) {
   const { mappedProp = 'children', allowsJSX = true, mappedArrayProp } =
-    (Component.fluentComposeConfig && Component.fluentComposeConfig.shorthandConfig) || {};
+    Component.shorthandConfig || Component.fluentComposeConfig?.shorthandConfig) || {};
 
   return createShorthandInternal<P>({
     Component,

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -1,5 +1,5 @@
 import { mergeStyles } from '@fluentui/styles';
-import { ComponentWithAs, ComposePreparedOptions } from '@fluentui/react-bindings';
+import { ComponentWithAs, ComposePreparedOptions, ShorthandConfig } from '@fluentui/react-bindings';
 import cx from 'classnames';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -240,28 +240,40 @@ export function createShorthandInternal<P>({
 }
 
 export function createShorthand<TFunctionComponent extends React.FunctionComponent>(
-  Component: TFunctionComponent & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TFunctionComponent>> },
+  Component: TFunctionComponent & {
+    shorthandConfig?: ShorthandConfig<PropsOf<TFunctionComponent>>;
+    fluentComposeConfig?: ComposePreparedOptions<PropsOf<TFunctionComponent>>;
+  },
   value?: ShorthandValue<PropsOf<TFunctionComponent>>,
   options?: CreateShorthandOptions<PropsOf<TFunctionComponent>>,
 ): React.ReactElement;
 export function createShorthand<TInstance extends React.Component>(
-  Component: { new (...args: any[]): TInstance } & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TInstance>> },
+  Component: { new (...args: any[]): TInstance } & {
+    shorthandConfig?: ShorthandConfig<PropsOf<TInstance>>;
+    fluentComposeConfig?: ComposePreparedOptions<PropsOf<TInstance>>;
+  },
   value?: ShorthandValue<PropsOf<TInstance>>,
   options?: CreateShorthandOptions<PropsOf<TInstance>>,
 ): React.ReactElement;
 export function createShorthand<E extends React.ElementType, P>(
-  Component: ComponentWithAs<E, P> & { fluentComposeConfig?: ComposePreparedOptions<P> },
+  Component: ComponentWithAs<E, P> & {
+    shorthandConfig?: ShorthandConfig<P>;
+    fluentComposeConfig?: ComposePreparedOptions<P>;
+  },
   value?: ShorthandValue<P>,
   options?: CreateShorthandOptions<P>,
 ): React.ReactElement;
 export function createShorthand<TElementType extends React.ElementType>(
-  Component: TElementType & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TElementType>> },
+  Component: TElementType & {
+    shorthandConfig?: ShorthandConfig<PropsOf<TElementType>>;
+    fluentComposeConfig?: ComposePreparedOptions<PropsOf<TElementType>>;
+  },
   value?: ShorthandValue<PropsOf<TElementType>>,
   options?: CreateShorthandOptions<PropsOf<TElementType>>,
 ): React.ReactElement;
 export function createShorthand<P>(Component, value?, options?) {
   const { mappedProp = 'children', allowsJSX = true, mappedArrayProp } =
-    Component.shorthandConfig || Component.fluentComposeConfig?.shorthandConfig) || {};
+    Component.shorthandConfig || Component.fluentComposeConfig?.shorthandConfig || {};
 
   return createShorthandInternal<P>({
     Component,

--- a/packages/fluentui/react-northstar/src/utils/factories.ts
+++ b/packages/fluentui/react-northstar/src/utils/factories.ts
@@ -6,6 +6,7 @@ import * as React from 'react';
 import * as ReactIs from 'react-is';
 
 import { ShorthandValue, Props, PropsOf, ShorthandRenderFunction } from '../types';
+import { ComposePreparedOptions } from '@fluentui/react-compose/dist/src';
 
 type HTMLTag = 'iframe' | 'img' | 'input';
 type ShorthandProp = 'children' | 'src' | 'type';
@@ -35,12 +36,6 @@ export type ShorthandFactory<P> = (
   value: ShorthandValue<P>,
   options?: CreateShorthandOptions<P>,
 ) => React.ReactElement | null | undefined;
-
-export interface ShorthandConfig<P> {
-  mappedProp?: keyof P;
-  mappedArrayProp?: keyof P;
-  allowsJSX?: boolean;
-}
 
 // ============================================================
 // Factory Creators
@@ -246,27 +241,28 @@ export function createShorthandInternal<P>({
 }
 
 export function createShorthand<TFunctionComponent extends React.FunctionComponent>(
-  Component: TFunctionComponent & { shorthandConfig?: ShorthandConfig<PropsOf<TFunctionComponent>> },
+  Component: TFunctionComponent & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TFunctionComponent>> },
   value?: ShorthandValue<PropsOf<TFunctionComponent>>,
   options?: CreateShorthandOptions<PropsOf<TFunctionComponent>>,
 ): React.ReactElement;
 export function createShorthand<TInstance extends React.Component>(
-  Component: { new (...args: any[]): TInstance } & { shorthandConfig?: ShorthandConfig<PropsOf<TInstance>> },
+  Component: { new (...args: any[]): TInstance } & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TInstance>> },
   value?: ShorthandValue<PropsOf<TInstance>>,
   options?: CreateShorthandOptions<PropsOf<TInstance>>,
 ): React.ReactElement;
 export function createShorthand<E extends React.ElementType, P>(
-  Component: ComponentWithAs<E, P> & { shorthandConfig?: ShorthandConfig<P> },
+  Component: ComponentWithAs<E, P> & { fluentComposeConfig?: ComposePreparedOptions<P> },
   value?: ShorthandValue<P>,
   options?: CreateShorthandOptions<P>,
 ): React.ReactElement;
 export function createShorthand<TElementType extends React.ElementType>(
-  Component: TElementType & { shorthandConfig?: ShorthandConfig<PropsOf<TElementType>> },
+  Component: TElementType & { fluentComposeConfig?: ComposePreparedOptions<PropsOf<TElementType>> },
   value?: ShorthandValue<PropsOf<TElementType>>,
   options?: CreateShorthandOptions<PropsOf<TElementType>>,
 ): React.ReactElement;
 export function createShorthand<P>(Component, value?, options?) {
-  const { mappedProp = 'children', allowsJSX = true, mappedArrayProp } = Component.shorthandConfig || {};
+  const { mappedProp = 'children', allowsJSX = true, mappedArrayProp } =
+    (Component.fluentComposeConfig && Component.fluentComposeConfig.shorthandConfig) || {};
 
   return createShorthandInternal<P>({
     Component,

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -47,6 +47,7 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
     overrideStyles?: boolean;
     slots?: Record<string, React.ElementType>;
     mapPropsToSlotProps?: (props: InputProps) => Record<string, object>;
+    shorthandConfig?: ShorthandConfig<InputProps>;
 };
 
 // @public (undocumented)
@@ -62,6 +63,7 @@ export type ComposePreparedOptions<Props = {}> = {
     slots: Record<string, React.ElementType>;
     mapPropsToSlotPropsChain: ((props: Props) => Record<string, object>)[];
     resolveSlotProps: <P>(props: P) => Record<string, object>;
+    shorthandConfig: ShorthandConfig<Props>;
 };
 
 // @public (undocumented)
@@ -79,6 +81,16 @@ export type InputComposeComponent<P = {}> = React.FunctionComponent<P> & {
 
 // @public (undocumented)
 export type PropsOfElement<E extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>> = JSX.LibraryManagedAttributes<E, React.ComponentPropsWithRef<E>>;
+
+// @public (undocumented)
+export interface ShorthandConfig<P> {
+    // (undocumented)
+    allowsJSX?: boolean;
+    // (undocumented)
+    mappedArrayProp?: keyof P;
+    // (undocumented)
+    mappedProp?: keyof P;
+}
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-compose/src/compose.test.tsx
+++ b/packages/react-compose/src/compose.test.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import compose from './compose';
+import { shallow } from 'enzyme';
+
+describe('compose', () => {
+  describe('shorthandConfig', () => {
+    it('is passed via composeOptions', () => {
+      const BaseComponent = compose(
+        (props, ref, composeOptions) => {
+          return (
+            <div
+              data-mapped-prop={composeOptions.shorthandConfig.mappedProp}
+              data-allows-jsx={composeOptions.shorthandConfig.allowsJSX}
+            />
+          );
+        },
+        {
+          shorthandConfig: {
+            allowsJSX: false,
+            mappedProp: 'content',
+          },
+        },
+      );
+
+      const ComposedComponent = compose(BaseComponent, {
+        shorthandConfig: {
+          mappedProp: 'as',
+        },
+      });
+
+      const wrapper = shallow(<BaseComponent />);
+      const composedWrapper = shallow(<ComposedComponent />);
+
+      expect(wrapper.prop('data-mapped-prop')).toEqual('content');
+      expect(wrapper.prop('data-allows-jsx')).toEqual(false);
+      expect(composedWrapper.prop('data-mapped-prop')).toEqual('as');
+      expect(composedWrapper.prop('data-allows-jsx')).toEqual(false);
+    });
+  });
+});

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+// tslint:disable-next-line:interface-name
 export interface ShorthandConfig<P> {
   mappedProp?: keyof P;
   mappedArrayProp?: keyof P;

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+export interface ShorthandConfig<P> {
+  mappedProp?: keyof P;
+  mappedArrayProp?: keyof P;
+  allowsJSX?: boolean;
+}
+
 //
 // "as" type safety
 //
@@ -58,6 +64,8 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
   slots?: Record<string, React.ElementType>;
 
   mapPropsToSlotProps?: (props: InputProps) => Record<string, object>;
+
+  shorthandConfig?: ShorthandConfig<InputProps>;
 };
 
 export type ClassDictionary = {
@@ -80,4 +88,5 @@ export type ComposePreparedOptions<Props = {}> = {
   mapPropsToSlotPropsChain: ((props: Props) => Record<string, object>)[];
 
   resolveSlotProps: <P>(props: P) => Record<string, object>;
+  shorthandConfig: ShorthandConfig<Props>;
 };

--- a/packages/react-compose/src/utils.ts
+++ b/packages/react-compose/src/utils.ts
@@ -33,6 +33,7 @@ export const defaultComposeOptions: ComposePreparedOptions = {
   slots: {},
   mapPropsToSlotPropsChain: [],
   resolveSlotProps: () => ({}),
+  shorthandConfig: {},
 };
 
 export function mergeComposeOptions(
@@ -83,6 +84,10 @@ export function mergeComposeOptions(
     },
     mapPropsToSlotPropsChain,
     resolveSlotProps,
+    shorthandConfig: {
+      ...parentOptions.shorthandConfig,
+      ...inputOptions.shorthandConfig,
+    },
   };
 }
 


### PR DESCRIPTION
`shorthandConfig` option was added to compose. If you are using `compose` in your component, make sure that you move the static `shorthandConfig` to the compose options. For backward compatibility, the factories are still handling the shorthandConfig defined as static prop too.

Before
```jsx
const Component = compose((props, ref, options) => {...});
Component.shorthandConfig = {
  mappedProp: 'content',
};
```

After
```jsx
const Component = compose((orios, ref, options) => {...}, {
  shorthandConfig: {
    mappedProp: 'content',
  };
);
```