### PR TITLE
perf: omit "_.findKey" usage in focusVisibleEnhancer()

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -70,6 +70,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `compose()` support for submenus in `MenuItem` @mnajdova ([#13300](https://github.com/microsoft/fluentui/pull/13300))
 - Use `compose()` in `ToolbarMenuDivider` @mnajdova ([#13318](https://github.com/microsoft/fluentui/pull/13318))
 
+### Performance
+- Omit `_.findKey()` usage in `focusVisibleEnhancer()` @layershifter ([#13343](https://github.com/microsoft/fluentui/pull/13343))
+
 ### Documentation
 - `Toolbar` recommendation using toolbar based on aria  @kolaps33 ([#13143](https://github.com/microsoft/fluentui/pull/13143))
 - Fix knobs labels on docsite  @pompomon ([#13248](https://github.com/microsoft/fluentui/pull/13248))

--- a/packages/fluentui/react-northstar/src/utils/felaFocusVisibleEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaFocusVisibleEnhancer.ts
@@ -1,6 +1,5 @@
 import { IRenderer } from 'fela';
 import { RULE_TYPE } from 'fela-utils';
-import * as _ from 'lodash';
 
 type Renderer = IRenderer & {
   cache: Record<string, RendererChange>;

--- a/packages/fluentui/react-northstar/src/utils/felaFocusVisibleEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaFocusVisibleEnhancer.ts
@@ -22,33 +22,20 @@ type RendererChange = {
  * selector. Modifies generated selectors:
  * `.a:focus-visible {}` => `html[data-whatinput="keyboard"] a:focus`.
  */
-const felaFocusVisibleEnhancer = (renderer: Renderer) => ({
-  ...renderer,
-  _emitChange: (change: RendererChange) => {
+const felaFocusVisibleEnhancer = (renderer: Renderer) => {
+  const existingEmitChange = renderer._emitChange.bind(renderer);
+
+  renderer._emitChange = (change: RendererChange) => {
     if (change.type === RULE_TYPE && change.selector.indexOf(':focus-visible') !== -1) {
-      const pseudo = change.pseudo ? change.pseudo.replace(':focus-visible', ':focus') : undefined;
-      const selector = `html[data-whatinput="keyboard"] ${change.selector.replace(':focus-visible', ':focus')}`;
-
-      const declarationReference = _.findKey(renderer.cache, change);
-      const enhancedChange = {
-        ...change,
-        pseudo,
-        selector,
-      };
-
-      // Fela has two types for rendering:
-      // - DOM via subscriptions that's why `_emitChange()` is replaced, it will notify all
-      //   subscriptions
-      // - static rendering, it directly accesses `.cache` via `clusterCache()` and generates
-      //   stylesheets from changes
-      renderer.cache[declarationReference] = enhancedChange;
-      renderer._emitChange(enhancedChange);
-
-      return;
+      // Fela uses objects by references, it's safe to override properties
+      change.pseudo = change.pseudo ? change.pseudo.replace(':focus-visible', ':focus') : undefined;
+      change.selector = `html[data-whatinput="keyboard"] ${change.selector.replace(':focus-visible', ':focus')}`;
     }
 
-    renderer._emitChange(change);
-  },
-});
+    existingEmitChange(change);
+  };
+
+  return renderer;
+};
 
 export default felaFocusVisibleEnhancer;

--- a/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
@@ -18,18 +18,21 @@ const stylis = new Stylis({
   semicolon: false,
 });
 
-const felaStylisEnhancer = (renderer: Renderer) => ({
-  ...renderer,
-  _emitChange: (change: RendererChange) => {
-    if (change.type === RULE_TYPE) {
+const felaStylisEnhancer = (renderer: Renderer) => {
+  const existingEmitChange = renderer._emitChange.bind(renderer);
+
+  renderer._emitChange = (change: RendererChange) => {
+    if (change.type === RULE_TYPE && !change.DO_NOT_PROCESS_BY_STYLIS) {
       const prefixed: string = stylis('', change.declaration);
 
       // Fela uses objects by references, it's safe to override properties
       change.declaration = prefixed.slice(1, -1);
     }
 
-    renderer._emitChange(change);
-  },
-});
+    existingEmitChange(change);
+  };
+
+  return renderer;
+};
 
 export default felaStylisEnhancer;

--- a/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
+++ b/packages/fluentui/react-northstar/src/utils/felaStylisEnhancer.ts
@@ -22,7 +22,7 @@ const felaStylisEnhancer = (renderer: Renderer) => {
   const existingEmitChange = renderer._emitChange.bind(renderer);
 
   renderer._emitChange = (change: RendererChange) => {
-    if (change.type === RULE_TYPE && !change.DO_NOT_PROCESS_BY_STYLIS) {
+    if (change.type === RULE_TYPE) {
       const prefixed: string = stylis('', change.declaration);
 
       // Fela uses objects by references, it's safe to override properties


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

It's fine to `change` by reference and update the object itself instead of creating a new one and trying to find a key via `_.findKey()`. There is around 2-3% perf improvement with these changes.

#### Focus areas to test

(optional)
