### PR TITLE
Fix the order of Concepts menu items and previous/next buttons of the affected pages

### DIFF
--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -148,21 +148,21 @@ class Sidebar extends React.Component<any, any> {
             },
           },
           {
-            key: 'composition',
-            title: {
-              as: NavLink,
-              content: 'Composition',
-              activeClassName: 'active',
-              to: '/composition',
-            },
-          },
-          {
             key: 'shorthand',
             title: {
               as: NavLink,
               content: 'Shorthand Props',
               activeClassName: 'active',
               to: '/shorthand-props',
+            },
+          },
+          {
+            key: 'composition',
+            title: {
+              as: NavLink,
+              content: 'Composition',
+              activeClassName: 'active',
+              to: '/composition',
             },
           },
           {

--- a/packages/fluentui/docs/src/pages/Composition.mdx
+++ b/packages/fluentui/docs/src/pages/Composition.mdx
@@ -2,8 +2,8 @@ import { Alert } from '@fluentui/react-northstar';
 
 export const meta = {
   title: 'Composition',
-  previous: { name: 'Introduction', url: '/' },
-  next: { name: 'Shorthand Props', url: '/shorthand-props' }
+  previous: { name: 'Shorthand Props', url: '/shorthand-props' },
+  next: { name: 'Icons', url: '/icon-viewer' }
 };
 
 ## `as` prop

--- a/packages/fluentui/docs/src/pages/ShorthandProps.mdx
+++ b/packages/fluentui/docs/src/pages/ShorthandProps.mdx
@@ -1,7 +1,7 @@
 export const meta = {
   title: 'Shorthand Props',
-  previous: { name: 'Composition', url: '/composition' },
-  next: { url: '/icon-viewer', name: 'Icons' },
+  previous: { name: 'Introduction', url: '/' },
+  next: { url: '/composition', name: 'Composition' },
 }
 
 Fluent UI components can have "slots" which accept shothand props. For example, `Loader` component has an `label` slot which value defines the message that will appear together with the loading indicator.

--- a/packages/fluentui/docs/src/views/IconViewer.tsx
+++ b/packages/fluentui/docs/src/views/IconViewer.tsx
@@ -289,7 +289,7 @@ const IconViewer = () => {
       </Flex>
       <Flex padding="padding.medium">
         <GuidesNavigationFooter
-          previous={{ name: 'Shorthand Props', url: 'shorthand-props' }}
+          previous={{ name: 'Composition', url: 'composition' }}
           next={{ name: 'Component Architecture', url: 'component-architecture' }}
         />
       </Flex>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13303
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
If #13303 would be considered as an issue from Information Architecture perspective, so this PR should fix it.
The PR does the following:
- Fixes the order of **Shorthand Props** in **Concepts menu**
- Fixes all the **previous and next buttons** of the **ONLY affected pages** 


#### Note
The command `yarn change` didn't produce any [Change Files](https://github.com/microsoft/fluentui/wiki/Change-Files)!
https://github.com/microsoft/fluentui/blob/7a2822b05a9a816056784a7b27acc3806315d9b9/package.json#L28
