### PR TITLE
Fix update release notes author name

### DIFF
--- a/scripts/beachball/customRenderers.ts
+++ b/scripts/beachball/customRenderers.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import { PackageChangelogRenderInfo, ChangelogEntry } from 'beachball';
 import { getPullRequestForCommit, fluentRepoDetails } from '../github';
 

--- a/scripts/beachball/customRenderers.ts
+++ b/scripts/beachball/customRenderers.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import { PackageChangelogRenderInfo, ChangelogEntry } from 'beachball';
 import { getPullRequestForCommit, fluentRepoDetails } from '../github';
 
@@ -8,7 +8,7 @@ if (!githubPAT && (process.argv.includes('bump') || process.argv.includes('publi
   console.warn('\nGITHUB_PAT environment variable not found. GitHub requests may be rate-limited.\n');
 }
 
-const github = new GitHubApi({
+const github = new Octokit({
   ...fluentRepoDetails,
   ...(githubPAT && { auth: 'token ' + githubPAT }),
 });

--- a/scripts/github/pullRequests.ts
+++ b/scripts/github/pullRequests.ts
@@ -1,8 +1,8 @@
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import { IPullRequest, IRepoDetails } from './types';
 
 export interface IGetPullRequestFromCommitParams {
-  github: GitHubApi;
+  github: Octokit;
   repoDetails: IRepoDetails;
   /** Commit hash */
   commit: string;
@@ -54,8 +54,8 @@ export async function getPullRequestForCommit(
  */
 export function processPullRequestApiResponse(
   pr:
-    | GitHubApi.ReposListPullRequestsAssociatedWithCommitResponseItem
-    | GitHubApi.SearchIssuesAndPullRequestsResponseItemsItem,
+    | Octokit.ReposListPullRequestsAssociatedWithCommitResponseItem
+    | Octokit.SearchIssuesAndPullRequestsResponseItemsItem,
   authorEmail?: string,
 ): IPullRequest {
   return {

--- a/scripts/github/pullRequests.ts
+++ b/scripts/github/pullRequests.ts
@@ -1,4 +1,4 @@
-import * as GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import { IPullRequest, IRepoDetails } from './types';
 
 export interface IGetPullRequestFromCommitParams {
@@ -53,7 +53,9 @@ export async function getPullRequestForCommit(
  * The `author.email` property is only present if `authorEmail` is provided.
  */
 export function processPullRequestApiResponse(
-  pr: GitHubApi.ReposListPullRequestsAssociatedWithCommitResponseItem | GitHubApi.PullsGetResponse,
+  pr:
+    | GitHubApi.ReposListPullRequestsAssociatedWithCommitResponseItem
+    | GitHubApi.SearchIssuesAndPullRequestsResponseItemsItem,
   authorEmail?: string,
 ): IPullRequest {
   return {

--- a/scripts/updateReleaseNotes/index.ts
+++ b/scripts/updateReleaseNotes/index.ts
@@ -4,7 +4,7 @@
  * given tag.
  */
 
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import { argv, repoDetails, github } from './init';
 import { getTagToChangelogMap, getTags } from './changelogsAndTags';
 import { getReleases } from './releases';
@@ -49,7 +49,7 @@ async function updateReleaseNotes() {
     console.log(`${hasBeenReleased ? 'Patching' : 'Creating'} release notes for ${entryInfo}...\n`);
     count++;
 
-    const releaseDetails: Partial<GitHubApi.ReposUpdateReleaseParams> = {
+    const releaseDetails: Partial<Octokit.ReposUpdateReleaseParams> = {
       ...repoDetails,
       tag_name: entry.tag,
       name: `${entry.name} v${entry.version}`,
@@ -64,9 +64,9 @@ async function updateReleaseNotes() {
     if (argv.apply) {
       try {
         if (hasBeenReleased) {
-          await github.repos.updateRelease(releaseDetails as GitHubApi.ReposUpdateReleaseParams);
+          await github.repos.updateRelease(releaseDetails as Octokit.ReposUpdateReleaseParams);
         } else {
-          await github.repos.createRelease(releaseDetails as GitHubApi.ReposCreateReleaseParams);
+          await github.repos.createRelease(releaseDetails as Octokit.ReposCreateReleaseParams);
         }
         console.log(`Successfully ${hasBeenReleased ? 'updated' : 'created'} release notes for ${entryInfo}`);
       } catch (err) {

--- a/scripts/updateReleaseNotes/index.ts
+++ b/scripts/updateReleaseNotes/index.ts
@@ -4,7 +4,7 @@
  * given tag.
  */
 
-import * as GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import { argv, repoDetails, github } from './init';
 import { getTagToChangelogMap, getTags } from './changelogsAndTags';
 import { getReleases } from './releases';

--- a/scripts/updateReleaseNotes/init.ts
+++ b/scripts/updateReleaseNotes/init.ts
@@ -1,4 +1,4 @@
-import GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import * as yargs from 'yargs';
 import { fluentRepoDetails } from '../github/index';
 

--- a/scripts/updateReleaseNotes/init.ts
+++ b/scripts/updateReleaseNotes/init.ts
@@ -1,4 +1,4 @@
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import * as yargs from 'yargs';
 import { fluentRepoDetails } from '../github/index';
 
@@ -48,7 +48,7 @@ export const repoDetails = {
 };
 
 // Authenticate with github and set up logging if debug arg is provided
-export const github = new GitHubApi({
+export const github = new Octokit({
   ...(argv.debug && { log: console }),
   auth: 'token ' + argv.token,
 });

--- a/scripts/updateReleaseNotes/markdown.ts
+++ b/scripts/updateReleaseNotes/markdown.ts
@@ -32,7 +32,7 @@ async function _getChangeComments(title: string, comments: ChangelogEntry[] | un
         // Prefer linking to the PR if we can find it (this is generally more useful than the commit)
         const pr = await getPullRequest(comment);
         if (pr) {
-          line += `PR #${pr.number} by [${pr.author}](${pr.author.url})`;
+          line += `PR #${pr.number} by [${pr.author.username}](${pr.author.url})`;
         } else {
           line += `[commit](https://github.com/${repoDetails.owner}/${repoDetails.repo}/commit/${comment.commit})`;
         }

--- a/scripts/updateReleaseNotes/pullRequests.ts
+++ b/scripts/updateReleaseNotes/pullRequests.ts
@@ -1,4 +1,4 @@
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import { ChangelogEntry } from 'beachball';
 import { IPullRequest, processPullRequestApiResponse, getPullRequestForCommit } from '../github/index';
 import { repoDetails, github } from './init';
@@ -93,7 +93,7 @@ async function getRecentPrsByAuthor(
       // Get the author's 10 most recently updated merged PRs
       console.log(`Getting ${count} most recent PRs by ${authorUsername}...`);
       // (this is not quite the right type, since merge_commit_sha doesn't exist on the real response)
-      const result: GitHubApi.SearchIssuesAndPullRequestsResponseItemsItem[] = (
+      const result: Octokit.SearchIssuesAndPullRequestsResponseItemsItem[] = (
         await github.search.issuesAndPullRequests({
           q: [
             'type:pr',

--- a/scripts/updateReleaseNotes/pullRequests.ts
+++ b/scripts/updateReleaseNotes/pullRequests.ts
@@ -1,4 +1,4 @@
-import * as GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import { ChangelogEntry } from 'beachball';
 import { IPullRequest, processPullRequestApiResponse, getPullRequestForCommit } from '../github/index';
 import { repoDetails, github } from './init';
@@ -93,7 +93,7 @@ async function getRecentPrsByAuthor(
       // Get the author's 10 most recently updated merged PRs
       console.log(`Getting ${count} most recent PRs by ${authorUsername}...`);
       // (this is not quite the right type, since merge_commit_sha doesn't exist on the real response)
-      const result: GitHubApi.PullsGetResponse[] = (
+      const result: GitHubApi.SearchIssuesAndPullRequestsResponseItemsItem[] = (
         await github.search.issuesAndPullRequests({
           q: [
             'type:pr',

--- a/scripts/updateReleaseNotes/releases.ts
+++ b/scripts/updateReleaseNotes/releases.ts
@@ -1,4 +1,4 @@
-import * as GitHubApi from '@octokit/rest';
+import { Octokit as GitHubApi } from '@octokit/rest';
 import { repoDetails, github } from './init';
 import { IRelease } from './types';
 

--- a/scripts/updateReleaseNotes/releases.ts
+++ b/scripts/updateReleaseNotes/releases.ts
@@ -1,4 +1,4 @@
-import { Octokit as GitHubApi } from '@octokit/rest';
+import { Octokit } from '@octokit/rest';
 import { repoDetails, github } from './init';
 import { IRelease } from './types';
 
@@ -32,7 +32,7 @@ export async function getReleases(tags?: string[]): Promise<Map<string, IRelease
     // Get all the releases
     console.log('Getting all releases...');
     try {
-      const res: GitHubApi.ReposListReleasesResponseItem[] = await github.paginate(
+      const res: Octokit.ReposListReleasesResponseItem[] = await github.paginate(
         github.repos.listReleases.endpoint.merge(repoDetails),
       );
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13376

#### Description of changes

The update release notes script was generating descriptions like:
`Add autoCapitalize property (PR #13335 by [object Object])`

Fix that and also get rid of the warning `[@octokit/rest] const Octokit = require("@octokit/rest") is deprecated. Use const { Octokit } = require("@octokit/rest") instead` that was showing up when running `yarn change`.

(I already ran the script to fix the existing release notes from the past 50 days when this was broken.)