### PR TITLE
Fix second builds of just-based projects in packages/fluentui

### DIFF
--- a/scripts/tasks/clean.js
+++ b/scripts/tasks/clean.js
@@ -13,5 +13,7 @@ exports.clean = cleanTask(
     'lib-es2015', // Keep this in clean for actually cleaning up legacy content.
     'coverage',
     'src/**/*.scss.ts',
+    '*.tsbuildinfo',
+    '.*.tsbuildinfo', // glob excludes dotfiles by default
   ].map(p => path.join(process.cwd(), p)),
 );

--- a/scripts/tasks/clean.js
+++ b/scripts/tasks/clean.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const { cleanTask } = require('just-scripts');
+const glob = require('glob');
 
 exports.clean = cleanTask(
   [
@@ -13,7 +14,6 @@ exports.clean = cleanTask(
     'lib-es2015', // Keep this in clean for actually cleaning up legacy content.
     'coverage',
     'src/**/*.scss.ts',
-    '*.tsbuildinfo',
-    '.*.tsbuildinfo', // glob excludes dotfiles by default
+    ...glob.sync(path.join(process.cwd(), '*.tsbuildinfo'), { dot: true }),
   ].map(p => path.join(process.cwd(), p)),
 );

--- a/scripts/tasks/clean.js
+++ b/scripts/tasks/clean.js
@@ -14,6 +14,6 @@ exports.clean = cleanTask(
     'lib-es2015', // Keep this in clean for actually cleaning up legacy content.
     'coverage',
     'src/**/*.scss.ts',
-    ...glob.sync(path.join(process.cwd(), '*.tsbuildinfo'), { dot: true }),
+    ...glob.sync('*.tsbuildinfo', { dot: true }),
   ].map(p => path.join(process.cwd(), p)),
 );

--- a/scripts/tasks/ts.js
+++ b/scripts/tasks/ts.js
@@ -28,12 +28,8 @@ module.exports.ts = {
   },
   esm: () => {
     const extraOptions = getExtraTscParams(argv());
-    return tscTask({
-      ...extraOptions,
-      outDir: 'lib',
-      module: 'esnext',
-      ...(useTsBuildInfo && { tsBuildInfoFile: '.tsbuildinfo' }),
-    });
+    // Use default tsbuildinfo for this variant
+    return tscTask({ ...extraOptions, outDir: 'lib', module: 'esnext' });
   },
   amd: () => {
     const extraOptions = getExtraTscParams(argv());
@@ -46,6 +42,7 @@ module.exports.ts = {
   },
   commonjsOnly: () => {
     const extraOptions = getExtraTscParams(argv());
+    // Use default tsbuildinfo for this variant (since it's the only variant)
     return tscTask({ ...extraOptions, outDir: 'lib', module: 'commonjs' });
   },
 };


### PR DESCRIPTION
Fix configuration issue from #13363 (use the default tsbuildinfo filename for the esnext build) and add tsbuildinfo files to the clean script. These together were breaking builds if the repo was in a "dirty" state.