### PR TITLE
Prevent ContextualMenu from re-mounting items when they are updated

### DIFF
--- a/change/office-ui-fabric-react-2020-05-27-11-01-01-context-menu-focus.json
+++ b/change/office-ui-fabric-react-2020-05-27-11-01-01-context-menu-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Prevent ContextualMenu from destroying existing menu items on every repaint",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T18:01:01.147Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.doc.tsx
@@ -5,6 +5,7 @@ import { CommandBarBasicExample } from './examples/CommandBar.Basic.Example';
 import { CommandBarButtonAsExample } from './examples/CommandBar.ButtonAs.Example';
 import { IndividualCommandBarButtonAsExampleWrapper } from './examples/CommandBar.CommandBarButtonAs.Example';
 import { CommandBarSplitDisabledExample } from './examples/CommandBar.SplitDisabled.Example';
+import { CommandBarLazyExample } from './examples/CommandBar.Lazy.Example';
 
 const CommandBarBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Basic.Example.tsx') as string;
 
@@ -13,6 +14,8 @@ const CommandBarButtonAsExampleCode = require('!raw-loader!office-ui-fabric-reac
 const IndividualCommandBarButtonAsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx') as string;
 
 const CommandBarSplitDisabledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.SplitDisabled.Example.tsx') as string;
+
+const CommandBarLazyExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx') as string;
 
 export const CommandBarPageProps: IDocPageProps = {
   title: 'CommandBar',
@@ -39,6 +42,11 @@ export const CommandBarPageProps: IDocPageProps = {
       title: 'CommandBar with split and disabled buttons',
       code: CommandBarSplitDisabledExampleCode,
       view: <CommandBarSplitDisabledExample />,
+    },
+    {
+      title: 'CommandBar with lazy-loading menus',
+      code: CommandBarLazyExampleCode,
+      view: <CommandBarLazyExample />,
     },
   ],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/CommandBar/docs/CommandBarOverview.md'),

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
+import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { useConstCallback } from '@uifabric/react-hooks';
+
+export const CommandBarLazyExample: React.FunctionComponent = () => {
+  const [menuItems, setMenuItems] = React.useState<ICommandBarItemProps[] | undefined>(undefined);
+
+  const timeoutRef = React.useRef<number | null>();
+
+  const onMenuDismissed = useConstCallback(() => {
+    setMenuItems(undefined);
+  });
+
+  const loadItems = useConstCallback(() => {
+    const itemCount = Math.floor(Math.random() * 5) + 1;
+
+    const newMenuItems: ICommandBarItemProps[] = [];
+
+    for (let i = 0; i < itemCount; i++) {
+      newMenuItems.push({
+        key: `sub-item-${i}`,
+        name: `Item ${i}`,
+      });
+    }
+
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = (setTimeout(() => {
+      setMenuItems(newMenuItems);
+    }, 2000) as unknown) as number;
+  });
+
+  const items = React.useMemo((): ICommandBarItemProps[] => {
+    return [
+      {
+        key: 'a',
+        name: 'Test',
+      },
+      {
+        key: 'menu',
+        name: 'Lazy-loaded menu',
+        subMenuProps: {
+          items: menuItems
+            ? [
+                ...menuItems,
+                {
+                  key: 'divider',
+                  name: '-',
+                  itemType: ContextualMenuItemType.Divider,
+                },
+                {
+                  key: 'permanent',
+                  name: 'Permanent option',
+                },
+              ]
+            : [],
+          onMenuOpened: loadItems,
+          onMenuDismissed: onMenuDismissed,
+        },
+      },
+    ];
+  }, [menuItems]);
+
+  return (
+    <div>
+      <CommandBar items={items} />
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -511,7 +511,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
     totalItemCount: number,
     hasCheckmarks: boolean,
     hasIcons: boolean,
-  ): React.ReactNode => {
+  ): JSX.Element => {
     const renderedItems: React.ReactNode[] = [];
     const iconProps = item.iconProps || { iconName: 'None' };
     const {
@@ -597,7 +597,9 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
         break;
     }
 
-    return renderedItems;
+    // Since multiple nodes *could* be rendered, wrap them all in a fragment with this item's key.
+    // This ensures the reconciler handles multi-item output per-node correctly and does not re-mount content.
+    return <React.Fragment key={item.key}>{renderedItems}</React.Fragment>;
   };
 
   private _defaultMenuItemRenderer = (item: IContextualMenuItemRenderProps): React.ReactNode => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -601,7 +601,7 @@ describe('ContextualMenu', () => {
       },
       {
         text: 'TestText 2',
-        key: 'TestKey3',
+        key: 'TestKey2',
       },
       {
         text: 'TestText 3',

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Lazy.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Lazy.Example.tsx.shot
@@ -1,0 +1,396 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders CommandBar.Lazy.Example.tsx correctly 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
+      >
+        <div
+          className=
+              ms-FocusZone
+              ms-CommandBar
+              &:focus {
+                outline: none;
+              }
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                background-color: #ffffff;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: 44px;
+                padding-bottom: 0;
+                padding-left: 24px;
+                padding-right: 14px;
+                padding-top: 0;
+              }
+          data-focuszone-id="FocusZone0"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="menubar"
+        >
+          <div
+            className=
+                ms-OverflowSet
+                ms-CommandBar-primaryCommand
+                {
+                  align-items: stretch;
+                  display: flex;
+                  flex-grow: 1;
+                  flex-wrap: nowrap;
+                  position: relative;
+                }
+            role="group"
+          >
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                className=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-CommandBarItem-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 100%;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable={true}
+                name="Test"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="menuitem"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Button-textContainer
+                        {
+                          display: block;
+                          flex-grow: 1;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__1"
+                    >
+                      Test
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-owns={null}
+                className=
+                    ms-Button
+                    ms-Button--commandBar
+                    ms-Button--hasMenu
+                    ms-CommandBarItem-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 100%;
+                      min-width: 40px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid transparent;
+                      bottom: 3px;
+                      content: "";
+                      left: 3px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 3px;
+                      top: 3px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: 4px;
+                      left: 4px;
+                      outline-color: ButtonText;
+                      right: 4px;
+                      top: 4px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border: none;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #106ebe;
+                    }
+                    &:hover .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #005a9e;
+                    }
+                    &:active .ms-Button-menuIcon {
+                      color: #323130;
+                    }
+                data-is-focusable={true}
+                name="Lazy-loaded menu"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="menuitem"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Button-textContainer
+                        {
+                          display: block;
+                          flex-grow: 1;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Button-label
+                          {
+                            display: block;
+                            font-weight: normal;
+                            line-height: 100%;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            white-space: nowrap;
+                          }
+                      id="id__4"
+                    >
+                      Lazy-loaded menu
+                    </span>
+                  </span>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-menuIcon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          flex-shrink: 0;
+                          font-size: 12px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                        }
+                    data-icon-name="ChevronDown"
+                    role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Fixed an issue where `ContextualMenu` would re-mount (destroy and recreate the HTML Elements) each menu item if the `items` prop changed while the menu is rendered.

The fix involves wrapping the render result for each item (typed as `React.ReactNode[]` in a `Fragment` and assigning a durable key. The issue was that the reconciler could not handle a possible 'array of arrays' in the output and was instead recreating all elements in the list.

Added an example for `CommandBar` with a 'lazy-loaded' command, to show how the bar reacts when commands are dynamically loaded.