### PR TITLE
Resolving Pivot Selected Key issue and cleaning up props

### DIFF
--- a/change/@fluentui-react-next-2020-06-04-14-57-35-fix-pivot-selected-key-fix.json
+++ b/change/@fluentui-react-next-2020-06-04-14-57-35-fix-pivot-selected-key-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Resolving Pivot Selected Key issue and cleaning up props.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T21:57:35.080Z"
+}

--- a/change/office-ui-fabric-react-2020-06-04-16-33-45-fix-pivot-selected-key-fix.json
+++ b/change/office-ui-fabric-react-2020-06-04-16-33-45-fix-pivot-selected-key-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Deprecating defaultSelectedIndex props in Pivot.types.ts.",
+  "packageName": "office-ui-fabric-react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T23:33:45.989Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6299,6 +6299,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
 export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<IPivot>;
+    // @deprecated
     defaultSelectedIndex?: number;
     defaultSelectedKey?: string;
     getTabId?: (itemKey: string, index: number) => string;

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -53,6 +53,8 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * otherwise, use the `selectedKey` property.
    *
    * This property is also mutually exclusive with `defaultSelectedKey`.
+   *
+   * @deprecated Use `defaultSelectedKey`
    */
   defaultSelectedIndex?: number;
 
@@ -60,7 +62,7 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Index of the pivot item initially selected. Mutually exclusive with `initialSelectedKey`.
    * Only provide this if the pivot is an uncontrolled component; otherwise, use `selectedKey`.
    *
-   * @deprecated Use `defaultSelectedIndex`
+   * @deprecated Use `defaultSelectedKey`
    */
   initialSelectedIndex?: number;
 

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -438,14 +438,9 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
 export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: React.RefObject<IPivot>;
-    defaultSelectedIndex?: number;
     defaultSelectedKey?: string;
     getTabId?: (itemKey: string, index: number) => string;
     headersOnly?: boolean;
-    // @deprecated
-    initialSelectedIndex?: number;
-    // @deprecated
-    initialSelectedKey?: string;
     linkFormat?: PivotLinkFormatType;
     linkSize?: PivotLinkSizeType;
     onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement>) => void;

--- a/packages/react-next/release.md
+++ b/packages/react-next/release.md
@@ -1,0 +1,7 @@
+# @fluentui/react Release Notes
+
+## Breaking changes
+
+### Pivot
+
+- Removed deprecated and redundant props from v7, including: `intialSelectedKey`, `defaultSelectedIndex`, and . Use `selectedKey` or `defaultSelectedKey` to define the selected tab, and provide `itemKey` on pivot item children.

--- a/packages/react-next/release.md
+++ b/packages/react-next/release.md
@@ -5,4 +5,4 @@
 ### Pivot
 
 - Converted Pivot to a function component.
-- Removed deprecated and redundant props from v7, including: `intialSelectedKey`, `defaultSelectedIndex`, and . Use `selectedKey` or `defaultSelectedKey` to define the selected tab, and provide `itemKey` on pivot item children.
+- Removed deprecated and redundant props from v7, including: `intialSelectedKey` and `defaultSelectedIndex`. Use `selectedKey` or `defaultSelectedKey` to define the selected tab, and provide `itemKey` on pivot item children.

--- a/packages/react-next/release.md
+++ b/packages/react-next/release.md
@@ -4,4 +4,5 @@
 
 ### Pivot
 
+- Converted Pivot to a function component.
 - Removed deprecated and redundant props from v7, including: `intialSelectedKey`, `defaultSelectedIndex`, and . Use `selectedKey` or `defaultSelectedKey` to define the selected tab, and provide `itemKey` on pivot item children.

--- a/packages/react-next/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { warnDeprecations, KeyCodes, getNativeProps, divProperties, classNamesFunction, warn } from '../../Utilities';
+import { KeyCodes, getNativeProps, divProperties, classNamesFunction, warn } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles, IPivot } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
@@ -7,9 +7,9 @@ import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { PivotItem } from './PivotItem';
 import { Icon } from '../../Icon';
 import { css } from 'office-ui-fabric-react';
-import { useId } from '@uifabric/react-hooks';
+import { useId, useControllableValue } from '@uifabric/react-hooks';
 
