### PR TITLE
Re-exporting react-button in react-next

### DIFF
--- a/change/@fluentui-react-next-2020-05-26-11-57-04-buttonFromReactNext.json
+++ b/change/@fluentui-react-next-2020-05-26-11-57-04-buttonFromReactNext.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Re-exporting react-button in react-next.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-26T18:57:04.362Z"
+}

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -1112,11 +1112,11 @@ export const Toggle: React.FunctionComponent<IToggleProps>;
 export const ToggleBase: React.FunctionComponent;
 
 
+export * from "@fluentui/react-button";
 export * from "office-ui-fabric-react/lib/ActivityItem";
 export * from "office-ui-fabric-react/lib/Announced";
 export * from "office-ui-fabric-react/lib/Autofill";
 export * from "office-ui-fabric-react/lib/Breadcrumb";
-export * from "office-ui-fabric-react/lib/Button";
 export * from "office-ui-fabric-react/lib/Calendar";
 export * from "office-ui-fabric-react/lib/Callout";
 export * from "office-ui-fabric-react/lib/Check";

--- a/packages/react-next/package.json
+++ b/packages/react-next/package.json
@@ -44,6 +44,7 @@
     "storybook-addon-performance": "^0.9.0"
   },
   "dependencies": {
+    "@fluentui/react-button": "^0.1.8",
     "@fluentui/react-theme-provider": "^0.1.8",
     "@uifabric/set-version": "^7.0.12",
     "office-ui-fabric-react": "^7.115.4",

--- a/packages/react-next/src/Button.ts
+++ b/packages/react-next/src/Button.ts
@@ -1,1 +1,1 @@
-export * from 'office-ui-fabric-react/lib/Button';
+export * from '@fluentui/react-button';

--- a/packages/react-next/src/components/Checkbox/examples/Checkbox.CustomStyle.Example.tsx
+++ b/packages/react-next/src/components/Checkbox/examples/Checkbox.CustomStyle.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from '@fluentui/react-next/lib/Checkbox';
 import { Stack } from '@fluentui/react-next/lib/Stack';
 import { Customizer } from '@fluentui/react-next/lib/Utilities';

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
 import { Link } from '@fluentui/react-next/lib/Link';
 import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
 import { Link } from '@fluentui/react-next/lib/Link';
 import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.DialogInPanel.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.DialogInPanel.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogType, DialogFooter } from '@fluentui/react-next/lib/Dialog';
-import { PrimaryButton } from '@fluentui/react-next/lib/Button';
 import { Panel, PanelType } from '@fluentui/react-next/lib/Panel';
 import { useBoolean } from '@uifabric/react-hooks';
 

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.FocusZone.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.FocusZone.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-next/lib/FocusZone';
 import { Toggle, IToggle } from '@fluentui/react-next/lib/Toggle';

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusTrapZone } from '@fluentui/react-next/lib/FocusTrapZone';
 import { Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
 import { Toggle, IToggleStyles } from '@fluentui/react-next/lib/Toggle';

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.test.tsx
@@ -3,7 +3,7 @@ import { ReactWrapper, mount } from 'enzyme';
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import * as sinon from 'sinon';
-import { CommandBarButton } from '../../Button';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { IKeytipProps } from '../../Keytip';
 import { KeytipLayer, KeytipLayerBase } from '../../KeytipLayer';
 import { arraysEqual, find } from '../../Utilities';

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IconButton, IButtonStyles } from '@fluentui/react-next/lib/Button';
+import { IconButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { Link } from '@fluentui/react-next/lib/Link';
 import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
 

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.BasicReversed.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.BasicReversed.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IconButton, IButtonStyles } from '@fluentui/react-next/lib/Button';
+import { IconButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { Link } from '@fluentui/react-next/lib/Link';
 import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
 

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { CommandBarButton, IButtonStyles, IOverflowSetItemProps, OverflowSet, Checkbox } from '@fluentui/react-next';
+import { CommandBarButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
+import { IOverflowSetItemProps, OverflowSet, Checkbox } from '@fluentui/react-next';
 
 const noOp = () => undefined;
 

--- a/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Vertical.Example.tsx
+++ b/packages/react-next/src/components/OverflowSet/examples/OverflowSet.Vertical.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CommandBarButton } from '@fluentui/react-next/lib/Button';
+import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { IOverflowSetItemProps, OverflowSet } from '@fluentui/react-next/lib/OverflowSet';
 
 const noOp = () => undefined;

--- a/packages/react-next/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.base.tsx
@@ -9,7 +9,7 @@ import {
   warn,
   initializeComponentRef,
 } from '../../Utilities';
-import { CommandButton } from '../../Button';
+import { CommandButton } from 'office-ui-fabric-react/lib/Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';

--- a/packages/react-next/src/components/Pivot/PivotItem.types.ts
+++ b/packages/react-next/src/components/Pivot/PivotItem.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IButtonProps } from '../../Button';
+import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { IRefObject, IRenderFunction } from '../../Utilities';
 import { IKeytipProps } from '../../Keytip';
 

