### PR TITLE
fix dependencies not being watched

### DIFF
--- a/scripts/monorepo/findRepoDeps.js
+++ b/scripts/monorepo/findRepoDeps.js
@@ -26,13 +26,13 @@ function findRepoDeps() {
 
     if (dep && packageInfo[dep]) {
       result.add(dep);
-    }
 
-    getDeps(dep.packageJson).forEach(child => {
-      if (!result.has(child)) {
-        packageDeps.push(child);
-      }
-    });
+      getDeps(packageInfo[dep].packageJson).forEach(child => {
+        if (child && packageInfo[child] && !result.has(child)) {
+          packageDeps.push(child);
+        }
+      });
+    }
   }
 
   return [...result].map(dep => packageInfo[dep]);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
I noticed `react-next` was not watching changes in dependency packages. After some digging, realizing `findRepoDeps` has a bug and it's not actually getting dependencies of dependencies.

#### Focus areas to test

`yarn start` should watch changes in all dependency packages
