### PR TITLE
feat(ToolbarMenuRadioGroup|ToolbarRadioGroup): use compose()

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,7 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `HeaderDescription` component which are passed to styles functions, @assuncaocharles ([#13296](https://github.com/microsoft/fluentui/pull/13296))
 - Restricted prop sets in the `Loader` component which are passed to styles functions, @assuncaocharles ([#13297](https://github.com/microsoft/fluentui/pull/13297))
 - Restricted prop sets in the `RadioGroupItem` component which are passed to styles functions, @assuncaocharles ([#13301](https://github.com/microsoft/fluentui/pull/13301))
-- `toolbarMenuRadioGroupSlotClassNames` were removed, `toolbarMenuRadioGroupClassName` should be used instead @layershifter ([#13322](https://github.com/microsoft/fluentui/pull/13322))
+- `toolbarMenuRadioGroupSlotClassNames` were removed, `toolbarMenuRadioGroupWrapperClassName` should be used instead @layershifter ([#13322](https://github.com/microsoft/fluentui/pull/13322))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -44,6 +44,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `HeaderDescription` component which are passed to styles functions, @assuncaocharles ([#13296](https://github.com/microsoft/fluentui/pull/13296))
 - Restricted prop sets in the `Loader` component which are passed to styles functions, @assuncaocharles ([#13297](https://github.com/microsoft/fluentui/pull/13297))
 - Restricted prop sets in the `RadioGroupItem` component which are passed to styles functions, @assuncaocharles ([#13301](https://github.com/microsoft/fluentui/pull/13301))
+- `toolbarMenuRadioGroupSlotClassNames` were removed, `toolbarMenuRadioGroupClassName` should be used instead @layershifter ([#13322](https://github.com/microsoft/fluentui/pull/13322))
 
 ### Fixes
 - Fix `splitButtonBehavior` to exclude `toggleButton` from focus zone @silviuavram ([#13043](https://github.com/microsoft/fluentui/pull/13043))
@@ -69,6 +70,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add children api support for `Menu` component @assuncaocharles ([#13227](https://github.com/microsoft/fluentui/pull/13227))
 - Add `compose()` support for submenus in `MenuItem` @mnajdova ([#13300](https://github.com/microsoft/fluentui/pull/13300))
 - Use `compose()` in `ToolbarMenuDivider` @mnajdova ([#13318](https://github.com/microsoft/fluentui/pull/13318))
+- Use `compose()` in `ToolbarMenuRadioGroup` and added dedicated slot's component `ToolbarMenuRadioGroupWrapper` @layershifter ([#13322](https://github.com/microsoft/fluentui/pull/13322))
+- Use `compose()` in `ToolbarRadioGroup` @layershifter ([#13322](https://github.com/microsoft/fluentui/pull/13322))
 
 ### Documentation
 - `Toolbar` recommendation using toolbar based on aria  @kolaps33 ([#13143](https://github.com/microsoft/fluentui/pull/13143))

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
@@ -17,6 +17,8 @@ const AttachmentBody = compose<'div', AttachmentBodyOwnProps, AttachmentBodyStyl
   {
     className: attachmentBodyClassName,
     displayName: 'AttachmentBody',
+
+    overrideStyles: true,
   },
 ) as ComponentWithAs<'div', AttachmentBodyProps> & { shorthandConfig: ShorthandConfig<AttachmentBodyProps> };
 

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -49,6 +49,7 @@ import ToolbarMenu, { ToolbarMenuProps } from './ToolbarMenu';
 import ToolbarMenuDivider from './ToolbarMenuDivider';
 import ToolbarMenuItem from './ToolbarMenuItem';
 import ToolbarMenuRadioGroup, { ToolbarMenuRadioGroupProps } from './ToolbarMenuRadioGroup';
+import ToolbarMenuRadioGroupWrapper from './ToolbarMenuRadioGroupWrapper';
 import ToolbarRadioGroup from './ToolbarRadioGroup';
 import { ToolbarVariablesProvider } from './toolbarVariablesContext';
 
@@ -128,6 +129,7 @@ const Toolbar: React.FC<WithAsProp<ToolbarProps>> &
     MenuDivider: typeof ToolbarMenuDivider;
     MenuItem: typeof ToolbarMenuItem;
     MenuRadioGroup: typeof ToolbarMenuRadioGroup;
+    MenuRadioGroupWrapper: typeof ToolbarMenuRadioGroupWrapper;
     RadioGroup: typeof ToolbarRadioGroup;
   } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
@@ -550,6 +552,7 @@ Toolbar.Menu = ToolbarMenu;
 Toolbar.MenuDivider = ToolbarMenuDivider;
 Toolbar.MenuItem = ToolbarMenuItem;
 Toolbar.MenuRadioGroup = ToolbarMenuRadioGroup;
+Toolbar.MenuRadioGroupWrapper = ToolbarMenuRadioGroupWrapper;
 Toolbar.RadioGroup = ToolbarRadioGroup;
 
 Toolbar.create = createShorthandFactory({ Component: Toolbar, mappedProp: 'content' });

--- a/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/Toolbar.tsx
@@ -34,6 +34,7 @@ import {
 } from '../../types';
 import {
   childrenExist,
+  createShorthand,
   createShorthandFactory,
   UIComponentProps,
   ContentComponentProps,
@@ -439,7 +440,7 @@ const Toolbar: React.FC<WithAsProp<ToolbarProps>> &
         case 'divider':
           return ToolbarDivider.create(item);
         case 'group':
-          return ToolbarRadioGroup.create(item);
+          return createShorthand(ToolbarRadioGroup, item);
         case 'toggle':
           return ToolbarItem.create(item, {
             defaultProps: () => ({ accessibility: toggleButtonBehavior }),

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -21,7 +21,6 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
-  createShorthand,
 } from '../../utils';
 
 import {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -14,6 +14,7 @@ import * as React from 'react';
 import { ThemeContext } from 'react-fela';
 
 import {
+  createShorthand,
   createShorthandFactory,
   commonPropTypes,
   childrenExist,
@@ -129,7 +130,7 @@ const ToolbarMenu: React.FC<WithAsProp<ToolbarMenuProps>> & FluentComponentStati
           return ToolbarMenuDivider.create(item);
 
         case 'group':
-          return ToolbarMenuRadioGroup.create(item, { overrideProps: handleRadioGroupOverrides });
+          return createShorthand(ToolbarMenuRadioGroup, item, { overrideProps: handleRadioGroupOverrides });
 
         case 'toggle':
           return ToolbarMenuItem.create(item, {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -5,7 +5,14 @@ import {
   ToolbarMenuRadioGroupBehaviorProps,
 } from '@fluentui/accessibility';
 import { mergeComponentVariables } from '@fluentui/styles';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  compose,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
@@ -14,23 +21,15 @@ import * as React from 'react';
 import { ThemeContext } from 'react-fela';
 
 import {
+  createShorthand,
   ChildrenComponentProps,
   ContentComponentProps,
-  createShorthandFactory,
   UIComponentProps,
   commonPropTypes,
 } from '../../utils';
-import {
-  ComponentEventHandler,
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-  ShorthandCollection,
-  ShorthandValue,
-  WithAsProp,
-  withSafeTypeForAs,
-} from '../../types';
+import { ComponentEventHandler, ProviderContextPrepared, ShorthandCollection, ShorthandValue } from '../../types';
 import ToolbarMenuItem, { ToolbarMenuItemProps } from './ToolbarMenuItem';
-import Box, { BoxProps } from '../Box/Box';
+import ToolbarMenuRadioGroupWrapper, { ToolbarMenuRadioGroupWrapperProps } from './ToolbarMenuRadioGroupWrapper';
 import { ToolbarVariablesContext, ToolbarVariablesProvider } from './toolbarVariablesContext';
 
 export interface ToolbarMenuRadioGroupProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
@@ -54,39 +53,33 @@ export interface ToolbarMenuRadioGroupProps extends UIComponentProps, ChildrenCo
   onItemClick?: ComponentEventHandler<ToolbarMenuItemProps>;
 
   /** Shorthand for the wrapper component. */
-  wrapper?: ShorthandValue<BoxProps>;
+  wrapper?: ShorthandValue<ToolbarMenuRadioGroupWrapperProps>;
 }
 
 export type ToolbarMenuRadioGroupStylesProps = never;
 
-export interface ToolbarMenuRadioGroupSlotClassNames {
-  wrapper: string;
-}
-
 export const toolbarMenuRadioGroupClassName = 'ui-toolbars'; // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
-export const toolbarMenuRadioGroupSlotClassNames: ToolbarMenuRadioGroupSlotClassNames = {
-  wrapper: `${toolbarMenuRadioGroupClassName}__wrapper`,
-};
 
-const ToolbarMenuRadioGroup: React.FC<WithAsProp<ToolbarMenuRadioGroupProps>> &
-  FluentComponentStaticProps<ToolbarMenuRadioGroupProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarMenuRadioGroup.displayName, context.telemetry);
-  setStart();
+/**
+ * A ToolbarMenuRadioGroup renders ToolbarMenuItem as a group of mutually exclusive options.
+ */
+const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarMenuRadioGroupStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
 
-  const { accessibility, activeIndex, className, design, items, styles, variables, wrapper } = props;
+    const { accessibility, activeIndex, className, design, items, styles, variables, wrapper } = props;
 
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
 
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarMenuRadioGroup.displayName,
-    rtl: context.rtl,
-  });
-  const { classes, styles: resolvedStyles } = useStyles<ToolbarMenuRadioGroupStylesProps>(
-    ToolbarMenuRadioGroup.displayName,
-    {
-      className: toolbarMenuRadioGroupClassName,
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarMenuRadioGroupStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
       mapPropsToInlineStyles: () => ({
         className,
         design,
@@ -94,59 +87,68 @@ const ToolbarMenuRadioGroup: React.FC<WithAsProp<ToolbarMenuRadioGroupProps>> &
         variables: mergedVariables,
       }),
       rtl: context.rtl,
-    },
-  );
+    });
 
-  const handleItemOverrides = (predefinedProps: ToolbarMenuItemProps): ToolbarMenuItemProps => ({
-    onClick: (e, itemProps) => {
-      _.invoke(predefinedProps, 'onClick', e, itemProps);
-      _.invoke(props, 'onItemClick', e, itemProps);
-    },
-    wrapper: null,
-  });
+    const handleItemOverrides = (predefinedProps: ToolbarMenuItemProps): ToolbarMenuItemProps => ({
+      onClick: (e, itemProps) => {
+        _.invoke(predefinedProps, 'onClick', e, itemProps);
+        _.invoke(props, 'onItemClick', e, itemProps);
+      },
+      wrapper: null,
+    });
 
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarMenuRadioGroup.handledProps, props);
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
 
-  const content = (
-    <ElementType {...getA11yProps('root', { ...unhandledProps, className: classes.root })}>
-      <ToolbarVariablesProvider value={mergedVariables}>
-        {_.map(items, (item, index) =>
-          ToolbarMenuItem.create(item, {
-            defaultProps: () => ({
-              accessibility: toolbarMenuItemRadioBehavior,
-              as: 'li',
-              active: activeIndex === index,
-              index,
+    const content = (
+      <ElementType {...getA11yProps('root', { ...unhandledProps, className: classes.root, ref })}>
+        <ToolbarVariablesProvider value={mergedVariables}>
+          {_.map(items, (item, index) =>
+            createShorthand(ToolbarMenuItem, item, {
+              defaultProps: () => ({
+                accessibility: toolbarMenuItemRadioBehavior,
+                as: 'li',
+                active: activeIndex === index,
+                index,
+              }),
+              overrideProps: handleItemOverrides,
             }),
-            overrideProps: handleItemOverrides,
-          }),
-        )}
-      </ToolbarVariablesProvider>
-    </ElementType>
-  );
-  const element = Box.create(wrapper, {
-    defaultProps: () =>
-      getA11yProps('wrapper', {
-        as: 'li',
-        className: toolbarMenuRadioGroupSlotClassNames.wrapper,
-        styles: resolvedStyles.wrapper,
-      }),
-    overrideProps: {
-      children: content,
-    },
-  });
-  setEnd();
+          )}
+        </ToolbarVariablesProvider>
+      </ElementType>
+    );
+    const element = createShorthand(ToolbarMenuRadioGroupWrapper, wrapper, {
+      defaultProps: () => getA11yProps('wrapper', {}),
+      overrideProps: {
+        children: content,
+      },
+    });
+    setEnd();
 
-  return element;
-};
+    return element;
+  },
+  {
+    className: toolbarMenuRadioGroupClassName,
+    displayName: 'ToolbarMenuRadioGroup',
 
-ToolbarMenuRadioGroup.displayName = 'ToolbarMenuRadioGroup';
-ToolbarMenuRadioGroup.defaultProps = {
-  as: 'ul',
-  accessibility: toolbarMenuRadioGroupBehavior,
-  wrapper: {},
-};
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'styles',
+      'variables',
+
+      'activeIndex',
+      'items',
+      'onItemClick',
+      'wrapper',
+    ],
+  },
+);
+
 ToolbarMenuRadioGroup.propTypes = {
   ...commonPropTypes.createCommon(),
   activeIndex: PropTypes.number,
@@ -154,13 +156,10 @@ ToolbarMenuRadioGroup.propTypes = {
   onItemClick: PropTypes.func,
   wrapper: customPropTypes.itemShorthand,
 };
-ToolbarMenuRadioGroup.handledProps = Object.keys(ToolbarMenuRadioGroup.propTypes) as any;
+ToolbarMenuRadioGroup.defaultProps = {
+  as: 'ul',
+  accessibility: toolbarMenuRadioGroupBehavior,
+  wrapper: {},
+};
 
-ToolbarMenuRadioGroup.create = createShorthandFactory({
-  Component: ToolbarMenuRadioGroup,
-});
-
-/**
- * A ToolbarMenuRadioGroup renders ToolbarMenuItem as a group of mutually exclusive options.
- */
-export default withSafeTypeForAs<typeof ToolbarMenuRadioGroup, ToolbarMenuRadioGroupProps, 'ul'>(ToolbarMenuRadioGroup);
+export default ToolbarMenuRadioGroup;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -81,6 +81,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
     });
     const { classes } = useStyles<ToolbarMenuRadioGroupStylesProps>(composeOptions.displayName, {
       className: composeOptions.className,
+      composeOptions,
       mapPropsToInlineStyles: () => ({
         className,
         design,
@@ -88,6 +89,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
         variables: mergedVariables,
       }),
       rtl: context.rtl,
+      unstable_props: props,
     });
 
     const handleItemOverrides = (predefinedProps: ToolbarMenuItemProps): ToolbarMenuItemProps => ({
@@ -119,7 +121,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
       </ElementType>
     );
     const element = createShorthand(composeOptions.slots.wrapper, wrapper, {
-      defaultProps: () => getA11yProps('wrapper', slotProps.wrapper),
+      defaultProps: () => getA11yProps('wrapper', slotProps.wrapper || {}),
       overrideProps: {
         children: content,
       },

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -71,6 +71,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
 
     const { accessibility, activeIndex, className, design, items, styles, variables, wrapper } = props;
 
+    const slotProps = composeOptions.resolveSlotProps<ToolbarMenuRadioGroupProps>(props);
     const parentVariables = React.useContext(ToolbarVariablesContext);
     const mergedVariables = mergeComponentVariables(parentVariables, variables);
 
@@ -117,8 +118,8 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
         </ToolbarVariablesProvider>
       </ElementType>
     );
-    const element = createShorthand(ToolbarMenuRadioGroupWrapper, wrapper, {
-      defaultProps: () => getA11yProps('wrapper', {}),
+    const element = createShorthand(composeOptions.slots.wrapper, wrapper, {
+      defaultProps: () => getA11yProps('wrapper', slotProps.wrapper),
       overrideProps: {
         children: content,
       },
@@ -130,6 +131,10 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
   {
     className: toolbarMenuRadioGroupClassName,
     displayName: 'ToolbarMenuRadioGroup',
+
+    slots: {
+      wrapper: ToolbarMenuRadioGroupWrapper,
+    },
 
     handledProps: [
       'accessibility',

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -1,0 +1,34 @@
+import { compose } from '@fluentui/react-bindings';
+
+import { commonPropTypes } from '../../utils';
+import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
+
+interface ToolbarMenuRadioGroupWrapperOwnProps {}
+export interface ToolbarMenuRadioGroupWrapperProps extends ToolbarMenuRadioGroupWrapperOwnProps, BoxProps {}
+
+export type ToolbarMenuRadioGroupWrapperStylesProps = never;
+export const toolbarMenuRadioGroupClassName = 'ui-toolbars__wrapper';
+
+/**
+ * An ToolbarMenuRadioGroupWrapper provides a wrapping slot for in  ToolbarMenuRadioGroup.
+ */
+const ToolbarMenuRadioGroupWrapper = compose<
+  'li',
+  ToolbarMenuRadioGroupWrapperOwnProps,
+  ToolbarMenuRadioGroupWrapperStylesProps,
+  BoxProps,
+  BoxStylesProps
+>(Box, {
+  className: toolbarMenuRadioGroupClassName,
+  displayName: 'ToolbarMenuRadioGroupWrapper',
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
+
+ToolbarMenuRadioGroupWrapper.defaultProps = {
+  as: 'li',
+};
+ToolbarMenuRadioGroupWrapper.propTypes = commonPropTypes.createCommon();
+
+export default ToolbarMenuRadioGroupWrapper;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -21,9 +21,8 @@ const ToolbarMenuRadioGroupWrapper = compose<
 >(Box, {
   className: toolbarMenuRadioGroupClassName,
   displayName: 'ToolbarMenuRadioGroupWrapper',
-  shorthandConfig: {
-    mappedProp: 'content',
-  },
+
+  shorthandConfig: { mappedProp: 'content' },
 });
 
 ToolbarMenuRadioGroupWrapper.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -3,7 +3,7 @@ import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
-interface ToolbarMenuRadioGroupWrapperOwnProps {}
+export interface ToolbarMenuRadioGroupWrapperOwnProps {}
 export interface ToolbarMenuRadioGroupWrapperProps extends ToolbarMenuRadioGroupWrapperOwnProps, BoxProps {}
 
 export type ToolbarMenuRadioGroupWrapperStylesProps = never;

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -7,7 +7,7 @@ interface ToolbarMenuRadioGroupWrapperOwnProps {}
 export interface ToolbarMenuRadioGroupWrapperProps extends ToolbarMenuRadioGroupWrapperOwnProps, BoxProps {}
 
 export type ToolbarMenuRadioGroupWrapperStylesProps = never;
-export const toolbarMenuRadioGroupClassName = 'ui-toolbars__wrapper';
+export const toolbarMenuRadioGroupWrapperClassName = 'ui-toolbars__wrapper';
 
 /**
  * An ToolbarMenuRadioGroupWrapper provides a wrapping slot for in  ToolbarMenuRadioGroup.
@@ -19,7 +19,7 @@ const ToolbarMenuRadioGroupWrapper = compose<
   BoxProps,
   BoxStylesProps
 >(Box, {
-  className: toolbarMenuRadioGroupClassName,
+  className: toolbarMenuRadioGroupWrapperClassName,
   displayName: 'ToolbarMenuRadioGroupWrapper',
 
   shorthandConfig: { mappedProp: 'content' },

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -22,6 +22,7 @@ const ToolbarMenuRadioGroupWrapper = compose<
   className: toolbarMenuRadioGroupWrapperClassName,
   displayName: 'ToolbarMenuRadioGroupWrapper',
 
+  overrideStyles: true,
   shorthandConfig: { mappedProp: 'content' },
 });
 

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroupWrapper.tsx
@@ -7,7 +7,7 @@ export interface ToolbarMenuRadioGroupWrapperOwnProps {}
 export interface ToolbarMenuRadioGroupWrapperProps extends ToolbarMenuRadioGroupWrapperOwnProps, BoxProps {}
 
 export type ToolbarMenuRadioGroupWrapperStylesProps = never;
-export const toolbarMenuRadioGroupWrapperClassName = 'ui-toolbars__wrapper';
+export const toolbarMenuRadioGroupWrapperClassName = 'ui-toolbars'; // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
 /**
  * An ToolbarMenuRadioGroupWrapper provides a wrapping slot for in  ToolbarMenuRadioGroup.

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -84,8 +84,10 @@ const ToolbarRadioGroup = compose<'div', ToolbarRadioGroupProps, ToolbarRadioGro
     });
     const { classes } = useStyles<ToolbarRadioGroupStylesProps>(composeOptions.displayName, {
       className: composeOptions.className,
+      composeOptions,
       mapPropsToInlineStyles: () => ({ className, design, styles, variables: mergedVariables }),
       rtl: context.rtl,
+      unstable_props: props,
     });
 
     const setFocusedItem = (event: React.KeyboardEvent, direction) => {

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -4,7 +4,14 @@ import {
   toolbarRadioGroupItemBehavior,
   ToolbarRadioGroupBehaviorProps,
 } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  compose,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import { mergeComponentVariables } from '@fluentui/styles';
@@ -17,18 +24,12 @@ import { ThemeContext } from 'react-fela';
 import {
   ChildrenComponentProps,
   ContentComponentProps,
-  createShorthandFactory,
+  createShorthand,
   UIComponentProps,
   childrenExist,
   commonPropTypes,
 } from '../../utils';
-import {
-  FluentComponentStaticProps,
-  ProviderContextPrepared,
-  ShorthandCollection,
-  WithAsProp,
-  withSafeTypeForAs,
-} from '../../types';
+import { ProviderContextPrepared, ShorthandCollection } from '../../types';
 import ToolbarDivider, { ToolbarDividerProps } from './ToolbarDivider';
 import ToolbarItem, { ToolbarItemProps } from './ToolbarItem';
 import { ToolbarVariablesContext, ToolbarVariablesProvider } from './toolbarVariablesContext';
@@ -54,131 +55,6 @@ export interface ToolbarRadioGroupProps extends UIComponentProps, ChildrenCompon
 export type ToolbarRadioGroupStylesProps = never;
 export const toolbarRadioGroupClassName = 'ui-toolbars'; // FIXME: required by getComponentInfo/isConformant. But this is group inside a toolbar not a group of toolbars
 
-const ToolbarRadioGroup: React.FC<WithAsProp<ToolbarRadioGroupProps>> &
-  FluentComponentStaticProps<ToolbarRadioGroupProps> = props => {
-  const context: ProviderContextPrepared = React.useContext(ThemeContext);
-  const { setStart, setEnd } = useTelemetry(ToolbarRadioGroup.displayName, context.telemetry);
-  setStart();
-
-  const { accessibility, activeIndex, children, className, design, items, variables, styles } = props;
-  const itemRefs: React.RefObject<HTMLElement>[] = [];
-
-  const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
-
-  const getA11yProps = useAccessibility(accessibility, {
-    debugName: ToolbarRadioGroup.displayName,
-    actionHandlers: {
-      nextItem: event => setFocusedItem(event, 1),
-      prevItem: event => setFocusedItem(event, -1),
-    },
-    rtl: context.rtl,
-  });
-  const { classes } = useStyles<ToolbarRadioGroupStylesProps>(ToolbarRadioGroup.displayName, {
-    className: toolbarRadioGroupClassName,
-    mapPropsToInlineStyles: () => ({ className, design, styles, variables: mergedVariables }),
-    rtl: context.rtl,
-  });
-
-  const setFocusedItem = (event: React.KeyboardEvent, direction) => {
-    // filter items which are not disabled
-    const filteredRadioItems: React.RefObject<HTMLElement>[] = _.filter(itemRefs, (item, index) => {
-      const currentItem = items[index] as ToolbarItemProps;
-      return currentItem && !currentItem.disabled;
-    });
-
-    // get the index of currently focused element (w/ tabindex = 0) or the first one as default
-    const currentFocusedIndex =
-      _.findIndex(filteredRadioItems, (item: React.RefObject<HTMLElement>) => {
-        return item.current.tabIndex === 0;
-      }) || 0;
-
-    const itemsLength = filteredRadioItems.length;
-    let nextIndex = currentFocusedIndex + direction;
-
-    if (nextIndex >= itemsLength) {
-      nextIndex = 0;
-    }
-
-    if (nextIndex < 0) {
-      nextIndex = itemsLength - 1;
-    }
-
-    const nextItemToFocus = filteredRadioItems[nextIndex].current;
-    if (nextItemToFocus) {
-      nextItemToFocus.focus();
-    }
-
-    if (context.target.activeElement === nextItemToFocus) {
-      event.stopPropagation();
-    }
-    event.preventDefault();
-  };
-
-  const renderItems = () => {
-    return _.map(items, (item, index) => {
-      const kind = _.get(item, 'kind', 'item');
-
-      const ref = React.createRef<HTMLElement>();
-      itemRefs[index] = ref;
-
-      if (kind === 'divider') {
-        return ToolbarDivider.create(item);
-      }
-
-      const toolbarItem = ToolbarItem.create(item, {
-        defaultProps: () => ({
-          accessibility: toolbarRadioGroupItemBehavior,
-          active: activeIndex === index,
-        }),
-      });
-
-      return (
-        <Ref innerRef={ref} key={toolbarItem.key}>
-          {toolbarItem}
-        </Ref>
-      );
-    });
-  };
-
-  const ElementType = getElementType(props);
-  const unhandledProps = useUnhandledProps(ToolbarRadioGroup.handledProps, props);
-
-  const element = (
-    <ElementType
-      {...getA11yProps('root', {
-        ...unhandledProps,
-        className: classes.root,
-      })}
-    >
-      <ToolbarVariablesProvider value={mergedVariables}>
-        {childrenExist(children) ? children : renderItems()}
-      </ToolbarVariablesProvider>
-    </ElementType>
-  );
-  setEnd();
-
-  return element;
-};
-
-ToolbarRadioGroup.displayName = 'ToolbarRadioGroup';
-
-ToolbarRadioGroup.propTypes = {
-  ...commonPropTypes.createCommon(),
-  activeIndex: PropTypes.number,
-  items: customPropTypes.collectionShorthandWithKindProp(['divider', 'item']),
-};
-ToolbarRadioGroup.handledProps = Object.keys(ToolbarRadioGroup.propTypes) as any;
-
-ToolbarRadioGroup.defaultProps = {
-  accessibility: toolbarRadioGroupBehavior,
-};
-
-ToolbarRadioGroup.create = createShorthandFactory({
-  Component: ToolbarRadioGroup,
-  mappedProp: 'content',
-});
-
 /**
  * A ToolbarRadioGroup renders Toolbar item as a group of mutually exclusive options.
  * Component doesn't implement mutual exclusiveness, it just serves accessibility purposes.
@@ -186,4 +62,141 @@ ToolbarRadioGroup.create = createShorthandFactory({
  * @accessibility
  * Implements [ARIA RadioGroup](https://www.w3.org/TR/wai-aria-practices/#radiobutton) design pattern.
  */
-export default withSafeTypeForAs<typeof ToolbarRadioGroup, ToolbarRadioGroupProps>(ToolbarRadioGroup);
+const ToolbarRadioGroup = compose<'div', ToolbarRadioGroupProps, ToolbarRadioGroupStylesProps, {}, {}>(
+  (props, ref, composeOptions) => {
+    const context: ProviderContextPrepared = React.useContext(ThemeContext);
+    const { setStart, setEnd } = useTelemetry(composeOptions.displayName, context.telemetry);
+    setStart();
+
+    const { accessibility, activeIndex, children, className, design, items, variables, styles } = props;
+    const itemRefs: React.RefObject<HTMLElement>[] = [];
+
+    const parentVariables = React.useContext(ToolbarVariablesContext);
+    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+
+    const getA11yProps = useAccessibility(accessibility, {
+      debugName: composeOptions.displayName,
+      actionHandlers: {
+        nextItem: event => setFocusedItem(event, 1),
+        prevItem: event => setFocusedItem(event, -1),
+      },
+      rtl: context.rtl,
+    });
+    const { classes } = useStyles<ToolbarRadioGroupStylesProps>(composeOptions.displayName, {
+      className: composeOptions.className,
+      mapPropsToInlineStyles: () => ({ className, design, styles, variables: mergedVariables }),
+      rtl: context.rtl,
+    });
+
+    const setFocusedItem = (event: React.KeyboardEvent, direction) => {
+      // filter items which are not disabled
+      const filteredRadioItems: React.RefObject<HTMLElement>[] = _.filter(itemRefs, (item, index) => {
+        const currentItem = items[index] as ToolbarItemProps;
+        return currentItem && !currentItem.disabled;
+      });
+
+      // get the index of currently focused element (w/ tabindex = 0) or the first one as default
+      const currentFocusedIndex =
+        _.findIndex(filteredRadioItems, (item: React.RefObject<HTMLElement>) => {
+          return item.current.tabIndex === 0;
+        }) || 0;
+
+      const itemsLength = filteredRadioItems.length;
+      let nextIndex = currentFocusedIndex + direction;
+
+      if (nextIndex >= itemsLength) {
+        nextIndex = 0;
+      }
+
+      if (nextIndex < 0) {
+        nextIndex = itemsLength - 1;
+      }
+
+      const nextItemToFocus = filteredRadioItems[nextIndex].current;
+      if (nextItemToFocus) {
+        nextItemToFocus.focus();
+      }
+
+      if (context.target.activeElement === nextItemToFocus) {
+        event.stopPropagation();
+      }
+      event.preventDefault();
+    };
+
+    const renderItems = () => {
+      return _.map(items, (item, index) => {
+        const kind = _.get(item, 'kind', 'item');
+
+        const ref = React.createRef<HTMLElement>();
+        itemRefs[index] = ref;
+
+        if (kind === 'divider') {
+          return createShorthand(ToolbarDivider, item);
+        }
+
+        const toolbarItem = createShorthand(ToolbarItem, item, {
+          defaultProps: () => ({
+            accessibility: toolbarRadioGroupItemBehavior,
+            active: activeIndex === index,
+          }),
+        });
+
+        return (
+          <Ref innerRef={ref} key={toolbarItem.key}>
+            {toolbarItem}
+          </Ref>
+        );
+      });
+    };
+
+    const ElementType = getElementType(props);
+    const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    const element = (
+      <ElementType
+        {...getA11yProps('root', {
+          ...unhandledProps,
+          className: classes.root,
+          ref,
+        })}
+      >
+        <ToolbarVariablesProvider value={mergedVariables}>
+          {childrenExist(children) ? children : renderItems()}
+        </ToolbarVariablesProvider>
+      </ElementType>
+    );
+    setEnd();
+
+    return element;
+  },
+  {
+    className: toolbarRadioGroupClassName,
+    displayName: 'ToolbarRadioGroup',
+
+    shorthandConfig: { mappedProp: 'content' },
+    handledProps: [
+      'accessibility',
+      'as',
+      'children',
+      'className',
+      'content',
+      'design',
+      'styles',
+      'variables',
+
+      'activeIndex',
+      'items',
+    ],
+  },
+);
+
+ToolbarRadioGroup.propTypes = {
+  ...commonPropTypes.createCommon(),
+  activeIndex: PropTypes.number,
+  items: customPropTypes.collectionShorthandWithKindProp(['divider', 'item']),
+};
+ToolbarRadioGroup.defaultProps = {
+  accessibility: toolbarRadioGroupBehavior,
+};
+
+export default ToolbarRadioGroup;

--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -205,6 +205,8 @@ export * from './components/Toolbar/ToolbarMenuItem';
 export { default as ToolbarMenuItem } from './components/Toolbar/ToolbarMenuItem';
 export * from './components/Toolbar/ToolbarMenuRadioGroup';
 export { default as ToolbarMenuRadioGroup } from './components/Toolbar/ToolbarMenuRadioGroup';
+export * from './components/Toolbar/ToolbarMenuRadioGroupWrapper';
+export { default as ToolbarMenuRadioGroupWrapper } from './components/Toolbar/ToolbarMenuRadioGroupWrapper';
 export * from './components/Toolbar/ToolbarRadioGroup';
 export { default as ToolbarRadioGroup } from './components/Toolbar/ToolbarRadioGroup';
 

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -109,6 +109,7 @@ export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuStyles';
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerStyles';
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemStyles';
 export { default as ToolbarMenuRadioGroup } from './components/Toolbar/toolbarMenuRadioGroupStyles';
+export { default as ToolbarMenuRadioGroupWrapper } from './components/Toolbar/toolbarMenuRadioGroupWrapperStyles';
 
 export { default as Tree } from './components/Tree/treeStyles';
 export { default as TreeItem } from './components/Tree/treeItemStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
@@ -95,6 +95,7 @@ export { default as ToolbarMenu } from './components/Toolbar/toolbarMenuVariable
 export { default as ToolbarMenuDivider } from './components/Toolbar/toolbarMenuDividerVariables';
 export { default as ToolbarMenuItem } from './components/Toolbar/toolbarMenuItemVariables';
 export { default as ToolbarMenuRadioGroup } from './components/Toolbar/toolbarMenuRadioGroupVariables';
+export { default as ToolbarMenuRadioGroupWrapper } from './components/Toolbar/toolbarMenuRadioGroupWrapperVariables';
 
 export { default as TreeTitle } from './components/Tree/treeTitleVariables';
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuRadioGroupWrapperStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuRadioGroupWrapperStyles.ts
@@ -1,0 +1,10 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+
+import { ToolbarMenuRadioGroupWrapperProps } from '../../../../components/Toolbar/ToolbarMenuRadioGroupWrapper';
+import { ToolbarVariables } from './toolbarVariables';
+
+const toolbarMenuRadioGroupStyles: ComponentSlotStylesPrepared<ToolbarMenuRadioGroupWrapperProps, ToolbarVariables> = {
+  root: (): ICSSInJSStyle => ({}),
+};
+
+export default toolbarMenuRadioGroupStyles;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuRadioGroupWrapperVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuRadioGroupWrapperVariables.ts
@@ -1,0 +1,1 @@
+export { default } from './toolbarVariables';

--- a/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroup-test.ts
@@ -1,11 +1,11 @@
 import { handlesAccessibility, isConformant } from 'test/specs/commonTests';
 
-import Box from 'src/components/Box/Box';
 import ToolbarMenuRadioGroup from 'src/components/Toolbar/ToolbarMenuRadioGroup';
+import ToolbarMenuRadioGroupWrapper from 'src/components/Toolbar/ToolbarMenuRadioGroupWrapper';
 
 describe('ToolbarMenuRadioGroup', () => {
   isConformant(ToolbarMenuRadioGroup, {
-    wrapperComponent: Box,
+    wrapperComponent: ToolbarMenuRadioGroupWrapper,
     constructorName: 'ToolbarMenuRadioGroup',
   });
 

--- a/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroupWrapper-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/components/Toolbar/ToolbarMenuRadioGroupWrapper-test.ts
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import ToolbarMenuRadioGroupWrapper from 'src/components/Toolbar/ToolbarMenuRadioGroupWrapper';
+
+describe('ToolbarMenuRadioGroupWrapper', () => {
+  isConformant(ToolbarMenuRadioGroupWrapper, { constructorName: 'ToolbarMenuRadioGroupWrapper' });
+});


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

# BREAKING CHANGES

`wrapper` slot in `ToolbarMenuRadioGroup` now is `ToolbarMenuRadioGroupWrapper` instead of `Box`.

1. `toolbarMenuRadioGroupSlotClassNames` and interface `ToolbarMenuRadioGroupSlotClassNames` were removed, please use `toolbarMenuRadioGroupWrapperClassName`.

```ts
// Before
console.log(toolbarMenuRadioGroupSlotClassNames.wrapper)

// After
console.log(toolbarMenuRadioGroupClassName)
```

2. Styles for `wrapper` slot in `ToolbarMenuRadioGroup` are moved to `ToolbarMenuRadioGroupWrapper`, please move matching styles to `toolbarMenuRadioGroupWrapperStyles`.

```tsx
// Before
const toolbarMenuRadioGroupStyles = {
  wrapper: (): ICSSInJSStyle => ({
    // styles
  }),
};

// After
const toolbarMenuRadioGroupWrapperStyles = {
  root: (): ICSSInJSStyle => ({
    // styles
  }),
};
```

#### Description of changes

This PR:
- add `compose()` usage to `ToolbarMenuRadioGroup` & `ToolbarRadioGroup`
- introduces `ToolbarMenuRadioGroupWrapper` components and moves styles there

#### Focus areas to test

(optional)