--- a/packages/react-next/src/components/Pivot/examples/Pivot.Override.Example.tsx
+++ b/packages/react-next/src/components/Pivot/examples/Pivot.Override.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Label } from '@fluentui/react-next/lib/Label';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
 import { Pivot, PivotItem } from '@fluentui/react-next/lib/Pivot';
 
 export const PivotOverrideExample = () => {

--- a/packages/react-next/src/components/Pivot/examples/Pivot.Remove.Example.tsx
+++ b/packages/react-next/src/components/Pivot/examples/Pivot.Remove.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Pivot, PivotItem, PivotLinkFormat, PivotLinkSize } from '@fluentui/react-next/lib/Pivot';
-import { DefaultButton } from '@fluentui/react-next/lib/Button';
 import { Label } from '@fluentui/react-next/lib/Label';
 import { useBoolean } from '@uifabric/react-hooks';
 

--- a/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
@@ -10,7 +10,7 @@ import {
   inputProperties,
 } from '../../Utilities';
 
-import { IconButton } from '../../Button';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from '../../Icon';
 
 const getClassNames = classNamesFunction<ISearchBoxStyleProps, ISearchBoxStyles>();

--- a/packages/react-next/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-next/src/components/SearchBox/SearchBox.types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
+import { IButtonProps } from 'office-ui-fabric-react/lib/Button';
 import { ITheme, IStyle } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
-import { IButtonProps } from '../../Button';
 import { IIconProps } from '../../Icon';
 
 /**

--- a/packages/react-next/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/react-next/src/components/SpinButton/SpinButton.styles.ts
@@ -6,7 +6,7 @@ import {
   IconFontSizes,
   getInputFocusStyle,
 } from '../../Styling';
-import { IButtonStyles } from '../../Button';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { ISpinButtonStyles } from './SpinButton.types';
 import { memoizeFunction } from '../../Utilities';
 

--- a/packages/react-next/src/components/SpinButton/SpinButton.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IconButton } from '../../Button';
+import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import { Label } from '../../Label';
 import { Icon } from '../../Icon';
 import {

--- a/packages/react-next/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/react-next/src/components/SpinButton/SpinButton.types.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IIconProps } from '../../Icon';
 import { ITheme, IStyle } from '../../Styling';
 import { ISpinButtonClassNames } from './SpinButton.classNames';
 import { KeyboardSpinDirection } from './SpinButton';
-import { IButtonStyles } from '../../Button';
 import { IKeytipProps } from '../../Keytip';
 import { IRefObject } from '../../Utilities';
 import { IButtonProps } from 'office-ui-fabric-react/lib/components/Button/Button.types';

--- a/packages/react-next/src/components/SpinButton/examples/SpinButton.CustomStyled.Example.tsx
+++ b/packages/react-next/src/components/SpinButton/examples/SpinButton.CustomStyled.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { SpinButton, ISpinButtonStyles } from '@fluentui/react-next/lib/SpinButton';
-import { IButtonStyles } from '@fluentui/react-next/lib/Button';
 
 const styles: Partial<ISpinButtonStyles> = {
   root: {

--- a/packages/react-next/src/components/TextField/examples/TextField.CustomRender.Example.tsx
+++ b/packages/react-next/src/components/TextField/examples/TextField.CustomRender.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
+import { DefaultButton, IconButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { TextField, ITextFieldProps } from '@fluentui/react-next/lib/TextField';
-import { DefaultButton, IconButton, IButtonStyles } from '@fluentui/react-next/lib/Button';
 import { Icon, IIconStyles } from '@fluentui/react-next/lib/Icon';
 import { Callout } from '@fluentui/react-next/lib/Callout';
 import { IStackTokens, Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes the `Button` in `@fluentui/react-next` export the version in `@fluentui/button` while making the changes inside the components in `@fluentui/react-next` to point to the `office-ui-fabric-react` version of the `Button` so they can continue working.

#### Focus areas to test

(optional)
