### PR TITLE
Add 'onGrowData' to Breadcrumb

### DIFF
--- a/change/office-ui-fabric-react-2020-06-02-21-54-20-breadcrumb-grow.json
+++ b/change/office-ui-fabric-react-2020-06-02-21-54-20-breadcrumb-grow.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add onGrowData to Breadcrumb",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-03T04:54:20.794Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1810,6 +1810,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     focusZoneProps?: IFocusZoneProps;
     items: IBreadcrumbItem[];
     maxDisplayedItems?: number;
+    onGrowData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
     onReduceData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
     onRenderItem?: IRenderFunction<IBreadcrumbItem>;
     onRenderOverflowIcon?: IRenderFunction<IButtonProps>;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -81,6 +81,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
 
     const {
       onReduceData = this._onReduceData,
+      onGrowData = this._onGrowData,
       overflowIndex,
       maxDisplayedItems,
       items,
@@ -101,22 +102,56 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       theme: theme!,
     });
 
-    return <ResizeGroup onRenderData={this._onRenderBreadcrumb} onReduceData={onReduceData} data={breadcrumbData} />;
+    return (
+      <ResizeGroup
+        onRenderData={this._onRenderBreadcrumb}
+        onReduceData={onReduceData}
+        onGrowData={onGrowData}
+        data={breadcrumbData}
+      />
+    );
   }
 
+  /**
+   * Remove the first rendered item past the overlow point and put it and the end the overflow set.
+   */
   private _onReduceData = (data: IBreadcrumbData): IBreadcrumbData | undefined => {
     let { renderedItems, renderedOverflowItems } = data;
     const { overflowIndex } = data.props;
 
     const movedItem = renderedItems[overflowIndex!];
+
+    if (!movedItem) {
+      return undefined;
+    }
+
     renderedItems = [...renderedItems];
     renderedItems.splice(overflowIndex!, 1);
 
     renderedOverflowItems = [...renderedOverflowItems, movedItem];
 
-    if (movedItem !== undefined) {
-      return { ...data, renderedItems, renderedOverflowItems };
+    return { ...data, renderedItems, renderedOverflowItems };
+  };
+
+  /**
+   * Remove the last item of the overflow set and insert the item as the start of the rendered set past the overflow
+   * point.
+   */
+  private _onGrowData = (data: IBreadcrumbData): IBreadcrumbData | undefined => {
+    let { renderedItems, renderedOverflowItems } = data;
+    const { overflowIndex, maxDisplayedItems } = data.props;
+
+    renderedOverflowItems = [...renderedOverflowItems];
+    const movedItem = renderedOverflowItems.pop();
+
+    if (!movedItem || renderedItems.length >= maxDisplayedItems!) {
+      return undefined;
     }
+
+    renderedItems = [...renderedItems];
+    renderedItems.splice(overflowIndex!, 0, movedItem);
+
+    return { ...data, renderedItems, renderedOverflowItems };
   };
 
   private _onRenderBreadcrumb = (data: IBreadcrumbData) => {

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -70,6 +70,12 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   onReduceData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
 
   /**
+   * Method that determines how to group the length of the breadcrumb.
+   * Return undefined to never increase breadcrumb length.
+   */
+  onGrowData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
+
+  /**
    * Aria label for the root element of the breadcrumb (which is a navigation landmark).
    */
   ariaLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -14,7 +14,13 @@ const items: IBreadcrumbItem[] = [
   { text: 'Folder 2', key: 'f2', onClick: _onBreadcrumbItemClicked },
   { text: 'Folder 3', key: 'f3', onClick: _onBreadcrumbItemClicked },
   { text: 'Folder 4 (non-clickable)', key: 'f4' },
-  { text: 'Folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true },
+  { text: 'Folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 6', key: 'f6', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 7', key: 'f7', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 8', key: 'f8', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 9', key: 'f9', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 10', key: 'f10', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 11', key: 'f11', onClick: _onBreadcrumbItemClicked, isCurrentItem: true },
 ];
 const itemsWithHref: IBreadcrumbItem[] = [
   // Normally each breadcrumb would have a unique href, but to make the navigation less disruptive
@@ -40,7 +46,7 @@ export const BreadcrumbBasicExample: React.FunctionComponent = () => {
       <Label styles={labelStyles}>With items rendered as buttons</Label>
       <Breadcrumb
         items={items}
-        maxDisplayedItems={3}
+        maxDisplayedItems={10}
         ariaLabel="Breadcrumb with items rendered as buttons"
         overflowAriaLabel="More links"
       />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -416,6 +416,167 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
+                    Folder 2
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
                     Folder 3
                   </div>
                 </button>
@@ -507,6 +668,972 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     Folder 4 (non-clickable)
                   </div>
                 </span>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 5
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 6
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 7
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 8
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 9
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Folder 10
+                  </div>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -666,7 +1793,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 5
+                    Folder 11
                   </div>
                 </button>
               </li>
@@ -746,7 +1873,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone7"
+            data-focuszone-id="FocusZone14"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -1386,7 +2513,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone14"
+            data-focuszone-id="FocusZone21"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -1865,7 +2992,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone18"
+            data-focuszone-id="FocusZone25"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}


### PR DESCRIPTION
There are edge cases when rendering a `Breadcrumb` in which the crumbs fully-collapse and never expand back to fill the available content width. This is due to the fact that `Breadcrumb` does not supply `onGrowData` to `ResizeGroup`, and thus has no way to incrementally expand back into its container.

This change implements `onGrowData` to implement the reverse behavior as `onReduceData`: as `ResizeGroup` asks for larger content, each overflowed item is removed from the end and inserted back into its place in the rendered items.

Updated the examples to feature a much-longer set of crumbs.