### PR TITLE
Add decorator for wrapping ThemeProvider in react-next storybook

### DIFF
--- a/apps/perf-test/src/scenarios/ThemeProvider.tsx
+++ b/apps/perf-test/src/scenarios/ThemeProvider.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { ThemeProvider } from '@fluentui/react-next';
+
+const scenario = <ThemeProvider />;
+
+export default scenario;

--- a/change/@fluentui-react-next-2020-05-28-17-34-15-xgao-next-perf.json
+++ b/change/@fluentui-react-next-2020-05-28-17-34-15-xgao-next-perf.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add decorator for wrapping ThemeProvider in storybook",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-05-29T00:34:15.221Z"
+}

--- a/packages/react-next/.storybook/decorators/ThemeProvider.js
+++ b/packages/react-next/.storybook/decorators/ThemeProvider.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ThemeProvider } from '@fluentui/react-next';
+import { useCustomizationOptions } from '../knobs/theme';
+
+export const ThemeProviderDecorator = storyFn => {
+  const customizationOptions = useCustomizationOptions();
+  const { customizations, isDark } = customizationOptions;
+  const themeProviderProps = {
+    theme: customizations ? { tokens: customizations.settings.theme } : undefined,
+    style: {
+      background: isDark ? 'black' : undefined,
+    },
+  };
+
+  return <ThemeProvider {...themeProviderProps}>{storyFn()}</ThemeProvider>;
+};

--- a/packages/react-next/.storybook/decorators/withThemeProvider.js
+++ b/packages/react-next/.storybook/decorators/withThemeProvider.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { ThemeProvider } from '@fluentui/react-next';
 import { useCustomizationOptions } from '../knobs/theme';
 
-export const ThemeProviderDecorator = storyFn => {
+export const withThemeProvider = storyFn => {
   const customizationOptions = useCustomizationOptions();
   const { customizations, isDark } = customizationOptions;
   const themeProviderProps = {

--- a/packages/react-next/.storybook/preview.js
+++ b/packages/react-next/.storybook/preview.js
@@ -7,10 +7,12 @@ import { withPerformance } from 'storybook-addon-performance';
 import { withKnobs } from '@storybook/addon-knobs';
 import { useCustomizationOptions } from './knobs/theme';
 import { ThemeProvider } from '@fluentui/react-next';
+import { ThemeProviderDecorator } from './decorators/ThemeProvider';
 
 addDecorator(withA11y());
 addDecorator(withPerformance);
 addDecorator(withKnobs({ escapeHTML: false }));
+addDecorator(ThemeProviderDecorator);
 addParameters({
   a11y: {
     manual: true,
@@ -33,21 +35,7 @@ function loadStories() {
     Object.keys(story).forEach(exampleName => {
       const example = story[exampleName];
       if (typeof example === 'function') {
-        story[exampleName] = () => {
-          const customizationOptions = useCustomizationOptions();
-          const { customizations, isDark } = customizationOptions;
-          const themeProviderProps = {
-            theme: customizations ? { tokens: customizations.settings.theme } : undefined,
-            style: {
-              background: isDark ? 'black' : undefined,
-            },
-          };
-
-          return React.createElement(ThemeProvider, {
-            ...themeProviderProps,
-            children: example(),
-          });
-        };
+        story[exampleName] = () => example();
       }
     });
   }

--- a/packages/react-next/.storybook/preview.js
+++ b/packages/react-next/.storybook/preview.js
@@ -1,18 +1,15 @@
-import React from 'react';
 import { initializeIcons } from '@uifabric/icons';
 import generateStoriesFromExamples from '@uifabric/build/storybook/generateStoriesFromExamples';
 import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { withPerformance } from 'storybook-addon-performance';
 import { withKnobs } from '@storybook/addon-knobs';
-import { useCustomizationOptions } from './knobs/theme';
-import { ThemeProvider } from '@fluentui/react-next';
-import { ThemeProviderDecorator } from './decorators/ThemeProvider';
+import { withThemeProvider } from './decorators/withThemeProvider';
 
 addDecorator(withA11y());
 addDecorator(withPerformance);
 addDecorator(withKnobs({ escapeHTML: false }));
-addDecorator(ThemeProviderDecorator);
+addDecorator(withThemeProvider);
 addParameters({
   a11y: {
     manual: true,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
move ThemeProvider in `react-next` storybook as a decorator.
It will still be wrapping all stories by default but won't be counted as part of the perf addon cost.

Also adding a perf-test for ThemeProvider component.

#### Focus areas to test

(optional)
