### PR TITLE
chore(HeaderDescription): Convert to RFC

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
@@ -24,7 +24,7 @@ export interface HeaderDescriptionProps
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<never>;
 }
 
 export const headerDescriptionClassName = 'ui-header__description';

--- a/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Header/HeaderDescription.tsx
@@ -4,17 +4,17 @@ import * as React from 'react';
 import {
   childrenExist,
   createShorthandFactory,
-  UIComponent,
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
-  ShorthandFactory,
 } from '../../utils';
-
-import { WithAsProp, withSafeTypeForAs } from '../../types';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+import { WithAsProp, withSafeTypeForAs, FluentComponentStaticProps, ProviderContextPrepared } from '../../types';
+import { useTelemetry, getElementType, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
 
 export interface HeaderDescriptionProps
   extends UIComponentProps,
@@ -28,36 +28,62 @@ export interface HeaderDescriptionProps
 }
 
 export const headerDescriptionClassName = 'ui-header__description';
+export type HeaderDescriptionStylesProps = Pick<HeaderDescriptionProps, 'color'>;
 
-class HeaderDescription extends UIComponent<WithAsProp<HeaderDescriptionProps>, any> {
-  static create: ShorthandFactory<HeaderDescriptionProps>;
+const HeaderDescription: React.FC<WithAsProp<HeaderDescriptionProps>> &
+  FluentComponentStaticProps<HeaderDescriptionProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(HeaderDescription.displayName, context.telemetry);
+  setStart();
+  const { children, content, color, className, design, styles, variables } = props;
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(HeaderDescription.handledProps, props);
 
-  static deprecated_className = headerDescriptionClassName;
+  const getA11yProps = useAccessibility<never>(props.accessibility, {
+    debugName: HeaderDescription.displayName,
+    rtl: context.rtl,
+  });
 
-  static displayName = 'HeaderDescription';
+  const { classes } = useStyles<HeaderDescriptionStylesProps>(HeaderDescription.displayName, {
+    className: headerDescriptionClassName,
+    mapPropsToStyles: () => ({
+      color,
+    }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  static propTypes = {
-    ...commonPropTypes.createCommon({ color: true }),
-  };
+  const element = (
+    <ElementType
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...unhandledProps,
+        ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
+      })}
+    >
+      {childrenExist(children) ? children : content}
+    </ElementType>
+  );
+  setEnd();
+  return element;
+};
 
-  static defaultProps = {
-    as: 'p',
-  };
+HeaderDescription.displayName = 'HeaderDescription';
 
-  renderComponent({ accessibility, ElementType, classes, unhandledProps }) {
-    const { children, content } = this.props;
-    return (
-      <ElementType
-        {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
-        {...accessibility.attributes.root}
-        {...unhandledProps}
-        className={classes.root}
-      >
-        {childrenExist(children) ? children : content}
-      </ElementType>
-    );
-  }
-}
+HeaderDescription.propTypes = {
+  ...commonPropTypes.createCommon({ color: true }),
+};
+
+HeaderDescription.defaultProps = {
+  as: 'p',
+};
+
+HeaderDescription.handledProps = Object.keys(HeaderDescription.propTypes) as any;
 
 HeaderDescription.create = createShorthandFactory({
   Component: HeaderDescription,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Header/headerDescriptionStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Header/headerDescriptionStyles.ts
@@ -1,11 +1,11 @@
 import * as _ from 'lodash';
 
 import { ICSSInJSStyle, ComponentSlotStylesPrepared } from '@fluentui/styles';
-import { HeaderDescriptionProps } from '../../../../components/Header/HeaderDescription';
+import { HeaderDescriptionStylesProps } from '../../../../components/Header/HeaderDescription';
 import { HeaderDescriptionVariables } from './headerDescriptionVariables';
 import { pxToRem } from '../../../../utils';
 
-const headerStyles: ComponentSlotStylesPrepared<HeaderDescriptionProps, HeaderDescriptionVariables> = {
+const headerStyles: ComponentSlotStylesPrepared<HeaderDescriptionStylesProps, HeaderDescriptionVariables> = {
   root: ({ props: p, variables: v }): ICSSInJSStyle => {
     const colors = v.colorScheme[p.color];
     return {

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -38,7 +38,7 @@ import { FlexStylesProps } from '../../components/Flex/Flex';
 import { FormStylesProps } from '../../components/Form/Form';
 import { FormFieldStylesProps } from '../../components/Form/FormField';
 import { GridProps } from '../../components/Grid/Grid';
-import { HeaderDescriptionProps } from '../../components/Header/HeaderDescription';
+import { HeaderDescriptionStylesProps } from '../../components/Header/HeaderDescription';
 import { HeaderStylesProps } from '../../components/Header/Header';
 import { ImageStylesProps } from '../../components/Image/Image';
 import { InputStylesProps } from '../../components/Input/Input';
@@ -132,7 +132,7 @@ export type TeamsThemeStylesProps = {
   FormField: FormFieldStylesProps;
   Grid: GridProps;
   Header: HeaderStylesProps;
-  HeaderDescription: HeaderDescriptionProps;
+  HeaderDescription: HeaderDescriptionStylesProps;
   SvgIcon: SvgIconStylesProps;
   Image: ImageStylesProps;
   Input: InputStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Header/HeaderDescription-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Header/HeaderDescription-test.ts
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests';
 import HeaderDescription from 'src/components/Header/HeaderDescription';
 
 describe('HeaderDescription', () => {
-  isConformant(HeaderDescription);
+  isConformant(HeaderDescription, { constructorName: 'HeaderDescription' });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `HeaderDescription` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `HeaderDescription`    |
| --------- |
| `color` |

#### Focus areas to test

(optional)
