### PR TITLE
Adjust custom panel navigation margins

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -202,10 +202,10 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     ],
     hiddenPanel: [
       !isOpen &&
-        !isAnimating &&
-        isHiddenOnDismiss && {
-          visibility: 'hidden',
-        },
+      !isAnimating &&
+      isHiddenOnDismiss && {
+        visibility: 'hidden',
+      },
     ],
     main: [
       classNames.main,
@@ -259,9 +259,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         marginTop: 18,
       },
-      hasCustomNavigation && {
-        marginTop: 'inherit',
-      },
     ],
     navigation: [
       classNames.navigation,
@@ -271,6 +268,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       },
       hasCustomNavigation && {
         height: commandBarHeight,
+        marginLeft: 20,
       },
     ],
     contentInner: [
@@ -289,9 +287,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         alignSelf: 'flex-start',
       },
       hasCloseButton &&
-        !hasCustomNavigation && {
-          flexGrow: 1,
-        },
+      !hasCustomNavigation && {
+        flexGrow: 1,
+      },
       hasCustomNavigation && {
         // Ensure that title doesn't shrink if screen is too small
         flexShrink: 0,


### PR DESCRIPTION
Adjust margins so the searchbox isn't hugging the top-left corner

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #12922

#### Description of changes

Adjusts margins around search box for custom navigation panel