### PR TITLE
Selection: respect 0 as selected key

### DIFF
--- a/change/@uifabric-utilities-2020-05-26-17-22-40-selection-key.json
+++ b/change/@uifabric-utilities-2020-05-26-17-22-40-selection-key.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Selection: respect 0 as selected key",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T00:22:40.231Z"
+}

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -488,5 +488,7 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
 }
 
 function defaultGetKey<TItem = IObjectWithKey>(item: TItem, index?: number): string | number {
-  return item && (item as IObjectWithKey).key ? (item as IObjectWithKey).key! : `${index}`;
+  // 0 may be used as a key
+  const { key = `${index}` } = (item || {}) as IObjectWithKey;
+  return key;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13299
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Selection was not respecting `0` (number) as a possible selected key due to incorrect use of a falsey value check in `defaultGetKey`. Fix that and add a test.