### PR TITLE
fix(useStyles): fix broken caching when "enableBooleanVariablesCaching" and there is no variables

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -55,6 +55,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Exclude useless updates, fix `fixed` positioning in `Popper` @layershifter @kolaps33 ([#13044](https://github.com/microsoft/fluentui/pull/13044))
 - Fix showing loading message in `Dropdown` when list of items has scroll @assuncaocharles ([#13175](https://github.com/microsoft/fluentui/pull/13175))
 - Stop propagation of left and right arrow key in `SplitButton` for the integration with toolbar @jurokapsiar ([#13311](https://github.com/microsoft/fluentui/pull/13311))
+- Fix broken caching when `enableBooleanVariablesCaching:true` and there is no variables @layershifter ([#13345](https://github.com/microsoft/fluentui/pull/13345))
 
 ### Features
 - Added icons: `TranscriptIcon`, `FilesGenericColoredIcon`, `FilesHtmlColoredIcon`, `FilesPdfColoredIcon`, `FilesPictureColoredIcon`, `FilesTextColoredIcon`, `PopupIcon`, `ShareGenericIcon`, `ComposeIcon`, `SpotlightStopIcon`, `TenantWorkIcon`, `TenantPersonalIcon`, `WorkOrSchoolIcon`, `EmailWithDotIcon`. Modified: `ShareLocationIcon`, `SpotlightIcon`. @TanelVari ([#12872](https://github.com/microsoft/fluentui/pull/12872))

--- a/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
@@ -80,7 +80,7 @@ const resolveStyles = (
       if (!hasOnlyBooleanVariables) {
         noVariableOverrides = false;
       }
-    } else {
+    } else if (!_.isNil(variables)) {
       noVariableOverrides = false;
     }
   }

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -322,6 +322,17 @@ describe('resolveStyles', () => {
       expect(renderStyles).toHaveBeenCalledTimes(1);
     });
 
+    test('avoids "classes" computation when enabled and there is no variables', () => {
+      const renderStyles = jest.fn().mockReturnValue('a');
+      const options = resolveStylesOptions({
+        performance: { enableBooleanVariablesCaching: true },
+      });
+
+      expect(resolveStyles(options, resolvedVariables, renderStyles)).toHaveProperty('classes.root', 'a');
+      expect(resolveStyles(options, resolvedVariables, renderStyles)).toHaveProperty('classes.root', 'a');
+      expect(renderStyles).toHaveBeenCalledTimes(1);
+    });
+
     test('forces "classes" computation when disabled', () => {
       const renderStyles = jest.fn().mockReturnValue('a');
       const options = resolveStylesOptions({


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue when `enableBooleanVariablesCaching` perf flag is enabled, but there is no `variables`:

```tsx
<Provider performance={{ enableBooleanVariablesCaching: true }}>
  <ListItem /> {/* was not cached before */}
</Provider>
```

#### Focus areas to test

(optional)
