### PR TITLE
Pivot: Replace onKeyPress with onKeyDown and ariaLabel with aria-label

### DIFF
--- a/change/@fluentui-react-next-2020-06-02-18-46-31-pivot-onkeydown.json
+++ b/change/@fluentui-react-next-2020-06-02-18-46-31-pivot-onkeydown.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Pivot: replace onKeyPress with onKeyDown and ariaLabel with aria-label",
+  "packageName": "@fluentui/react-next",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-02T22:46:31.509Z"
+}

--- a/change/office-ui-fabric-react-2020-06-03-11-01-43-pivot-onkeydown.json
+++ b/change/office-ui-fabric-react-2020-06-03-11-01-43-pivot-onkeydown.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Pivot: replace onKeyPress with onKeyDown and ariaLabel with aria-label",
+  "packageName": "office-ui-fabric-react",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-03T15:01:43.427Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -180,8 +180,8 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
         key={itemKey}
         className={isSelected ? this._classNames.linkIsSelected : this._classNames.link}
         onClick={this._onLinkClick.bind(this, itemKey)}
-        onKeyPress={this._onKeyPress.bind(this, itemKey)}
-        ariaLabel={link.ariaLabel}
+        onKeyDown={this._onKeyDown.bind(this, itemKey)}
+        aria-label={link.ariaLabel}
         role="tab"
         aria-selected={isSelected}
         name={link.headerText}
@@ -299,9 +299,9 @@ export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   }
 
   /**
-   * Handle the onKeyPress event on the PivotLinks
+   * Handle the onKeyDown event on the PivotLinks
    */
-  private _onKeyPress(itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void {
+  private _onKeyDown(itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void {
     if (ev.which === KeyCodes.enter) {
       ev.preventDefault();
       this._updateSelectedItem(itemKey);

--- a/packages/react-next/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.base.tsx
@@ -106,7 +106,7 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
       );
     };
 
-    const onKeyPress = (itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void => {
+    const onKeyDown = (itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void => {
       if (ev.which === KeyCodes.enter) {
         ev.preventDefault();
         updateSelectedItem(itemKey);
@@ -138,8 +138,8 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
           key={itemKey}
           className={css(classNames.link, isSelected && classNames.linkIsSelected)}
           onClick={onLinkClick.bind(this, itemKey)}
-          onKeyPress={onKeyPress.bind(this, itemKey)}
-          ariaLabel={link.ariaLabel}
+          onKeyDown={onKeyDown.bind(this, itemKey)}
+          aria-label={link.ariaLabel}
           role="tab"
           aria-selected={isSelected}
           name={link.headerText}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13429
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixing PR feedback from @jurokapsiar on #13370:
* Replace the onKeyPress handler with onKeyDown
* Replace `ariaLabel` with `aria-label`

#### Focus areas to test

I've locally tested these affected scenarios
* Using the Enter key to switch tabs
* Setting ariaLabel on PivotItem
