### PR TITLE
chore(babel): enable "loose" mode

### DIFF
--- a/scripts/babel/index.js
+++ b/scripts/babel/index.js
@@ -17,6 +17,7 @@ module.exports = api => {
     [
       '@babel/preset-env',
       {
+        loose: true,
         modules: useESModules ? false : 'cjs',
         targets: isNode ? { node: '10' } : undefined,
         exclude: [
@@ -30,10 +31,10 @@ module.exports = api => {
     ['@babel/preset-typescript', { allowNamespaces: true }],
   ];
   const plugins = [
-    '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-nullish-coalescing-operator',
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
+    ['@babel/plugin-proposal-nullish-coalescing-operator', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true, useBuiltIns: true }],
-    '@babel/plugin-proposal-optional-chaining',
+    ['@babel/plugin-proposal-optional-chaining', { loose: true }],
     '@babel/plugin-syntax-dynamic-import',
     ['@babel/plugin-transform-runtime', { useESModules }],
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR starts a round of Treeshaking improvements for `@fluentui/react-northstar`. It enables [`loose` mode](https://2ality.com/2015/12/babel6-loose-mode.html) `@babel/preset-env` and other plugins.

There are two main reasons to do it:

#### [`babel-plugin-proposal-class-properties`](https://babeljs.io/docs/en/babel-plugin-proposal-class-properties)

Without `loose` mode produces the code that can't be eliminated by Terser:

```tsx
class Bork {
  static a = 'foo';
}
```

```tsx
// non loose
var Bork = function Bork() {
  babelHelpers.classCallCheck(this, Bork);
};

Object.defineProperty(Bork, "a", { // produces side-effect
  configurable: true,
  enumerable: true,
  writable: true,
  value: 'foo'
});

// loose
var Bork = function Bork() {
  babelHelpers.classCallCheck(this, Bork);
}; // (!!!) this output will be still non-treeshakable
Bork.a = 'foo';
```

#### [`babel-plugin-transform-template-literals`](https://babeljs.io/docs/en/babel-plugin-transform-template-literals)

Without `loose` mode produces the code that can't be eliminated by Terser:

```tsx
`foo${bar}`;
```

```tsx
// non loose
"foo".concat(bar); // produces side effect
// loose
"foo" + bar;
```

https://codesandbox.io/s/upbeat-shaw-0u6zw?file=/src/index.js
