### PR TITLE
Fix missing themable token for Tile border color

### DIFF
--- a/change/@uifabric-experiments-2020-05-27-20-59-38-tile-border.json
+++ b/change/@uifabric-experiments-2020-05-27-20-59-38-tile-border.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Tile border color declarations so they don't get elided",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-05-28T03:59:38.456Z"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -82,7 +82,8 @@
       bottom: 0;
       right: 0;
       pointer-events: none;
-      border: 2px solid $ms-color-white;
+      border: 2px solid;
+      border-color: $ms-color-white;
     }
   }
 
@@ -159,7 +160,8 @@
       bottom: 0;
       right: 0;
       pointer-events: none;
-      border: 2px solid $ms-color-white;
+      border: 2px solid;
+      border-color: $ms-color-white;
     }
   }
 }


### PR DESCRIPTION
The `Tile.scss` module exported by `@uifabric/experiments` contained CSS rules like `""border:2px solid "`, missing the value for `$ms-color-white`. This change moves the color rule to a separate `border-color` assignment.