### PR TITLE
fix: include ParentProps in ComposeConfig

### DIFF
--- a/change/@fluentui-react-compose-2020-05-22-10-43-26-feat-chat-messages-header-slot.json
+++ b/change/@fluentui-react-compose-2020-05-22-10-43-26-feat-chat-messages-header-slot.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: allow ParentProps in ComposeOptions",
+  "packageName": "@fluentui/react-compose",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-22T08:43:26.058Z"
+}

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -47,7 +47,7 @@ const MenuItemBlue = compose<'a', MenuItemBlueProps, MenuItemStylesProps, MenuIt
       indicator: MenuitemIndicatorSaturated,
       wrapper: MenuItemWrapperDashed,
     },
-    mapPropsToSlotProps: (props: MenuItemProps & { level?: number }) => ({
+    mapPropsToSlotProps: props => ({
       menu: {
         level: props.level + 1,
       },

--- a/packages/fluentui/react-bindings/test/compose/compose-test.tsx
+++ b/packages/fluentui/react-bindings/test/compose/compose-test.tsx
@@ -154,7 +154,7 @@ const BaseComponentWithSlots: React.FC<BaseComponentProps> = compose<
       main: 'b',
       end: 'i',
     },
-    mapPropsToSlotProps: (props: any) => ({
+    mapPropsToSlotProps: props => ({
       start: {
         'data-attr': props['data-start'],
       },

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -30,7 +30,7 @@ export interface ComponentWithAs<E extends React.ElementType = 'div', P = {}> ex
 }
 
 // @public (undocumented)
-export function compose<ElementType extends React.ElementType, InputProps, InputStylesProps, ParentProps, ParentStylesProps>(input: Input<ElementType, InputProps>, inputOptions?: ComposeOptions<InputProps, InputStylesProps, ParentStylesProps>): ComponentWithAs<ElementType, InputProps & ParentProps>;
+export function compose<ElementType extends React.ElementType, InputProps, InputStylesProps, ParentProps, ParentStylesProps>(input: Input<ElementType, InputProps>, inputOptions?: ComposeOptions<InputProps, InputStylesProps, ParentProps, ParentStylesProps>): ComponentWithAs<ElementType, InputProps & ParentProps>;
 
 // @public (undocumented)
 export type ComposedComponent<P = {}> = React.FunctionComponent<P> & {
@@ -38,7 +38,7 @@ export type ComposedComponent<P = {}> = React.FunctionComponent<P> & {
 };
 
 // @public (undocumented)
-export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesProps = {}> = {
+export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentProps = {}, ParentStylesProps = {}> = {
     className?: string;
     classes?: ClassDictionary;
     displayName?: string;
@@ -46,8 +46,8 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
     handledProps?: (keyof InputProps | 'as')[];
     overrideStyles?: boolean;
     slots?: Record<string, React.ElementType>;
-    mapPropsToSlotProps?: (props: InputProps) => Record<string, object>;
-    shorthandConfig?: ShorthandConfig<InputProps>;
+    mapPropsToSlotProps?: (props: ParentProps & InputProps) => Record<string, object>;
+    shorthandConfig?: ShorthandConfig<ParentProps & InputProps>;
 };
 
 // @public (undocumented)

--- a/packages/react-compose/src/compose.ts
+++ b/packages/react-compose/src/compose.ts
@@ -5,7 +5,7 @@ import { mergeComposeOptions, wasComposedPreviously } from './utils';
 
 function compose<ElementType extends React.ElementType, InputProps, InputStylesProps, ParentProps, ParentStylesProps>(
   input: Input<ElementType, InputProps>,
-  inputOptions: ComposeOptions<InputProps, InputStylesProps, ParentStylesProps> = {},
+  inputOptions: ComposeOptions<InputProps, InputStylesProps, ParentProps, ParentStylesProps> = {},
 ) {
   const composeOptions = mergeComposeOptions(
     input as Input,

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -52,7 +52,7 @@ export type ComposeRenderFunction<T extends React.ElementType = 'div', P = {}> =
   composeOptions: ComposePreparedOptions,
 ) => React.ReactElement | null;
 
-export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesProps = {}> = {
+export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentProps = {}, ParentStylesProps = {}> = {
   className?: string;
   classes?: ClassDictionary;
   displayName?: string;
@@ -64,9 +64,9 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentStylesP
 
   slots?: Record<string, React.ElementType>;
 
-  mapPropsToSlotProps?: (props: InputProps) => Record<string, object>;
+  mapPropsToSlotProps?: (props: ParentProps & InputProps) => Record<string, object>;
 
-  shorthandConfig?: ShorthandConfig<InputProps>;
+  shorthandConfig?: ShorthandConfig<ParentProps & InputProps>;
 };
 
 export type ClassDictionary = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR includes `ParentProps` to `ComposeConfig` and this allows to use them under `mapPropsToSlotProps()`.

#### Focus areas to test

(optional)
