### PR TITLE
Make ts composite builds use separate buildinfo files for variants

### DIFF
--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -5,7 +5,7 @@ const { tscTask, argv } = require('just-scripts');
 const libPath = path.resolve(process.cwd(), 'lib');
 const srcPath = path.resolve(process.cwd(), 'src');
 // Temporary hack: only use tsbuildinfo file for things under packages/fluentui
-const isV0 = /[\\/]packages[\\/]fluentui\b/.test(process.cwd());
+const isV0 = /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd());
 
 function getExtraTscParams(args) {
   return {

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -5,7 +5,7 @@ const { tscTask, argv } = require('just-scripts');
 const libPath = path.resolve(process.cwd(), 'lib');
 const srcPath = path.resolve(process.cwd(), 'src');
 // Temporary hack: only use tsbuildinfo file for things under packages/fluentui
-const isV0 = /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd());
+const isV0 = /[\\/]packages[\\/]fluentui\b/.test(process.cwd());
 
 function getExtraTscParams(args) {
   return {

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -16,15 +16,20 @@ function getExtraTscParams(args) {
 module.exports.ts = {
   commonjs: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({ ...extraOptions, outDir: 'lib-commonjs', module: 'commonjs' });
+    return tscTask({
+      ...extraOptions,
+      outDir: 'lib-commonjs',
+      module: 'commonjs',
+      tsBuildInfoFile: '.commonjs.tsbuildinfo',
+    });
   },
   esm: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({ ...extraOptions, outDir: 'lib', module: 'esnext' });
+    return tscTask({ ...extraOptions, outDir: 'lib', module: 'esnext', tsBuildInfoFile: '.tsbuildinfo' });
   },
   amd: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({ ...extraOptions, outDir: 'lib-amd', module: 'amd' });
+    return tscTask({ ...extraOptions, outDir: 'lib-amd', module: 'amd', tsBuildInfoFile: '.amd.tsbuildinfo' });
   },
   commonjsOnly: () => {
     const extraOptions = getExtraTscParams(argv());

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -4,6 +4,8 @@ const path = require('path');
 const { tscTask, argv } = require('just-scripts');
 const libPath = path.resolve(process.cwd(), 'lib');
 const srcPath = path.resolve(process.cwd(), 'src');
+// Temporary hack: only use tsbuildinfo file for things under packages/fluentui
+const isV0 = /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd());
 
 function getExtraTscParams(args) {
   return {
@@ -20,16 +22,26 @@ module.exports.ts = {
       ...extraOptions,
       outDir: 'lib-commonjs',
       module: 'commonjs',
-      tsBuildInfoFile: '.commonjs.tsbuildinfo',
+      ...(isV0 && { tsBuildInfoFile: '.commonjs.tsbuildinfo' }),
     });
   },
   esm: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({ ...extraOptions, outDir: 'lib', module: 'esnext', tsBuildInfoFile: '.tsbuildinfo' });
+    return tscTask({
+      ...extraOptions,
+      outDir: 'lib',
+      module: 'esnext',
+      ...(isV0 && { tsBuildInfoFile: '.tsbuildinfo' }),
+    });
   },
   amd: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({ ...extraOptions, outDir: 'lib-amd', module: 'amd', tsBuildInfoFile: '.amd.tsbuildinfo' });
+    return tscTask({
+      ...extraOptions,
+      outDir: 'lib-amd',
+      module: 'amd',
+      ...(isV0 && { tsBuildInfoFile: '.amd.tsbuildinfo' }),
+    });
   },
   commonjsOnly: () => {
     const extraOptions = getExtraTscParams(argv());

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -5,7 +5,8 @@ const { tscTask, argv } = require('just-scripts');
 const libPath = path.resolve(process.cwd(), 'lib');
 const srcPath = path.resolve(process.cwd(), 'src');
 // Temporary hack: only use tsbuildinfo file for things under packages/fluentui
-const isV0 = /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd());
+const useTsBuildInfo =
+  /[\\/]packages[\\/]fluentui[\\/]/.test(process.cwd()) && path.basename(process.cwd()) !== 'perf-test';
 
 function getExtraTscParams(args) {
   return {
@@ -22,7 +23,7 @@ module.exports.ts = {
       ...extraOptions,
       outDir: 'lib-commonjs',
       module: 'commonjs',
-      ...(isV0 && { tsBuildInfoFile: '.commonjs.tsbuildinfo' }),
+      ...(useTsBuildInfo && { tsBuildInfoFile: '.commonjs.tsbuildinfo' }),
     });
   },
   esm: () => {
@@ -31,7 +32,7 @@ module.exports.ts = {
       ...extraOptions,
       outDir: 'lib',
       module: 'esnext',
-      ...(isV0 && { tsBuildInfoFile: '.tsbuildinfo' }),
+      ...(useTsBuildInfo && { tsBuildInfoFile: '.tsbuildinfo' }),
     });
   },
   amd: () => {
@@ -40,7 +41,7 @@ module.exports.ts = {
       ...extraOptions,
       outDir: 'lib-amd',
       module: 'amd',
-      ...(isV0 && { tsBuildInfoFile: '.amd.tsbuildinfo' }),
+      ...(useTsBuildInfo && { tsBuildInfoFile: '.amd.tsbuildinfo' }),
     });
   },
   commonjsOnly: () => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

I believe the v0 code all have project references. With that there are caches being created. The only issue is that anything using just-scripts inside v0 will need to have separate caches based on the variants. This will delineate the caches based on the variants.

#### Focus areas to test

(optional)
