### PR TITLE
perf: remove `camelCaseProperty` call in `renderRule()` inside Fela

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -93,6 +93,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Performance
 - Omit `_.findKey()` usage in `focusVisibleEnhancer()` @layershifter ([#13343](https://github.com/microsoft/fluentui/pull/13343))
 - Use `mergeVariablesOverrides()` to avoid cache breaks when variables are not passed in `Toolbar`, `Menu` & `Table` components @layershifter ([#13374](https://github.com/microsoft/fluentui/pull/13374))
+- Remove `camelCaseProperty` call inside Fela renderer @layershifter ([#13308](https://github.com/microsoft/fluentui/pull/13308))
 
 ### Documentation
 - `Toolbar` recommendation using toolbar based on aria  @kolaps33 ([#13143](https://github.com/microsoft/fluentui/pull/13143))

--- a/packages/fluentui/perf/src/index.tsx
+++ b/packages/fluentui/perf/src/index.tsx
@@ -18,7 +18,7 @@ const performanceExamplesContext = require.context('@fluentui/docs/src/examples/
 // We want to randomize examples to avoid any notable issues with always first example
 const performanceExampleNames: string[] = _.shuffle(performanceExamplesContext.keys());
 
-const asyncRender = (element: React.ReactElement<any>, container: Element) =>
+const asyncRender = (element: React.ReactElement, container: Element) =>
   new Promise(resolve => {
     ReactDOM.render(element, container, () => {
       ReactDOM.unmountComponentAtNode(container);
@@ -43,7 +43,7 @@ const renderCycle = async (
             _.values(telemetryRef.current.performance),
             (acc, next) => {
               return {
-                componentCount: acc.componentCount + next.count,
+                componentCount: acc.componentCount + next.instances,
                 renderComponentTime: acc.renderComponentTime + next.msTotal,
               };
             },

--- a/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
@@ -1,3 +1,9 @@
+//
+// This file is one-to-one copy-paste from Fela source code. It includes `_renderStyleToClassNames()` and all
+// non-exported utils.
+// A single change is only one line inside `generateDeclarationReference()`.
+//
+
 import { ICSSInJSStyle } from '@fluentui/styles';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import cssifyDeclaration from 'css-in-js-utils/lib/cssifyDeclaration';
@@ -55,11 +61,12 @@ function generateDeclarationReference(
   support: string = '',
 ): string {
   //
-  //
   // This a single perf change here, it removes `camelCaseProperty()` call
   //
-  //
+
+  // CHANGE:START
   return support + media + pseudo + property + value;
+  // CHANGE:END
 }
 
 //

--- a/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
@@ -71,7 +71,7 @@ export default function felaPerformanceEnhancer(renderer) {
     media: string = '',
     support: string = '',
   ): string {
-    let classNames = _className ? ' ' + _className : '';
+    let classNames = _className ? ` ${_className}` : '';
 
     for (const property in style) {
       const value = style[property];

--- a/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaPerformanceEnhancer.ts
@@ -1,0 +1,146 @@
+import { ICSSInJSStyle } from '@fluentui/styles';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import cssifyDeclaration from 'css-in-js-utils/lib/cssifyDeclaration';
+import {
+  // @ts-ignore
+  generateCombinedMediaQuery,
+  // @ts-ignore
+  generateCSSSelector,
+  // @ts-ignore
+  isMediaQuery,
+  // @ts-ignore
+  isNestedSelector,
+  // @ts-ignore
+  isSupport,
+  // @ts-ignore
+  isUndefinedValue,
+  // @ts-ignore
+  normalizeNestedProperty,
+  RULE_TYPE,
+} from 'fela-utils';
+
+function isPlainObject(val) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
+const chars = 'abcdefghijklmnopqrstuvwxyz';
+const charLength = chars.length;
+
+function generateUniqueClassName(id: number, className: string = ''): string {
+  if (id <= charLength) {
+    return chars[id - 1] + className;
+  }
+
+  // Bitwise floor as safari performs much faster
+  // https://jsperf.com/math-floor-vs-math-round-vs-parseint/55
+  return generateUniqueClassName((id / charLength) | 0, chars[id % charLength] + className);
+}
+
+function generateClassName(getId: Function, filterClassName: Function = () => true): string {
+  const startId = getId();
+  const generatedClassName = generateUniqueClassName(startId);
+
+  if (!filterClassName(generatedClassName)) {
+    return generateClassName(getId, filterClassName);
+  }
+
+  return generatedClassName;
+}
+
+function generateDeclarationReference(
+  property: string,
+  value: any,
+  pseudo: string = '',
+  media: string = '',
+  support: string = '',
+): string {
+  //
+  //
+  // This a single perf change here, it removes `camelCaseProperty()` call
+  //
+  //
+  return support + media + pseudo + property + value;
+}
+
+//
+
+export default function felaPerformanceEnhancer(renderer) {
+  renderer._renderStyleToClassNames = function _renderStyleToClassNames(
+    { _className, ...style }: ICSSInJSStyle & { _className: string },
+    pseudo: string = '',
+    media: string = '',
+    support: string = '',
+  ): string {
+    let classNames = _className ? ' ' + _className : '';
+
+    for (const property in style) {
+      const value = style[property];
+
+      if (isPlainObject(value)) {
+        if (isNestedSelector(property)) {
+          classNames += renderer._renderStyleToClassNames(
+            value,
+            pseudo + normalizeNestedProperty(property),
+            media,
+            support,
+          );
+        } else if (isMediaQuery(property)) {
+          const combinedMediaQuery = generateCombinedMediaQuery(media, property.slice(6).trim());
+          classNames += renderer._renderStyleToClassNames(value, pseudo, combinedMediaQuery, support);
+        } else if (isSupport(property)) {
+          const combinedSupport = generateCombinedMediaQuery(support, property.slice(9).trim());
+          classNames += renderer._renderStyleToClassNames(value, pseudo, media, combinedSupport);
+        } else {
+          console.warn(`The object key "${property}" is not a valid nested key in Fela.
+Maybe you forgot to add a plugin to resolve it?
+Check http://fela.js.org/docs/basics/Rules.html#styleobject for more information.`);
+        }
+      } else {
+        const declarationReference = generateDeclarationReference(property, value, pseudo, media, support);
+
+        if (!renderer.cache.hasOwnProperty(declarationReference)) {
+          // we remove undefined values to enable
+          // usage of optional props without side-effects
+          if (isUndefinedValue(value)) {
+            renderer.cache[declarationReference] = {
+              className: '',
+            };
+            /* eslint-disable no-continue */
+            continue;
+            /* eslint-enable */
+          }
+
+          const className =
+            renderer.selectorPrefix + generateClassName(renderer.getNextRuleIdentifier, renderer.filterClassName);
+
+          const declaration = cssifyDeclaration(property, value);
+          const selector = generateCSSSelector(className, pseudo);
+
+          const change = {
+            type: RULE_TYPE,
+            className,
+            selector,
+            declaration,
+            pseudo,
+            media,
+            support,
+          };
+
+          renderer.cache[declarationReference] = change;
+          renderer._emitChange(change);
+        }
+
+        const cachedClassName = renderer.cache[declarationReference].className;
+
+        // only append if we got a class cached
+        if (cachedClassName) {
+          classNames += ` ${cachedClassName}`;
+        }
+      }
+    }
+
+    return classNames;
+  };
+
+  return renderer;
+}

--- a/packages/fluentui/react-northstar/src/utils/felaRenderer.tsx
+++ b/packages/fluentui/react-northstar/src/utils/felaRenderer.tsx
@@ -9,6 +9,7 @@ import felaDisableAnimationsPlugin from './felaDisableAnimationsPlugin';
 import felaExpandCssShorthandsPlugin from './felaExpandCssShorthandsPlugin';
 import felaFocusVisibleEnhancer from './felaFocusVisibleEnhancer';
 import felaInvokeKeyframesPlugin from './felaInvokeKeyframesPlugin';
+import felaPerformanceEnhancer from './felaPerformanceEnhancer';
 import felaSanitizeCss from './felaSanitizeCssPlugin';
 import felaStylisEnhancer from './felaStylisEnhancer';
 
@@ -52,7 +53,7 @@ const filterClassName = (className: string): boolean =>
 const rendererConfig = {
   devMode: felaDevMode,
   filterClassName,
-  enhancers: [felaFocusVisibleEnhancer, felaStylisEnhancer],
+  enhancers: [felaPerformanceEnhancer, felaFocusVisibleEnhancer, felaStylisEnhancer],
   plugins: [
     felaDisableAnimationsPlugin(),
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

[`renderRule()`](http://fela.js.org/docs/basics/Renderer.html#renderrule) is a hot function for us as we are calling it on each our cache miss. A callstack for Fela looks like this:

```
renderRule(rule, props)
  _renderStyle((rule, props)) // styles are passed resolved; performs plugins calls
    _renderStyleToClassNames(style) // performs Fela cache lookups
````

Inside `_renderStyleToClassNames()` exists a call to `generateDeclarationReference()` what creates a lookup key for Fela cache:

https://github.com/robinweser/fela/blob/97148419e7941dbd5867b35df6ac4de6c5ed3e55/packages/fela/src/createRenderer.js#L269-L277

```js
          const declarationReference = generateDeclarationReference(
            property,
            value,
            pseudo,
            media,
            support
          )

          if (!renderer.cache.hasOwnProperty(declarationReference)) {
```

Inside `generateDeclarationReference()` there is call to [`camelCaseProperty()`](https://github.com/robinweser/css-in-js-utils/blob/master/modules/camelCaseProperty.js) which performs a transform to force camelcase via regexps (and actually this makes this function slow). This is visible in our perfs and in my test environment:

```
- Fela                                        69346 ops/sec
- Fela without `camelCaseProperty()`         261801 ops/sec
```

<details>
 <summary>Test rule</summary>

```js
const fullRule = () => ({
  backgroundColor: "transparent",
  backgroundPosition: "center",
  display: "flex",
  float: 0,
  left: 0,
  right: 0,
  flexGrow: 1,
  marginLeft: 0,
  marginRight: 0,
  marginBottom: 0,
  marginTop: 0,
  paddingLeft: 0,
  paddingRight: 0,
  paddingBottom: 0,
  paddingTop: 0,
  outline: 0,
  opacity: 1,
  height: "20px",
  maxHeight: "20px",
  minWidth: "20px",
  width: "20px",
  visibility: "hidden",
  zIndex: 1,
});
```

</details>

------

__Sad part:__ This will break rehydration process from SSR content, but as we are not using it we are fine to go.

------

## Benchmarks 🚀 

A quick improvement summary, all data from benchmarks are available below:

### `new-page`
| Example                      | Improvement |
| ---------------------------- | ----------- |
| ChatWithPopover.perf.tsx     | -8%         |
| DropdownManyItems.perf.tsx   | -12%        |
| TreeWith60ListItems.perf.tsx | -4%         |
### `same-page`
| Example                      | Improvement |
| ---------------------------- | ----------- |
| ChatWithPopover.perf.tsx     | -15%        |
| DropdownManyItems.perf.tsx   | -23%        |
| TreeWith60ListItems.perf.tsx | -24%        |

<details>
  <summary>All data from benchmarks</summary>

# `master`

### `new-page`
| Example                      | min    | avg    | median | max    |
| ---------------------------- | ------ | ------ | ------ | ------ |
| ChatWithPopover.perf.tsx     | 237.22 | 248.88 | 246.91 | 308.35 |
| ChatWithPopover.perf.tsx     | 229.51 | 246.61 | 243.15 | 325.39 |
| DropdownManyItems.perf.tsx   | 252.27 | 263.55 | 261.07 | 323.86 |
| DropdownManyItems.perf.tsx   | 245.89 | 257.4  | 254.37 | 312.04 |
| TreeWith60ListItems.perf.tsx | 146.86 | 156.25 | 155.14 | 187.97 |
| TreeWith60ListItems.perf.tsx | 135.93 | 141.01 | 140    | 167.06 |
### `same-page`
| Example                      | min    | avg    | median | max    |
| ---------------------------- | ------ | ------ | ------ | ------ |
| ChatWithPopover.perf.tsx     | 109.36 | 128.45 | 122.3  | 248.05 |
| ChatWithPopover.perf.tsx     | 108.77 | 125.84 | 118.78 | 253.32 |
| DropdownManyItems.perf.tsx   | 120.85 | 137.22 | 131.49 | 234.47 |
| DropdownManyItems.perf.tsx   | 123.85 | 138.49 | 132.56 | 236.83 |
| TreeWith60ListItems.perf.tsx | 57.13  | 74.35  | 70.11  | 138.08 |
| TreeWith60ListItems.perf.tsx | 58.71  | 72.57  | 67.63  | 151.7  |

---

# With changes

### `new-page`
| Example                      | min    | avg    | median | max    |
| ---------------------------- | ------ | ------ | ------ | ------ |
| ChatWithPopover.perf.tsx     | 218.36 | 228.24 | 225.52 | 271.82 |
| ChatWithPopover.perf.tsx     | 217.68 | 229.73 | 227.19 | 280.93 |
| DropdownManyItems.perf.tsx   | 216.5  | 231.2  | 227.94 | 268.09 |
| TreeWith60ListItems.perf.tsx | 135.24 | 143.21 | 141.79 | 175.94 |
| TreeWith60ListItems.perf.tsx | 136.88 | 142.5  | 140.67 | 177    |
### `same-page`
| Example                      | min   | avg    | median | max    |
| ---------------------------- | ----- | ------ | ------ | ------ |
| ChatWithPopover.perf.tsx     | 93.71 | 105.98 | 98.85  | 200.73 |
| ChatWithPopover.perf.tsx     | 98.78 | 115.03 | 106.32 | 217.35 |
| DropdownManyItems.perf.tsx   | 96.13 | 111.63 | 105.56 | 206.32 |
| DropdownManyItems.perf.tsx   | 95.76 | 107.7  | 103.16 | 198.6  |
| TreeWith60ListItems.perf.tsx | 47.56 | 57.13  | 54.51  | 115.5  |
| TreeWith60ListItems.perf.tsx | 47.23 | 58.66  | 53.23  | 133.9  |

</details>