### PR TITLE
Copying FocusTrapZone to react-next, in preparation for converting to function component.

### DIFF
--- a/change/@fluentui-react-next-2020-05-21-17-14-33-feat-focus-trap-zone.json
+++ b/change/@fluentui-react-next-2020-05-21-17-14-33-feat-focus-trap-zone.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Copying FocusTrapZone to react-next, in preparation for converting to function component.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-22T00:14:33.037Z"
+}

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -45,6 +45,23 @@ export const Fabric: React.FunctionComponent<IFabricProps>;
 // @public (undocumented)
 export const FabricBase: React.ForwardRefExoticComponent<IFabricProps & React.RefAttributes<HTMLDivElement>>;
 
+// @public (undocumented)
+export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> implements IFocusTrapZone {
+    constructor(props: IFocusTrapZoneProps);
+    // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
+    componentDidUpdate(prevProps: IFocusTrapZoneProps): void;
+    // (undocumented)
+    componentWillUnmount(): void;
+    // (undocumented)
+    focus(): void;
+    // (undocumented)
+    render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void;
+    }
+
 // @public
 export const getMeasurementCache: () => {
     getCachedMeasurement: (data: any) => number | undefined;
@@ -153,6 +170,25 @@ export interface IFabricStyles {
     bodyThemed: IStyle;
     // (undocumented)
     root: IStyle;
+}
+
+// @public (undocumented)
+export interface IFocusTrapZone {
+    focus: () => void;
+}
+
+// @public (undocumented)
+export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement> {
+    ariaLabelledBy?: string;
+    componentRef?: IRefObject<IFocusTrapZone>;
+    disabled?: boolean;
+    disableFirstFocus?: boolean;
+    elementToFocusOnDismiss?: HTMLElement;
+    firstFocusableSelector?: string | (() => string);
+    focusPreviouslyFocusedInnerElement?: boolean;
+    forceFocusInsideTrap?: boolean;
+    ignoreExternalFocusing?: boolean;
+    isClickableOutsideFocusTrap?: boolean;
 }
 
 // @public (undocumented)
@@ -1100,7 +1136,6 @@ export * from "office-ui-fabric-react/lib/Dropdown";
 export * from "office-ui-fabric-react/lib/ExtendedPicker";
 export * from "office-ui-fabric-react/lib/Facepile";
 export * from "office-ui-fabric-react/lib/FloatingPicker";
-export * from "office-ui-fabric-react/lib/FocusTrapZone";
 export * from "office-ui-fabric-react/lib/FocusZone";
 export * from "office-ui-fabric-react/lib/Grid";
 export * from "office-ui-fabric-react/lib/GroupedList";

--- a/packages/react-next/src/FocusTrapZone.ts
+++ b/packages/react-next/src/FocusTrapZone.ts
@@ -1,1 +1,1 @@
-export * from 'office-ui-fabric-react/lib/FocusTrapZone';
+export * from './components/FocusTrapZone/index';

--- a/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.doc.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.doc.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { IDocPageProps } from '../../common/DocPage.types';
+
+import { FocusTrapZoneBoxExample } from './examples/FocusTrapZone.Box.Example';
+const FocusTrapZoneBoxExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx') as string;
+
+import { FocusTrapZoneBoxCustomElementExample } from './examples/FocusTrapZone.Box.FocusOnCustomElement.Example';
+const FocusTrapZoneBoxCustomElementExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx') as string;
+
+import { FocusTrapZoneBoxClickExample } from './examples/FocusTrapZone.Box.Click.Example';
+const FocusTrapZoneBoxClickExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx') as string;
+
+import { FocusTrapZoneNestedExample } from './examples/FocusTrapZone.Nested.Example';
+const FocusTrapZoneNestedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx') as string;
+
+import { FocusTrapZoneFocusZoneExample } from './examples/FocusTrapZone.FocusZone.Example';
+const FocusTrapZoneFocusZoneExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.FocusZone.Example.tsx') as string;
+
+import { FocusTrapZoneDialogInPanelExample } from './examples/FocusTrapZone.DialogInPanel.Example';
+const FocusTrapZoneDialogInPanelExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/examples/FocusTrapZone.DialogInPanel.Example.tsx') as string;
+
+export const FocusTrapZonePageProps: IDocPageProps = {
+  title: 'FocusTrapZone',
+  componentName: 'FocusTrapZone',
+  componentUrl:
+    'https://github.com/microsoft/fluentui/tree/master/packages/office-ui-fabric-react/src/components/FocusTrapZone',
+  examples: [
+    {
+      title: 'Simple box',
+      code: FocusTrapZoneBoxExampleCode,
+      view: <FocusTrapZoneBoxExample />,
+    },
+    {
+      title: 'Simple box with focus on custom focusable element',
+      code: FocusTrapZoneBoxCustomElementExampleCode,
+      view: <FocusTrapZoneBoxCustomElementExample />,
+    },
+    {
+      title: 'Simple box with clicking outside trap zone enabled',
+      code: FocusTrapZoneBoxClickExampleCode,
+      view: <FocusTrapZoneBoxClickExample />,
+    },
+    {
+      title: 'Multiple nested FocusTrapZones',
+      code: FocusTrapZoneNestedExampleCode,
+      view: <FocusTrapZoneNestedExample />,
+    },
+    {
+      title: 'FocusTrapZone with FocusZones',
+      code: FocusTrapZoneFocusZoneExampleCode,
+      view: <FocusTrapZoneFocusZoneExample />,
+    },
+    {
+      title: 'A Dialog nested in a Panel',
+      code: FocusTrapZoneDialogInPanelExampleCode,
+      view: <FocusTrapZoneDialogInPanelExample />,
+    },
+  ],
+  overview: require<
+    string
+  >('!raw-loader!office-ui-fabric-react/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md'),
+  bestPractices: '',
+  dos: '',
+  donts: '',
+  isHeaderVisible: true,
+  isFeedbackVisible: true,
+  allowNativeProps: true,
+};

--- a/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -1,0 +1,760 @@
+import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import { KeyCodes } from '../../Utilities';
+import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusTrapZone } from './FocusTrapZone';
+import { IFocusTrapZoneProps } from './FocusTrapZone.types';
+
+// rAF does not exist in node - let's mock it
+window.requestAnimationFrame = (callback: FrameRequestCallback) => {
+  const r = window.setTimeout(callback, 0);
+  jest.runAllTimers();
+  return r;
+};
+
+jest.useFakeTimers();
+
+class FocusTrapZoneTestComponent extends React.Component<{}, { isShowingFirst: boolean; isShowingSecond: boolean }> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { isShowingFirst: true, isShowingSecond: false };
+  }
+
+  public render() {
+    return (
+      <div>
+        <FocusTrapZone forceFocusInsideTrap={true} isClickableOutsideFocusTrap={false}>
+          <button className={'a'} onClick={this._toggleFirst}>
+            a
+          </button>
+          <button className={'b'} onClick={this._toggleSecond}>
+            b
+          </button>
+        </FocusTrapZone>
+
+        {this.state.isShowingFirst && (
+          <FocusTrapZone forceFocusInsideTrap={false} isClickableOutsideFocusTrap={false}>
+            <FocusZone data-is-visible={true}>First</FocusZone>
+          </FocusTrapZone>
+        )}
+        {this.state.isShowingSecond && (
+          <FocusTrapZone forceFocusInsideTrap={false} isClickableOutsideFocusTrap={true}>
+            <FocusZone data-is-visible={true}>First</FocusZone>
+          </FocusTrapZone>
+        )}
+      </div>
+    );
+  }
+
+  private _toggleFirst = () => {
+    this.setState({ isShowingFirst: !this.state.isShowingFirst });
+  };
+
+  private _toggleSecond = () => {
+    this.setState({ isShowingSecond: !this.state.isShowingSecond });
+  };
+}
+
+describe('FocusTrapZone', () => {
+  // document.activeElement can be used to detect activeElement after component mount, but it does not
+  // update based on focus events due to limitations of ReactDOM. Use lastFocusedElement to detect focus
+  // change events.
+  let lastFocusedElement: HTMLElement | undefined;
+  let addEventListener: any;
+  let componentEventListeners: any = {};
+  const ftzClassname = 'ftzTestClassname';
+
+  function _onFocus(ev: any): void {
+    lastFocusedElement = ev.target;
+  }
+
+  function setupElement(
+    element: HTMLElement,
+    {
+      clientRect,
+      isVisible = true,
+    }: {
+      clientRect: {
+        top: number;
+        left: number;
+        bottom: number;
+        right: number;
+      };
+      isVisible?: boolean;
+    },
+  ): void {
+    element.getBoundingClientRect = () =>
+      ({
+        top: clientRect.top,
+        left: clientRect.left,
+        bottom: clientRect.bottom,
+        right: clientRect.right,
+        width: clientRect.right - clientRect.left,
+        height: clientRect.bottom - clientRect.top,
+      } as DOMRect);
+
+    element.setAttribute('data-is-visible', String(isVisible));
+
+    element.focus = () => ReactTestUtils.Simulate.focus(element);
+  }
+
+  /**
+   * Helper to get FocusTrapZone bumpers. Requires classname attribute of
+   * 'ftzClassname' on FTZ.
+   */
+  function getFtzBumpers(
+    element: HTMLElement,
+  ): {
+    firstBumper: Element;
+    lastBumper: Element;
+  } {
+    const ftz = element.querySelector('.' + ftzClassname) as HTMLElement;
+    const ftzNodes = ftz.children;
+    const firstBumper = ftzNodes[0];
+    const lastBumper = ftzNodes[ftzNodes.length - 1];
+
+    return { firstBumper, lastBumper };
+  }
+
+  beforeAll(() => {
+    // Test DOM won't bubble up events to window listeners, so instead we call the window listeners directly.
+    // By mocking window.addEventListener we can store callbacks that the component under test registers.
+    // Then we can call them directly to simulate window events.
+    addEventListener = window.addEventListener;
+    window.addEventListener = jest.fn().mockImplementation((event, cb) => {
+      componentEventListeners[event] = cb;
+    });
+  });
+
+  beforeEach(() => {
+    lastFocusedElement = undefined;
+  });
+
+  afterEach(() => {
+    // Make sure registered listeners are cleared between tests.
+    componentEventListeners = {};
+  });
+
+  afterAll(() => {
+    window.addEventListener = addEventListener;
+  });
+
+  describe('Tab and shift-tab wrap at extreme ends of the FTZ', () => {
+    it('can tab across FocusZones with different button structures', async () => {
+      expect.assertions(3);
+
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div onFocusCapture={_onFocus}>
+          <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
+            <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
+              <div data-is-visible={true}>
+                <button className="a">a</button>
+              </div>
+              <div data-is-visible={true}>
+                <button className="b">b</button>
+              </div>
+              <div data-is-visible={true}>
+                <button className="c">c</button>
+              </div>
+            </FocusZone>
+            <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
+              <div data-is-visible={true}>
+                <div data-is-visible={true}>
+                  <button className="d">d</button>
+                  <button className="e">e</button>
+                  <button className="f">f</button>
+                </div>
+              </div>
+            </FocusZone>
+          </FocusTrapZone>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonC = topLevelDiv.querySelector('.c') as HTMLElement;
+      const buttonD = topLevelDiv.querySelector('.d') as HTMLElement;
+      const buttonE = topLevelDiv.querySelector('.e') as HTMLElement;
+      const buttonF = topLevelDiv.querySelector('.f') as HTMLElement;
+
+      const { firstBumper, lastBumper } = getFtzBumpers(topLevelDiv);
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonA, { clientRect: { top: 0, bottom: 30, left: 0, right: 30 } });
+      setupElement(buttonB, { clientRect: { top: 0, bottom: 30, left: 30, right: 60 } });
+      setupElement(buttonC, { clientRect: { top: 0, bottom: 30, left: 60, right: 90 } });
+      setupElement(buttonD, { clientRect: { top: 30, bottom: 60, left: 0, right: 30 } });
+      setupElement(buttonE, { clientRect: { top: 30, bottom: 60, left: 30, right: 60 } });
+      setupElement(buttonF, { clientRect: { top: 30, bottom: 60, left: 60, right: 90 } });
+
+      ReactTestUtils.Simulate.focus(buttonA);
+      expect(lastFocusedElement).toBe(buttonA);
+
+      // Simulate shift+tab event which would focus first bumper
+      ReactTestUtils.Simulate.focus(firstBumper);
+      expect(lastFocusedElement).toBe(buttonD);
+
+      // Simulate tab event which would focus last bumper
+      ReactTestUtils.Simulate.focus(lastBumper);
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('can tab across a FocusZone with different button structures', async () => {
+      expect.assertions(3);
+
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div onFocusCapture={_onFocus}>
+          <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
+            <div data-is-visible={true}>
+              <button className="x">x</button>
+            </div>
+            <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
+              <div data-is-visible={true}>
+                <button className="a">a</button>
+              </div>
+              <div data-is-visible={true}>
+                <div data-is-visible={true}>
+                  <button className="b">b</button>
+                  <button className="c">c</button>
+                  <button className="d">d</button>
+                </div>
+              </div>
+            </FocusZone>
+          </FocusTrapZone>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonX = topLevelDiv.querySelector('.x') as HTMLElement;
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonC = topLevelDiv.querySelector('.c') as HTMLElement;
+      const buttonD = topLevelDiv.querySelector('.d') as HTMLElement;
+
+      const { firstBumper, lastBumper } = getFtzBumpers(topLevelDiv);
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonX, { clientRect: { top: 0, bottom: 30, left: 0, right: 30 } });
+      setupElement(buttonA, { clientRect: { top: 0, bottom: 30, left: 0, right: 30 } });
+      setupElement(buttonB, { clientRect: { top: 0, bottom: 30, left: 30, right: 60 } });
+      setupElement(buttonC, { clientRect: { top: 0, bottom: 30, left: 60, right: 90 } });
+      setupElement(buttonD, { clientRect: { top: 30, bottom: 60, left: 0, right: 30 } });
+
+      ReactTestUtils.Simulate.focus(buttonX);
+      expect(lastFocusedElement).toBe(buttonX);
+
+      // Simulate shift+tab event which would focus first bumper
+      ReactTestUtils.Simulate.focus(firstBumper);
+      expect(lastFocusedElement).toBe(buttonA);
+
+      // Simulate tab event which would focus last bumper
+      ReactTestUtils.Simulate.focus(lastBumper);
+      expect(lastFocusedElement).toBe(buttonX);
+    });
+
+    it(`can trap focus when FTZ bookmark elements are FocusZones, and those elements have inner elements focused that
+      are not the first inner element`, async () => {
+      expect.assertions(4);
+
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div onFocusCapture={_onFocus}>
+          <button className={'z1'}>z1</button>
+          <FocusTrapZone forceFocusInsideTrap={false} className={ftzClassname}>
+            <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
+              <button className={'a'}>a</button>
+              <button className={'b'}>b</button>
+              <button className={'c'}>c</button>
+            </FocusZone>
+            <button className={'d'}>d</button>
+            <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible={true}>
+              <button className={'e'}>e</button>
+              <button className={'f'}>f</button>
+              <button className={'g'}>g</button>
+            </FocusZone>
+          </FocusTrapZone>
+          <button className={'z2'}>z2</button>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonC = topLevelDiv.querySelector('.c') as HTMLElement;
+      const buttonD = topLevelDiv.querySelector('.d') as HTMLElement;
+      const buttonE = topLevelDiv.querySelector('.e') as HTMLElement;
+      const buttonF = topLevelDiv.querySelector('.f') as HTMLElement;
+      const buttonG = topLevelDiv.querySelector('.g') as HTMLElement;
+      const buttonZ2 = topLevelDiv.querySelector('.z2') as HTMLElement;
+
+      const { firstBumper, lastBumper } = getFtzBumpers(topLevelDiv);
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonZ1, { clientRect: { top: 0, bottom: 10, left: 0, right: 10 } });
+      setupElement(buttonA, { clientRect: { top: 10, bottom: 30, left: 0, right: 10 } });
+      setupElement(buttonB, { clientRect: { top: 10, bottom: 30, left: 10, right: 20 } });
+      setupElement(buttonC, { clientRect: { top: 10, bottom: 30, left: 20, right: 30 } });
+      setupElement(buttonD, { clientRect: { top: 30, bottom: 40, left: 0, right: 10 } });
+      setupElement(buttonE, { clientRect: { top: 40, bottom: 60, left: 0, right: 10 } });
+      setupElement(buttonF, { clientRect: { top: 40, bottom: 60, left: 10, right: 20 } });
+      setupElement(buttonG, { clientRect: { top: 40, bottom: 60, left: 20, right: 30 } });
+      setupElement(buttonZ2, { clientRect: { top: 60, bottom: 70, left: 0, right: 10 } });
+
+      // Focus the middle button in the first FZ.
+      ReactTestUtils.Simulate.focus(buttonA);
+      ReactTestUtils.Simulate.keyDown(buttonA, { which: KeyCodes.right });
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Focus the middle button in the second FZ.
+      ReactTestUtils.Simulate.focus(buttonE);
+      ReactTestUtils.Simulate.keyDown(buttonE, { which: KeyCodes.right });
+      expect(lastFocusedElement).toBe(buttonF);
+
+      // Simulate tab event which would focus last bumper
+      ReactTestUtils.Simulate.focus(lastBumper);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Simulate shift+tab event which would focus first bumper
+      ReactTestUtils.Simulate.focus(firstBumper);
+      expect(lastFocusedElement).toBe(buttonF);
+    });
+  });
+
+  describe('Tab and shift-tab do nothing (keep focus where it is) when the FTZ contains 0 tabbable items', () => {
+    function setupTest(props: IFocusTrapZoneProps) {
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div onFocusCapture={_onFocus}>
+          <button className={'z1'}>z1</button>
+          <FocusTrapZone className={ftzClassname} forceFocusInsideTrap={true} {...props}>
+            <button className={'a'} tabIndex={-1}>
+              a
+            </button>
+            <button className={'b'} tabIndex={-1}>
+              b
+            </button>
+            <button className={'c'} tabIndex={-1}>
+              c
+            </button>
+          </FocusTrapZone>
+          <button className={'z2'}>z2</button>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonC = topLevelDiv.querySelector('.c') as HTMLElement;
+      const buttonZ2 = topLevelDiv.querySelector('.z2') as HTMLElement;
+
+      const { firstBumper, lastBumper } = getFtzBumpers(topLevelDiv);
+
+      // Have to set bumpers as "visible" for focus utilities to find them.
+      // This is needed for 0 tabbable element tests to make sure that next tabbable element
+      // from one bumper is the other bumper.
+      firstBumper.setAttribute('data-is-visible', String(true));
+      lastBumper.setAttribute('data-is-visible', String(true));
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonZ1, { clientRect: { top: 0, bottom: 10, left: 0, right: 10 } });
+      setupElement(buttonA, { clientRect: { top: 10, bottom: 20, left: 0, right: 10 } });
+      setupElement(buttonB, { clientRect: { top: 20, bottom: 30, left: 0, right: 10 } });
+      setupElement(buttonC, { clientRect: { top: 30, bottom: 40, left: 0, right: 10 } });
+      setupElement(buttonZ2, { clientRect: { top: 40, bottom: 50, left: 0, right: 10 } });
+
+      return { buttonZ1, buttonA, buttonB, buttonC, buttonZ2, firstBumper, lastBumper };
+    }
+
+    it('focuses first focusable element when focusing first bumper', async () => {
+      expect.assertions(2);
+
+      const { buttonA, buttonB, firstBumper } = setupTest({});
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Simulate shift+tab event which would focus first bumper
+      ReactTestUtils.Simulate.focus(firstBumper);
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('focuses first focusable element when focusing last bumper', async () => {
+      expect.assertions(2);
+
+      const { buttonA, buttonB, lastBumper } = setupTest({});
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Simulate tab event which would focus first bumper
+      ReactTestUtils.Simulate.focus(lastBumper);
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('focuses first focusable element when focusing outside of FTZ with 0 tabbable items', async () => {
+      expect.assertions(2);
+
+      const { buttonA, buttonB, buttonZ2 } = setupTest({});
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Directly call window listener to simulate focus leaving FTZ.
+      componentEventListeners.focus({
+        target: buttonZ2,
+        preventDefault: () => {
+          /*noop*/
+        },
+        stopPropagation: () => {
+          /*noop*/
+        },
+      });
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('focuses previously focused element when focusing outside of FTZ with 0 tabbable items', async () => {
+      expect.assertions(2);
+
+      const { buttonB, buttonZ2 } = setupTest({ focusPreviouslyFocusedInnerElement: true });
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Directly call window listener to simulate focus leaving FTZ.
+      componentEventListeners.focus({
+        target: buttonZ2,
+        preventDefault: () => {
+          /*noop*/
+        },
+        stopPropagation: () => {
+          /*noop*/
+        },
+      });
+      expect(lastFocusedElement).toBe(buttonB);
+    });
+  });
+
+  describe('Focus behavior based on default and explicit prop values', () => {
+    function setupTest(props: IFocusTrapZoneProps) {
+      // data-is-visible is embedded in buttons here for testing focus behavior on initial render.
+      // Components have to be marked visible before setupElement has a chance to apply the data-is-visible attribute.
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div>
+          <div onFocusCapture={_onFocus}>
+            <button className={'z1'}>z1</button>
+            <FocusTrapZone data-is-visible={true} {...props} className={ftzClassname}>
+              <button className={'a'} data-is-visible={true}>
+                a
+              </button>
+              <button className={'b'} data-is-visible={true}>
+                b
+              </button>
+              <button className={'c'} data-is-visible={true}>
+                c
+              </button>
+            </FocusTrapZone>
+            <button className={'z2'}>z2</button>
+          </div>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonZ1 = topLevelDiv.querySelector('.z1') as HTMLElement;
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonC = topLevelDiv.querySelector('.c') as HTMLElement;
+      const buttonZ2 = topLevelDiv.querySelector('.z2') as HTMLElement;
+
+      const { firstBumper, lastBumper } = getFtzBumpers(topLevelDiv);
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonZ1, { clientRect: { top: 0, bottom: 10, left: 0, right: 10 } });
+      setupElement(buttonA, { clientRect: { top: 10, bottom: 20, left: 0, right: 10 } });
+      setupElement(buttonB, { clientRect: { top: 20, bottom: 30, left: 0, right: 10 } });
+      setupElement(buttonC, { clientRect: { top: 30, bottom: 40, left: 0, right: 10 } });
+      setupElement(buttonZ2, { clientRect: { top: 40, bottom: 50, left: 0, right: 10 } });
+
+      return { buttonZ1, buttonA, buttonB, buttonC, buttonZ2, firstBumper, lastBumper };
+    }
+
+    it('Restores focus to FTZ when clicking outside FTZ', async () => {
+      expect.assertions(2);
+
+      const { buttonA, buttonB, buttonZ2 } = setupTest({});
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Directly call window listener to simulate focus leaving FTZ.
+      componentEventListeners.click({
+        target: buttonZ2,
+        preventDefault: () => {
+          /*noop*/
+        },
+        stopPropagation: () => {
+          /*noop*/
+        },
+      });
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('Does not restore focus to FTZ when clicking outside FTZ with isClickableOutsideFocusTrap', async () => {
+      expect.assertions(1);
+
+      setupTest({ isClickableOutsideFocusTrap: true });
+
+      // FTZ doesn't register a window click listener when isClickableOutsideFocusTrap is true, so we can't simulate
+      // clicks directly. Therefore we test indirectly by making sure FTZ doesn't register a window click listener.
+      expect(componentEventListeners.click).toBeUndefined();
+    });
+
+    it('Focuses first element when FTZ does not have focus and first bumper receives focus', async () => {
+      expect.assertions(2);
+
+      const { buttonA, buttonZ1, firstBumper } = setupTest({ isClickableOutsideFocusTrap: true });
+
+      ReactTestUtils.Simulate.focus(buttonZ1);
+      expect(lastFocusedElement).toBe(buttonZ1);
+
+      ReactTestUtils.Simulate.focus(firstBumper);
+      expect(lastFocusedElement).toBe(buttonA);
+    });
+
+    it('Focuses last element when FTZ does not have focus and last bumper receives focus', async () => {
+      expect.assertions(2);
+
+      const { buttonC, buttonZ2, lastBumper } = setupTest({ isClickableOutsideFocusTrap: true });
+
+      ReactTestUtils.Simulate.focus(buttonZ2);
+      expect(lastFocusedElement).toBe(buttonZ2);
+
+      ReactTestUtils.Simulate.focus(lastBumper);
+      expect(lastFocusedElement).toBe(buttonC);
+    });
+
+    it('Restores focus to FTZ when focusing outside FTZ', async () => {
+      expect.assertions(2);
+
+      const { buttonB, buttonZ2 } = setupTest({});
+
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Focusing outside trap brings focus back to FTZ
+      componentEventListeners.focus({
+        target: buttonZ2,
+        preventDefault: () => {
+          /*noop*/
+        },
+        stopPropagation: () => {
+          /*noop*/
+        },
+      });
+      expect(lastFocusedElement).toBe(buttonB);
+    });
+
+    it('Does not restore focus to FTZ when forceFocusInsideTrap is false', async () => {
+      expect.assertions(1);
+
+      setupTest({ forceFocusInsideTrap: false });
+
+      // FTZ doesn't register a window focus listener when isClickableOutsideFocusTrap is true, so we can't simulate
+      // focus directly. Therefore we test indirectly by making sure FTZ doesn't register a window focus listener.
+      expect(componentEventListeners.focus).toBeUndefined();
+    });
+
+    it('Focuses first on mount', async () => {
+      expect.assertions(1);
+
+      const { buttonA } = setupTest({});
+
+      expect(document.activeElement).toBe(buttonA);
+    });
+
+    it('Does not focus first on mount with disableFirstFocus', async () => {
+      expect.assertions(1);
+
+      const activeElement = document.activeElement;
+
+      setupTest({ disableFirstFocus: true });
+
+      // document.activeElement can be used to detect activeElement after component mount, but it does not
+      // update based on focus events due to limitations of ReactDOM.
+      // Make sure activeElement didn't change.
+      expect(document.activeElement).toBe(activeElement);
+    });
+
+    it('Does not focus first on mount while disabled', async () => {
+      expect.assertions(1);
+
+      const activeElement = document.activeElement;
+
+      setupTest({ disabled: true });
+
+      // document.activeElement can be used to detect activeElement after component mount, but it does not
+      // update based on focus events due to limitations of ReactDOM.
+      // Make sure activeElement didn't change.
+      expect(document.activeElement).toBe(activeElement);
+    });
+
+    it('Focuses on firstFocusableSelector on mount', async () => {
+      expect.assertions(1);
+
+      const { buttonC } = setupTest({ firstFocusableSelector: 'c' });
+
+      expect(document.activeElement).toBe(buttonC);
+    });
+
+    it('Does not focus on firstFocusableSelector on mount while disabled', async () => {
+      expect.assertions(1);
+
+      const activeElement = document.activeElement;
+
+      setupTest({ firstFocusableSelector: 'c', disabled: true });
+
+      expect(document.activeElement).toBe(activeElement);
+    });
+
+    it('Falls back to first focusable element with invalid firstFocusableSelector', async () => {
+      const { buttonA } = setupTest({ firstFocusableSelector: 'invalidSelector' });
+
+      expect(document.activeElement).toBe(buttonA);
+    });
+  });
+
+  describe('Focusing the FTZ', () => {
+    function setupTest(focusPreviouslyFocusedInnerElement: boolean) {
+      const focusTrapZoneRef = React.createRef<FocusTrapZone>();
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div onFocusCapture={_onFocus}>
+          <FocusTrapZone
+            forceFocusInsideTrap={false}
+            focusPreviouslyFocusedInnerElement={focusPreviouslyFocusedInnerElement}
+            data-is-focusable={true}
+            ref={focusTrapZoneRef}
+          >
+            <button className={'f'}>f</button>
+            <FocusZone>
+              <button className={'a'}>a</button>
+              <button className={'b'}>b</button>
+            </FocusZone>
+          </FocusTrapZone>
+          <button className={'z'}>z</button>
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonF = topLevelDiv.querySelector('.f') as HTMLElement;
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+      const buttonZ = topLevelDiv.querySelector('.z') as HTMLElement;
+
+      // Assign bounding locations to buttons.
+      setupElement(buttonF, { clientRect: { top: 0, bottom: 10, left: 0, right: 10 } });
+      setupElement(buttonA, { clientRect: { top: 10, bottom: 20, left: 0, right: 10 } });
+      setupElement(buttonB, { clientRect: { top: 20, bottom: 30, left: 0, right: 10 } });
+      setupElement(buttonZ, { clientRect: { top: 30, bottom: 40, left: 0, right: 10 } });
+
+      return { focusTrapZone: focusTrapZoneRef.current!, buttonF, buttonA, buttonB, buttonZ };
+    }
+
+    it('goes to previously focused element when focusing the FTZ', async () => {
+      expect.assertions(4);
+
+      const { focusTrapZone, buttonF, buttonB, buttonZ } = setupTest(true /*focusPreviouslyFocusedInnerElement*/);
+
+      // Manually focusing FTZ when FTZ has never
+      // had focus within should go to 1st focusable inner element.
+      focusTrapZone.focus();
+      expect(lastFocusedElement).toBe(buttonF);
+
+      // Focus inside the trap zone, not the first element.
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Focus outside the trap zone
+      ReactTestUtils.Simulate.focus(buttonZ);
+      expect(lastFocusedElement).toBe(buttonZ);
+
+      // Manually focusing FTZ should return to originally focused inner element.
+      focusTrapZone.focus();
+      expect(lastFocusedElement).toBe(buttonB);
+    });
+
+    it('goes to first focusable element when focusing the FTZ', async () => {
+      expect.assertions(4);
+
+      const { focusTrapZone, buttonF, buttonB, buttonZ } = setupTest(false /*focusPreviouslyFocusedInnerElement*/);
+
+      // Manually focusing FTZ when FTZ has never
+      // had focus within should go to 1st focusable inner element.
+      focusTrapZone.focus();
+      expect(lastFocusedElement).toBe(buttonF);
+
+      // Focus inside the trap zone, not the first element.
+      ReactTestUtils.Simulate.focus(buttonB);
+      expect(lastFocusedElement).toBe(buttonB);
+
+      // Focus outside the trap zone
+      ReactTestUtils.Simulate.focus(buttonZ);
+      expect(lastFocusedElement).toBe(buttonZ);
+
+      // Manually focusing FTZ should go to the first focusable element.
+      focusTrapZone.focus();
+      expect(lastFocusedElement).toBe(buttonF);
+    });
+  });
+
+  describe('Nested FocusTrapZones Stack Behavior', () => {
+    function getFocusStack(): FocusTrapZone[] {
+      return (FocusTrapZone as any)._focusStack;
+    }
+
+    beforeAll(() => {
+      getFocusStack().length = 0;
+    });
+
+    it('FocusTrapZone maintains a proper stack of FocusTrapZones as more are mounted/unmounted.', async () => {
+      let focusTrapZoneFocusStack: FocusTrapZone[] = getFocusStack();
+      const topLevelDiv = (ReactTestUtils.renderIntoDocument(
+        <div>
+          <FocusTrapZoneTestComponent />
+        </div>,
+      ) as unknown) as HTMLElement;
+
+      const buttonA = topLevelDiv.querySelector('.a') as HTMLElement;
+
+      const buttonB = topLevelDiv.querySelector('.b') as HTMLElement;
+
+      expect(focusTrapZoneFocusStack.length).toBe(2);
+      const baseFocusTrapZone = focusTrapZoneFocusStack[0];
+      expect(baseFocusTrapZone.props.forceFocusInsideTrap).toBe(true);
+      expect(baseFocusTrapZone.props.isClickableOutsideFocusTrap).toBe(false);
+
+      const firstFocusTrapZone = focusTrapZoneFocusStack[1];
+      expect(firstFocusTrapZone.props.forceFocusInsideTrap).toBe(false);
+      expect(firstFocusTrapZone.props.isClickableOutsideFocusTrap).toBe(false);
+
+      // There should be now 3 focus trap zones (base/first/second)
+      ReactTestUtils.Simulate.click(buttonB);
+      expect(focusTrapZoneFocusStack.length).toBe(3);
+      expect(focusTrapZoneFocusStack[0]).toBe(baseFocusTrapZone);
+      expect(focusTrapZoneFocusStack[1]).toBe(firstFocusTrapZone);
+      const secondFocusTrapZone = focusTrapZoneFocusStack[2];
+      expect(secondFocusTrapZone.props.forceFocusInsideTrap).toBe(false);
+      expect(secondFocusTrapZone.props.isClickableOutsideFocusTrap).toBe(true);
+
+      // we remove the middle one
+      // unmounting a focus trap zone should remove it from the focus stack.
+      // but we also check that it removes the right focustrapzone (the middle one)
+      ReactTestUtils.Simulate.click(buttonA);
+      focusTrapZoneFocusStack = getFocusStack();
+
+      expect(focusTrapZoneFocusStack.length).toBe(2);
+      expect(focusTrapZoneFocusStack[0]).toBe(baseFocusTrapZone);
+      expect(focusTrapZoneFocusStack[1]).toBe(secondFocusTrapZone);
+
+      // finally remove the last focus trap zone.
+      ReactTestUtils.Simulate.click(buttonB);
+      focusTrapZoneFocusStack = getFocusStack();
+
+      expect(focusTrapZoneFocusStack.length).toBe(1);
+      expect(focusTrapZoneFocusStack[0]).toBe(baseFocusTrapZone);
+    });
+  });
+});

--- a/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -1,0 +1,342 @@
+import * as React from 'react';
+import {
+  elementContains,
+  getNativeProps,
+  divProperties,
+  getFirstTabbable,
+  getLastTabbable,
+  getNextElement,
+  getDocument,
+  focusAsync,
+  initializeComponentRef,
+  on,
+} from '../../Utilities';
+import { IFocusTrapZone, IFocusTrapZoneProps } from './FocusTrapZone.types';
+
+export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> implements IFocusTrapZone {
+  private static _focusStack: FocusTrapZone[] = [];
+
+  private _root = React.createRef<HTMLDivElement>();
+  private _firstBumper = React.createRef<HTMLDivElement>();
+  private _lastBumper = React.createRef<HTMLDivElement>();
+  private _hasFocus: boolean = false;
+
+  private _previouslyFocusedElementOutsideTrapZone: HTMLElement;
+  private _previouslyFocusedElementInTrapZone?: HTMLElement;
+  private _disposeFocusHandler: (() => void) | undefined;
+  private _disposeClickHandler: (() => void) | undefined;
+
+  public constructor(props: IFocusTrapZoneProps) {
+    super(props);
+    initializeComponentRef(this);
+  }
+
+  public componentDidMount(): void {
+    this._bringFocusIntoZone();
+    this._updateEventHandlers(this.props);
+  }
+
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void {
+    const { elementToFocusOnDismiss } = nextProps;
+    if (elementToFocusOnDismiss && this._previouslyFocusedElementOutsideTrapZone !== elementToFocusOnDismiss) {
+      this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss;
+    }
+
+    this._updateEventHandlers(nextProps);
+  }
+
+  public componentDidUpdate(prevProps: IFocusTrapZoneProps) {
+    const prevForceFocusInsideTrap =
+      prevProps.forceFocusInsideTrap !== undefined ? prevProps.forceFocusInsideTrap : true;
+    const newForceFocusInsideTrap =
+      this.props.forceFocusInsideTrap !== undefined ? this.props.forceFocusInsideTrap : true;
+    const prevDisabled = prevProps.disabled !== undefined ? prevProps.disabled : false;
+    const newDisabled = this.props.disabled !== undefined ? this.props.disabled : false;
+
+    if ((!prevForceFocusInsideTrap && newForceFocusInsideTrap) || (prevDisabled && !newDisabled)) {
+      // Transition from forceFocusInsideTrap / FTZ disabled to enabled.
+      // Emulate what happens when a FocusTrapZone gets mounted.
+      this._bringFocusIntoZone();
+    } else if ((prevForceFocusInsideTrap && !newForceFocusInsideTrap) || (!prevDisabled && newDisabled)) {
+      // Transition from forceFocusInsideTrap / FTZ enabled to disabled.
+      // Emulate what happens when a FocusTrapZone gets unmounted.
+      this._returnFocusToInitiator();
+    }
+  }
+
+  public componentWillUnmount(): void {
+    // don't handle return focus unless forceFocusInsideTrap is true or focus is still within FocusTrapZone
+    if (
+      !this.props.disabled ||
+      this.props.forceFocusInsideTrap ||
+      !elementContains(this._root.current, this._getDocument().activeElement as HTMLElement)
+    ) {
+      this._returnFocusToInitiator();
+    }
+
+    // Dispose of event handlers so their closures can be garbage-collected
+    if (this._disposeClickHandler) {
+      this._disposeClickHandler();
+      this._disposeClickHandler = undefined;
+    }
+
+    if (this._disposeFocusHandler) {
+      this._disposeFocusHandler();
+      this._disposeFocusHandler = undefined;
+    }
+
+    // Dispose of element references so the DOM Nodes can be garbage-collected
+    delete this._previouslyFocusedElementInTrapZone;
+    delete this._previouslyFocusedElementOutsideTrapZone;
+  }
+
+  public render(): JSX.Element {
+    const { className, disabled = false, ariaLabelledBy } = this.props;
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
+
+    const bumperProps = {
+      style: {
+        pointerEvents: 'none',
+        position: 'fixed', // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them
+      },
+      tabIndex: disabled ? -1 : 0, // make bumpers tabbable only when enabled
+      'data-is-visible': true,
+    } as React.HTMLAttributes<HTMLDivElement>;
+
+    return (
+      <div
+        {...divProps}
+        className={className}
+        ref={this._root}
+        aria-labelledby={ariaLabelledBy}
+        onFocusCapture={this._onFocusCapture}
+        onFocus={this._onRootFocus}
+        onBlur={this._onRootBlur}
+      >
+        <div {...bumperProps} ref={this._firstBumper} onFocus={this._onFirstBumperFocus} />
+        {this.props.children}
+        <div {...bumperProps} ref={this._lastBumper} onFocus={this._onLastBumperFocus} />
+      </div>
+    );
+  }
+
+  public focus() {
+    const { focusPreviouslyFocusedInnerElement, firstFocusableSelector } = this.props;
+
+    if (
+      focusPreviouslyFocusedInnerElement &&
+      this._previouslyFocusedElementInTrapZone &&
+      elementContains(this._root.current, this._previouslyFocusedElementInTrapZone)
+    ) {
+      // focus on the last item that had focus in the zone before we left the zone
+      this._focusAsync(this._previouslyFocusedElementInTrapZone);
+      return;
+    }
+
+    const focusSelector =
+      typeof firstFocusableSelector === 'string'
+        ? firstFocusableSelector
+        : firstFocusableSelector && firstFocusableSelector();
+
+    let _firstFocusableChild: HTMLElement | null = null;
+
+    if (this._root.current) {
+      if (focusSelector) {
+        _firstFocusableChild = this._root.current.querySelector('.' + focusSelector);
+      }
+
+      // Fall back to first element if query selector did not match any elements.
+      if (!_firstFocusableChild) {
+        _firstFocusableChild = getNextElement(
+          this._root.current,
+          this._root.current.firstChild as HTMLElement,
+          false,
+          false,
+          false,
+          true,
+        );
+      }
+    }
+    if (_firstFocusableChild) {
+      this._focusAsync(_firstFocusableChild);
+    }
+  }
+
+  private _focusAsync(element: HTMLElement): void {
+    if (!this._isBumper(element)) {
+      focusAsync(element);
+    }
+  }
+
+  private _onRootFocus = (ev: React.FocusEvent<HTMLDivElement>) => {
+    if (this.props.onFocus) {
+      this.props.onFocus(ev);
+    }
+
+    this._hasFocus = true;
+  };
+
+  private _onRootBlur = (ev: React.FocusEvent<HTMLDivElement>) => {
+    if (this.props.onBlur) {
+      this.props.onBlur(ev);
+    }
+
+    let relatedTarget = ev.relatedTarget;
+    if (ev.relatedTarget === null) {
+      // In IE11, due to lack of support, event.relatedTarget is always
+      // null making every onBlur call to be "outside" of the ComboBox
+      // even when it's not. Using document.activeElement is another way
+      // for us to be able to get what the relatedTarget without relying
+      // on the event
+      relatedTarget = this._getDocument().activeElement as Element;
+    }
+
+    if (!elementContains(this._root.current, relatedTarget as HTMLElement)) {
+      this._hasFocus = false;
+    }
+  };
+
+  private _onFirstBumperFocus = () => {
+    this._onBumperFocus(true);
+  };
+
+  private _onLastBumperFocus = () => {
+    this._onBumperFocus(false);
+  };
+
+  private _onBumperFocus = (isFirstBumper: boolean) => {
+    if (this.props.disabled) {
+      return;
+    }
+
+    const currentBumper = (isFirstBumper === this._hasFocus
+      ? this._lastBumper.current
+      : this._firstBumper.current) as HTMLElement;
+
+    if (this._root.current) {
+      const nextFocusable =
+        isFirstBumper === this._hasFocus
+          ? getLastTabbable(this._root.current, currentBumper, true, false)
+          : getFirstTabbable(this._root.current, currentBumper, true, false);
+
+      if (nextFocusable) {
+        if (this._isBumper(nextFocusable)) {
+          // This can happen when FTZ contains no tabbable elements.
+          // focus will take care of finding a focusable element in FTZ.
+          this.focus();
+        } else {
+          nextFocusable.focus();
+        }
+      }
+    }
+  };
+
+  private _bringFocusIntoZone(): void {
+    const { elementToFocusOnDismiss, disabled = false, disableFirstFocus = false } = this.props;
+
+    if (disabled) {
+      return;
+    }
+
+    FocusTrapZone._focusStack.push(this);
+
+    this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss
+      ? elementToFocusOnDismiss
+      : (this._getDocument().activeElement as HTMLElement);
+    if (!disableFirstFocus && !elementContains(this._root.current, this._previouslyFocusedElementOutsideTrapZone)) {
+      this.focus();
+    }
+  }
+
+  private _returnFocusToInitiator(): void {
+    const { ignoreExternalFocusing } = this.props;
+
+    FocusTrapZone._focusStack = FocusTrapZone._focusStack.filter((value: FocusTrapZone) => {
+      return this !== value;
+    });
+
+    const doc = this._getDocument();
+    const activeElement = doc.activeElement as HTMLElement;
+    if (
+      !ignoreExternalFocusing &&
+      this._previouslyFocusedElementOutsideTrapZone &&
+      typeof this._previouslyFocusedElementOutsideTrapZone.focus === 'function' &&
+      (elementContains(this._root.current, activeElement) || activeElement === doc.body)
+    ) {
+      this._focusAsync(this._previouslyFocusedElementOutsideTrapZone);
+    }
+  }
+
+  private _updateEventHandlers(newProps: IFocusTrapZoneProps): void {
+    const { isClickableOutsideFocusTrap = false, forceFocusInsideTrap = true } = newProps;
+
+    if (forceFocusInsideTrap && !this._disposeFocusHandler) {
+      this._disposeFocusHandler = on(window, 'focus', this._forceFocusInTrap, true);
+    } else if (!forceFocusInsideTrap && this._disposeFocusHandler) {
+      this._disposeFocusHandler();
+      this._disposeFocusHandler = undefined;
+    }
+
+    if (!isClickableOutsideFocusTrap && !this._disposeClickHandler) {
+      this._disposeClickHandler = on(window, 'click', this._forceClickInTrap, true);
+    } else if (isClickableOutsideFocusTrap && this._disposeClickHandler) {
+      this._disposeClickHandler();
+      this._disposeClickHandler = undefined;
+    }
+  }
+
+  private _onFocusCapture = (ev: React.FocusEvent<HTMLDivElement>) => {
+    if (this.props.onFocusCapture) {
+      this.props.onFocusCapture(ev);
+    }
+
+    if (ev.target !== ev.currentTarget && !this._isBumper(ev.target)) {
+      // every time focus changes within the trap zone, remember the focused element so that
+      // it can be restored if focus leaves the pane and returns via keystroke (i.e. via a call to this.focus(true))
+      this._previouslyFocusedElementInTrapZone = ev.target as HTMLElement;
+    }
+  };
+
+  private _isBumper(element: HTMLElement): boolean {
+    return element === this._firstBumper.current || element === this._lastBumper.current;
+  }
+
+  private _forceFocusInTrap = (ev: FocusEvent): void => {
+    if (this.props.disabled) {
+      return;
+    }
+
+    if (FocusTrapZone._focusStack.length && this === FocusTrapZone._focusStack[FocusTrapZone._focusStack.length - 1]) {
+      const focusedElement = this._getDocument().activeElement as HTMLElement;
+
+      if (!elementContains(this._root.current, focusedElement)) {
+        this.focus();
+        this._hasFocus = true; // set focus here since we stop event propagation
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    }
+  };
+
+  private _forceClickInTrap = (ev: MouseEvent): void => {
+    if (this.props.disabled) {
+      return;
+    }
+
+    if (FocusTrapZone._focusStack.length && this === FocusTrapZone._focusStack[FocusTrapZone._focusStack.length - 1]) {
+      const clickedElement = ev.target as HTMLElement;
+
+      if (clickedElement && !elementContains(this._root.current, clickedElement)) {
+        this.focus();
+        this._hasFocus = true; // set focus here since we stop event propagation
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    }
+  };
+
+  private _getDocument(): Document {
+    return getDocument(this._root.current)!;
+  }
+}

--- a/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.types.ts
+++ b/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.types.ts
@@ -1,0 +1,81 @@
+import * as React from 'react';
+import { IRefObject } from '../../Utilities';
+
+/**
+ * {@docCategory FocusTrapZone}
+ */
+export interface IFocusTrapZone {
+  /**
+   * Sets focus to a descendant in the Trap Zone.
+   * See firstFocusableSelector and focusPreviouslyFocusedInnerElement for details.
+   */
+  focus: () => void;
+}
+
+/**
+ * {@docCategory FocusTrapZone}
+ */
+export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * Optional callback to access the IFocusTrapZone interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: IRefObject<IFocusTrapZone>;
+
+  /**
+   * Whether to disable the FocusTrapZone's focus trapping behavior.
+   * @defaultvalue false
+   */
+  disabled?: boolean;
+
+  /**
+   * Sets the element to focus on when exiting the FocusTrapZone.
+   * @defaultvalue The `element.target` that triggered the FTZ.
+   */
+  elementToFocusOnDismiss?: HTMLElement;
+
+  /**
+   * Sets the aria-labelledby attribute.
+   */
+  ariaLabelledBy?: string;
+
+  /**
+   * Whether clicks are allowed outside this FocusTrapZone.
+   * @defaultvalue false
+   */
+  isClickableOutsideFocusTrap?: boolean;
+
+  /**
+   * If false (the default), the trap zone will restore focus to the element which activated it
+   * once the trap zone is unmounted or disabled. Set to true to disable this behavior.
+   * @defaultvalue false
+   */
+  ignoreExternalFocusing?: boolean;
+
+  /**
+   * Whether the focus trap zone should force focus to stay inside of it.
+   * @defaultvalue true
+   */
+  forceFocusInsideTrap?: boolean;
+
+  /**
+   * Class name (not actual selector) for first focusable item. Do not append a dot.
+   * Only applies if `focusPreviouslyFocusedInnerElement` is false.
+   */
+  firstFocusableSelector?: string | (() => string);
+
+  /**
+   * Do not put focus onto the first element inside the focus trap zone.
+   * @defaultvalue false
+   */
+  disableFirstFocus?: boolean;
+
+  /**
+   * Specifies which descendant element to focus when `focus()` is called.
+   * If false, use the first focusable descendant, filtered by the `firstFocusableSelector` property if present.
+   * If true, use the element that was focused when the trap zone last had a focused descendant
+   * (or fall back to the first focusable descendant if the trap zone has never been focused).
+   * @defaultvalue false
+   */
+  focusPreviouslyFocusedInnerElement?: boolean;
+}

--- a/packages/react-next/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
+++ b/packages/react-next/src/components/FocusTrapZone/docs/FocusTrapZoneOverview.md
@@ -1,0 +1,3 @@
+FocusTrapZone is used to trap the focus in any html element. Pressing tab will circle focus within the inner focusable elements of the FocusTrapZone.
+
+**Note:** Trapping focus will restrict interaction with other elements in the website such as the side nav. Turn off the "Use trap zone" toggle control to allow this interaction to happen again.

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Click.Example.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
+import { Link } from '@fluentui/react-next/lib/Link';
+import { TextField, ITextFieldStyles } from '@fluentui/react-next/lib/TextField';
+import { Toggle, IToggle } from '@fluentui/react-next/lib/Toggle';
+import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
+import { memoizeFunction } from '@fluentui/react-next/lib/Utilities';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const getStackStyles = memoizeFunction(
+  (useTrapZone: boolean): Partial<IStackStyles> => ({
+    root: { border: `2px dashed ${useTrapZone ? '#ababab' : 'transparent'}`, padding: 10 },
+  }),
+);
+const textFieldStyles: Partial<ITextFieldStyles> = { root: { width: 300 } };
+const stackTokens = { childrenGap: 15 };
+
+export const FocusTrapZoneBoxClickExample: React.FunctionComponent = () => {
+  const [useTrapZone, { toggle: toggleUseTrapZone }] = useBoolean(false);
+  const toggle = React.useRef<IToggle>(null);
+  return (
+    <FocusTrapZone disabled={!useTrapZone} isClickableOutsideFocusTrap forceFocusInsideTrap={false}>
+      <Stack horizontalAlign="start" tokens={stackTokens} styles={getStackStyles(useTrapZone)}>
+        <Toggle
+          label="Use trap zone"
+          componentRef={toggle}
+          checked={useTrapZone}
+          onChange={toggleUseTrapZone}
+          onText="On (toggle to exit)"
+          offText="Off"
+        />
+        <TextField label="Input inside trap zone" styles={textFieldStyles} />
+        <Link href="https://bing.com" target="_blank">
+          Hyperlink inside trap zone
+        </Link>
+      </Stack>
+    </FocusTrapZone>
+  );
+};

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
+import { Link } from '@fluentui/react-next/lib/Link';
+import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
+import { Text } from '@fluentui/react-next/lib/Text';
+import { TextField, ITextFieldStyles } from '@fluentui/react-next/lib/TextField';
+import { Toggle, IToggle } from '@fluentui/react-next/lib/Toggle';
+import { memoizeFunction } from '@fluentui/react-next/lib/Utilities';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const getStackStyles = memoizeFunction(
+  (useTrapZone: boolean): Partial<IStackStyles> => ({
+    root: { border: `2px solid ${useTrapZone ? '#ababab' : 'transparent'}`, padding: 10 },
+  }),
+);
+const textFieldStyles: Partial<ITextFieldStyles> = { root: { width: 300 } };
+const stackTokens = { childrenGap: 8 };
+
+export const FocusTrapZoneBoxExample: React.FunctionComponent = () => {
+  const toggle = React.useRef<IToggle>(null);
+  const [useTrapZone, { toggle: toggleUseTrapZone }] = useBoolean(false);
+  return (
+    <Stack tokens={stackTokens}>
+      <Stack.Item>
+        <Text>
+          If this button is used to enable FocusTrapZone, focus should return to this button after the FocusTrapZone is
+          disabled.
+        </Text>
+      </Stack.Item>
+      <Stack.Item>
+        <DefaultButton onClick={toggleUseTrapZone} text="Trap Focus" />
+      </Stack.Item>
+      <FocusTrapZone disabled={!useTrapZone}>
+        <Stack horizontalAlign="start" tokens={stackTokens} styles={getStackStyles(useTrapZone)}>
+          <Toggle
+            label="Use trap zone"
+            componentRef={toggle}
+            checked={useTrapZone}
+            onChange={toggleUseTrapZone}
+            onText="On (toggle to exit)"
+            offText="Off"
+          />
+          <TextField label="Input inside trap zone" styles={textFieldStyles} />
+          <Link href="https://bing.com" target="_blank">
+            Hyperlink inside trap zone
+          </Link>
+        </Stack>
+      </FocusTrapZone>
+    </Stack>
+  );
+};

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
+import { Link } from '@fluentui/react-next/lib/Link';
+import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
+import { Text } from '@fluentui/react-next/lib/Text';
+import { TextField, ITextFieldStyles } from '@fluentui/react-next/lib/TextField';
+import { Toggle, IToggle } from '@fluentui/react-next/lib/Toggle';
+import { memoizeFunction } from '@fluentui/react-next/lib/Utilities';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const getStackStyles = memoizeFunction(
+  (useTrapZone: boolean): Partial<IStackStyles> => ({
+    root: { border: `2px solid ${useTrapZone ? '#ababab' : 'transparent'}`, padding: 10 },
+  }),
+);
+const textFieldStyles: Partial<ITextFieldStyles> = { root: { width: 300 } };
+const stackTokens = { childrenGap: 8 };
+const focusClassName = 'shouldFocusInput';
+
+export const FocusTrapZoneBoxCustomElementExample = () => {
+  const [useTrapZone, { toggle: toggleUseTrapZone }] = useBoolean(false);
+  const toggle = React.useRef<IToggle>(null);
+  return (
+    <Stack tokens={stackTokens}>
+      <Stack.Item>
+        <Text>If this button is used to enable FocusTrapZone, the hyperlink should be focused.</Text>
+      </Stack.Item>
+      <Stack.Item>
+        <DefaultButton onClick={toggleUseTrapZone} text="Focus Custom Element" />
+      </Stack.Item>
+      <FocusTrapZone disabled={!useTrapZone} firstFocusableSelector={focusClassName}>
+        <Stack horizontalAlign="start" tokens={stackTokens} styles={getStackStyles(useTrapZone)}>
+          <Toggle
+            label="Use trap zone"
+            componentRef={toggle}
+            checked={useTrapZone}
+            onChange={toggleUseTrapZone}
+            onText="On (toggle to exit)"
+            offText="Off"
+          />
+          <TextField label="Input inside trap zone" styles={textFieldStyles} />
+          <Link href="https://bing.com" className={focusClassName} target="_blank">
+            Hyperlink which will receive initial focus when trap zone is activated
+          </Link>
+        </Stack>
+      </FocusTrapZone>
+    </Stack>
+  );
+};

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.DialogInPanel.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.DialogInPanel.Example.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { Dialog, DialogType, DialogFooter } from '@fluentui/react-next/lib/Dialog';
+import { PrimaryButton } from '@fluentui/react-next/lib/Button';
+import { Panel, PanelType } from '@fluentui/react-next/lib/Panel';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const dialogContentProps = {
+  type: DialogType.normal,
+  title: 'This dialog also makes use of FocusTrapZone. Focus should be trapped in the dialog.',
+  subText: "Focus will move back to the panel if you press 'OK' or 'Cancel'.",
+};
+
+const modelProps = {
+  titleAriaId: 'myLabelId',
+  subtitleAriaId: 'mySubTextId',
+  isBlocking: false,
+  styles: { main: { maxWidth: 450 } },
+};
+
+export const FocusTrapZoneDialogInPanelExample: React.FunctionComponent = () => {
+  const [showPanel, { toggle: toggleShowPanel }] = useBoolean(false);
+  const [hideDialog, { toggle: toggleHideDialog }] = useBoolean(true);
+  return (
+    <div>
+      <DefaultButton text="Open Panel" secondaryText="Opens the Sample Panel" onClick={toggleShowPanel} />
+      <Panel
+        isOpen={showPanel}
+        type={PanelType.smallFixedFar}
+        onDismiss={toggleShowPanel}
+        headerText="This panel makes use of FocusTrapZone. Focus should be trapped in the panel."
+        closeButtonAriaLabel="Close"
+      >
+        <DefaultButton text="Open Dialog" secondaryText="Opens the Sample Dialog" onClick={toggleHideDialog} />
+        <Dialog
+          hidden={hideDialog}
+          onDismiss={toggleHideDialog}
+          isBlocking
+          dialogContentProps={dialogContentProps}
+          modalProps={modelProps}
+        >
+          <DialogFooter>
+            <PrimaryButton onClick={toggleHideDialog} text="OK" />
+            <DefaultButton onClick={toggleHideDialog} text="Cancel" />
+          </DialogFooter>
+        </Dialog>
+      </Panel>
+    </div>
+  );
+};

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.FocusZone.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.FocusZone.Example.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
+import { FocusZone, FocusZoneDirection } from '@fluentui/react-next/lib/FocusZone';
+import { Toggle, IToggle } from '@fluentui/react-next/lib/Toggle';
+import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
+import { memoizeFunction } from '@fluentui/react-next/lib/Utilities';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const stackTokens = { childrenGap: 10 };
+const getTrapZoneStackStyles = memoizeFunction(
+  (useTrapZone: boolean): Partial<IStackStyles> => ({
+    root: { border: `2px solid ${useTrapZone ? '#ababab' : 'transparent'}`, padding: 10 },
+  }),
+);
+const focusZoneStackStyles: Partial<IStackStyles> = {
+  root: {
+    border: '2px dashed #ababab',
+    padding: 10,
+  },
+};
+
+export const FocusTrapZoneFocusZoneExample: React.FunctionComponent = () => {
+  const [useTrapZone, { toggle: toggleUseTrapZone }] = useBoolean(false);
+  const toggle = React.useRef<IToggle>(null);
+  return (
+    <FocusTrapZone disabled={!useTrapZone} forceFocusInsideTrap focusPreviouslyFocusedInnerElement>
+      <Stack tokens={stackTokens} horizontalAlign="start" styles={getTrapZoneStackStyles(useTrapZone)}>
+        <Toggle
+          label="Use trap zone"
+          componentRef={toggle}
+          checked={useTrapZone}
+          onChange={toggleUseTrapZone}
+          onText="On (toggle to exit)"
+          offText="Off"
+        />
+        <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible>
+          <Stack horizontal tokens={stackTokens} styles={focusZoneStackStyles}>
+            <DefaultButton text="FZ1" />
+            <DefaultButton text="FZ1" />
+            <DefaultButton text="FZ1" />
+          </Stack>
+        </FocusZone>
+        <DefaultButton text="No FZ" />
+        <FocusZone direction={FocusZoneDirection.horizontal} data-is-visible>
+          <Stack horizontal tokens={stackTokens} styles={focusZoneStackStyles}>
+            <DefaultButton text="FZ2" />
+            <DefaultButton text="FZ2" />
+            <DefaultButton text="FZ2" />
+          </Stack>
+        </FocusZone>
+      </Stack>
+    </FocusTrapZone>
+  );
+};

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
+import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
+import { Toggle, IToggleStyles } from '@fluentui/react-next/lib/Toggle';
+import { memoizeFunction } from '@fluentui/react-next/lib/Utilities';
+import { useBoolean } from '@uifabric/react-hooks';
+
+const getStackStyles = memoizeFunction(
+  (isActive: boolean): Partial<IStackStyles> => ({
+    root: { border: `2px solid ${isActive ? '#ababab' : 'transparent'}`, padding: 10 },
+  }),
+);
+
+const stackTokens = { childrenGap: 10 };
+const fixedWidthToggleStyles: Partial<IToggleStyles> = { root: { width: 200 } };
+const FocusTrapComponent: React.FunctionComponent<React.PropsWithChildren<{ zoneNumber: number }>> = props => {
+  const [isActive, { toggle: toggleIsActive }] = useBoolean(false);
+  const { zoneNumber, children } = props;
+  const onStringButtonClicked = (): void => {
+    alert(`Button ${zoneNumber} clicked`);
+  };
+
+  return (
+    <FocusTrapZone disabled={!isActive} forceFocusInsideTrap={false}>
+      <Stack horizontalAlign="start" tokens={stackTokens} styles={getStackStyles(isActive)}>
+        <Toggle
+          checked={isActive}
+          onChange={toggleIsActive}
+          label={'Enable trap zone ' + zoneNumber}
+          onText="On (toggle to exit)"
+          offText="Off"
+          // Set a width on these toggles in the horizontal zone to prevent jumping when enabled
+          styles={zoneNumber >= 2 && zoneNumber <= 4 ? fixedWidthToggleStyles : undefined}
+        />
+        <DefaultButton onClick={onStringButtonClicked} text={`Zone ${zoneNumber} button`} />
+        {children}
+      </Stack>
+    </FocusTrapZone>
+  );
+};
+
+export const FocusTrapZoneNestedExample = () => (
+  <div>
+    <FocusTrapComponent zoneNumber={1}>
+      <FocusTrapComponent zoneNumber={2}>
+        <FocusTrapComponent zoneNumber={3} />
+        <FocusTrapComponent zoneNumber={4} />
+      </FocusTrapComponent>
+      <FocusTrapComponent zoneNumber={5} />
+    </FocusTrapComponent>
+  </div>
+);

--- a/packages/react-next/src/components/FocusTrapZone/index.ts
+++ b/packages/react-next/src/components/FocusTrapZone/index.ts
@@ -1,0 +1,2 @@
+export * from './FocusTrapZone';
+export * from './FocusTrapZone.types';


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

This change does not modify `FocusTrapZone`; it simply moves it to react-next for better diffing in the actual conversion PR.
