### PR TITLE
SplitButton: Making imperative focus call on touch events

### DIFF
--- a/change/office-ui-fabric-react-2020-05-27-13-53-03-buttonFocusOnTouch.json
+++ b/change/office-ui-fabric-react-2020-05-27-13-53-03-buttonFocusOnTouch.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: Making imperative focus call on touch events.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-27T20:53:03.371Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -862,7 +862,7 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   private _handleTouchAndPointerEvent() {
     // If we already have an existing timeeout from a previous touch and pointer event
-    // cancel that timeout so we can set a nwe one.
+    // cancel that timeout so we can set a new one.
     if (this._lastTouchTimeoutId !== undefined) {
       this._async.clearTimeout(this._lastTouchTimeoutId);
       this._lastTouchTimeoutId = undefined;
@@ -872,6 +872,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
     this._lastTouchTimeoutId = this._async.setTimeout(() => {
       this._processingTouch = false;
       this._lastTouchTimeoutId = undefined;
+
+      // Touch and pointer events don't focus the button naturally,
+      // so adding an imperative focus call to guarantee this behavior.
+      this.focus();
     }, TouchIdleDelay);
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12486
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`SplitButtons` in touch scenarios would return to their last focused input when tapped twice. This made interactions with them more difficult. This PR adds an imperative focus call as part of handling the touch events to resolve this issue, which makes the touch handling match closer to the click handling (which does this behavior as part of the browser handling of click events)

#### Focus areas to test

(optional)