-const getClassNamesCall = classNamesFunction<IPivotStyleProps, IPivotStyles>({
+const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>({
   useStaticStyles: true,
 });
 
@@ -28,12 +28,15 @@ const getTabId = (props: IPivotProps, pivotId: string, itemKey: string, index: n
   return pivotId + `-Tab${index}`;
 };
 
+// Gets the set of PivotLinks as array of IPivotItemProps
+// The set of Links is determined by child components of type PivotItem
 const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection => {
   const result: PivotLinkCollection = {
     links: [],
     keyToIndexMapping: {},
     keyToTabIdMapping: {},
   };
+
   React.Children.forEach(React.Children.toArray(props.children), (child: React.ReactChild, index: number) => {
     if (isPivotItem(child)) {
       const { linkText, ...pivotItemProps } = child.props;
@@ -52,20 +55,6 @@ const getLinkItems = (props: IPivotProps, pivotId: string): PivotLinkCollection 
   return result;
 };
 
-const getDefaultKey = (props: IPivotProps, pivotId: string): string => {
-  const { defaultSelectedKey, defaultSelectedIndex } = props;
-  if (defaultSelectedKey !== undefined) {
-    return defaultSelectedKey;
-  }
-  const pivotLinks = getLinkItems(props, pivotId).links;
-  if (defaultSelectedIndex !== undefined) {
-    return pivotLinks[defaultSelectedIndex]?.itemKey || '';
-  } else if (pivotLinks.length) {
-    return pivotLinks[0]?.itemKey || '';
-  }
-  return '';
-};
-
 const isPivotItem = (item: React.ReactNode): item is PivotItem => {
   return ((item as React.ReactElement)?.type as React.ComponentType)?.name === PivotItem.name;
 };
@@ -74,8 +63,10 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
   (props: IPivotProps, ref: React.Ref<HTMLDivElement>) => {
     const { componentRef } = props;
     const pivotId: string = useId('Pivot');
-    const [selectedKey, setSelectedKey] = React.useState<string>(() => getDefaultKey(props, pivotId));
+    let linkCollection = getLinkItems(props, pivotId);
     const focusZoneRef = React.useRef<IFocusZone>(null);
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
+    const [selectedKey, setSelectedKey] = useControllableValue(props.selectedKey, props.defaultSelectedKey);
     let classNames: { [key in keyof IPivotStyles]: string };
 
     React.useImperativeHandle(componentRef as React.RefObject<IPivot>, () => ({
@@ -83,13 +74,6 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
         focusZoneRef.current?.focus();
       },
     }));
-
-    if (process.env.NODE_ENV !== 'production') {
-      warnDeprecations(pivotId, props, {
-        initialSelectedKey: 'defaultSelectedKey',
-        initialSelectedIndex: 'defaultSelectedIndex',
-      });
-    }
 
     const renderLinkContent = (link: IPivotItemProps): JSX.Element => {
       const { itemCount, itemIcon, headerText } = link;
@@ -106,13 +90,6 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
       );
     };
 
-    const onKeyDown = (itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void => {
-      if (ev.which === KeyCodes.enter) {
-        ev.preventDefault();
-        updateSelectedItem(itemKey);
-      }
-    };
-
     const renderPivotLink = (
       renderLinkCollection: PivotLinkCollection,
       link: IPivotItemProps,
@@ -123,13 +100,16 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
       const { onRenderItemLink } = link;
       let linkContent: JSX.Element | null;
       const isSelected: boolean = renderPivotLinkSelectedKey === itemKey;
+
       if (onRenderItemLink) {
         linkContent = onRenderItemLink(link, renderLinkContent);
       } else {
         linkContent = renderLinkContent(link);
       }
+
       let contentString = link.headerText || '';
       contentString += link.itemCount ? ' (' + link.itemCount + ')' : '';
+      // Adding space supplementary for icon
       contentString += link.itemIcon ? ' xx' : '';
       return (
         <CommandButton
@@ -156,32 +136,32 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
       updateSelectedItem(itemKey, ev);
     };
 
+    const onKeyDown = (itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void => {
+      if (ev.which === KeyCodes.enter) {
+        ev.preventDefault();
+        updateSelectedItem(itemKey);
+      }
+    };
+
     const updateSelectedItem = (itemKey: string, ev?: React.MouseEvent<HTMLElement>): void => {
       setSelectedKey(itemKey);
       linkCollection = getLinkItems(props, pivotId);
       if (props.onLinkClick && linkCollection.keyToIndexMapping[itemKey] >= 0) {
-        index = linkCollection.keyToIndexMapping[itemKey];
-        const item = React.Children.toArray(props.children)[index];
+        const selectedIndex = linkCollection.keyToIndexMapping[itemKey];
+        const item = React.Children.toArray(props.children)[selectedIndex];
         if (isPivotItem(item)) {
           props.onLinkClick(item, ev);
         }
       }
     };
 
-    const getClassNames = (): { [key in keyof IPivotStyles]: string } => {
-      const { theme, linkSize, linkFormat } = props;
-
-      return getClassNamesCall(props.styles!, {
-        theme: theme!,
-        linkSize,
-        linkFormat,
-      });
-    };
-
     const renderPivotItem = (itemKey: string | undefined, isActive: boolean): JSX.Element | null => {
       if (props.headersOnly || !itemKey) {
         return null;
       }
+
+      const index = linkCollection.keyToIndexMapping[itemKey];
+      const selectedTabId = linkCollection.keyToTabIdMapping[itemKey];
       return (
         <div
           role="tabpanel"
@@ -196,13 +176,29 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
       );
     };
 
-    let linkCollection = getLinkItems(props, pivotId);
-    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
-    let index = linkCollection.keyToIndexMapping[selectedKey];
-    const selectedTabId = linkCollection.keyToTabIdMapping[selectedKey];
-    const renderSelectedKey = selectedKey;
-    classNames = getClassNames();
-    const items = linkCollection.links.map(l => renderPivotLink(linkCollection, l, renderSelectedKey));
+    const isKeyValid = (itemKey: string | null | undefined): boolean => {
+      return itemKey !== undefined && itemKey !== null && linkCollection.keyToIndexMapping[itemKey] !== undefined;
+    };
+
+    const getSelectedKey = () => {
+      if (isKeyValid(selectedKey)) {
+        return selectedKey;
+      }
+      if (linkCollection.links.length) {
+        return linkCollection.links[0].itemKey;
+      }
+      return undefined;
+    };
+
+    const { theme, linkSize, linkFormat } = props;
+    classNames = getClassNames(props.styles!, {
+      theme: theme!,
+      linkSize,
+      linkFormat,
+    });
+
+    const renderedSelectedKey = getSelectedKey();
+    const items = linkCollection.links.map(l => renderPivotLink(linkCollection, l, renderedSelectedKey));
     return (
       <div role="toolbar" {...divProps} ref={ref}>
         <FocusZone
@@ -213,11 +209,11 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
         >
           {items}
         </FocusZone>
-        {selectedKey &&
+        {renderedSelectedKey &&
           linkCollection.links.map(
             link =>
-              (link.alwaysRender === true || selectedKey === link.itemKey) &&
-              renderPivotItem(link.itemKey, selectedKey === link.itemKey),
+              (link.alwaysRender === true || renderedSelectedKey === link.itemKey) &&
+              renderPivotItem(link.itemKey, renderedSelectedKey === link.itemKey),
           )}
       </div>
     );

--- a/packages/react-next/src/components/Pivot/Pivot.test.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.test.tsx
@@ -48,7 +48,7 @@ describe('Pivot', () => {
 
   it('supports JSX expressions', () => {
     const component = renderer.create(
-      <Pivot defaultSelectedIndex={1}>
+      <Pivot defaultSelectedKey={'1'}>
         <PivotItem headerText="Test Link 1">
           <div>This is item 1</div>
         </PivotItem>

--- a/packages/react-next/src/components/Pivot/Pivot.test.tsx
+++ b/packages/react-next/src/components/Pivot/Pivot.test.tsx
@@ -48,7 +48,7 @@ describe('Pivot', () => {
 
   it('supports JSX expressions', () => {
     const component = renderer.create(
-      <Pivot defaultSelectedKey={'1'}>
+      <Pivot defaultSelectedKey="1">
         <PivotItem headerText="Test Link 1">
           <div>This is item 1</div>
         </PivotItem>

--- a/packages/react-next/src/components/Pivot/Pivot.types.ts
+++ b/packages/react-next/src/components/Pivot/Pivot.types.ts
@@ -48,30 +48,6 @@ export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement> {
   defaultSelectedKey?: string;
 
   /**
-   * Default selected index for the pivot. Only provide this if the pivot is an uncontrolled component;
-   * otherwise, use the `selectedKey` property.
-   *
-   * This property is also mutually exclusive with `defaultSelectedKey`.
-   */
-  defaultSelectedIndex?: number;
-
-  /**
-   * Index of the pivot item initially selected. Mutually exclusive with `initialSelectedKey`.
-   * Only provide this if the pivot is an uncontrolled component; otherwise, use `selectedKey`.
-   *
-   * @deprecated Use `defaultSelectedIndex`
-   */
-  initialSelectedIndex?: number;
-
-  /**
-   * Key of the pivot item initially selected. Mutually exclusive with `initialSelectedIndex`.
-   * Only provide this if the pivot is an uncontrolled component; otherwise, use `selectedKey`.
-   *
-   * @deprecated Use `defaultSelectedKey`
-   */
-  initialSelectedKey?: string;
-
-  /**
    * Key of the selected pivot item. Updating this will override the Pivot's selected item state.
    * Only provide this if the pivot is a controlled component where you are maintaining the
    * current state; otherwise, use `defaultSelectedKey`.


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes
- Resolves `selectedKey` issue in: #13456
- Added release.md to React-Next.
- Removed deprecated and redundant props from v7, including: `intialSelectedKey` and `defaultSelectedIndex`

#### Focus areas to test
`Pivot`
