### PR TITLE
SpinButton: reintroduce incorrect semi-controlled behavior

### DIFF
--- a/change/@fluentui-react-next-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
+++ b/change/@fluentui-react-next-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "SpinButton: reintroduce incorrect behavior of allowing updates when value is provided",
+  "comment": "SpinButton: Reintroduce incorrect behavior of allowing updates when value is provided to prevent breaking partners.",
   "packageName": "@fluentui/react-next",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-next-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
+++ b/change/@fluentui-react-next-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "SpinButton: reintroduce incorrect behavior of allowing updates when value is provided",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-28T00:09:55.581Z"
+}

--- a/change/office-ui-fabric-react-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
+++ b/change/office-ui-fabric-react-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "SpinButton: reintroduce incorrect behavior of allowing updates when value is provided",
+  "comment": "SpinButton: Reintroduce incorrect behavior of allowing updates when value is provided to prevent breaking partners.",
   "packageName": "office-ui-fabric-react",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
+++ b/change/office-ui-fabric-react-2020-05-27-17-09-55-spinbutton-reintroduce-wrong-behavior.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: reintroduce incorrect behavior of allowing updates when value is provided",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-28T00:09:51.693Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.deprecated.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import { ReactWrapper, mount } from 'enzyme';
+import { SpinButton, ISpinButtonState } from './SpinButton';
+import { ISpinButton, ISpinButtonProps } from './SpinButton.types';
+import { mockEvent } from '../../common/testUtilities';
+
+describe('SpinButton', () => {
+  let ref: React.RefObject<ISpinButton>;
+  let wrapper: ReactWrapper<ISpinButtonProps, ISpinButtonState, SpinButton> | undefined;
+
+  beforeEach(() => {
+    ref = React.createRef<ISpinButton>();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  // Documenting current incorrect behavior.
+  // The test SHOULD be "ignores user-entered values when value prop is set"
+  it('incorrectly accepts user-entered values when value prop is set', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
+    ReactTestUtils.Simulate.blur(inputDOM);
+
+    // Once the incorrect behavior is fixed, these will still be '12'
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -379,7 +379,7 @@ describe('SpinButton', () => {
         componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        value="12"
+        defaultValue="12"
         // tslint:disable-next-line:jsx-no-lambda
         onValidate={(newValue: string): string | void => {
           const numberValue: number = Number(newValue);

--- a/packages/react-next/src/components/SpinButton/SpinButton.deprecated.test.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.deprecated.test.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import * as ReactTestUtils from 'react-dom/test-utils';
+import { ReactWrapper, mount } from 'enzyme';
+import { SpinButton, ISpinButtonState } from './SpinButton';
+import { ISpinButton, ISpinButtonProps } from './SpinButton.types';
+import { mockEvent } from '../../common/testUtilities';
+
+describe('SpinButton', () => {
+  let ref: React.RefObject<ISpinButton>;
+  let wrapper: ReactWrapper<ISpinButtonProps, ISpinButtonState, SpinButton> | undefined;
+
+  beforeEach(() => {
+    ref = React.createRef<ISpinButton>();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  // Documenting current incorrect behavior.
+  // The test SHOULD be "ignores user-entered values when value prop is set"
+  it('incorrectly accepts user-entered values when value prop is set', () => {
+    wrapper = mount(<SpinButton componentRef={ref} value="12" />);
+
+    const inputDOM = wrapper.getDOMNode().querySelector('input')!;
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent('21'));
+    ReactTestUtils.Simulate.blur(inputDOM);
+
+    // Once the incorrect behavior is fixed, these will still be '12'
+    expect(ref.current!.value).toBe('21');
+    expect(inputDOM.value).toBe('21');
+    expect(inputDOM.getAttribute('aria-valuenow')).toBe('21');
+  });
+});

--- a/packages/react-next/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.test.tsx
@@ -379,7 +379,7 @@ describe('SpinButton', () => {
         componentRef={ref}
         min={exampleMinValue}
         max={exampleMaxValue}
-        value="12"
+        defaultValue="12"
         // tslint:disable-next-line:jsx-no-lambda
         onValidate={(newValue: string): string | void => {
           const numberValue: number = Number(newValue);


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Prior to #13174, the SpinButton incorrectly had "semi-controlled" behavior: even when the `value` prop was provided, it would respect user updates until a new `value` was passed in. (Providing `value` is supposed to mean that the component is controlled and *will not* respect updates, unless the consumer passes in a new `value` in response to change events.) 

While the SpinButton will definitely have strict controlled behavior in version 8, unintentionally introducing it in version 7 was a breaking change for some consumers. So this PR reverts to the semi-controlled behavior.