### PR TITLE
Convert ShimmeredDetailsList to use hooks (and add useShallowMemo hook)

### DIFF
--- a/change/@uifabric-react-hooks-2020-05-26-17-48-31-details-shimmer.json
+++ b/change/@uifabric-react-hooks-2020-05-26-17-48-31-details-shimmer.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Implement useShallowMemo hook",
+  "packageName": "@uifabric/react-hooks",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T00:48:31.941Z"
+}

--- a/change/office-ui-fabric-react-2020-05-26-17-48-31-details-shimmer.json
+++ b/change/office-ui-fabric-react-2020-05-26-17-48-31-details-shimmer.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Convert ShimmeredDetailsList to use hooks",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T00:48:28.555Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9009,11 +9009,7 @@ export const ShimmerCircleBase: React.FunctionComponent<IShimmerCircleProps>;
 export const ShimmeredDetailsList: React.FunctionComponent<IShimmeredDetailsListProps>;
 
 // @public (undocumented)
-export class ShimmeredDetailsListBase extends React.Component<IShimmeredDetailsListProps, {}> {
-    constructor(props: IShimmeredDetailsListProps);
-    // (undocumented)
-    render(): JSX.Element;
-    }
+export function ShimmeredDetailsListBase(props: IShimmeredDetailsListProps): JSX.Element | null;
 
 // @public
 export enum ShimmerElementsDefaultHeights {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.base.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import { classNamesFunction, css } from '../../Utilities';
-import { IProcessedStyleSet } from '../../Styling';
 import { SelectionMode } from '../../utilities/selection/interfaces';
 import { DetailsList } from './DetailsList';
 import { IDetailsRowProps } from './DetailsRow.types';
@@ -12,6 +11,7 @@ import {
   IShimmeredDetailsListStyles,
 } from './ShimmeredDetailsList.types';
 import { CheckboxVisibility } from './DetailsList.types';
+import { useShallowMemo } from '@uifabric/react-hooks';
 
 import { DEFAULT_CELL_STYLE_PROPS, DEFAULT_ROW_HEIGHTS } from './DetailsRow.styles';
 
@@ -21,141 +21,145 @@ const SHIMMER_INITIAL_ITEMS = 10;
 const DEFAULT_SHIMMER_HEIGHT = 7;
 const SHIMMER_LINE_VS_CELL_WIDTH_RATIO = 0.95;
 
-export class ShimmeredDetailsListBase extends React.Component<IShimmeredDetailsListProps, {}> {
-  private _shimmerItems: null[];
-  private _classNames: IProcessedStyleSet<IShimmeredDetailsListStyles>;
+export function ShimmeredDetailsListBase(props: IShimmeredDetailsListProps): JSX.Element | null {
+  const {
+    detailsListStyles,
+    enableShimmer,
+    items,
+    listProps,
+    onRenderCustomPlaceholder,
+    removeFadingOverlay,
+    shimmerLines,
+    styles,
+    theme,
+    ariaLabelForGrid,
+    ariaLabelForShimmer,
+    ...restProps
+  } = props;
 
-  constructor(props: IShimmeredDetailsListProps) {
-    super(props);
+  const detailsListProps = useShallowMemo(() => restProps, restProps);
 
-    this._shimmerItems = props.shimmerLines ? new Array(props.shimmerLines) : new Array(SHIMMER_INITIAL_ITEMS);
-  }
+  const shimmerItems = React.useMemo(() => {
+    return shimmerLines ? new Array(shimmerLines) : new Array(SHIMMER_INITIAL_ITEMS);
+  }, [shimmerLines]);
 
-  public render(): JSX.Element {
-    const {
-      detailsListStyles,
-      enableShimmer,
-      items,
-      listProps,
-      onRenderCustomPlaceholder,
-      removeFadingOverlay,
-      shimmerLines,
-      styles,
-      theme,
-      ariaLabelForGrid,
-      ariaLabelForShimmer,
-      ...restProps
-    } = this.props;
+  const listClassName = listProps && listProps.className;
 
-    const listClassName = listProps && listProps.className;
+  const classNames = React.useMemo(
+    () =>
+      getClassNames(styles, {
+        theme: theme!,
+      }),
+    [styles, theme],
+  );
 
-    this._classNames = getClassNames(styles, {
-      theme: theme!,
-    });
-
-    const newListProps = {
+  const newListProps = React.useMemo(() => {
+    return {
       ...listProps,
       // Adds to the optional listProp className a fading out overlay className only when `enableShimmer` toggled on
       // and the overlay is not disabled by `removeFadingOverlay` prop.
-      className: enableShimmer && !removeFadingOverlay ? css(this._classNames.root, listClassName) : listClassName,
+      className: enableShimmer && !removeFadingOverlay ? css(classNames.root, listClassName) : listClassName,
     };
+  }, [listProps, enableShimmer, removeFadingOverlay, classNames.root, listClassName]);
 
+  const onRenderShimmerPlaceholder = React.useCallback(
+    (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
+      const placeholderElements: React.ReactNode = onRenderCustomPlaceholder
+        ? onRenderCustomPlaceholder(rowProps, index, renderDefaultShimmerPlaceholder)
+        : renderDefaultShimmerPlaceholder(rowProps);
+
+      return <Shimmer customElementsGroup={placeholderElements} />;
+    },
+    [onRenderCustomPlaceholder],
+  );
+
+  return React.useMemo(() => {
     return (
       <DetailsList
-        {...restProps}
+        {...detailsListProps}
         styles={detailsListStyles}
-        items={enableShimmer ? this._shimmerItems : items}
+        items={enableShimmer ? shimmerItems : items}
         isPlaceholderData={enableShimmer}
         ariaLabelForGrid={(enableShimmer && ariaLabelForShimmer) || ariaLabelForGrid}
-        onRenderMissingItem={this._onRenderShimmerPlaceholder}
+        onRenderMissingItem={onRenderShimmerPlaceholder}
         listProps={newListProps}
       />
     );
-  }
+  }, [detailsListProps, detailsListStyles, enableShimmer, shimmerItems, items, ariaLabelForShimmer, newListProps]);
+}
 
-  private _onRenderShimmerPlaceholder = (index: number, rowProps: IDetailsRowProps): React.ReactNode => {
-    const { onRenderCustomPlaceholder } = this.props;
+function renderDefaultShimmerPlaceholder(rowProps: IDetailsRowProps): React.ReactNode {
+  const { columns, compact, selectionMode, checkboxVisibility, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = rowProps;
 
-    const placeholderElements: React.ReactNode = onRenderCustomPlaceholder
-      ? onRenderCustomPlaceholder(rowProps, index, this._renderDefaultShimmerPlaceholder)
-      : this._renderDefaultShimmerPlaceholder(rowProps);
+  const { rowHeight, compactRowHeight } = DEFAULT_ROW_HEIGHTS;
+  // 1px to take into account the border-bottom of DetailsRow.
+  const gapHeight: number = compact ? compactRowHeight : rowHeight + 1;
 
-    return <Shimmer customElementsGroup={placeholderElements} />;
-  };
+  const shimmerElementsRow: JSX.Element[] = [];
 
-  private _renderDefaultShimmerPlaceholder = (rowProps: IDetailsRowProps): React.ReactNode => {
-    const { columns, compact, selectionMode, checkboxVisibility, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = rowProps;
+  const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
 
-    const { rowHeight, compactRowHeight } = DEFAULT_ROW_HEIGHTS;
-    // 1px to take into account the border-bottom of DetailsRow.
-    const gapHeight: number = compact ? compactRowHeight : rowHeight + 1;
-
-    const shimmerElementsRow: JSX.Element[] = [];
-
-    const showCheckbox = selectionMode !== SelectionMode.none && checkboxVisibility !== CheckboxVisibility.hidden;
-
-    if (showCheckbox) {
-      shimmerElementsRow.push(
-        <ShimmerElementsGroup
-          key={'checkboxGap'}
-          shimmerElements={[{ type: ShimmerElementType.gap, width: '40px', height: gapHeight }]}
-        />,
-      );
-    }
-
-    columns.map((column, columnIdx) => {
-      const shimmerElements: IShimmerElement[] = [];
-      const groupWidth: number =
-        cellStyleProps.cellLeftPadding +
-        cellStyleProps.cellRightPadding +
-        column.calculatedWidth! +
-        (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0);
-
-      shimmerElements.push({
-        type: ShimmerElementType.gap,
-        width: cellStyleProps.cellLeftPadding,
-        height: gapHeight,
-      });
-
-      if (column.isIconOnly) {
-        shimmerElements.push({
-          type: ShimmerElementType.line,
-          width: column.calculatedWidth!,
-          height: column.calculatedWidth!,
-        });
-        shimmerElements.push({
-          type: ShimmerElementType.gap,
-          width: cellStyleProps.cellRightPadding,
-          height: gapHeight,
-        });
-      } else {
-        shimmerElements.push({
-          type: ShimmerElementType.line,
-          width: column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO,
-          height: DEFAULT_SHIMMER_HEIGHT,
-        });
-        shimmerElements.push({
-          type: ShimmerElementType.gap,
-          width:
-            cellStyleProps.cellRightPadding +
-            (column.calculatedWidth! - column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO) +
-            (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0),
-          height: gapHeight,
-        });
-      }
-      shimmerElementsRow.push(
-        <ShimmerElementsGroup key={columnIdx} width={`${groupWidth}px`} shimmerElements={shimmerElements} />,
-      );
-    });
-    // When resizing the window from narrow to wider, we need to cover the exposed Shimmer wave
-    // until the column resizing logic is done.
+  if (showCheckbox) {
     shimmerElementsRow.push(
       <ShimmerElementsGroup
-        key={'endGap'}
-        width={'100%'}
-        shimmerElements={[{ type: ShimmerElementType.gap, width: '100%', height: gapHeight }]}
+        key={'checkboxGap'}
+        shimmerElements={[{ type: ShimmerElementType.gap, width: '40px', height: gapHeight }]}
       />,
     );
-    return <div style={{ display: 'flex' }}>{shimmerElementsRow}</div>;
-  };
+  }
+
+  columns.map((column, columnIdx) => {
+    const shimmerElements: IShimmerElement[] = [];
+    const groupWidth: number =
+      cellStyleProps.cellLeftPadding +
+      cellStyleProps.cellRightPadding +
+      column.calculatedWidth! +
+      (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0);
+
+    shimmerElements.push({
+      type: ShimmerElementType.gap,
+      width: cellStyleProps.cellLeftPadding,
+      height: gapHeight,
+    });
+
+    if (column.isIconOnly) {
+      shimmerElements.push({
+        type: ShimmerElementType.line,
+        width: column.calculatedWidth!,
+        height: column.calculatedWidth!,
+      });
+      shimmerElements.push({
+        type: ShimmerElementType.gap,
+        width: cellStyleProps.cellRightPadding,
+        height: gapHeight,
+      });
+    } else {
+      shimmerElements.push({
+        type: ShimmerElementType.line,
+        width: column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO,
+        height: DEFAULT_SHIMMER_HEIGHT,
+      });
+      shimmerElements.push({
+        type: ShimmerElementType.gap,
+        width:
+          cellStyleProps.cellRightPadding +
+          (column.calculatedWidth! - column.calculatedWidth! * SHIMMER_LINE_VS_CELL_WIDTH_RATIO) +
+          (column.isPadded ? cellStyleProps.cellExtraRightPadding : 0),
+        height: gapHeight,
+      });
+    }
+    shimmerElementsRow.push(
+      <ShimmerElementsGroup key={columnIdx} width={`${groupWidth}px`} shimmerElements={shimmerElements} />,
+    );
+  });
+  // When resizing the window from narrow to wider, we need to cover the exposed Shimmer wave
+  // until the column resizing logic is done.
+  shimmerElementsRow.push(
+    <ShimmerElementsGroup
+      key={'endGap'}
+      width={'100%'}
+      shimmerElements={[{ type: ShimmerElementType.gap, width: '100%', height: gapHeight }]}
+    />,
+  );
+  return <div style={{ display: 'flex' }}>{shimmerElementsRow}</div>;
 }

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -8,3 +8,4 @@ export * from './useControllableValue';
 export * from './useAsync';
 export * from './useOnEvent';
 export * from './useForceUpdate';
+export * from './useShallowMemo';

--- a/packages/react-hooks/src/useShallowMemo.test.tsx
+++ b/packages/react-hooks/src/useShallowMemo.test.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { useShallowMemo } from './useShallowMemo';
+
+describe('useShallowMemo', () => {
+  it('calls the callback only when deps change', () => {
+    const getValue = jest.fn();
+
+    getValue.mockReturnValue('test');
+
+    const mockComponent = jest.fn();
+    mockComponent.mockImplementation(() => {
+      const value = useShallowMemo(getValue, {
+        a: 1,
+      });
+      return <div>{value}</div>;
+    });
+
+    const MockComponent: React.FunctionComponent<{}> = mockComponent;
+
+    const wrapper = mount(<MockComponent />);
+
+    expect(wrapper.text()).toEqual('test');
+
+    getValue.mockReturnValue('foo');
+
+    mockComponent.mockImplementation(() => {
+      const value = useShallowMemo(getValue, {
+        a: 2,
+      });
+      return <div>{value}</div>;
+    });
+
+    wrapper.setProps({});
+
+    expect(getValue).toHaveBeenCalledTimes(2);
+
+    expect(wrapper.text()).toEqual('foo');
+
+    getValue.mockReturnValue('bar');
+
+    mockComponent.mockImplementation(() => {
+      const value = useShallowMemo(getValue, {
+        a: 2,
+      });
+      return <div>{value}</div>;
+    });
+
+    wrapper.setProps({});
+
+    expect(getValue).toHaveBeenCalledTimes(2);
+
+    getValue.mockReturnValue('bar');
+
+    mockComponent.mockImplementation(() => {
+      const value = useShallowMemo(getValue, {});
+      return <div>{value}</div>;
+    });
+
+    wrapper.setProps({});
+
+    expect(getValue).toHaveBeenCalledTimes(3);
+
+    expect(wrapper.text()).toEqual('bar');
+  });
+});

--- a/packages/react-hooks/src/useShallowMemo.ts
+++ b/packages/react-hooks/src/useShallowMemo.ts
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { shallowCompare } from '@uifabric/utilities';
+
+/**
+ * Hook which evaluates the given expression only if the given deps object is shallow-different than
+ * for the previous invocation of the hook.
+ * This is essentially `React.useMemo`, except it shallow-compares a single deps object
+ * rather than an array of deps values.
+ * @public
+ */
+export function useShallowMemo<TValue>(getValue: () => TValue, deps: object): TValue {
+  const ref = React.useRef<object>();
+
+  const current = ref.current;
+
+  if (current !== deps && (!current || !deps || !shallowCompare(ref.current, deps))) {
+    ref.current = deps;
+  }
+
+  return React.useMemo(getValue, [ref.current]);
+}


### PR DESCRIPTION
Converted `ShimmeredDetailsList` to use hooks, since it does not have any advanced state to manage. This allows it to memoize its injections into `listProps`, as well as debounce rendered to the real `DetailsList` component thanks to use of a new `useShallowMemo` hook.

The new `useShallowMemo` hook is just like `useMemo` except its `deps` value is a single object of any set of fields. If the new value of `deps` fails a shallow-equal comparison to the old, then the callback is re-evaluated and the new result returned. This callback can be used in places where `useMemo` cannot, for example when comparing 'the rest of a props object' within a decorator-style component.