### PR TITLE
Fixing GroupedList custom example aria error

### DIFF
--- a/change/office-ui-fabric-react-2020-06-03-18-38-06-groupedListCustomExampleAccessibility.json
+++ b/change/office-ui-fabric-react-2020-06-03-18-38-06-groupedListCustomExampleAccessibility.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing GroupedList custom example aria error.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T01:38:06.095Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/examples/GroupedList.Custom.Example.tsx
@@ -43,8 +43,10 @@ const onRenderHeader = (props: IGroupHeaderProps): JSX.Element => {
 
 const onRenderCell = (nestingDepth: number, item: IExampleItem, itemIndex: number): JSX.Element => {
   return (
-    <div data-selection-index={itemIndex}>
-      <span className={classNames.name}>{item.name}</span>
+    <div role="row" data-selection-index={itemIndex}>
+      <span role="cell" className={classNames.name}>
+        {item.name}
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13407
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the correct aria roles to the `GroupedList` custom example's `onRenderCell` to fix this that was missing for accessibility conformance.

#### Focus areas to test

(optional)
