### PR TITLE
chore: reexport themes separately

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Header` component which are passed to styles functions and remove the usage of `descriptionColor` as a resolved variable, @assuncaocharles ([#13253](https://github.com/microsoft/fluentui/pull/13253))
 - Updated durations and timing functions, removed `bounce` animations and added new animations in Teams theme @mnajdova ([#13046](https://github.com/microsoft/fluentui/pull/13046))
 - Removed `dismissActionColorActive`, `dismissActionBackgroundColorActive`, `dismissActionBorderColorActive` from `Alert`'s variables in Teams theme @mnajdova ([#13046](https://github.com/microsoft/fluentui/pull/13046))
+- Removed `themes` export, each theme is exported separately @layershifter ([#13268](https://github.com/microsoft/fluentui/pull/13268))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))

--- a/packages/fluentui/code-sandbox/src/SandboxApp.tsx
+++ b/packages/fluentui/code-sandbox/src/SandboxApp.tsx
@@ -1,5 +1,15 @@
 import { KnobInspector, KnobProvider } from '@fluentui/docs-components';
-import { Divider, Flex, Header, Provider, RadioGroup, Text, themes } from '@fluentui/react-northstar';
+import {
+  Divider,
+  Flex,
+  Header,
+  Provider,
+  RadioGroup,
+  Text,
+  teamsTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+} from '@fluentui/react-northstar';
 // @ts-ignore
 import pkg from '@fluentui/react-northstar/package.json';
 import * as React from 'react';
@@ -11,19 +21,25 @@ const items = [
   {
     key: 'light',
     label: 'Teams Light',
-    value: 'teams',
+    value: 'teamsTheme',
   },
   {
     key: 'dark',
     label: 'Teams Dark',
-    value: 'teamsDark',
+    value: 'teamsDarkTheme',
   },
   {
     key: 'hc',
     label: 'Teams High Contrast',
-    value: 'teamsHighContrast',
+    value: 'teamsHighContrastTheme',
   },
 ];
+
+const themes = {
+  teamsTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+};
 
 const SandboxApp: React.FunctionComponent = props => {
   const { children } = props;

--- a/packages/fluentui/docs/src/app.tsx
+++ b/packages/fluentui/docs/src/app.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { hot } from 'react-hot-loader/root';
-import { Provider, Debug, themes } from '@fluentui/react-northstar';
+import { Provider, Debug, teamsTheme, teamsDarkTheme, teamsHighContrastTheme } from '@fluentui/react-northstar';
 
 import { mergeThemes } from '@fluentui/styles';
 import { ThemeContext, ThemeContextData, themeContextDefaults } from './context/ThemeContext';
@@ -13,6 +13,12 @@ import { setup } from '@fluentui/ability-attributes';
 if (process.env.NODE_ENV !== 'production' && !process.env.SCREENER) {
   setup();
 }
+
+const themes = {
+  teamsTheme,
+  teamsDarkTheme,
+  teamsHighContrastTheme,
+};
 
 class App extends React.Component<any, ThemeContextData> {
   // State also contains the updater function so it will

--- a/packages/fluentui/docs/src/components/DocsLayout.tsx
+++ b/packages/fluentui/docs/src/components/DocsLayout.tsx
@@ -1,4 +1,4 @@
-import { Provider, themes, pxToRem, createTheme } from '@fluentui/react-northstar';
+import { Provider, pxToRem, createTheme, teamsDarkTheme } from '@fluentui/react-northstar';
 // This is loaded from a CDN, so it's not in dependencies.
 // @ts-ignore
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -95,7 +95,7 @@ class DocsLayout extends React.Component<any, any> {
       <>
         <Provider
           theme={mergeThemes(
-            themes.teamsDark,
+            teamsDarkTheme,
             createTheme(
               {
                 // adjust Teams' theme to Semantic UI's font size scheme

--- a/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
+++ b/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
@@ -1,4 +1,4 @@
-import { Provider, themes } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, teamsHighContrastTheme, teamsDarkTheme } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as React from 'react';
 import { match } from 'react-router-dom';
@@ -17,6 +17,12 @@ type ExternalExampleLayoutProps = {
     exampleName: string;
     rtl: string;
   }>;
+};
+
+const themes = {
+  teams: teamsTheme,
+  teamsHighContrast: teamsHighContrastTheme,
+  teamsDark: teamsDarkTheme,
 };
 
 const ExternalExampleLayout: React.FC<ExternalExampleLayoutProps> = props => {

--- a/packages/fluentui/docs/src/context/ThemeContext.tsx
+++ b/packages/fluentui/docs/src/context/ThemeContext.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import * as _ from 'lodash';
-import { themes } from '@fluentui/react-northstar';
 
-type ThemeName = keyof typeof themes;
+type ThemeName = 'teamsTheme' | 'teamsDarkTheme' | 'teamsHighContrastTheme';
 type ThemeOption = { text: string; value: ThemeName };
-
-const getThemeOptions = (): ThemeOption[] => {
-  const themesKeys = Object.keys(themes);
-  return themesKeys.map(key => ({ text: _.startCase(key), value: key as ThemeName }));
-};
 
 export type ThemeContextData = {
   themeName: ThemeName;
@@ -17,8 +10,12 @@ export type ThemeContextData = {
 };
 
 export const themeContextDefaults: ThemeContextData = {
-  themeName: 'teams',
-  themeOptions: getThemeOptions(),
+  themeName: 'teamsTheme',
+  themeOptions: [
+    { text: 'Teams', value: 'teamsTheme' },
+    { text: 'Teams Dark', value: 'teamsDarkTheme' },
+    { text: 'Teams High Contrast', value: 'teamsHighContrastTheme' },
+  ],
   changeTheme: () => {},
 };
 

--- a/packages/fluentui/docs/src/examples/components/Accordion/Performance/AccordionDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Accordion/Performance/AccordionDefault.bsize.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Provider, themes, Accordion } from '@fluentui/react-northstar';
+import { Provider, Accordion, teamsTheme } from '@fluentui/react-northstar';
 
 const panels = [
   {
@@ -15,7 +15,7 @@ const panels = [
 ];
 
 const AccordionDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Accordion defaultActiveIndex={[0]} panels={panels} />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Alert/Performance/AlertDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Alert/Performance/AlertDefault.bsize.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Provider, themes, Alert } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Alert } from '@fluentui/react-northstar';
 
 const AlertDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Alert content="This is a default alert" />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Attachment/Performance/AttachmentDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Attachment/Performance/AttachmentDefault.bsize.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Provider, themes, Attachment } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Attachment } from '@fluentui/react-northstar';
 
 const AttachmentDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Attachment header="Document.docx" />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Avatar/Performance/AvatarDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Performance/AvatarDefault.bsize.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Provider, themes, Avatar } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Avatar } from '@fluentui/react-northstar';
 
 const AvatarDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Avatar name="John Doe" />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Box/Performance/BoxDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Box/Performance/BoxDefault.bsize.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Provider, themes, Box } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Box } from '@fluentui/react-northstar';
 
 const BoxDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Box content="Box" />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Button/Performance/ButtonDefault.bsize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Performance/ButtonDefault.bsize.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { Provider, themes, Button } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Button } from '@fluentui/react-northstar';
 
 const ButtonDefaultBsize = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Button content="Click here" />
   </Provider>
 );

--- a/packages/fluentui/docs/src/examples/components/Provider/Performance/ProviderMergeThemes.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Performance/ProviderMergeThemes.perf.tsx
@@ -1,4 +1,4 @@
-import { mergeThemes, callable, ComponentStyleFunctionParam, themes } from '@fluentui/react-northstar';
+import { mergeThemes, callable, ComponentStyleFunctionParam, teamsTheme } from '@fluentui/react-northstar';
 import * as React from 'react';
 import * as _ from 'lodash';
 
@@ -6,7 +6,7 @@ import * as _ from 'lodash';
  * Not a real performance test, just a temporary POC
  */
 const providerMergeThemesPerf = () => {
-  const merged = mergeThemes(..._.times(100, n => themes.teams));
+  const merged = mergeThemes(..._.times(100, n => teamsTheme));
   const resolvedStyles = _.mapValues(merged.componentStyles, (componentStyle, componentName) => {
     const compVariables = _.get(merged.componentVariables, componentName, callable({}))(merged.siteVariables);
     const styleParam: ComponentStyleFunctionParam = {

--- a/packages/fluentui/docs/src/examples/components/Provider/Types/ProviderExampleStyles.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Types/ProviderExampleStyles.shorthand.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { mergeThemes, Provider, themes } from '@fluentui/react-northstar';
+import { mergeThemes, Provider, teamsDarkTheme } from '@fluentui/react-northstar';
 
 const ProviderExampleShorthand = () => (
   <Provider
     variables={{ background: 'red' }}
     design={{ padding: '20px' }}
     styles={{ borderBottom: '3px solid blue' }}
-    theme={mergeThemes(themes.teamsDark, {
+    theme={mergeThemes(teamsDarkTheme, {
       siteVariables: {
         bodyBackground: 'salmon',
       },

--- a/packages/fluentui/docs/src/examples/components/Provider/Usage/ProviderExampleTarget.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Usage/ProviderExampleTarget.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Attachment, Button, Provider, themes } from '@fluentui/react-northstar';
+import { Attachment, Button, Provider, teamsTheme } from '@fluentui/react-northstar';
 
 type PortalWindowProps = {
   children: (externalDocument: Document) => React.ReactElement;
@@ -39,7 +39,7 @@ const ProviderExampleTarget = () => {
       {open && (
         <PortalWindow onClose={() => setOpen(false)}>
           {externalDocument => (
-            <Provider theme={themes.teams} target={externalDocument}>
+            <Provider theme={teamsTheme} target={externalDocument}>
               <Attachment header="Document.docx" />
             </Provider>
           )}

--- a/packages/fluentui/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Usage/ProviderExampleTargetFrame.tsx
@@ -1,4 +1,4 @@
-import { Attachment, Button, Provider, themes } from '@fluentui/react-northstar';
+import { Attachment, Button, Provider, teamsTheme } from '@fluentui/react-northstar';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -30,7 +30,7 @@ const PortalFrame: React.FunctionComponent<PortalFrameProps> = ({ children }) =>
 const ProviderExampleTargetFrame = () => (
   <PortalFrame>
     {externalDocument => (
-      <Provider theme={themes.teams} target={externalDocument}>
+      <Provider theme={teamsTheme} target={externalDocument}>
         <Attachment actionable header="Document.docx" />
         <Button content="Hello world!" />
       </Provider>

--- a/packages/fluentui/docs/src/examples/components/Toolbar/Performance/CustomToolbar.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Performance/CustomToolbar.perf.tsx
@@ -17,10 +17,10 @@ import {
   StatusProps,
   pxToRem,
   Provider,
-  themes,
   mergeThemes,
   Tooltip,
   tooltipAsLabelBehavior,
+  teamsDarkTheme,
 } from '@fluentui/react-northstar';
 import {
   CallControlCloseTrayIcon,
@@ -510,7 +510,7 @@ const CustomToolbar: React.FunctionComponent<CustomToolbarProps> = props => {
 
 const CustomToolbarPrototype = () => {
   let theme = {};
-  theme = mergeThemes(themes.teamsDark, darkThemeOverrides);
+  theme = mergeThemes(teamsDarkTheme, darkThemeOverrides);
 
   return (
     <Provider theme={theme}>

--- a/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.rtl.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarItemShorthandKinds,
   ToolbarMenuItemProps,
   ToolbarMenuItemShorthandKinds,
-  themes,
+  teamsTheme,
 } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -149,7 +149,7 @@ const ToolbarExampleOverflowPositioningShorthand: React.FC = () => (
         dir="rtl" /* we need to force this as global Provider is already in RTL */
         styles={{ overflow: 'hidden', height: 'inherit', width: 'inherit' }}
         target={externalDocument}
-        theme={themes.teams}
+        theme={teamsTheme}
       >
         <EditorToolbar />
       </Provider>

--- a/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleOverflowPositioning.shorthand.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarItemShorthandKinds,
   ToolbarMenuItemProps,
   ToolbarMenuItemShorthandKinds,
-  themes,
+  teamsTheme,
 } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -149,7 +149,7 @@ const ToolbarExampleOverflowPositioningShorthand: React.FC = () => (
       <Provider
         styles={{ overflow: 'hidden', height: 'inherit', width: 'inherit' }}
         target={externalDocument}
-        theme={themes.teams}
+        theme={teamsTheme}
       >
         <EditorToolbar />
       </Provider>

--- a/packages/fluentui/docs/src/prototypes/EditorToolbar/index.tsx
+++ b/packages/fluentui/docs/src/prototypes/EditorToolbar/index.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { ComponentPrototype, PrototypeSection } from '../Prototypes';
 import EditorToolbar from './EditorToolbar';
 import { editorToolbarReducer, initialState } from './editorToolbarReducer';
-import { Button, Divider, Provider, themes } from '@fluentui/react-northstar';
+import { Button, Divider, Provider, teamsTheme } from '@fluentui/react-northstar';
 import PortalWindow from './PortalWindow';
 
 const EditorToolbarPrototype = () => {
@@ -36,7 +36,7 @@ const EditorToolbarInWindowPrototype = () => {
           {externalDocument => (
             <Provider
               rtl={rtl}
-              theme={themes.teams}
+              theme={teamsTheme}
               styles={{ overflow: 'hidden', height: 'inherit', width: 'inherit' }}
               target={externalDocument}
             >

--- a/packages/fluentui/docs/src/prototypes/customToolbar/index.tsx
+++ b/packages/fluentui/docs/src/prototypes/customToolbar/index.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { KnobsSnippet } from '@fluentui/code-sandbox';
 import { Telemetry } from '@fluentui/react-bindings';
 import { KnobProvider, useBooleanKnob, useSelectKnob, KnobInspector } from '@fluentui/docs-components';
-import { Provider, Flex, themes, mergeThemes } from '@fluentui/react-northstar';
+import { Provider, Flex, mergeThemes, teamsDarkTheme, teamsHighContrastTheme } from '@fluentui/react-northstar';
 
 import { darkThemeOverrides } from './darkThemeOverrides';
 import { highContrastThemeOverrides } from './highContrastThemeOverrides';
@@ -55,9 +55,9 @@ const CustomToolbarPrototype: React.FunctionComponent = () => {
 
   let theme = {};
   if (themeName === 'teamsDark') {
-    theme = mergeThemes(themes.teamsDark, darkThemeOverrides);
+    theme = mergeThemes(teamsDarkTheme, darkThemeOverrides);
   } else if (themeName === 'teamsHighContrast') {
-    theme = mergeThemes(themes.teamsHighContrast, darkThemeOverrides, highContrastThemeOverrides);
+    theme = mergeThemes(teamsHighContrastTheme, darkThemeOverrides, highContrastThemeOverrides);
   }
 
   React.useEffect(() => {

--- a/packages/fluentui/docs/src/views/CategoryColorSchemes.tsx
+++ b/packages/fluentui/docs/src/views/CategoryColorSchemes.tsx
@@ -3,7 +3,14 @@ import DocPage from '../components/DocPage/DocPage';
 import GuidesNavigationFooter from '../components/GuidesNavigationFooter';
 import CategoryColorSchemes from '../components/CategoryColorSchemes';
 
-import { Dropdown, themes, Flex, Provider } from '@fluentui/react-northstar';
+import {
+  Dropdown,
+  Flex,
+  Provider,
+  teamsHighContrastTheme,
+  teamsDarkTheme,
+  teamsTheme,
+} from '@fluentui/react-northstar';
 import { faderStyles } from '../components/Fader';
 import { colorVariantsStyles } from '../components/ColorVariants';
 import { colorBoxStyles, colorBoxVariables } from '../components/ColorBox';
@@ -50,7 +57,7 @@ export default () => {
             onChange={(e, { value }) => setColor(value as string)}
           />
           <CategoryColorSchemes
-            themes={[themes.teams, themes.teamsHighContrast, themes.teamsDark]}
+            themes={[teamsTheme, teamsHighContrastTheme, teamsDarkTheme]}
             headers={[
               {
                 as: 'h3',

--- a/packages/fluentui/docs/src/views/ColorSchemes.tsx
+++ b/packages/fluentui/docs/src/views/ColorSchemes.tsx
@@ -3,7 +3,14 @@ import DocPage from '../components/DocPage/DocPage';
 import GuidesNavigationFooter from '../components/GuidesNavigationFooter';
 import ColorSchemes from '../components/ColorSchemes';
 
-import { Dropdown, themes, Flex, Provider } from '@fluentui/react-northstar';
+import {
+  Dropdown,
+  Flex,
+  Provider,
+  teamsTheme,
+  teamsHighContrastTheme,
+  teamsDarkTheme,
+} from '@fluentui/react-northstar';
 import { faderStyles } from '../components/Fader';
 import { colorVariantsStyles } from '../components/ColorVariants';
 import { colorBoxStyles, colorBoxVariables } from '../components/ColorBox';
@@ -37,7 +44,7 @@ export default () => {
             onChange={(e, { value }) => setColor(value as string)}
           />
           <ColorSchemes
-            themes={[themes.teams, themes.teamsHighContrast, themes.teamsDark]}
+            themes={[teamsTheme, teamsHighContrastTheme, teamsDarkTheme]}
             headers={[
               {
                 as: 'h3',

--- a/packages/fluentui/docs/src/views/Colors.tsx
+++ b/packages/fluentui/docs/src/views/Colors.tsx
@@ -8,7 +8,9 @@ import {
   Text,
   Alert,
   mergeThemes,
-  themes,
+  teamsTheme,
+  teamsHighContrastTheme,
+  teamsDarkTheme,
 } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as React from 'react';
@@ -222,11 +224,11 @@ const theme = {
 
 const ColorSchemeExample = () => (
   <React.Fragment>
-    <Provider theme={mergeThemes(themes.teams, theme)}>
-      <Box content="themes.teams" />
+    <Provider theme={mergeThemes(teamsTheme, theme)}>
+      <Box content="teamsTheme" />
     </Provider>
-    <Provider theme={mergeThemes(themes.teamsHighContrast, theme)}>
-      <Box content="themes.teamsHighContrast" />
+    <Provider theme={mergeThemes(teamsHighContrastTheme, theme)}>
+      <Box content="teamsHighContrastTheme" />
     </Provider>
   </React.Fragment>
 );
@@ -235,11 +237,11 @@ export default ColorSchemeExample;
         `}
             render={() => (
               <React.Fragment>
-                <Provider theme={mergeThemes(themes.teams, theme)}>
-                  <Box content="themes.teams" />
+                <Provider theme={mergeThemes(teamsTheme, theme)}>
+                  <Box content="teamsTheme" />
                 </Provider>
-                <Provider theme={mergeThemes(themes.teamsHighContrast, theme)}>
-                  <Box content="themes.teamsHighContrast" />
+                <Provider theme={mergeThemes(teamsHighContrastTheme, theme)}>
+                  <Box content="teamsHighContrastTheme" />
                 </Provider>
               </React.Fragment>
             )}
