### PR TITLE
docs(pages): Fix the navigational next button of Component Architecture page

### DIFF
--- a/packages/fluentui/docs/src/pages/ComponentArchitecture.mdx
+++ b/packages/fluentui/docs/src/pages/ComponentArchitecture.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Component Architecture',
   previous: { url: "/icon-viewer", name: "Icons" },
-  next: { url: '/quick-start', name: 'Quick Start' },
+  next: { url: '/theming-specification', name: 'Theming specification' },
 }
 
 The design and architecture of components should follow from a set of first principles.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13302
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
This PR fixes the navigational next button in the footer of **Component Architecture** page and make it linked with the appropriate following page which is **Theming specification**

#### Note
The command `yarn change` didn't produce any [Change Files](https://github.com/microsoft/fluentui/wiki/Change-Files)!
https://github.com/microsoft/fluentui/blob/7a2822b05a9a816056784a7b27acc3806315d9b9/package.json#L28
