### PR TITLE
Update styling package sideEffects to only the ones needed

### DIFF
--- a/change/@uifabric-styling-2020-06-01-10-15-03-xgao-bundle.json
+++ b/change/@uifabric-styling-2020-06-01-10-15-03-xgao-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update styling package sideEffects to only the ones needed",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-01T17:15:03.722Z"
+}

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -9,7 +9,10 @@
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "sideEffects": true,
+  "sideEffects": [
+    "lib/version.js",
+    "lib/styles/theme.js"
+  ],
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "just-scripts build",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
This change is to reduce unneeded bundle size. 
`sideEffects` that we need is [code that registers fonts](https://github.com/microsoft/fluentui/blob/master/packages/styling/src/styles/DefaultFontStyles.ts) and [initialize default theme in Customizations](https://github.com/microsoft/fluentui/blob/master/packages/styling/src/styles/theme.ts)

Since `theme.js` imports `DefaultFontStyles`, the only file we need to have in the `sideEffects` list is `theme.js` file.

#### Focus areas to test
Tested importing and using single component still has default theme with updated `sideEffects` in styling package
