### PR TITLE
Fixing prototype pollution vulnerability 

### DIFF
--- a/change/@uifabric-utilities-2020-06-01-15-34-02-proto-fix.json
+++ b/change/@uifabric-utilities-2020-06-01-15-34-02-proto-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed prototype pollution vulnerability.",
+  "packageName": "@uifabric/utilities",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-01T21:34:02.662Z"
+}

--- a/packages/fluentui/styles/src/deepmerge.ts
+++ b/packages/fluentui/styles/src/deepmerge.ts
@@ -1,4 +1,5 @@
 const isObject = o => o !== null && typeof o === 'object' && !Array.isArray(o);
+const isValid = k => k !== '__proto__' && k !== 'prototype' && k !== 'constructor';
 
 // Heads Up!
 // Changes here need to consider breaking all object references.
@@ -6,14 +7,16 @@ const isObject = o => o !== null && typeof o === 'object' && !Array.isArray(o);
 const deepmerge = (...sources) => {
   const inner = (target, source) => {
     Object.keys(source).forEach(k => {
-      if (isObject(source[k])) {
-        if (!isObject(target[k])) {
-          target[k] = {};
-        }
+      if (isValid(k)) {
+        if (isObject(source[k])) {
+          if (!isObject(target[k])) {
+            target[k] = {};
+          }
 
-        inner(target[k], source[k]);
-      } else {
-        target[k] = source[k]; // TODO: do deep clone for arrays? We currently do not have any deep arrays in variables
+          inner(target[k], source[k]);
+        } else {
+          target[k] = source[k]; // TODO: do deep clone for arrays? We currently do not have any deep arrays in variables
+        }
       }
     });
     return target;

--- a/packages/fluentui/styles/test/deepmerge-test.ts
+++ b/packages/fluentui/styles/test/deepmerge-test.ts
@@ -151,4 +151,32 @@ describe('deepmerge', () => {
       dd: 'bbS3',
     });
   });
+
+  it('can handle prototype pollution', () => {
+    const obj1 = {
+      __proto__: { payload: 'malicious value' },
+      constructor: { foo: 'malicious value' },
+    };
+    // used to check it keeps other properties
+    const obj2 = {
+      __proto__: { payload: 'malicious value' },
+      prototype: { payload: 'malicious value' },
+      constructor: { foo: 'malicious value' },
+      foo: { bar: 'baz' },
+    };
+    // used to check deep cycles
+    const obj3 = {
+      __proto__: { payload: 'malicious value' },
+      constructor: { foo: 'malicious value' },
+      a: { b: 'baz', __proto__: { payload: 'malicious value' } },
+    };
+
+    expect(deepmerge({}, obj1)).toEqual({});
+    expect(deepmerge({}, obj2)).toEqual({ foo: { bar: 'baz' } });
+    expect(deepmerge({}, obj1, obj2)).toEqual({ foo: { bar: 'baz' } });
+    expect(deepmerge(obj1, obj2, obj3)).toEqual({
+      a: { b: 'baz' },
+      foo: { bar: 'baz' },
+    });
+  });
 });

--- a/packages/utilities/src/merge.ts
+++ b/packages/utilities/src/merge.ts
@@ -23,14 +23,16 @@ function _merge<T extends Object>(target: T, source: T, circularReferences: any[
 
   for (let name in source) {
     if (source.hasOwnProperty(name)) {
-      const value: T[Extract<keyof T, string>] = source[name];
-      if (typeof value === 'object' && value !== null) {
-        const isCircularReference = circularReferences.indexOf(value) > -1;
-        target[name] = (isCircularReference
-          ? value
-          : _merge(target[name] || {}, value, circularReferences)) as T[Extract<keyof T, string>];
-      } else {
-        target[name] = value;
+      if (name !== '__proto__' && name !== 'constructor' && name !== 'prototype') {
+        const value: T[Extract<keyof T, string>] = source[name];
+        if (typeof value === 'object' && value !== null) {
+          const isCircularReference = circularReferences.indexOf(value) > -1;
+          target[name] = (isCircularReference
+            ? value
+            : _merge(target[name] || {}, value, circularReferences)) as T[Extract<keyof T, string>];
+        } else {
+          target[name] = value;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes the prototype pollution vulnerability. Here is a little more context on how the vulnerability works: https://snyk.io/vuln/SNYK-JS-ASSIGNDEEP-450211. There are two packages that are affected and are fixed by adding a check for '__proto__', 'prototype', and 'constructor' properties. If an object to be merged has one of the three properties, they will be skipped and the other properties will be merged.

