### PR TITLE
perf: use mergeVariablesOverrides() to avoid cache breaks when variables are not passed

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -88,6 +88,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Performance
 - Omit `_.findKey()` usage in `focusVisibleEnhancer()` @layershifter ([#13343](https://github.com/microsoft/fluentui/pull/13343))
+- Use `mergeVariablesOverrides()` to avoid cache breaks when variables are not passed in `Toolbar`, `Menu` & `Table` components @layershifter ([#13374](https://github.com/microsoft/fluentui/pull/13374))
 
 ### Documentation
 - `Toolbar` recommendation using toolbar based on aria  @kolaps33 ([#13143](https://github.com/microsoft/fluentui/pull/13143))

--- a/packages/fluentui/react-bindings/src/index.ts
+++ b/packages/fluentui/react-bindings/src/index.ts
@@ -29,3 +29,4 @@ export * from './telemetry/types';
 
 export { default as getElementType } from './utils/getElementType';
 export { default as getUnhandledProps } from './utils/getUnhandledProps';
+export { default as mergeVariablesOverrides } from './utils/mergeVariablesOverrides';

--- a/packages/fluentui/react-bindings/src/utils/mergeVariablesOverrides.ts
+++ b/packages/fluentui/react-bindings/src/utils/mergeVariablesOverrides.ts
@@ -1,4 +1,4 @@
-import { ComponentVariablesInput, mergeComponentVariables } from '@fluentui/styles';
+import { ComponentVariablesInput, ComponentVariablesPrepared, mergeComponentVariables } from '@fluentui/styles';
 
 /**
  mergeComponentVariables() is always creating a function even if the arguments are undefined we have this temporary
@@ -8,6 +8,6 @@ import { ComponentVariablesInput, mergeComponentVariables } from '@fluentui/styl
 export default function mergeVariablesOverrides(
   variables: ComponentVariablesInput,
   overrides: ComponentVariablesInput,
-) {
+): ComponentVariablesPrepared {
   return (variables || overrides) && mergeComponentVariables(variables, overrides);
 }

--- a/packages/fluentui/react-bindings/src/utils/mergeVariablesOverrides.ts
+++ b/packages/fluentui/react-bindings/src/utils/mergeVariablesOverrides.ts
@@ -1,0 +1,13 @@
+import { ComponentVariablesInput, mergeComponentVariables } from '@fluentui/styles';
+
+/**
+ mergeComponentVariables() is always creating a function even if the arguments are undefined we have this temporary
+ fix in place to avoid creating empty function because it is breaking caching we should either fix
+ mergeComponentVariables(), or handle this in a more generic way.
+ */
+export default function mergeVariablesOverrides(
+  variables: ComponentVariablesInput,
+  overrides: ComponentVariablesInput,
+) {
+  return (variables || overrides) && mergeComponentVariables(variables, overrides);
+}

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -3,13 +3,13 @@ import {
   ComponentWithAs,
   compose,
   getElementType,
+  mergeVariablesOverrides,
   useAccessibility,
   useStyles,
   useTelemetry,
   useUnhandledProps,
 } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -69,13 +69,6 @@ export interface AttachmentProps extends UIComponentProps, ChildrenComponentProp
 
 export type AttachmentStylesProps = Required<Pick<AttachmentProps, 'actionable' | 'disabled'>>;
 export const attachmentClassName = 'ui-attachment';
-
-// mergeComponentVariables is always creating a function even if the arguments are undefined
-// we have this temporary fix in place to avoid creating empty function because it is breaking caching
-// we should either fix mergeComponentVariables, or handle this in a more generic way
-const mergeShorthandVariables = (variables, shorthandVariables) => {
-  return (variables || shorthandVariables) && mergeComponentVariables(variables, shorthandVariables);
-};
 
 /**
  * An Attachment represents a file or media attachment, which may contain some metadata or actions.
@@ -152,7 +145,7 @@ const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps, {}, {}
         {createShorthand(composeOptions.slots.icon, icon, {
           defaultProps: () => slotProps.icon,
           overrideProps: predefinedProps => ({
-            variables: mergeShorthandVariables(variables, predefinedProps.variables),
+            variables: mergeVariablesOverrides(variables, predefinedProps.variables),
           }),
         })}
 
@@ -165,25 +158,25 @@ const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps, {}, {}
                   {createShorthand(composeOptions.slots.header, header, {
                     defaultProps: () => slotProps.header,
                     overrideProps: predefinedProps => ({
-                      variables: mergeShorthandVariables(variables, predefinedProps.variables),
+                      variables: mergeVariablesOverrides(variables, predefinedProps.variables),
                     }),
                   })}
                   {createShorthand(composeOptions.slots.description, description, {
                     defaultProps: () => slotProps.description,
                     overrideProps: predefinedProps => ({
-                      variables: mergeShorthandVariables(variables, predefinedProps.variables),
+                      variables: mergeVariablesOverrides(variables, predefinedProps.variables),
                     }),
                   })}
                 </>
               ),
-              variables: mergeShorthandVariables(variables, predefinedProps.variables),
+              variables: mergeVariablesOverrides(variables, predefinedProps.variables),
             }),
           })}
 
         {createShorthand(composeOptions.slots.action, action, {
           defaultProps: () => slotProps.action,
           overrideProps: predefinedProps => ({
-            variables: mergeShorthandVariables(variables, predefinedProps.variables),
+            variables: mergeVariablesOverrides(variables, predefinedProps.variables),
           }),
         })}
         {!_.isNil(progress) && <div className="ui-attachment__progress" style={{ width: `${progress}%` }} />}

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -1,6 +1,12 @@
 import { tabListBehavior, Accessibility } from '@fluentui/accessibility';
-import { useTelemetry, getElementType, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
-import { mergeComponentVariables } from '@fluentui/styles';
+import {
+  useTelemetry,
+  mergeVariablesOverrides,
+  getElementType,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+} from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as customPropTypes from '@fluentui/react-proptypes';
@@ -119,7 +125,7 @@ export const CarouselNavigation: React.FC<WithAsProp<CarouselNavigationProps>> &
       _.invoke(props, 'onItemClick', e, itemProps);
       _.invoke(predefinedProps, 'onClick', e, itemProps);
     },
-    variables: mergeComponentVariables(variables, predefinedProps.variables),
+    variables: mergeVariablesOverrides(variables, predefinedProps.variables),
   });
 
   const renderItems = () => {

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -3,6 +3,7 @@ import {
   compose,
   ComponentWithAs,
   getElementType,
+  mergeVariablesOverrides,
   useAccessibility,
   useAutoControlled,
   useStyles,
@@ -12,7 +13,6 @@ import {
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -256,11 +256,11 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
         }
         _.invoke(predefinedProps, 'onActiveChanged', e, props);
       },
-      variables: mergeComponentVariables(variables, predefinedProps.variables),
+      variables: mergeVariablesOverrides(variables, predefinedProps.variables),
     });
 
     const handleDividerOverrides = predefinedProps => ({
-      variables: mergeComponentVariables(variables, predefinedProps.variables),
+      variables: mergeVariablesOverrides(variables, predefinedProps.variables),
     });
 
     const renderItems = () => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -1,9 +1,9 @@
 import { Accessibility, MenuDividerBehaviorProps, menuDividerBehavior } from '@fluentui/accessibility';
-import { mergeComponentVariables } from '@fluentui/styles';
 import {
   compose,
   ComponentWithAs,
   getElementType,
+  mergeVariablesOverrides,
   useAccessibility,
   useTelemetry,
   useStyles,
@@ -108,7 +108,7 @@ const MenuDivider = compose<'li', MenuDividerProps, MenuDividerStylesProps, {}, 
         className,
         design,
         styles,
-        variables: mergeComponentVariables(variables, parentProps.variables),
+        variables: mergeVariablesOverrides(variables, parentProps.variables),
       }),
       rtl: context.rtl,
       unstable_props: props,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -2,6 +2,7 @@ import { Accessibility, submenuBehavior, menuItemBehavior, MenuItemBehaviorProps
 import {
   compose,
   focusAsync,
+  mergeVariablesOverrides,
   useTelemetry,
   useAutoControlled,
   getElementType,
@@ -38,7 +39,6 @@ import { Popper, PopperShorthandProps, getPopperPropsFromShorthand } from '../..
 import { ThemeContext } from 'react-fela';
 import { MenuContext, MenuItemSubscribedValue } from './menuContext';
 import { useContextSelectors } from '@fluentui/react-context-selector';
-import { mergeComponentVariables } from '@fluentui/styles';
 
 export interface MenuItemSlotClassNames {
   submenu: string;
@@ -236,7 +236,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     const slotProps = composeOptions.resolveSlotProps<MenuItemProps & MenuItemState>({
       ...props,
       accessibility,
-      variables: mergeComponentVariables(variables, parentProps.variables),
+      variables: mergeVariablesOverrides(variables, parentProps.variables),
       isFromKeyboard,
       menuOpen,
     });
@@ -282,7 +282,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         className,
         design,
         styles,
-        variables: mergeComponentVariables(parentProps.variables, variables),
+        variables: mergeVariablesOverrides(parentProps.variables, variables),
       }),
       rtl: context.rtl,
       composeOptions,

--- a/packages/fluentui/react-northstar/src/components/Table/Table.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/Table.tsx
@@ -1,5 +1,12 @@
 import { Accessibility, tableBehavior, TableBehaviorProps } from '@fluentui/accessibility';
-import { getElementType, useTelemetry, useUnhandledProps, useAccessibility, useStyles } from '@fluentui/react-bindings';
+import {
+  getElementType,
+  useTelemetry,
+  mergeVariablesOverrides,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+} from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
@@ -11,7 +18,6 @@ import {
   childrenExist,
   createShorthandFactory,
 } from '../../utils';
-import { mergeComponentVariables } from '@fluentui/styles';
 import TableRow, { TableRowProps } from './TableRow';
 import TableCell from './TableCell';
 // @ts-ignore
@@ -48,10 +54,6 @@ export interface TableProps extends UIComponentProps, ChildrenComponentProps {
    */
   compact?: boolean;
 }
-
-const handleVariablesOverrides = variables => predefinedProps => ({
-  variables: mergeComponentVariables(variables, predefinedProps.variables),
-});
 
 export const tableClassName = 'ui-table';
 export const tableSlotClassNames: TableSlotClassNames = {
@@ -90,43 +92,33 @@ export const Table: React.FC<WithAsProp<TableProps>> &
   });
 
   const renderRows = () => {
-    return _.map(rows, (row: TableRowProps, index: number) => {
-      const props = {
-        compact,
-        onClick: (e, props) => {
-          _.invoke(row, 'onClick', e, props);
-        },
-      } as TableRowProps;
-      const overrideProps = handleVariablesOverrides(variables);
+    return _.map(rows, (row: TableRowProps) => {
       return TableRow.create(row, {
         defaultProps: () =>
           getA11yProps('row', {
-            ...props,
+            compact,
+            onClick: (e, props) => {
+              _.invoke(row, 'onClick', e, props);
+            },
           }),
-        overrideProps,
+        overrideProps: predefinedProps => ({
+          variables: mergeVariablesOverrides(variables, predefinedProps.variables),
+        }),
       });
     });
   };
 
   const renderHeader = () => {
-    if (!header) {
-      return null;
-    }
-
-    const headerRowProps = {
-      header: true,
-      compact,
-      className: tableSlotClassNames.header,
-    } as TableRowProps;
-
-    const overrideProps = handleVariablesOverrides(variables);
-
     return TableRow.create(header, {
       defaultProps: () =>
         getA11yProps('row', {
-          ...headerRowProps,
+          header: true,
+          compact,
+          className: tableSlotClassNames.header,
         }),
-      overrideProps,
+      overrideProps: predefinedProps => ({
+        variables: mergeVariablesOverrides(variables, predefinedProps.variables),
+      }),
     });
   };
 

--- a/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/TableRow.tsx
@@ -1,8 +1,14 @@
 import { Accessibility, tableRowBehavior, GridRowBehaviorProps } from '@fluentui/accessibility';
-import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
+import {
+  getElementType,
+  mergeVariablesOverrides,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+  useUnhandledProps,
+} from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
@@ -53,10 +59,6 @@ export interface TableRowProps extends UIComponentProps {
    */
   onClick?: ComponentEventHandler<TableRowProps>;
 }
-
-const handleVariablesOverrides = variables => predefinedProps => ({
-  variables: mergeComponentVariables(variables, predefinedProps.variables),
-});
 
 export const tableRowClassName = 'ui-table__row';
 
@@ -113,13 +115,12 @@ const TableRow: React.FC<WithAsProp<TableRowProps>> & FluentComponentStaticProps
   };
 
   const renderCells = () => {
-    return _.map(items, (item: TableCellProps, index: number) => {
-      const overrideProps = handleVariablesOverrides(variables);
+    return _.map(items, (item: TableCellProps) => {
       return TableCell.create(item, {
-        defaultProps: () =>
-          getA11yProps('cell', {
-            ...overrideProps,
-          }),
+        defaultProps: () => getA11yProps('cell', {}),
+        overrideProps: predefinedProps => ({
+          variables: mergeVariablesOverrides(variables, predefinedProps.variables),
+        }),
       });
     });
   };

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarCustomItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarCustomItem.tsx
@@ -2,12 +2,12 @@ import { Accessibility, IS_FOCUSABLE_ATTRIBUTE } from '@fluentui/accessibility';
 import {
   compose,
   getElementType,
+  mergeVariablesOverrides,
   useUnhandledProps,
   useAccessibility,
   useStyles,
   useTelemetry,
 } from '@fluentui/react-bindings';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -81,7 +81,7 @@ const ToolbarCustomItem = compose<'div', ToolbarCustomItemProps, ToolbarCustomIt
         className,
         design,
         styles,
-        variables: mergeComponentVariables(parentVariables, variables),
+        variables: mergeVariablesOverrides(parentVariables, variables),
       }),
       rtl: context.rtl,
       unstable_props: props,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarDivider.tsx
@@ -1,13 +1,13 @@
 import { Accessibility } from '@fluentui/accessibility';
 import {
   getElementType,
+  mergeVariablesOverrides,
   useUnhandledProps,
   useAccessibility,
   useStyles,
   useTelemetry,
   compose,
 } from '@fluentui/react-bindings';
-import { mergeComponentVariables } from '@fluentui/styles';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 import * as React from 'react';
@@ -48,7 +48,7 @@ const ToolbarDivider = compose<'div', ToolbarDividerProps, ToolbarDividerStylesP
         className,
         design,
         styles,
-        variables: mergeComponentVariables(parentVariables, variables),
+        variables: mergeVariablesOverrides(parentVariables, variables),
       }),
       rtl: context.rtl,
       composeOptions,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -2,6 +2,7 @@ import { Accessibility, toolbarItemBehavior, ToolbarItemBehaviorProps } from '@f
 import {
   compose,
   getElementType,
+  mergeVariablesOverrides,
   useUnhandledProps,
   useAccessibility,
   useStyles,
@@ -11,7 +12,6 @@ import { handleRef, Ref } from '@fluentui/react-component-ref';
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -140,7 +140,7 @@ const ToolbarItem = compose<'button', ToolbarItemProps, ToolbarItemStylesProps, 
     const menuRef = React.useRef<HTMLElement>();
 
     const parentVariables = React.useContext(ToolbarVariablesContext);
-    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
 
     const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -4,9 +4,15 @@ import {
   toolbarMenuItemCheckboxBehavior,
   ToolbarMenuBehaviorProps,
 } from '@fluentui/accessibility';
-import { getElementType, useUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
+import {
+  getElementType,
+  mergeVariablesOverrides,
+  useUnhandledProps,
+  useAccessibility,
+  useStyles,
+  useTelemetry,
+} from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -82,7 +88,7 @@ const ToolbarMenu: React.FC<WithAsProp<ToolbarMenuProps>> & FluentComponentStati
   const { accessibility, className, children, design, items, submenu, submenuIndicator, styles, variables } = props;
 
   const parentVariables = React.useContext(ToolbarVariablesContext);
-  const mergedVariables = mergeComponentVariables(parentVariables, variables);
+  const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
 
   const getA11yProps = useAccessibility(accessibility, {
     debugName: ToolbarMenu.displayName,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuDivider.tsx
@@ -1,6 +1,7 @@
 import { Accessibility } from '@fluentui/accessibility';
 import {
   getElementType,
+  mergeVariablesOverrides,
   useUnhandledProps,
   useAccessibility,
   useStyles,
@@ -8,7 +9,6 @@ import {
   compose,
   ComponentWithAs,
 } from '@fluentui/react-bindings';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
@@ -50,7 +50,7 @@ const ToolbarMenuDivider = compose<'li', ToolbarMenuDividerProps, ToolbarMenuDiv
         className,
         design,
         styles,
-        variables: mergeComponentVariables(parentVariables, variables),
+        variables: mergeVariablesOverrides(parentVariables, variables),
       }),
       rtl: context.rtl,
       unstable_props: props,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -15,6 +15,7 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import {
   compose,
   focusAsync,
+  mergeVariablesOverrides,
   useTelemetry,
   useStyles,
   useAutoControlled,
@@ -22,7 +23,6 @@ import {
   useUnhandledProps,
   useAccessibility,
 } from '@fluentui/react-bindings';
-import { mergeComponentVariables } from '@fluentui/styles';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 import { GetRefs, NodeRef, Unstable_NestingAuto } from '@fluentui/react-component-nesting-registry';
@@ -162,7 +162,7 @@ const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMenuItemS
     const menuRef = React.useRef<HTMLElement>();
 
     const parentVariables = React.useContext(ToolbarVariablesContext);
-    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
 
     const ElementType = getElementType(props);
     const slotProps = composeOptions.resolveSlotProps<ToolbarMenuItemProps>(props);

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -4,9 +4,9 @@ import {
   toolbarMenuItemRadioBehavior,
   ToolbarMenuRadioGroupBehaviorProps,
 } from '@fluentui/accessibility';
-import { mergeComponentVariables } from '@fluentui/styles';
 import {
   compose,
+  mergeVariablesOverrides,
   getElementType,
   useUnhandledProps,
   useAccessibility,
@@ -73,7 +73,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
 
     const slotProps = composeOptions.resolveSlotProps<ToolbarMenuRadioGroupProps>(props);
     const parentVariables = React.useContext(ToolbarVariablesContext);
-    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
 
     const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarRadioGroup.tsx
@@ -7,6 +7,7 @@ import {
 import {
   compose,
   getElementType,
+  mergeVariablesOverrides,
   useUnhandledProps,
   useAccessibility,
   useStyles,
@@ -14,7 +15,6 @@ import {
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { mergeComponentVariables } from '@fluentui/styles';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
@@ -73,7 +73,7 @@ const ToolbarRadioGroup = compose<'div', ToolbarRadioGroupProps, ToolbarRadioGro
 
     const slotProps = composeOptions.resolveSlotProps(props);
     const parentVariables = React.useContext(ToolbarVariablesContext);
-    const mergedVariables = mergeComponentVariables(parentVariables, variables);
+    const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
 
     const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fixes an issues that we have found with improved telemetry, see https://github.com/microsoft/fluentui/pull/13346#issuecomment-635210963.

This PR introduces `mergeVariablesOverrides()` which we already uses in `Attachment` to avoid creation of variables functions even if there is no overrides as that breaks caching.

#### Focus areas to test

(optional)
