### PR TITLE
Fixing issue: VerticalStackedBarChart: y-axis values getting truncated

### DIFF
--- a/change/@uifabric-charting-2020-06-04-21-35-25-y-axis-value-getting-truncated.json
+++ b/change/@uifabric-charting-2020-06-04-21-35-25-y-axis-value-getting-truncated.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing issue: y-axis values getting truncated",
+  "packageName": "@uifabric/charting",
+  "email": "t-tujape@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T16:05:25.793Z"
+}

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -492,6 +492,8 @@ export class VerticalStackedBarChartBase extends React.Component<
     if (node === null) {
       return;
     }
+    yAxis.ticks(this._yAxisTickCount, 's');
+    yAxis.tickPadding(5);
     d3Select(node).call(yAxis);
   }
 }

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -192,8 +192,9 @@ export class VerticalStackedBarChartBase extends React.Component<
       .range([this._height, 0]);
     const yAxis = d3AxisLeft(yAxisScale)
       .tickSizeInner(-this._width)
-      .tickPadding(10)
-      .tickValues(domains);
+      .tickPadding(5)
+      .tickValues(domains)
+      .ticks(this._yAxisTickCount, 's');
     return yAxis;
   }
 
@@ -492,8 +493,6 @@ export class VerticalStackedBarChartBase extends React.Component<
     if (node === null) {
       return;
     }
-    yAxis.ticks(this._yAxisTickCount, 's');
-    yAxis.tickPadding(5);
     d3Select(node).call(yAxis);
   }
 }

--- a/packages/charting/src/components/VerticalStackedBarChart/examples/VerticalStackedBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/examples/VerticalStackedBarChart.Basic.Example.tsx
@@ -7,21 +7,21 @@ export class VerticalStackedBarChartBasicExample extends React.Component<Readonl
     const firstChartPoints: IVSChartDataPoint[] = [
       {
         legend: 'Metadata1',
-        data: 40,
+        data: 40000,
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '40%',
       },
       {
         legend: 'Metadata2',
-        data: 5,
+        data: 50000,
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '5%',
       },
       {
         legend: 'Metadata3',
-        data: 20,
+        data: 20000,
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '50%',
@@ -31,21 +31,21 @@ export class VerticalStackedBarChartBasicExample extends React.Component<Readonl
     const secondChartPoints: IVSChartDataPoint[] = [
       {
         legend: 'Metadata1',
-        data: 30,
+        data: 30000,
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',
       },
       {
         legend: 'Metadata2',
-        data: 20,
+        data: 20000,
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',
       },
       {
         legend: 'Metadata3',
-        data: 40,
+        data: 40000,
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '40%',
@@ -55,21 +55,21 @@ export class VerticalStackedBarChartBasicExample extends React.Component<Readonl
     const thirdChartPoints: IVSChartDataPoint[] = [
       {
         legend: 'Metadata1',
-        data: 44,
+        data: 44000,
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '10%',
       },
       {
         legend: 'Metadata2',
-        data: 28,
+        data: 28000,
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '60%',
       },
       {
         legend: 'Metadata3',
-        data: 30,
+        data: 30000,
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',
@@ -79,21 +79,21 @@ export class VerticalStackedBarChartBasicExample extends React.Component<Readonl
     const fourthChartPoints: IVSChartDataPoint[] = [
       {
         legend: 'Metadata1',
-        data: 88,
+        data: 88000,
         color: DefaultPalette.accent,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '10%',
       },
       {
         legend: 'Metadata2',
-        data: 22,
+        data: 22000,
         color: DefaultPalette.blueMid,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '60%',
       },
       {
         legend: 'Metadata3',
-        data: 30,
+        data: 30000,
         color: DefaultPalette.blueLight,
         xAxisCalloutData: '2020/04/30',
         yAxisCalloutData: '30%',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13462

- [x] Include a change request file using `$ yarn change`

#### Description of changes

On passing large values for y-axis, the values were getting truncated. This PR fixes this issue.

Earlier:
![before-fix](https://user-images.githubusercontent.com/66400291/83772548-1f1a8a80-a6a1-11ea-86b9-979ae180aa16.PNG)

After fixing: 
![after-fix](https://user-images.githubusercontent.com/66400291/83772611-30fc2d80-a6a1-11ea-9c6d-ab073756134b.PNG)
Large values are formatted

![small-values-unaffected](https://user-images.githubusercontent.com/66400291/83773712-81c05600-a6a2-11ea-85b0-f54b80129a07.PNG)
Small values remain unaffected

#### Focus areas to test

(optional)
