### PR TITLE
chore: add mode to perf tests

### DIFF
--- a/packages/fluentui/perf/src/index.tsx
+++ b/packages/fluentui/perf/src/index.tsx
@@ -18,7 +18,7 @@ const performanceExamplesContext = require.context('@fluentui/docs/src/examples/
 // We want to randomize examples to avoid any notable issues with always first example
 const performanceExampleNames: string[] = _.shuffle(performanceExamplesContext.keys());
 
-const asyncRender = (element: React.ReactElement<any>, container: Element) =>
+const asyncRender = (element: React.ReactElement, container: Element) =>
   new Promise(resolve => {
     ReactDOM.render(element, container, () => {
       ReactDOM.unmountComponentAtNode(container);
@@ -43,7 +43,7 @@ const renderCycle = async (
             _.values(telemetryRef.current.performance),
             (acc, next) => {
               return {
-                componentCount: acc.componentCount + next.count,
+                componentCount: acc.componentCount + next.instances,
                 renderComponentTime: acc.renderComponentTime + next.msTotal,
               };
             },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `mode` setting to v0 perf tests to better understand caching effect as it runs test suites on the same page.

#### Focus areas to test

(optional)
