### PR TITLE
Adding some functionalities in UnifiedPeoplePicker- Paste, OnItemsRemoved, parent updates

### DIFF
--- a/change/@uifabric-experiments-2020-05-21-12-53-24-u-nebhatna-uppPasteAndSelect.json
+++ b/change/@uifabric-experiments-2020-05-21-12-53-24-u-nebhatna-uppPasteAndSelect.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Added missing functionalities in UnifiedPeoplePicker and Example",
+  "packageName": "@uifabric/experiments",
+  "email": "nebhatna@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-21T19:53:24.465Z"
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
@@ -7,8 +7,8 @@ import { SuggestionItemNormal } from './FloatingPeopleSuggestionItems/Suggestion
 
 export const FloatingPeopleSuggestions = (props: IFloatingPeopleSuggestionsProps): JSX.Element => {
   const renderSuggestionItem = React.useCallback(
-    (suggestionItemprops: IFloatingSuggestionOnRenderItemProps<IPersonaProps>): JSX.Element => {
-      return SuggestionItemNormal({ ...suggestionItemprops.item });
+    (suggestionItemProps: IFloatingSuggestionOnRenderItemProps<IPersonaProps>): JSX.Element => {
+      return SuggestionItemNormal({ ...suggestionItemProps.item });
     },
     [],
   );

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -38,7 +38,10 @@ export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Eleme
       <UnifiedPicker
         {...props}
         onRenderSelectedItems={renderSelectedItems}
-        onRenderFloatingSuggestions={FloatingPeopleSuggestions}
+        onRenderFloatingSuggestions={floatingPeoplePickerProps => {
+          floatingPeoplePickerProps.suggestions = [...peopleSuggestions];
+          return FloatingPeopleSuggestions(floatingPeoplePickerProps);
+        }}
       />
     </>
   );

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -10,8 +10,8 @@ import { UnifiedPicker } from '../UnifiedPicker';
 
 export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Element => {
   // update the suggestion like componentWillReceiveProps
-  // React.useEffect(()=>{
-
+  // React.useEffect(() => {
+  //   console.log('Re-rendered');
   // }, [props.floatingSuggestionProps.suggestions]);
 
   const renderSelectedItems = (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -9,11 +9,6 @@ import {
 import { UnifiedPicker } from '../UnifiedPicker';
 
 export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Element => {
-  // update the suggestion like componentWillReceiveProps
-  // React.useEffect(() => {
-  //   console.log('Re-rendered');
-  // }, [props.floatingSuggestionProps.suggestions]);
-
   const renderSelectedItems = (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {
     return <SelectedPeopleList {...selectedPeopleListProps} ref={null} />;
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -7,11 +7,32 @@ import {
   ISelectedPeopleListProps,
 } from '../../SelectedItemsList/SelectedPeopleList/SelectedPeopleList';
 import { UnifiedPicker } from '../UnifiedPicker';
+import { IFloatingSuggestionItemProps } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 
 export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Element => {
-  const renderSelectedItems = (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {
-    return <SelectedPeopleList {...selectedPeopleListProps} ref={null} />;
-  };
+  // update the suggestion like componentWillReceiveProps
+  const [peopleSuggestions, setPeopleSuggestions] = React.useState<IFloatingSuggestionItemProps<IPersonaProps>[]>([]);
+
+  React.useEffect(() => {
+    setPeopleSuggestions(props.floatingSuggestionProps.suggestions);
+  }, [props.floatingSuggestionProps.suggestions]);
+
+  // update the selectedListItems like componentWillReceiveProps
+  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
+
+  React.useEffect(() => {
+    if (props.selectedItemsListProps.selectedItems) {
+      setPeopleSelectedItems(props.selectedItemsListProps.selectedItems);
+    }
+  }, [props.selectedItemsListProps.selectedItems]);
+
+  const renderSelectedItems = React.useCallback(
+    (selectedPeopleListProps: ISelectedPeopleListProps<IPersonaProps>): JSX.Element => {
+      return <SelectedPeopleList {...selectedPeopleListProps} ref={null} />;
+    },
+    [peopleSelectedItems],
+  );
+
   return (
     <>
       <UnifiedPicker

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../SelectedItemsList/SelectedPeopleList/SelectedPeopleList';
 import { UnifiedPicker } from '../UnifiedPicker';
 import { IFloatingSuggestionItemProps } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
+import { IFloatingPeopleSuggestionsProps } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 
 export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Element => {
   // update the suggestion like componentWillReceiveProps
@@ -33,15 +34,19 @@ export const UnifiedPeoplePicker = (props: IUnifiedPeoplePickerProps): JSX.Eleme
     [peopleSelectedItems],
   );
 
+  const renderFloatingPeopleSuggestions = React.useCallback(
+    (floatingPeoplePickerProps: IFloatingPeopleSuggestionsProps): JSX.Element => {
+      return <FloatingPeopleSuggestions {...floatingPeoplePickerProps} />;
+    },
+    [peopleSuggestions],
+  );
+
   return (
     <>
       <UnifiedPicker
         {...props}
         onRenderSelectedItems={renderSelectedItems}
-        onRenderFloatingSuggestions={floatingPeoplePickerProps => {
-          floatingPeoplePickerProps.suggestions = [...peopleSuggestions];
-          return FloatingPeopleSuggestions(floatingPeoplePickerProps);
-        }}
+        onRenderFloatingSuggestions={renderFloatingPeopleSuggestions}
       />
     </>
   );

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -8,7 +8,6 @@ import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePick
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { mru, people } from '@uifabric/example-data';
 import { ISelectedPeopleListProps } from '@uifabric/experiments/lib/SelectedItemsList';
-import { suggestionsSpinner } from '../../../FloatingSuggestions/Suggestions/SuggestionsControl.scss';
 
 const _suggestions = [
   {
@@ -73,17 +72,10 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     ev: React.MouseEvent<HTMLElement, MouseEvent>,
     suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
   ) => {
-    // Intentionally checking on key here instead of id, as for all the suggestions, id does not exist.
-    // Also checking the key property first before accessing it to skip static check failures.
+    // Intentionally checking on complete item object to ensure it is removed. Id cannot be used as the
+    // property is not populated for all the suggestions, and key does not exist on type checking.
     setPeopleSuggestions(suggestions => {
-      const modifiedSuggestions = suggestions.filter(
-        suggestion =>
-          suggestion.item &&
-          suggestion.item['key'] &&
-          suggestionToRemove.item &&
-          suggestionToRemove.item['key'] &&
-          suggestion.item['key'] !== suggestionToRemove.item['key'],
-      );
+      const modifiedSuggestions = suggestions.filter(suggestion => suggestion.item !== suggestionToRemove.item);
       return modifiedSuggestions;
     });
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -8,6 +8,7 @@ import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePick
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { mru, people } from '@uifabric/example-data';
 import { ISelectedPeopleListProps } from '@uifabric/experiments/lib/SelectedItemsList';
+import { suggestionsSpinner } from '../../../FloatingSuggestions/Suggestions/SuggestionsControl.scss';
 
 const _suggestions = [
   {
@@ -72,11 +73,16 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     ev: React.MouseEvent<HTMLElement, MouseEvent>,
     suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
   ) => {
+    // Intentionally checking on key here instead of id, as for all the suggestions, id does not exist.
+    // Also checking the key property first before accessing it to skip static check failures.
     setPeopleSuggestions(suggestions => {
-      // Since key is unique, we will be filtering based on that instead of id, which does not exist for other suggestions.
       const modifiedSuggestions = suggestions.filter(
         suggestion =>
-          suggestion.item.key && suggestion.item.key !== suggestionToRemove.item.key && suggestionToRemove.item.key,
+          suggestion.item &&
+          suggestion.item['key'] &&
+          suggestionToRemove.item &&
+          suggestionToRemove.item['key'] &&
+          suggestion.item['key'] !== suggestionToRemove.item['key'],
       );
       return modifiedSuggestions;
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -75,7 +75,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     setPeopleSuggestions(suggestions => {
       // Since key is unique, we will be filtering based on that instead of id, which does not exist for other suggestions.
       const modifiedSuggestions = suggestions.filter(
-        suggestion => suggestion.item.key !== suggestionToRemove.item?.key,
+        suggestion => suggestion.item?.key !== suggestionToRemove.item?.key,
       );
       return modifiedSuggestions;
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -73,6 +73,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
   ) => {
     setPeopleSuggestions(suggestions => {
+      // Since key is unique, we will be filtering based on that instead of id, which does not exist for other suggestions.
       const modifiedSuggestions = suggestions.filter(suggestion => suggestion.item.key !== suggestionToRemove.item.key);
       return modifiedSuggestions;
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -8,7 +8,6 @@ import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePick
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { mru, people } from '@uifabric/example-data';
 import { ISelectedPeopleListProps } from '@uifabric/experiments/lib/SelectedItemsList';
-import { Selection } from 'office-ui-fabric-react/lib/Selection';
 
 const _suggestions = [
   {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -75,7 +75,8 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     setPeopleSuggestions(suggestions => {
       // Since key is unique, we will be filtering based on that instead of id, which does not exist for other suggestions.
       const modifiedSuggestions = suggestions.filter(
-        suggestion => suggestion.item?.key !== suggestionToRemove.item?.key,
+        suggestion =>
+          suggestion.item.key && suggestion.item.key !== suggestionToRemove.item.key && suggestionToRemove.item.key,
       );
       return modifiedSuggestions;
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -73,7 +73,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
   ) => {
     setPeopleSuggestions(suggestions => {
-      const modifiedSuggestions = suggestions.filter(item => item.id !== suggestionToRemove.id);
+      const modifiedSuggestions = suggestions.filter(suggestion => suggestion.item.key !== suggestionToRemove.item.key);
       return modifiedSuggestions;
     });
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -74,7 +74,9 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
   ) => {
     setPeopleSuggestions(suggestions => {
       // Since key is unique, we will be filtering based on that instead of id, which does not exist for other suggestions.
-      const modifiedSuggestions = suggestions.filter(suggestion => suggestion.item.key !== suggestionToRemove.item.key);
+      const modifiedSuggestions = suggestions.filter(
+        suggestion => suggestion.item.key !== suggestionToRemove.item?.key,
+      );
       return modifiedSuggestions;
     });
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -58,9 +58,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     ..._suggestions,
   ]);
 
-  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IFloatingSuggestionItemProps<IPersonaProps>[]>(
-    [],
-  );
+  const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
 
   const _onSuggestionSelected = (
     ev: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -108,17 +106,18 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     // and update the selectedItemsList to rerender everthing.
     let finalList: IPersonaProps[] = [];
     if (pastedValue != null) {
-      finalList = pastedValue.split(',').map(val => {
+      pastedValue.split(',').map(val => {
         if (val) {
-          peopleSuggestions.forEach(suggestionItem => {
+          peopleSuggestions.map(suggestionItem => {
             if (suggestionItem.item.text === val) {
-              return suggestionItem;
+              finalList.push(suggestionItem.item);
             }
           });
         }
       });
     }
-    setPeopleSelectedItems(peopleSelectedItems.concat(finalList));
+    finalList = finalList.concat(selectedItemsList);
+    setPeopleSelectedItems(finalList);
   };
 
   const _onItemsRemoved = (itemsToRemove: IPersonaProps[]): void => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -103,21 +103,20 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const _onPaste = (pastedValue: string, selectedItemsList: IPersonaProps[]): void => {
     // Find the suggestion corresponding to the specific text name
-    // and update the selectedItemsList to rerender everthing.
+    // and update the selectedItemsList to re-render everthing.
     let finalList: IPersonaProps[] = [];
     if (pastedValue != null) {
-      pastedValue.split(',').map(val => {
-        if (val) {
+      pastedValue.split(',').map(textValue => {
+        if (textValue) {
           peopleSuggestions.map(suggestionItem => {
-            if (suggestionItem.item.text === val) {
+            if (suggestionItem.item.text === textValue) {
               finalList.push(suggestionItem.item);
             }
           });
         }
       });
     }
-    finalList = finalList.concat(selectedItemsList);
-    setPeopleSelectedItems(finalList);
+    setPeopleSelectedItems(selectedItemsList.concat(finalList));
   };
 
   const _onItemsRemoved = (itemsToRemove: IPersonaProps[]): void => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -102,7 +102,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const _onPaste = (pastedValue: string, selectedItemsList: IPersonaProps[]): void => {
     // Find the suggestion corresponding to the specific text name
-    // and update the selectedItemsList to re-render everthing.
+    // and update the selectedItemsList to re-render everything.
     let finalList: IPersonaProps[] = [];
     if (pastedValue != null) {
       pastedValue.split(',').map(textValue => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -103,8 +103,8 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
   const _onPaste = (pastedValue: string, selectedItemsList: IPersonaProps[]): void => {
     // Find the suggestion corresponding to the specific text name
     // and update the selectedItemsList to re-render everything.
-    let finalList: IPersonaProps[] = [];
-    if (pastedValue != null) {
+    const finalList: IPersonaProps[] = [];
+    if (pastedValue !== null) {
       pastedValue.split(',').map(textValue => {
         if (textValue) {
           people.map(suggestionItem => {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/examples/UnifiedPeoplePicker.Example.tsx
@@ -107,9 +107,9 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     if (pastedValue != null) {
       pastedValue.split(',').map(textValue => {
         if (textValue) {
-          peopleSuggestions.map(suggestionItem => {
-            if (suggestionItem.item.text === textValue) {
-              finalList.push(suggestionItem.item);
+          people.map(suggestionItem => {
+            if (suggestionItem.text === textValue) {
+              finalList.push(suggestionItem);
             }
           });
         }

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -185,7 +185,6 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (props.floatingSuggestionProps.onRemoveSuggestion) {
       props.floatingSuggestionProps.onRemoveSuggestion(ev, item);
     }
-    removeItems([item.item]);
     // We want to keep showing the picker to show the user that the entry has been removed from the list.
     showPicker(true);
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -35,6 +35,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     selectPreviousSuggestion,
     selectNextSuggestion,
   } = useFloatingSuggestionItems(suggestions, selectedSuggestionIndex, isSuggestionsVisible);
+
   const { selectedItems, addItems, removeItems, removeItemAt, removeSelectedItems, unselectAll } = useSelectedItems(
     selection,
     props.selectedItemsListProps.selectedItems,
@@ -156,7 +157,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _renderSelectedItemsList = (): JSX.Element => {
     return onRenderSelectedItems({
       ...selectedItemsListProps,
-      selectedItems: selectedItemsListProps.selectedItems,
+      selectedItems: selectedItems,
       focusedItemIndices: focusedItemIndices,
       onItemsRemoved: _onRemoveSelectedItems,
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -36,10 +36,15 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     selectNextSuggestion,
   } = useFloatingSuggestionItems(suggestions, selectedSuggestionIndex, isSuggestionsVisible);
 
-  const { selectedItems, addItems, removeItems, removeItemAt, removeSelectedItems, unselectAll } = useSelectedItems(
-    selection,
-    props.selectedItemsListProps.selectedItems,
-  );
+  const {
+    selectedItems,
+    addItems,
+    removeItems,
+    removeItemAt,
+    removeSelectedItems,
+    unselectAll,
+    getSelectedItems,
+  } = useSelectedItems(selection, props.selectedItemsListProps.selectedItems);
 
   const _onSelectionChanged = () => {
     showPicker(false);
@@ -78,10 +83,16 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       ) {
         showPicker(false);
         ev.preventDefault();
+        if (props.selectedItemsListProps.onItemsRemoved) {
+          props.selectedItemsListProps.onItemsRemoved([selectedItems[selectedItems.length - 1]]);
+        }
         removeItemAt(selectedItems.length - 1);
       } else if (focusedItemIndices.length > 0) {
         showPicker(false);
         ev.preventDefault();
+        if (props.selectedItemsListProps.onItemsRemoved) {
+          props.selectedItemsListProps.onItemsRemoved(getSelectedItems());
+        }
         removeSelectedItems();
         input.current?.focus();
       }

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -156,7 +156,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const _renderSelectedItemsList = (): JSX.Element => {
     return onRenderSelectedItems({
       ...selectedItemsListProps,
-      selectedItems: selectedItems,
+      selectedItems: selectedItemsListProps.selectedItems,
       focusedItemIndices: focusedItemIndices,
       onItemsRemoved: _onRemoveSelectedItems,
     });

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -181,6 +181,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     }
     showPicker(false);
   };
+  const _onFloatingSuggestionRemoved = (ev: any, item: IFloatingSuggestionItemProps<T>) => {
+    if (props.floatingSuggestionProps.onRemoveSuggestion) {
+      props.floatingSuggestionProps.onRemoveSuggestion(ev, item);
+    }
+    removeItems([item.item]);
+    // We want to keep showing the picker to show the user that the entry has been removed from the list.
+    showPicker(true);
+  };
   const _onSuggestionSelected = (ev: any, item: IFloatingSuggestionItemProps<T>) => {
     if (props.floatingSuggestionProps.onSuggestionSelected) {
       props.floatingSuggestionProps.onSuggestionSelected(ev, item);
@@ -207,6 +215,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       onFloatingSuggestionsDismiss: _onFloatingSuggestionsDismiss,
       onSuggestionSelected: _onSuggestionSelected,
       onKeyDown: _onInputKeyDown,
+      onRemoveSuggestion: _onFloatingSuggestionRemoved,
     });
 
   return (

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -162,6 +162,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       ev.preventDefault();
       // Pass current selected items
       props.onPaste(inputText, selectedItems);
+      addItems(selectedItems);
     }
   };
 

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useSelectedItems.ts
@@ -21,6 +21,10 @@ export const useSelectedItems = <T extends {}>(
 ): IUseSelectedItemsResponse<T> => {
   const [items, setSelectedItems] = React.useState(selectedItems || []);
 
+  React.useEffect(() => {
+    setSelectedItems(selectedItems ? selectedItems : []);
+  }, [selectedItems]);
+
   const addItems = (itemsToAdd: T[]): void => {
     const newItems: T[] = items.concat(itemsToAdd);
     setSelectedItems(newItems);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Added changes to handle state at the parent level ( UnifiedPeoplePicker) so that we are able to get/maintain updates from the children.
- Added Paste functionality in the example, as a sample to test out paste functionality in unified picker. Selection, Ctrl +C and Ctrl+V works now. Made sure the pasted entities can also be selected.
- Added logic to update the state on items removed at the parent level, so we are able to reflect it correctly across parent and children.

#### Focus areas to test

(optional)
