### PR TITLE
Remove implicit dep on lodash in charting package

### DIFF
--- a/change/@uifabric-charting-2020-05-22-22-12-06-charting-no-lodash.json
+++ b/change/@uifabric-charting-2020-05-22-22-12-06-charting-no-lodash.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove implicit dep on lodash and fix other imports",
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-23T05:12:06.167Z"
+}

--- a/change/@uifabric-utilities-2020-05-22-22-26-26-charting-no-lodash.json
+++ b/change/@uifabric-utilities-2020-05-22-22-26-26-charting-no-lodash.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "findIndex: add fromIndex parameter",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-23T05:26:26.952Z"
+}

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -16,11 +16,11 @@ import {
 } from './GroupedVerticalBarChart.types';
 import {
   IGroupedVerticalBarChartData,
-  IGVBarChartSeriesPoint,
   IGVDataPoint,
-  IGVSingleDataPoint,
   IGVForBarChart,
-} from '@uifabric/charting';
+  IGVSingleDataPoint,
+  IGVBarChartSeriesPoint,
+} from '../../types/index';
 
 const getClassNames = classNamesFunction<IGroupedVerticalBarChartStyleProps, IGroupedVerticalBarChartStyles>();
 type stringAxis = D3Axis<string>;

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.types.tsx
@@ -1,8 +1,8 @@
 import { ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IGroupedVerticalBarChartData } from '@uifabric/charting';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IOverflowSetProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IFocusZoneProps } from '@fluentui/react-focus';
+import { IGroupedVerticalBarChartData } from '../../types/index';
 
 export interface IGroupedVerticalBarChartProps {
   /**

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { classNamesFunction, find } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
-import { IChartProps, IHorizontalBarChartProps, IHorizontalBarChartStyles, IChartDataPoint } from './index';
+import {
+  IChartProps,
+  IHorizontalBarChartProps,
+  IHorizontalBarChartStyleProps,
+  IHorizontalBarChartStyles,
+  IChartDataPoint,
+} from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
-import { IHorizontalBarChartStyleProps } from '@uifabric/charting';
 
 const getClassNames = classNamesFunction<IHorizontalBarChartStyleProps, IHorizontalBarChartStyles>();
 

--- a/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ScaleTime } from 'd3-scale';
+import { findIndex } from 'office-ui-fabric-react/lib/Utilities';
 import { ILineDef, LabelLink, ILabelDef } from './LabelLink';
 import { IEventsAnnotationProps } from '../LineChart.types';
 
@@ -106,7 +107,10 @@ function calculateLabels(lineDefs: ILineDef[], textWidth: number, maxX: number, 
       idx = lineDefs.length;
     }
 
-    const aggregatedIdx = range(currentIdx, idx);
+    const aggregatedIdx: number[] = [];
+    for (let i = currentIdx; i < idx; i++) {
+      aggregatedIdx.push(i);
+    }
     const next = calculateLabel(bd, idx);
 
     next.unshift({ x: lineDefs[currentIdx].x, anchor, aggregatedIdx });
@@ -116,9 +120,7 @@ function calculateLabels(lineDefs: ILineDef[], textWidth: number, maxX: number, 
   return calculateLabel(minX, 0);
 }
 
-// Copies of lodash functions. None of these are complex enough to justify a dep on lodash
-// (and we should never have implicit deps).
-
+/** Get unique items of `arr`, comparing based on the result of calling `iteratee` on each item. */
 function uniqBy<T>(arr: T[], iteratee: (x: T) => string): T[] {
   const seen: string[] = [];
   const result: T[] = [];
@@ -130,21 +132,4 @@ function uniqBy<T>(arr: T[], iteratee: (x: T) => string): T[] {
     }
   }
   return result;
-}
-
-function range(min: number, max: number): number[] {
-  const nums: number[] = [];
-  for (let i = min; i < max; i++) {
-    nums.push(i);
-  }
-  return nums;
-}
-
-function findIndex<T>(arr: T[], predicate: (x: T) => boolean, fromIndex: number): number {
-  for (let i = fromIndex; i < arr.length; i++) {
-    if (predicate(arr[i])) {
-      return i;
-    }
-  }
-  return -1;
 }

