### PR TITLE
chore(RadioGroupItem): Convert to RFC

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Removed `themes` export, each theme is exported separately @layershifter ([#13268](https://github.com/microsoft/fluentui/pull/13268))
 - Restricted prop sets in the `HeaderDescription` component which are passed to styles functions, @assuncaocharles ([#13296](https://github.com/microsoft/fluentui/pull/13296))
 - Restricted prop sets in the `Loader` component which are passed to styles functions, @assuncaocharles ([#13297](https://github.com/microsoft/fluentui/pull/13297))
+- Restricted prop sets in the `RadioGroupItem` component which are passed to styles functions, @assuncaocharles ([#13301](https://github.com/microsoft/fluentui/pull/13301))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))

--- a/packages/fluentui/accessibility/src/behaviors/Radio/radioGroupItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Radio/radioGroupItemBehavior.ts
@@ -35,7 +35,7 @@ const radioGroupItemBehavior: Accessibility<RadioGroupItemBehaviorProps> = props
 
 export default radioGroupItemBehavior;
 
-type RadioGroupItemBehaviorProps = {
+export type RadioGroupItemBehaviorProps = {
   /** Indicates if radio item is selected. */
   checked?: boolean;
   /** Indicates if radio item is disabled. */

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -63,6 +63,7 @@ export { default as toolbarRadioGroupBehavior } from './Toolbar/toolbarRadioGrou
 export { default as toolbarRadioGroupItemBehavior } from './Toolbar/toolbarRadioGroupItemBehavior';
 export { default as radioGroupBehavior } from './Radio/radioGroupBehavior';
 export { default as radioGroupItemBehavior } from './Radio/radioGroupItemBehavior';
+export * from './Radio/radioGroupItemBehavior';
 export * from './Popup/popupBehavior';
 export { default as popupBehavior } from './Popup/popupBehavior';
 export { default as chatBehavior } from './Chat/chatBehavior';

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -91,7 +91,7 @@ const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(RadioGroupItem.displayName, context.telemetry);
   setStart();
-  const { label, indicator, disabled, vertical, className, design, styles, variables } = props;
+  const { label, indicator, disabled, vertical, className, design, styles, variables, shouldFocus } = props;
   const elementRef = React.useRef<HTMLElement>();
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(RadioGroupItem.handledProps, props);
@@ -108,9 +108,9 @@ const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
   };
 
   React.useEffect(() => {
-    checked && props.shouldFocus && elementRef.current.focus();
+    checked && shouldFocus && elementRef.current.focus();
     _.invoke(props, 'onChange', undefined, { ...props, checked });
-  }, [checked]);
+  }, [checked, shouldFocus]);
 
   const { classes, styles: resolvedStyles } = useStyles<RadioGroupItemStylesProps>(RadioGroupItem.displayName, {
     className: radioGroupItemClassName,

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -104,12 +104,14 @@ const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
 
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     _.invoke(props, 'onClick', e, props);
-    setChecked(prevChecked => !prevChecked);
+    setChecked(prevChecked => {
+      _.invoke(props, 'onChange', undefined, { ...props, checked: !prevChecked });
+      return !prevChecked;
+    });
   };
 
   React.useEffect(() => {
     if (checked && shouldFocus) elementRef.current.focus();
-    _.invoke(props, 'onChange', undefined, { ...props, checked });
   }, [checked, shouldFocus]);
 
   const { classes, styles: resolvedStyles } = useStyles<RadioGroupItemStylesProps>(RadioGroupItem.displayName, {

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -1,21 +1,29 @@
-import { Accessibility, radioGroupItemBehavior } from '@fluentui/accessibility';
+import { Accessibility, radioGroupItemBehavior, RadioGroupItemBehaviorProps } from '@fluentui/accessibility';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
-
-import {
-  AutoControlledComponent,
-  createShorthandFactory,
-  UIComponentProps,
-  ChildrenComponentProps,
-  commonPropTypes,
-  applyAccessibilityKeyHandlers,
-  ShorthandFactory,
-} from '../../utils';
+import { createShorthandFactory, UIComponentProps, ChildrenComponentProps, commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
-import { ComponentEventHandler, WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types';
+import {
+  ComponentEventHandler,
+  WithAsProp,
+  ShorthandValue,
+  withSafeTypeForAs,
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+} from '../../types';
+import {
+  useAutoControlled,
+  getElementType,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+  useUnhandledProps,
+} from '@fluentui/react-bindings';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 
 export interface RadioGroupItemSlotClassNames {
   indicator: string;
@@ -23,7 +31,7 @@ export interface RadioGroupItemSlotClassNames {
 
 export interface RadioGroupItemProps extends UIComponentProps, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<RadioGroupItemBehaviorProps>;
 
   /** Whether or not radio item is checked. */
   checked?: boolean;
@@ -76,93 +84,124 @@ export const radioGroupItemSlotClassNames: RadioGroupItemSlotClassNames = {
   indicator: `${radioGroupItemClassName}__indicator`,
 };
 
-class RadioGroupItem extends AutoControlledComponent<WithAsProp<RadioGroupItemProps>, RadioGroupItemState> {
-  elementRef = React.createRef<HTMLElement>();
+export type RadioGroupItemStylesProps = Required<Pick<RadioGroupItemProps, 'disabled' | 'vertical' | 'checked'>>;
 
-  static create: ShorthandFactory<RadioGroupItemProps>;
+const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
+  FluentComponentStaticProps<RadioGroupItemProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(RadioGroupItem.displayName, context.telemetry);
+  setStart();
+  const { label, indicator, disabled, vertical, className, design, styles, variables } = props;
+  const elementRef = React.useRef<HTMLElement>();
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(RadioGroupItem.handledProps, props);
 
-  static displayName = 'RadioGroupItem';
+  const [checked, setChecked] = useAutoControlled({
+    defaultValue: props.defaultChecked,
+    value: props.checked,
+    initialValue: false,
+  });
 
-  static deprecated_className = radioGroupItemClassName;
+  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+    _.invoke(props, 'onClick', e, props);
+    setChecked(prevChecked => !prevChecked);
+  };
 
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false,
+  React.useEffect(() => {
+    checked && props.shouldFocus && elementRef.current.focus();
+    _.invoke(props, 'onChange', undefined, { ...props, checked });
+  }, [checked]);
+
+  const { classes, styles: resolvedStyles } = useStyles<RadioGroupItemStylesProps>(RadioGroupItem.displayName, {
+    className: radioGroupItemClassName,
+    mapPropsToStyles: () => ({
+      vertical,
+      disabled,
+      checked,
     }),
-    checked: PropTypes.bool,
-    defaultChecked: PropTypes.bool,
-    disabled: PropTypes.bool,
-    indicator: customPropTypes.shorthandAllowingChildren,
-    label: customPropTypes.itemShorthand,
-    name: PropTypes.string,
-    onClick: PropTypes.func,
-    onChange: PropTypes.func,
-    shouldFocus: PropTypes.bool,
-    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    vertical: PropTypes.bool,
-  };
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
 
-  static defaultProps = {
-    accessibility: radioGroupItemBehavior,
-    indicator: {},
-  };
-
-  static autoControlledProps = ['checked'];
-
-  actionHandlers = {
-    performClick: e => {
-      e.preventDefault();
-      this.handleClick(e);
+  const getA11yProps = useAccessibility<RadioGroupItemBehaviorProps>(props.accessibility, {
+    debugName: RadioGroupItem.displayName,
+    actionHandlers: {
+      performClick: e => {
+        e.preventDefault();
+        handleClick(e);
+      },
     },
-  };
+    mapPropsToBehavior: () => ({
+      checked,
+      disabled,
+    }),
+    rtl: context.rtl,
+  });
 
-  handleClick = e => {
-    _.invoke(this.props, 'onClick', e, this.props);
-  };
-
-  handleChange = (e: React.ChangeEvent) => {
+  const handleChange = (e: React.ChangeEvent) => {
     // RadioGroupItem component doesn't present any `input` component in markup, however all of our
     // components should handle events transparently.
-    _.invoke(this.props, 'onChange', e, { ...this.props, checked: this.state.checked });
+    _.invoke(props, 'onChange', e, { ...props, checked });
   };
 
-  componentDidUpdate(prevProps, prevState) {
-    const checked = this.state.checked;
-    if (checked !== prevState.checked) {
-      checked && this.props.shouldFocus && this.elementRef.current.focus();
-      _.invoke(this.props, 'onChange', undefined, { ...this.props, checked });
-    }
-  }
+  const element = getA11yProps.unstable_wrapWithFocusZone(
+    <Ref innerRef={elementRef}>
+      <ElementType
+        {...getA11yProps('root', {
+          className: classes.root,
+          onClick: handleClick,
+          onChange: handleChange,
+          ...unhandledProps,
+        })}
+      >
+        {Box.create(indicator, {
+          defaultProps: () => ({
+            className: radioGroupItemSlotClassNames.indicator,
+            styles: resolvedStyles.indicator,
+          }),
+        })}
+        {Box.create(label, {
+          defaultProps: () => ({
+            as: 'span',
+          }),
+        })}
+      </ElementType>
+    </Ref>,
+  );
+  setEnd();
+  return element;
+};
 
-  renderComponent({ ElementType, classes, unhandledProps, styles, accessibility }) {
-    const { label, indicator } = this.props;
+RadioGroupItem.displayName = 'RadioGroupItem';
 
-    return (
-      <Ref innerRef={this.elementRef}>
-        <ElementType
-          onClick={this.handleClick}
-          onChange={this.handleChange}
-          className={classes.root}
-          {...accessibility.attributes.root}
-          {...unhandledProps}
-          {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
-        >
-          {Box.create(indicator, {
-            defaultProps: () => ({
-              className: radioGroupItemSlotClassNames.indicator,
-              styles: styles.indicator,
-            }),
-          })}
-          {Box.create(label, {
-            defaultProps: () => ({
-              as: 'span',
-            }),
-          })}
-        </ElementType>
-      </Ref>
-    );
-  }
-}
+RadioGroupItem.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false,
+  }),
+  checked: PropTypes.bool,
+  defaultChecked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  indicator: customPropTypes.shorthandAllowingChildren,
+  label: customPropTypes.itemShorthand,
+  name: PropTypes.string,
+  onClick: PropTypes.func,
+  onChange: PropTypes.func,
+  shouldFocus: PropTypes.bool,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  vertical: PropTypes.bool,
+};
+
+RadioGroupItem.defaultProps = {
+  accessibility: radioGroupItemBehavior,
+  indicator: {},
+};
+
+RadioGroupItem.handledProps = Object.keys(RadioGroupItem.propTypes) as any;
 
 RadioGroupItem.create = createShorthandFactory({ Component: RadioGroupItem, mappedProp: 'label' });
 

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -108,7 +108,7 @@ const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
   };
 
   React.useEffect(() => {
-    checked && shouldFocus && elementRef.current.focus();
+    if (checked && shouldFocus) elementRef.current.focus();
     _.invoke(props, 'onChange', undefined, { ...props, checked });
   }, [checked, shouldFocus]);
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/RadioGroup/radioGroupItemStyles.ts
@@ -1,7 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import {
-  RadioGroupItemProps,
-  RadioGroupItemState,
+  RadioGroupItemStylesProps,
   radioGroupItemSlotClassNames,
 } from '../../../../components/RadioGroup/RadioGroupItem';
 import { RadioGroupItemVariables } from './radioGroupItemVariables';
@@ -20,7 +19,7 @@ const restHoverFocusTextColor = textColor => ({
   },
 });
 
-const radioStyles: ComponentSlotStylesPrepared<RadioGroupItemProps & RadioGroupItemState, RadioGroupItemVariables> = {
+const radioStyles: ComponentSlotStylesPrepared<RadioGroupItemStylesProps, RadioGroupItemVariables> = {
   root: ({ props: p, variables: v, theme: { siteVariables } }): ICSSInJSStyle => ({
     position: 'relative',
     alignItems: 'center',

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -57,7 +57,7 @@ import { MenuStylesProps } from '../../components/Menu/Menu';
 import { MenuDividerStylesProps } from '../../components/Menu/MenuDivider';
 import { PopupContentStylesProps } from '../../components/Popup/PopupContent';
 import { PortalProps } from '../../components/Portal/Portal';
-import { RadioGroupItemProps } from '../../components/RadioGroup/RadioGroupItem';
+import { RadioGroupItemStylesProps } from '../../components/RadioGroup/RadioGroupItem';
 import { RadioGroupProps } from '../../components/RadioGroup/RadioGroup';
 import { ReactionStylesProps } from '../../components/Reaction/Reaction';
 import { ReactionGroupStylesProps } from '../../components/Reaction/ReactionGroup';
@@ -152,7 +152,7 @@ export type TeamsThemeStylesProps = {
   Portal: PortalProps;
   PopupContent: PopupContentStylesProps;
   RadioGroup: RadioGroupProps;
-  RadioGroupItem: RadioGroupItemProps;
+  RadioGroupItem: RadioGroupItemStylesProps;
   Reaction: ReactionStylesProps;
   ReactionGroup: ReactionGroupStylesProps;
   Segment: SegmentStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/RadioGroup/RadioGroupItem-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/RadioGroup/RadioGroupItem-test.ts
@@ -3,7 +3,7 @@ import { isConformant, handlesAccessibility } from 'test/specs/commonTests';
 import RadioGroupItem from 'src/components/RadioGroup/RadioGroupItem';
 
 describe('RadioGroupItem', () => {
-  isConformant(RadioGroupItem, { autoControlledProps: ['checked'] });
+  isConformant(RadioGroupItem, { constructorName: 'RadioGroupItem', autoControlledProps: ['checked'] });
 
   describe('accessibility', () => {
     handlesAccessibility(RadioGroupItem, {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

This PR converts `RadioGroupItem` component to be functional. Restricting props set that will be passed to styles functions.

Related to #12237

## Prop sets

| `RadioGroupItem`    |
| --------- |
| `vertical` |
| `disabled` |
| `checked` |

#### Focus areas to test

(optional)
