### PR TITLE
Build: do not clean on start

### DIFF
--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -98,8 +98,8 @@ module.exports = function preset() {
   task('code-style', series('prettier', 'tslint'));
   task('update-api', series('clean', 'copy', 'sass', 'ts', 'api-extractor:update'));
 
-  task('dev:storybook', series('clean', 'copy', 'sass', 'storybook:start'));
-  task('dev', series('clean', 'copy', 'sass', 'webpack-dev-server'));
+  task('dev:storybook', series('copy', 'sass', 'storybook:start'));
+  task('dev', series('copy', 'sass', 'webpack-dev-server'));
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs-only')).cached();
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
No need to clean when `yarn start`. It's very frustrating to need to `yarn build` again after `yarn start` because of this.

#### Focus areas to test

(optional)