--- a/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
@@ -10,8 +10,7 @@ interface IEventsAnnotationExtendProps extends IEventsAnnotationProps {
   chartYTop: number;
 }
 
-/* tslint:disable-next-line:function-name */
-export function EventsAnnotation(props: IEventsAnnotationExtendProps) {
+export const EventsAnnotation: React.FunctionComponent<IEventsAnnotationExtendProps> = props => {
   const textWidth = props.labelWidth ? props.labelWidth : 105;
   const textY = props.chartYTop - 20;
   const lineTopY = textY + 7;
@@ -58,7 +57,7 @@ export function EventsAnnotation(props: IEventsAnnotationExtendProps) {
       {labelLinks}
     </>
   );
-}
+};
 
 function calculateLabels(lineDefs: ILineDef[], textWidth: number, maxX: number, minX: number): ILabelDef[] {
   const calculateLabel = (lastX: number, currentIdx: number): ILabelDef[] => {

--- a/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/EventAnnotation.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { findIndex, range, unionBy } from 'lodash';
 import { ScaleTime } from 'd3-scale';
 import { ILineDef, LabelLink, ILabelDef } from './LabelLink';
 import { IEventsAnnotationProps } from '../LineChart.types';
@@ -24,7 +23,7 @@ export function EventsAnnotation(props: IEventsAnnotationExtendProps) {
 
   lineDefs.sort((e1, e2) => +e1.date - +e2.date);
 
-  const lines = unionBy(lineDefs, x => x.date.toString()).map((x, i) => (
+  const lines = uniqBy(lineDefs, x => x.date.toString()).map((x, i) => (
     <line
       key={i}
       x1={x.x}
@@ -115,4 +114,37 @@ function calculateLabels(lineDefs: ILineDef[], textWidth: number, maxX: number, 
   };
 
   return calculateLabel(minX, 0);
+}
+
+// Copies of lodash functions. None of these are complex enough to justify a dep on lodash
+// (and we should never have implicit deps).
+
+function uniqBy<T>(arr: T[], iteratee: (x: T) => string): T[] {
+  const seen: string[] = [];
+  const result: T[] = [];
+  for (const x of arr) {
+    const comp = iteratee(x);
+    if (seen.indexOf(comp) === -1) {
+      result.push(x);
+      seen.push(comp);
+    }
+  }
+  return result;
+}
+
+function range(min: number, max: number): number[] {
+  const nums: number[] = [];
+  for (let i = min; i < max; i++) {
+    nums.push(i);
+  }
+  return nums;
+}
+
+function findIndex<T>(arr: T[], predicate: (x: T) => boolean, fromIndex: number): number {
+  for (let i = fromIndex; i < arr.length; i++) {
+    if (predicate(arr[i])) {
+      return i;
+    }
+  }
+  return -1;
 }

--- a/packages/charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Callout, FocusZone, FocusZoneDirection, List } from 'office-ui-fabric-react';
-import { Textbox } from '@uifabric/charting';
 import { IEventAnnotation } from '../../../types/IEventAnnotation';
+import { Textbox } from './Textbox';
 
 export interface ILineDef extends IEventAnnotation {
   x: number;

--- a/packages/charting/src/components/LineChart/eventAnnotation/Textbox.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/Textbox.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { select } from 'd3-selection';
-import { omit } from 'lodash';
 
 interface ITextboxProps {
   text: string;
@@ -52,5 +51,7 @@ export function Textbox(props: ITextboxProps) {
   };
   React.useEffect(wrapWords);
 
-  return <text ref={textElementRef} {...omit(props, 'lineHeight')} />;
+  const { lineHeight, ...rest } = props;
+
+  return <text ref={textElementRef} {...rest} />;
 }

--- a/packages/charting/src/components/LineChart/eventAnnotation/Textbox.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/Textbox.tsx
@@ -12,8 +12,7 @@ interface ITextboxProps {
   fill?: string;
 }
 
-/* tslint:disable-next-line:function-name */
-export function Textbox(props: ITextboxProps) {
+export const Textbox: React.FunctionComponent<ITextboxProps> = props => {
   const textElementRef: React.RefObject<SVGTextElement> = React.useRef(null);
 
   const wrapWords = () => {
@@ -54,4 +53,4 @@ export function Textbox(props: ITextboxProps) {
   const { lineHeight, ...rest } = props;
 
   return <text ref={textElementRef} {...rest} />;
-}
+};

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.styles.ts
@@ -1,5 +1,4 @@
-import { IMultiStackedBarChartStyles } from '@uifabric/charting';
-import { IMultiStackedBarChartStyleProps } from './MultiStackedBarChart.types';
+import { IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles } from './MultiStackedBarChart.types';
 
 export const getMultiStackedBarChartStyles = (props: IMultiStackedBarChartStyleProps): IMultiStackedBarChartStyles => {
   const { className, width, barHeight, legendColor, shouldHighlight, theme, href } = props;

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -5,7 +5,6 @@ import { scaleBand as d3ScaleBand, scaleLinear as d3ScaleLinear, ScaleLinear as 
 import { select as d3Select } from 'd3-selection';
 import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
-import { IVSChartDataPoint, IDataPoint, IVerticalStackedChartProps } from '@uifabric/charting';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
 import { ILegend, Legends } from '../Legends/index';
@@ -15,6 +14,7 @@ import {
   IVerticalStackedBarChartStyleProps,
   IVerticalStackedBarChartStyles,
 } from './VerticalStackedBarChart.types';
+import { IVerticalStackedChartProps, IDataPoint, IVSChartDataPoint } from '../../types/index';
 
 const getClassNames = classNamesFunction<IVerticalStackedBarChartStyleProps, IVerticalStackedBarChartStyles>();
 type numericAxis = D3Axis<number | { valueOf(): number }>;

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -1,8 +1,8 @@
 import { ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
-import { IVerticalStackedChartProps } from '@uifabric/charting';
 import { IOverflowSetProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { IFocusZoneProps } from '@fluentui/react-focus';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
+import { IVerticalStackedChartProps } from '../../types/index';
 
 export interface IVerticalStackedBarChartProps {
   /**

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -264,7 +264,7 @@ export function find<T>(array: T[], cb: (item: T, index: number) => boolean): T 
 export function findElementRecursive(element: HTMLElement | null, matchFunction: (element: HTMLElement) => boolean): HTMLElement | null;
 
 // @public
-export function findIndex<T>(array: T[], cb: (item: T, index: number) => boolean): number;
+export function findIndex<T>(array: T[], cb: (item: T, index: number) => boolean, fromIndex?: number): number;
 
 // @public
 export function findScrollableParent(startingElement: HTMLElement | null): HTMLElement | null;

--- a/packages/utilities/src/array.ts
+++ b/packages/utilities/src/array.ts
@@ -5,11 +5,12 @@
  * @public
  * @param array - Array to search.
  * @param cb - Callback which returns true on matches.
+ * @param fromIndex - Optional index to start from (defaults to 0)
  */
-export function findIndex<T>(array: T[], cb: (item: T, index: number) => boolean): number {
+export function findIndex<T>(array: T[], cb: (item: T, index: number) => boolean, fromIndex: number = 0): number {
   let index = -1;
 
-  for (let i = 0; array && i < array.length; i++) {
+  for (let i = fromIndex; array && i < array.length; i++) {
     if (cb(array[i], i)) {
       index = i;
       break;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13294
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#12681 added references to `lodash` in some files in the charting package. Charting doesn't have a dep on `lodash` (and we don't want to add one), so the references to lodash need to be removed. (@SamuelQZQ FYI for future contributions.)
- Replace `omit` with object spread
- Replace `findIndex` with one from `@uifabric/utilities` (and add a `fromIndex` arg to the utility)
- Replace `range` with inline implementation
- Replace `unionBy` with local implementation of `uniqBy` (`unionBy` does additional array flattening which is unnecessary)

Also fix some imports within the charting package which referenced the package by name (instead of using relative paths) for some reason.

We'll be adding an eslint rule soon which would have caught both of these issues.