@@ -269,7 +271,7 @@ export const colorScheme = {
 
           <Fader url={'color-schemes'}>
             <ColorSchemes
-              themes={[themes.teams, themes.teamsHighContrast, themes.teamsDark]}
+              themes={[teamsTheme, teamsHighContrastTheme, teamsDarkTheme]}
               headers={[
                 {
                   as: 'h3',

--- a/packages/fluentui/docs/src/views/FAQ.tsx
+++ b/packages/fluentui/docs/src/views/FAQ.tsx
@@ -168,14 +168,14 @@ export default () => (
           <CodeSnippet
             mode="js"
             value={`
-              import { themes } from '@fluentui/react-northstar'
+              import { teamsTheme } from '@fluentui/react-northstar'
 
               // 💡 Your overrides should be defined before rendering any Fluent UI components
 
               // will remove all existing fontFaces
-              themes.teams.fontFaces = []
+              teamsTheme.fontFaces = []
               // will replace with own definitions
-              themes.teams.fontFaces = [{
+              teamsTheme.fontFaces = [{
                 name: 'Segoe UI',
                 paths: ['https://...'],
                 style: { fontWeight: 600 },

--- a/packages/fluentui/docs/src/views/Performance.tsx
+++ b/packages/fluentui/docs/src/views/Performance.tsx
@@ -39,7 +39,7 @@ export default () => (
 
         function App() {
           return (
-            <Provider theme={themes.teams}>
+            <Provider theme={teamsTheme}>
               <h1>Fluent UI Menu with blocked rendering</h1>
               <hr />
               <Menu defaultActiveIndex={0} items={items} primary vertical />

--- a/packages/fluentui/docs/src/views/QuickStart.tsx
+++ b/packages/fluentui/docs/src/views/QuickStart.tsx
@@ -35,7 +35,7 @@ export default () => (
         import App from './App'
 
         ReactDOM.render(
-          <Provider theme={themes.teams}>
+          <Provider theme={teamsTheme}>
             <App />
           </Provider>,
           document.getElementById('root'),

--- a/packages/fluentui/docs/src/views/ThemingExamples.tsx
+++ b/packages/fluentui/docs/src/views/ThemingExamples.tsx
@@ -47,7 +47,7 @@ export default () => (
         import { AddIcon, EmailIcon, EmojiIcon, CloseIcon } from '@fluentui/react-icons-northstar'
 
         export default () =>
-         <Provider theme={themes.teams}>
+         <Provider theme={teamsTheme}>
             <Button content="Button" />
             <Button icon={<AddIcon />} iconOnly primary />
             <Button icon={<EmailIcon />} content="Send email" secondary />

--- a/packages/fluentui/e2e/server/app.tsx
+++ b/packages/fluentui/e2e/server/app.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import E2EExample from './E2EExample';
 import routes from './routes';
 import { BrowserRouter, Route, Switch, Link } from 'react-router-dom';
-import { Provider, themes, Flex, Header, List } from '@fluentui/react-northstar';
+import { Provider, Flex, Header, List, teamsTheme } from '@fluentui/react-northstar';
 
 const ContentList = () => (
   <>
@@ -22,7 +22,7 @@ const ContentList = () => (
 
 const App = () => (
   <BrowserRouter>
-    <Provider theme={themes.teams}>
+    <Provider theme={teamsTheme}>
       <Switch>
         <Route exact path="/:exampleName" component={E2EExample} />
         <Route component={ContentList} />

--- a/packages/fluentui/local-sandbox/src/index.tsx
+++ b/packages/fluentui/local-sandbox/src/index.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { Provider, themes, Button } from '@fluentui/react-northstar';
+import { Provider, teamsTheme, Button } from '@fluentui/react-northstar';
 
 const App = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Button>Click here</Button>
   </Provider>
 );

--- a/packages/fluentui/perf-test/.digest/config.tsx
+++ b/packages/fluentui/perf-test/.digest/config.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Provider, themes } from '@fluentui/react-northstar';
+import { Provider, teamsTheme } from '@fluentui/react-northstar';
 
 const reqContexts = [
   // TODO: Relative pathing isn't the best here, but docs containing perf stories isn't a package that can be added as a dep.
@@ -11,7 +11,7 @@ const reqContexts = [
 
 // TODO: can comment this out to remove Provider. this should be made part of URL / digest bundle.
 // TODO: should this be specified by story? disabled by story? applied and not applied centrally?
-const decorator = content => <Provider theme={themes.teams}>{content}</Provider>;
+const decorator = content => <Provider theme={teamsTheme}>{content}</Provider>;
 // const decorator = content => content;
 
 // TODO: type errors in this file aren't generating build errors. scripts should be typechecked as part of digest build.

--- a/packages/fluentui/perf/src/index.tsx
+++ b/packages/fluentui/perf/src/index.tsx
@@ -1,6 +1,6 @@
 import '@babel/polyfill';
 
-import { Provider, Telemetry, themes } from '@fluentui/react-northstar';
+import { Provider, Telemetry, teamsTheme } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as minimatch from 'minimatch';
 import * as React from 'react';
@@ -35,7 +35,7 @@ const renderCycle = async (
   const telemetryRef: React.Ref<Telemetry> = React.createRef();
 
   await asyncRender(
-    <Provider theme={themes.teams} telemetryRef={telemetryRef}>
+    <Provider theme={teamsTheme} telemetryRef={telemetryRef}>
       <Profiler
         id={exampleName}
         onRender={(id: string, phase: string, actualTime: number, startTime: number, commitTime: number) => {
@@ -105,7 +105,7 @@ const Control: React.FunctionComponent = () => {
     // Heads up! On first run, this Provider increases measured time due to style DOM elements being
     // rendered to the browser. Subsequent rerenders, in contrast, are not rendering these style DOM
     // elements again.
-    <Provider theme={themes.teams}>
+    <Provider theme={teamsTheme}>
       <label htmlFor="filter">
         Filter (use <code>minimatch</code>):
       </label>

--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -1,9 +1,10 @@
-import * as themes from './themes';
+//
+// Themes
+//
+export { default as teamsTheme } from './themes/teams';
+export { default as teamsDarkTheme } from './themes/teams-dark';
+export { default as teamsHighContrastTheme } from './themes/teams-high-contrast';
 
-//
-// Theme
-//
-export { themes };
 export * from './themes/types';
 export * from './themes/colorUtils';
 

--- a/packages/fluentui/react-northstar/src/themes/index.ts
+++ b/packages/fluentui/react-northstar/src/themes/index.ts
@@ -1,4 +1,0 @@
-// Themes
-export { default as teams } from './teams';
-export { default as teamsDark } from './teams-dark';
-export { default as teamsHighContrast } from './teams-high-contrast';

--- a/scripts/gulp/tasks/test-projects/cra/App.tsx
+++ b/scripts/gulp/tasks/test-projects/cra/App.tsx
@@ -12,14 +12,14 @@ import {
   Input,
   Popup,
   Provider,
-  themes,
+  teamsTheme,
 } from '@fluentui/react-northstar';
 import * as React from 'react';
 
 class App extends React.Component {
   render() {
     return (
-      <Provider theme={themes.teams}>
+      <Provider theme={teamsTheme}>
         <div>
           <Accordion panels={[{ title: 'Title', content: 'Content' }]} />
           <Animation name="spinner">

--- a/scripts/gulp/tasks/test-projects/nextjs/index.js
+++ b/scripts/gulp/tasks/test-projects/nextjs/index.js
@@ -1,8 +1,8 @@
-import { Button, Dropdown, Provider, themes } from '@fluentui/react-northstar';
+import { Button, Dropdown, Provider, teamsTheme } from '@fluentui/react-northstar';
 import React from 'react';
 
 const Page = () => (
-  <Provider theme={themes.teams}>
+  <Provider theme={teamsTheme}>
     <Dropdown items={['Foo', 'Bar', 'Baz', 'Qux']} />
     <Button>Welcome to Next.js!</Button>
   </Provider>

--- a/scripts/gulp/tasks/test-projects/rollup/app.js
+++ b/scripts/gulp/tasks/test-projects/rollup/app.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Button, Provider, themes } from '@fluentui/react-northstar';
+import { Button, Provider, teamsTheme } from '@fluentui/react-northstar';
 
 ReactDOM.render(
-  React.createElement(Provider, { theme: themes.teams }, React.createElement(Button, { content: 'Theming' })),
+  React.createElement(Provider, { theme: teamsTheme }, React.createElement(Button, { content: 'Theming' })),
   document.getElementById('root'),
 );

--- a/scripts/gulp/tasks/test-projects/typings/index.tsx
+++ b/scripts/gulp/tasks/test-projects/typings/index.tsx
@@ -2,7 +2,7 @@ import * as FluentUI from '@fluentui/react-northstar';
 import * as React from 'react';
 
 const App = () => (
-  <FluentUI.Provider theme={FluentUI.themes.teams}>
+  <FluentUI.Provider theme={FluentUI.teamsTheme}>
     <FluentUI.Button accessibility={FluentUI.buttonBehavior} content="Click me" />
   </FluentUI.Provider>
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR removes `themes` export from `@fluentui/react-northstar`. Instead of it please use direct exports of themes.

### Before

```tsx
import { themes } from '@fluentui/react-northstar'
// ---
<Provider theme={themes.teams} />
```

### After

```tsx
import { teamsTheme, teamsDarkTheme, teamsHighContrastTheme } from '@fluentui/react-northstar'
// ---
<Provider theme={teamsTheme} />
```

#### Description of changes

https://github.com/microsoft/fluentui/blob/57c30ddeb0e6991456869ef38cb036743c3c16d4/packages/fluentui/react-northstar/src/index.ts#L1-L6

Existing reexport breaks treeshaking because it fails `ModuleConcatenation` process in Webpack:

```
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-bindings/dist/es/telemetry/useTelemetry.js because of ./packages/fluentui/react-northstar/dist/es/index.js */
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-bindings/dist/es/utils/getElementType.js because of ./packages/fluentui/react-northstar/dist/es/index.js */
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-northstar/dist/es/components/Box/Box.js because of ./packages/fluentui/react-northstar/dist/es/index.js */
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-northstar/dist/es/types.js because of ./packages/fluentui/react-northstar/dist/es/index.js */
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-northstar/dist/es/utils/childrenExist.js because of ./packages/fluentui/react-northstar/dist/es/utils/index.js */
/*! ModuleConcatenation bailout: Cannot concat with ./packages/fluentui/react-northstar/dist/es/utils/factories.js because of ./packages/fluentui/react-northstar/dist/es/index.js */
```

If Webpack fails to concatenate modules it makes dead-code elimination via Terser almost useless 💣 

Measures are taken from
`packages/fluentui/docs/src/examples/components/Accordion/Performance/AccordionDefault.bsize.tsx` with enabled [`concatenateModules`](https://webpack.js.org/configuration/optimization/#optimizationconcatenatemodules) in `webpack.config.stats.ts`.

### Before

873KB

![image](https://user-images.githubusercontent.com/14183168/82572908-5b1ffc80-9b85-11ea-9156-6c07ea1dae4d.png)

### After

704KB **(-169KB/20%)**

![image](https://user-images.githubusercontent.com/14183168/82572971-71c65380-9b85-11ea-83b1-ce38cafda1de.png)

***

As a side-effect it also decouples themes. As namespace reexports are handled by Webpack in a different way than in Rollup they were all included to bundles.

```js
import { themes } from "./index";
console.log(themes.teams);
```

![image](https://user-images.githubusercontent.com/14183168/82574394-53f9ee00-9b87-11ea-9033-fcbdcf5581ac.png)