### PR TITLE
Bump beachball version and clean up from publish failure

### DIFF
--- a/change/@uifabric-pr-deploy-site-2020-04-06-10-28-34-caperez-filemap-mar2020-fab7.json
+++ b/change/@uifabric-pr-deploy-site-2020-04-06-10-28-34-caperez-filemap-mar2020-fab7.json
@@ -1,9 +1,0 @@
-{
-  "type": "patch",
-  "comment": "removing more references to wrong filetype icons from a deprecated folder",
-  "packageName": "@uifabric/pr-deploy-site",
-  "email": "caperez@microsoft.com",
-  "commit": "0f6deac5848224a8fdb827e57894d0f2e8286c3a",
-  "dependentChangeType": "patch",
-  "date": "2020-04-06T17:28:16.352Z"
-}

--- a/change/office-ui-fabric-react-2020-06-03-10-13-21-beachball-bump.json
+++ b/change/office-ui-fabric-react-2020-06-03-10-13-21-beachball-bump.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix mismatch with published version",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-03T17:13:21.752Z"
+}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "vrtest": "cd apps && cd vr-tests && npm run screener"
   },
   "devDependencies": {
-    "beachball": "^1.29.4",
+    "beachball": "^1.31.2",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5",
     "cross-env": "^5.1.4",

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-ui-fabric-react",
-  "version": "7.117.1",
+  "version": "7.117.2",
   "description": "Reusable React components for building experiences for Microsoft 365.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -65,7 +65,7 @@
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
-    "beachball": "^1.29.4",
+    "beachball": "^1.31.2",
     "chalk": "^2.1.0",
     "circular-dependency-plugin": "^5.0.2",
     "clean-webpack-plugin": "^0.1.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5488,10 +5488,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.29.4:
-  version "1.29.4"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.29.4.tgz#a1b0ab3d6b7aa95bcd1c52ecb2d6e32239886bb5"
-  integrity sha512-ST9is6S8F9xH6FqSfhnpleJE6tRZi26Fiu4tzdi5Jd7As1fbH4jv20UZWEKk6Eosne3rg3jGCIZ1LfsJdO9RJg==
+beachball@^1.31.2:
+  version "1.31.2"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.31.2.tgz#068792e0d202797a28fa1cce3929d51197435c31"
+  integrity sha512-waXb4KXYijdy7SqAl+xH0Rm/agMoXzlsEIHlfFi8AkTJ93I0wU2rbqojuetXOm1DHARybr54KzYb2YQJjuighw==
   dependencies:
     cosmiconfig "^6.0.0"
     fs-extra "^8.0.1"


### PR DESCRIPTION
Bump beachball to latest version with better logging of errors for publish retries.

Sync OUFR version with latest published version after publishing problems.

Delete a random change file for a private package (not needed).