### PR TITLE
Adding createClassResolver helper to react-compose

### DIFF
--- a/change/@fluentui-react-compose-2020-05-26-16-33-15-feat-create-class-resolver.json
+++ b/change/@fluentui-react-compose-2020-05-26-16-33-15-feat-create-class-resolver.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding createClassResolver to help with auto resolving class names given class map and props.",
+  "packageName": "@fluentui/react-compose",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-26T23:33:15.423Z"
+}

--- a/packages/react-compose/etc/react-compose.api.md
+++ b/packages/react-compose/etc/react-compose.api.md
@@ -6,10 +6,8 @@
 
 import * as React from 'react';
 
-// @public (undocumented)
-export type ClassDictionary = {
-    [key: string]: string;
-};
+// @public
+export type ClassDictionary = Record<string, string>;
 
 // @public (undocumented)
 export interface ComponentWithAs<E extends React.ElementType = 'div', P = {}> extends React.FunctionComponent {
@@ -70,6 +68,12 @@ export type ComposePreparedOptions<Props = {}> = {
 
 // @public (undocumented)
 export type ComposeRenderFunction<T extends React.ElementType = 'div', P = {}> = (props: P, ref: React.Ref<T extends keyof HTMLElementTagNameMap ? HTMLElementTagNameMap[T] : T>, composeOptions: ComposePreparedOptions) => React.ReactElement | null;
+
+// @public
+export const createClassResolver: (classes: Record<string, string>) => (state: Record<string, any>, slots: Record<string, any>) => Record<string, string>;
+
+// @public
+export type GenericDictionary = Record<string, any>;
 
 // @public (undocumented)
 export type Input<T extends React.ElementType = 'div', P = {}> = InputComposeComponent<P> | ComposeRenderFunction<T, P & {

--- a/packages/react-compose/src/createClassResolver.test.ts
+++ b/packages/react-compose/src/createClassResolver.test.ts
@@ -1,0 +1,47 @@
+import { createClassResolver } from './createClassResolver';
+
+describe('createClassResolver', () => {
+  const classResolver = createClassResolver({
+    root: 'root',
+    slot1: 'slot1',
+    slot2: 'slot2',
+    primary: 'primary',
+    size_small: 'small',
+    size_medium: 'medium',
+  });
+  const slots = { root: null, slot1: null, slot2: null };
+
+  it('can resolve slot classes', () => {
+    expect(classResolver({}, slots)).toEqual({
+      root: 'root',
+      slot1: 'slot1',
+      slot2: 'slot2',
+    });
+  });
+
+  it('can resolve modifiers', () => {
+    expect(classResolver({ primary: true }, slots)).toEqual({
+      root: 'root primary',
+      slot1: 'slot1',
+      slot2: 'slot2',
+    });
+  });
+
+  it('can resolve enums', () => {
+    // Can resolve
+    expect(classResolver({ size: 'small' }, slots)).toEqual({
+      root: 'root small',
+      slot1: 'slot1',
+      slot2: 'slot2',
+    });
+  });
+
+  it('can resolve mixed content, including a className in props', () => {
+    // Can resolve
+    expect(classResolver({ className: 'foo', primary: true, size: 'medium' }, slots)).toEqual({
+      root: 'foo root primary medium',
+      slot1: 'slot1',
+      slot2: 'slot2',
+    });
+  });
+});

--- a/packages/react-compose/src/createClassResolver.test.ts
+++ b/packages/react-compose/src/createClassResolver.test.ts
@@ -22,17 +22,24 @@ describe('createClassResolver', () => {
   it('can resolve modifiers', () => {
     expect(classResolver({ primary: true }, slots)).toEqual({
       root: 'root primary',
-      slot1: 'slot1',
-      slot2: 'slot2',
+      slot1: 'slot1 primary',
+      slot2: 'slot2 primary',
     });
   });
 
+  it("can ignore props which don't resolve to slots or modifiers", () => {
+    expect(classResolver({ primary: true, secondary: true }, slots)).toEqual({
+      root: 'root primary',
+      slot1: 'slot1 primary',
+      slot2: 'slot2 primary',
+    });
+  });
   it('can resolve enums', () => {
     // Can resolve
     expect(classResolver({ size: 'small' }, slots)).toEqual({
       root: 'root small',
-      slot1: 'slot1',
-      slot2: 'slot2',
+      slot1: 'slot1 small',
+      slot2: 'slot2 small',
     });
   });
 
@@ -40,8 +47,8 @@ describe('createClassResolver', () => {
     // Can resolve
     expect(classResolver({ className: 'foo', primary: true, size: 'medium' }, slots)).toEqual({
       root: 'foo root primary medium',
-      slot1: 'slot1',
-      slot2: 'slot2',
+      slot1: 'slot1 primary medium',
+      slot2: 'slot2 primary medium',
     });
   });
 });

--- a/packages/react-compose/src/createClassResolver.ts
+++ b/packages/react-compose/src/createClassResolver.ts
@@ -1,0 +1,68 @@
+import { GenericDictionary, ClassDictionary } from './types';
+
+/**
+ * `createClassResolver` is a factory function which creates a state to classmap resolver for
+ * slot specific class names. It can be used in conjunction with the `compose` option `classes` to
+ * inject css modules without writing cx(...) logic manually distributing classnames.
+ *
+ * Class names which map to slots are automatically distributed to correct slot props.
+ *
+ * Class names with an underscore are interpretted as enum matchable classes. For example,
+ * the class "size_large" would be applied to the `root` slot when the component's state contains
+ * a prop `size` with a value `large`.
+ *
+ * Remaining class names would be interpretted as modifiers, applied to the `root` slot when
+ * the component `state` contains a truthy matching prop name.
+ */
+export const createClassResolver = (classes: ClassDictionary) => (
+  state: GenericDictionary,
+  slots: GenericDictionary,
+): ClassDictionary => {
+  // tslint:disable-next-line:no-any
+  const classMap: Record<string, any> = {};
+
+  // Add the default className to root
+  // tslint:disable-next-line: no-any
+  addClassTo(classMap, 'root', (state as any).className);
+
+  if (classes) {
+    // Iterate through classes
+    Object.keys(classes).forEach((key: string) => {
+      // If the class is named the same as a slot, add it to the slot.
+      // tslint:disable-next-line: no-any
+      if ((slots as any).hasOwnProperty(key)) {
+        addClassTo(classMap, key, classes[key]);
+      } else if (key.indexOf('_') >= 0) {
+        // The class is an enum value. Add if the prop exists and matches.
+        const parts = key.split('_');
+        const enumName = parts[0];
+        const enumValue = parts[1];
+
+        // tslint:disable-next-line: no-any
+        addClassTo(classMap, 'root', (state as any)[enumName] === enumValue && classes[key]);
+      } else {
+        // tslint:disable-next-line: no-any
+        addClassTo(classMap, 'root', (state as any)[key] && classes[key]);
+      }
+    });
+  }
+
+  // Convert the className arrays to strings.
+  Object.keys(classMap).forEach((key: string) => (classMap[key] = classMap[key].join(' ')));
+
+  return classMap;
+};
+
+/**
+ * Helper function to update `className` arrays on slots within a dictionary.
+ */
+// tslint:disable-next-line:no-any
+function addClassTo(slotProps: Record<string, any>, slotName: string, className?: string | false) {
+  if (className) {
+    if (!slotProps[slotName]) {
+      slotProps[slotName] = [className];
+    } else {
+      slotProps[slotName].push(className);
+    }
+  }
+}

--- a/packages/react-compose/src/createClassResolver.ts
+++ b/packages/react-compose/src/createClassResolver.ts
@@ -18,46 +18,45 @@ export const createClassResolver = (classes: ClassDictionary) => (
   state: GenericDictionary,
   slots: GenericDictionary,
 ): ClassDictionary => {
-  // tslint:disable-next-line:no-any
-  const classMap: Record<string, any> = {};
+  const classMap: GenericDictionary = {};
+  const modifiers: string[] = [];
 
   // Add the default className to root
-  // tslint:disable-next-line: no-any
-  addClassTo(classMap, 'root', (state as any).className);
+  addClassTo(classMap, 'root', state.className);
 
   if (classes) {
     // Iterate through classes
     Object.keys(classes).forEach((key: string) => {
-      // If the class is named the same as a slot, add it to the slot.
-      // tslint:disable-next-line: no-any
-      if ((slots as any).hasOwnProperty(key)) {
-        addClassTo(classMap, key, classes[key]);
-      } else if (key.indexOf('_') >= 0) {
-        // The class is an enum value. Add if the prop exists and matches.
-        const parts = key.split('_');
-        const enumName = parts[0];
-        const enumValue = parts[1];
+      const classValue = classes[key];
 
-        // tslint:disable-next-line: no-any
-        addClassTo(classMap, 'root', (state as any)[enumName] === enumValue && classes[key]);
-      } else {
-        // tslint:disable-next-line: no-any
-        addClassTo(classMap, 'root', (state as any)[key] && classes[key]);
+      if (classValue) {
+        // If the class is named the same as a slot, add it to the slot.
+        if (slots.hasOwnProperty(key)) {
+          addClassTo(classMap, key, classValue);
+        } else if (key.indexOf('_') >= 0) {
+          // The class is an enum value. Add if the prop exists and matches.
+          const parts = key.split('_');
+          const enumName = parts[0];
+          const enumValue = parts[1];
+
+          state[enumName] === enumValue && modifiers.push(classValue);
+        } else {
+          state[key] && modifiers.push(classValue);
+        }
       }
     });
-  }
 
-  // Convert the className arrays to strings.
-  Object.keys(classMap).forEach((key: string) => (classMap[key] = classMap[key].join(' ')));
+    // Convert the className arrays to strings.
+    Object.keys(classMap).forEach((key: string) => (classMap[key] = classMap[key].concat(modifiers).join(' ')));
+  }
 
   return classMap;
 };
 
 /**
- * Helper function to update `className` arrays on slots within a dictionary.
+ * Helper function to update slot arrays within a class map.
  */
-// tslint:disable-next-line:no-any
-function addClassTo(slotProps: Record<string, any>, slotName: string, className?: string | false) {
+function addClassTo(slotProps: GenericDictionary, slotName: string, className?: string | false) {
   if (className) {
     if (!slotProps[slotName]) {
       slotProps[slotName] = [className];

--- a/packages/react-compose/src/index.ts
+++ b/packages/react-compose/src/index.ts
@@ -1,2 +1,3 @@
 export { default as compose } from './compose';
+export { createClassResolver } from './createClassResolver';
 export * from './types';

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -69,9 +69,15 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentProps =
   shorthandConfig?: ShorthandConfig<ParentProps & InputProps>;
 };
 
+/**
+ * Generic name to any dictionary.
+ */
 // tslint:disable-next-line:no-any
 export type GenericDictionary = Record<string, any>;
 
+/**
+ * Generic set of module to class name map.
+ */
 export type ClassDictionary = Record<string, string>;
 
 export type ComposePreparedOptions<Props = {}> = {

--- a/packages/react-compose/src/types.ts
+++ b/packages/react-compose/src/types.ts
@@ -69,9 +69,10 @@ export type ComposeOptions<InputProps = {}, InputStylesProps = {}, ParentProps =
   shorthandConfig?: ShorthandConfig<ParentProps & InputProps>;
 };
 
-export type ClassDictionary = {
-  [key: string]: string;
-};
+// tslint:disable-next-line:no-any
+export type GenericDictionary = Record<string, any>;
+
+export type ClassDictionary = Record<string, string>;
 
 export type ComposePreparedOptions<Props = {}> = {
   className: string;


### PR DESCRIPTION
Separating a PR out for the class resolver utility. Expected usage would be:

```tsx
import * as classes from './some.module.css';

compose(Thing, {
  classes: createClassResolver(classes)
});
```
