### PR TITLE
FocusZone: Defaulting to false for the preventDefaultWhenHandled prop to maintain old behavior

### DIFF
--- a/change/@fluentui-react-focus-2020-05-20-13-50-16-preventDefaultWhenHandledFalse.json
+++ b/change/@fluentui-react-focus-2020-05-20-13-50-16-preventDefaultWhenHandledFalse.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Defaulting to false for the preventDefaultWhenHandled prop to maintain old behavior.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-20T20:50:16.220Z"
+}

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -71,7 +71,6 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
   public static defaultProps: IFocusZoneProps = {
     isCircularNavigation: false,
     direction: FocusZoneDirection.bidirectional,
-    preventDefaultWhenHandled: true,
   };
 
   private _root: React.RefObject<HTMLElement> = React.createRef();

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -233,7 +233,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /**
    * If true, FocusZone prevents the default behavior of Keyboard events when changing focus between elements.
-   * @defaultvalue true
+   * @defaultvalue false
    */
   preventDefaultWhenHandled?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13210
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR changes the default value of the `preventDefaultWhenHandled` prop in `FocusZone` to maintain old behavior, making it opt-in and not breaking other components/partners.

#### Focus areas to test

(optional)
