### PR TITLE
Picker/PeoplePicker: Fix issue where default value wouldn't trigger suggestions

### DIFF
--- a/change/office-ui-fabric-react-2020-06-04-15-08-39-fix-picker-defaulttext.json
+++ b/change/office-ui-fabric-react-2020-06-04-15-08-39-fix-picker-defaulttext.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Picker/PeoplePicker: Fix issue where default value wouldn't trigger suggestions",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-04T22:08:38.991Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -313,7 +313,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // (undocumented)
     protected onChange(items?: T[]): void;
     protected onClick: (ev: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
-    // (undocumented)
     protected onEmptyInputFocus(): void;
     // (undocumented)
     protected onGetMoreResults: () => void;
@@ -373,7 +372,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>, updatedValue?: string): void;
     // (undocumented)
     protected updateValue(updatedValue: string): void;
-}
+    }
 
 // @public (undocumented)
 export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BasePicker<T, P> {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -390,7 +390,7 @@ describe('BasePicker', () => {
 
     jest.runAllTimers();
 
-    expect(getSuggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
   });
 
   it('Opens menu when input refocused after search has happened', () => {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -393,40 +393,6 @@ describe('BasePicker', () => {
     expect(getSuggestions).toBeTruthy();
   });
 
-  it('Opens menu on click when suggestions has been dismissed', () => {
-    jest.useFakeTimers();
-    document.body.appendChild(root);
-
-    const picker = React.createRef<IBasePicker<ISimple>>();
-
-    ReactDOM.render(
-      <BasePickerWithType
-        onResolveSuggestions={onResolveSuggestions}
-        onRenderItem={onRenderItem}
-        onRenderSuggestionsItem={basicSuggestionRenderer}
-        componentRef={picker}
-      />,
-      root,
-    );
-
-    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
-    input.focus();
-    input.value = 'asdff';
-    ReactTestUtils.Simulate.input(input);
-    jest.runAllTimers();
-
-    expect(getSuggestions(document)).toBeTruthy();
-
-    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
-
-    expect(getSuggestions(document)).toBeFalsy();
-    ReactTestUtils.Simulate.click(input, { button: 0 });
-
-    jest.runAllTimers();
-
-    expect(getSuggestions(document)).toBeTruthy();
-  });
-
   it('Opens menu when input refocused after search has happened', () => {
     jest.useFakeTimers();
     document.body.appendChild(root);

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -52,6 +52,7 @@ describe('BasePicker', () => {
 
   afterEach(() => {
     ReactDOM.unmountComponentAtNode(root);
+    document.body.textContent = '';
   });
   const BasePickerWithType = BasePicker as new (props: IBasePickerProps<ISimple>) => BasePicker<
     ISimple,
@@ -327,5 +328,184 @@ describe('BasePicker', () => {
 
     const currentPicker = picker.current!.items;
     expect(currentPicker).toHaveLength(0);
+  });
+
+  it('Closes menu when escape is pressed', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    const picker = React.createRef<IBasePicker<ISimple>>();
+
+    ReactDOM.render(
+      <BasePickerWithType
+        onResolveSuggestions={onResolveSuggestions}
+        onRenderItem={onRenderItem}
+        onRenderSuggestionsItem={basicSuggestionRenderer}
+        componentRef={picker}
+      />,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    input.value = 'asdff';
+    ReactTestUtils.Simulate.input(input);
+    jest.runAllTimers();
+
+    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(suggestions).toBeTruthy();
+
+    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
+    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
+
+    expect(againSugs).toBeFalsy();
+  });
+
+  it('Opens menu on click when suggestions has been dismissed', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    const picker = React.createRef<IBasePicker<ISimple>>();
+
+    ReactDOM.render(
+      <BasePickerWithType
+        onResolveSuggestions={onResolveSuggestions}
+        onRenderItem={onRenderItem}
+        onRenderSuggestionsItem={basicSuggestionRenderer}
+        componentRef={picker}
+      />,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    input.value = 'asdff';
+    ReactTestUtils.Simulate.input(input);
+    jest.runAllTimers();
+
+    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(suggestions).toBeTruthy();
+
+    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
+    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
+
+    expect(againSugs).toBeFalsy();
+    ReactTestUtils.Simulate.click(input, { button: 0 });
+
+    jest.runAllTimers();
+
+    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(getAgain).toBeTruthy();
+  });
+
+  it('Opens menu on click when suggestions has been dismissed', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    const picker = React.createRef<IBasePicker<ISimple>>();
+
+    ReactDOM.render(
+      <BasePickerWithType
+        onResolveSuggestions={onResolveSuggestions}
+        onRenderItem={onRenderItem}
+        onRenderSuggestionsItem={basicSuggestionRenderer}
+        componentRef={picker}
+      />,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    input.value = 'asdff';
+    ReactTestUtils.Simulate.input(input);
+    jest.runAllTimers();
+
+    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(suggestions).toBeTruthy();
+
+    ReactTestUtils.Simulate.keyDown(input, { which: 27 });
+    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
+
+    expect(againSugs).toBeFalsy();
+    ReactTestUtils.Simulate.click(input, { button: 0 });
+
+    jest.runAllTimers();
+
+    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(getAgain).toBeTruthy();
+  });
+
+  it('Opens menu when input refocused after search has happened', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    const picker = React.createRef<IBasePicker<ISimple>>();
+
+    ReactDOM.render(
+      <div>
+        <BasePickerWithType
+          onResolveSuggestions={onResolveSuggestions}
+          onRenderItem={onRenderItem}
+          onRenderSuggestionsItem={basicSuggestionRenderer}
+          componentRef={picker}
+        />
+        <button id="toFocus">focus me</button>
+      </div>,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    input.value = 'bl';
+    ReactTestUtils.Simulate.input(input);
+    jest.runAllTimers();
+
+    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(suggestions).toBeTruthy();
+
+    (document.querySelector('#toFocus') as any).focus();
+
+    // Implicit test to ensure suggestions are dismissed when focus lost
+    const dismissedSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(dismissedSugs).toBeFalsy();
+
+    jest.runAllTimers();
+    input.focus();
+    jest.runAllTimers();
+
+    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(getAgain).toBeTruthy();
+  });
+
+  it('Opens calls onResolveSuggestions if it currently doesnt have suggestions', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    let count = 0;
+    const resolveCounter = (val: string) => {
+      count++;
+      return onResolveSuggestions(val);
+    };
+    const picker = React.createRef<IBasePicker<ISimple>>();
+
+    ReactDOM.render(
+      <BasePickerWithType
+        onResolveSuggestions={resolveCounter}
+        onRenderItem={onRenderItem}
+        onRenderSuggestionsItem={basicSuggestionRenderer}
+        componentRef={picker}
+        inputProps={{ defaultVisibleValue: 'bl' }}
+      />,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    jest.runAllTimers();
+
+    expect(count).toEqual(1);
+
+    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
+    expect(suggestions).toBeTruthy();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -359,7 +359,7 @@ describe('BasePicker', () => {
     expect(getSuggestions(document)).toBeFalsy();
   });
 
-  it('Opens menu on click when suggestions has been dismissed', () => {
+  it('Opens menu on click when suggestions have been dismissed', () => {
     jest.useFakeTimers();
     document.body.appendChild(root);
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -43,6 +43,10 @@ const basicSuggestionRenderer = (props: ISimple) => {
   return <div> {props.name} </div>;
 };
 
+const getSuggestions = (root: HTMLElement | Document) => {
+  return document.querySelector<HTMLElement>('.ms-Suggestions');
+};
+
 describe('BasePicker', () => {
   let root: HTMLDivElement;
   beforeEach(() => {
@@ -113,8 +117,7 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-    expect(suggestions).toBeDefined();
+    expect(getSuggestions(document)).toBeDefined();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(2);
@@ -159,8 +162,7 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-    expect(suggestions).toBeDefined();
+    expect(getSuggestions(document)).toBeDefined();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(0);
@@ -211,8 +213,7 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-    expect(suggestions).toBeDefined();
+    expect(getSuggestions(document)).toBeDefined();
 
     const forceButton = document.querySelectorAll('[data-automationid=sug-forceResolve]');
     expect(forceButton.length).toEqual(1);
@@ -320,8 +321,7 @@ describe('BasePicker', () => {
     const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
     input.focus();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLInputElement;
-    expect(suggestions).toBeDefined();
+    expect(getSuggestions(document)).toBeDefined();
 
     const suggestionOptions = document.querySelectorAll('.ms-Suggestions-itemButton');
     expect(suggestionOptions.length).toEqual(15);
@@ -352,13 +352,11 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(suggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
 
     ReactTestUtils.Simulate.keyDown(input, { which: 27 });
-    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
 
-    expect(againSugs).toBeFalsy();
+    expect(getSuggestions(document)).toBeFalsy();
   });
 
   it('Opens menu on click when suggestions has been dismissed', () => {
@@ -383,19 +381,16 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(suggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
 
     ReactTestUtils.Simulate.keyDown(input, { which: 27 });
-    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
 
-    expect(againSugs).toBeFalsy();
+    expect(getSuggestions(document)).toBeFalsy();
     ReactTestUtils.Simulate.click(input, { button: 0 });
 
     jest.runAllTimers();
 
-    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(getAgain).toBeTruthy();
+    expect(getSuggestions).toBeTruthy();
   });
 
   it('Opens menu on click when suggestions has been dismissed', () => {
@@ -420,19 +415,16 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(suggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
 
     ReactTestUtils.Simulate.keyDown(input, { which: 27 });
-    const againSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
 
-    expect(againSugs).toBeFalsy();
+    expect(getSuggestions(document)).toBeFalsy();
     ReactTestUtils.Simulate.click(input, { button: 0 });
 
     jest.runAllTimers();
 
-    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(getAgain).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
   });
 
   it('Opens menu when input refocused after search has happened', () => {
@@ -460,21 +452,18 @@ describe('BasePicker', () => {
     ReactTestUtils.Simulate.input(input);
     jest.runAllTimers();
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(suggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
 
     (document.querySelector('#toFocus') as any).focus();
 
     // Implicit test to ensure suggestions are dismissed when focus lost
-    const dismissedSugs = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(dismissedSugs).toBeFalsy();
+    expect(getSuggestions(document)).toBeFalsy();
 
     jest.runAllTimers();
     input.focus();
     jest.runAllTimers();
 
-    const getAgain = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(getAgain).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
   });
 
   it('Opens calls onResolveSuggestions if it currently doesnt have suggestions', () => {
@@ -505,7 +494,6 @@ describe('BasePicker', () => {
 
     expect(count).toEqual(1);
 
-    const suggestions = document.querySelector('.ms-Suggestions') as HTMLElement;
-    expect(suggestions).toBeTruthy();
+    expect(getSuggestions(document)).toBeTruthy();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -440,7 +440,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 
     // Only attempt to resolve suggestions if it exists
     if (emptyResolveSuggestions) {
-      const suggestions = emptyResolveSuggestions!(this.state.items);
+      const suggestions = emptyResolveSuggestions(this.state.items);
 
       this.updateSuggestionsList(suggestions);
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -104,7 +104,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
   // tslint:disable-next-line:deprecation
   private _styledSuggestions = getStyledSuggestions(this.SuggestionOfProperType);
   private _id: string;
-  private _requestSuggestionsOnClick = false;
   private _async: Async;
 
   constructor(basePickerProps: P) {
@@ -223,7 +222,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       selectItemFunction();
     }
 
-    this._requestSuggestionsOnClick = false;
     this.setState({ suggestionsVisible: false });
   };
 
@@ -430,14 +428,28 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     this.forceUpdate();
   }
 
+  /**
+   * Only to be called when there is nothing in the input. Checks to see if the consumer has
+   * provided a function to resolve suggestions
+   */
   protected onEmptyInputFocus() {
     const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions
       ? this.props.onEmptyResolveSuggestions
       : // tslint:disable-next-line:deprecation
         this.props.onEmptyInputFocus;
 
-    const suggestions = emptyResolveSuggestions!(this.state.items);
-    this.updateSuggestionsList(suggestions);
+    // Only attempt to resolve suggestions if it exists
+    if (emptyResolveSuggestions) {
+      const suggestions = emptyResolveSuggestions!(this.state.items);
+
+      this.updateSuggestionsList(suggestions);
+
+      this.setState({
+        isMostRecentlyUsedVisible: true,
+        suggestionsVisible: true,
+        moreSuggestionsAvailable: false,
+      });
+    }
   }
 
   protected updateValue(updatedValue: string) {
@@ -517,7 +529,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 
   protected onSuggestionClick = (ev: React.MouseEvent<HTMLElement>, item: any, index: number): void => {
     this.addItemByIndex(index);
-    this._requestSuggestionsOnClick = false;
   };
 
   protected onSuggestionRemove = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
@@ -535,25 +546,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       this.setState({ isFocused: true });
       this.selection.setAllSelected(false);
 
-      if (
-        this.input.current &&
-        this.input.current.value === '' &&
-        // tslint:disable-next-line:deprecation
-        (this.props.onEmptyResolveSuggestions || this.props.onEmptyInputFocus) &&
-        !this._requestSuggestionsOnClick
-      ) {
-        this.onEmptyInputFocus();
-        this.setState({
-          isMostRecentlyUsedVisible: true,
-          moreSuggestionsAvailable: false,
-          suggestionsVisible: true,
-        });
-      } else if (this.input.current && this.input.current.value && !this._requestSuggestionsOnClick) {
-        this.setState({
-          isMostRecentlyUsedVisible: false,
-          suggestionsVisible: true,
-        });
-      }
+      this._userTriggeredSuggestions();
+
       if (this.props.inputProps && this.props.inputProps.onFocus) {
         this.props.inputProps.onFocus(ev as React.FocusEvent<HTMLInputElement>);
       }
@@ -597,29 +591,13 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
    * without shifting focus.
    */
   protected onClick = (ev: React.MouseEvent<HTMLInputElement>): void => {
-    const input = this.input.current ? this.input.current.value : '';
-
     if (this.props.inputProps !== undefined && this.props.inputProps.onClick !== undefined) {
       this.props.inputProps.onClick(ev);
     }
 
     // Only primary (left) clicks show suggestions.
-    if (ev.button === 0 && !this.state.suggestionsVisible) {
-      const emptyResolveSuggestions = this.props.onEmptyResolveSuggestions
-        ? this.props.onEmptyResolveSuggestions
-        : // tslint:disable-next-line:deprecation
-          this.props.onEmptyInputFocus;
-
-      if (input === '') {
-        if (emptyResolveSuggestions) {
-          this.setState({ suggestionsVisible: true });
-          const suggestions = emptyResolveSuggestions!(this.state.items);
-          this.updateSuggestionsList(suggestions);
-        }
-      } else {
-        this._requestSuggestionsOnClick = true;
-        this._onResolveSuggestions(input);
-      }
+    if (ev.button === 0) {
+      this._userTriggeredSuggestions();
     }
   };
 
@@ -628,7 +606,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     switch (keyCode) {
       case KeyCodes.escape:
         if (this.state.suggestionsVisible) {
-          this._requestSuggestionsOnClick = false;
           this.setState({ suggestionsVisible: false });
           ev.preventDefault();
           ev.stopPropagation();
@@ -947,7 +924,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       this.input.current !== undefined &&
       this.input.current !== null &&
       this.input.current.inputElement === document.activeElement &&
-      (this.input.current.value !== '' || this._requestSuggestionsOnClick);
+      this.input.current.value !== '';
 
     return areSuggestionsVisible;
   }
@@ -983,6 +960,28 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
       return '';
     }
   }
+
+  /**
+   * This should be called when the user does something other than use text entry to trigger suggestions.
+   *
+   */
+  private _userTriggeredSuggestions = () => {
+    if (!this.state.suggestionsVisible) {
+      const input = this.input.current ? this.input.current.value : '';
+      if (!input) {
+        this.onEmptyInputFocus();
+      } else {
+        if (this.suggestionStore.suggestions.length === 0) {
+          this._onResolveSuggestions(input);
+        } else {
+          this.setState({
+            isMostRecentlyUsedVisible: false,
+            suggestionsVisible: true,
+          });
+        }
+      }
+    }
+  };
 }
 
 export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BasePicker<T, P> {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #12612
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Original Behavior: If the picker's input contained some default value via `inputProps: {defaultVisibleValue: 'foo'}}` when the picker received focus, it would not show suggestions.

The fix: The picker now attempts to callback to get suggestions if it currently contains a text value and does not have any current suggestions.

#### Focus areas to test

(optional)
