### PR TITLE
Perf-test: support testing re-renders

### DIFF
--- a/apps/perf-test/package.json
+++ b/apps/perf-test/package.json
@@ -21,7 +21,7 @@
     "@types/webpack-node-externals": "1.6.3",
     "@uifabric/tslint-rules": "^7.2.1",
     "@uifabric/build": "^7.0.0",
-    "flamegrill": "0.1.3",
+    "flamegrill": "0.2.0",
     "lodash": "^4.17.15"
   },
   "dependencies": {

--- a/apps/perf-test/src/index.scenarios.tsx
+++ b/apps/perf-test/src/index.scenarios.tsx
@@ -10,6 +10,10 @@ initializeIcons();
 const div = document.createElement('div');
 document.body.appendChild(div);
 
+const renderFinishedMarkerId = 'render-done';
+const renderFinishedMarker = document.createElement('div');
+renderFinishedMarker.id = renderFinishedMarkerId;
+
 // TODO: could default to displaying list of scenarios if param is not provided.
 const defaultScenarioName = Object.keys(scenarios)[0];
 const defaultIterations = 10;
@@ -17,11 +21,46 @@ const defaultIterations = 10;
 const queryParams = qs.parse(window.location.search.substring(1));
 const iterations = queryParams.iterations ? parseInt(queryParams.iterations as string, 10) : defaultIterations;
 const scenario = queryParams.scenario ? (queryParams.scenario as string) : defaultScenarioName;
+const renderType = queryParams.renderType;
 
-// TODO: This seems to increase React (unstable_runWithPriority) render consumption from 4% to 72%!
-// const ScenarioContent = Array.from({ length: iterations }, () => scenarios[scenario]);
+const PerfTestScenario = scenarios[scenario];
 
-// TODO: Using React Fragments increases React (unstable_runWithPriority) render consumption from 4% to 26%.
-// It'd be interesting to root cause why at some point.
-// ReactDOM.render(<>{Array.from({ length: iterations }, () => (scenarios[scenario]))}</>, div);
-ReactDOM.render(<div>{Array.from({ length: iterations }, () => scenarios[scenario])}</div>, div);
+if (renderType === 'rerender') {
+  const PerfTestScenarioWrapper: React.FunctionComponent = () => {
+    const [renderCount, setRenderCounter] = React.useState(0);
+    React.useEffect(() => {
+      if (renderCount < iterations) {
+        setRenderCounter(renderCount + 1);
+      }
+    }, [renderCount]);
+
+    if (renderCount < iterations) {
+      return <PerfTestScenario />;
+    } else {
+      return (
+        <div>
+          <PerfTestScenario />
+          <div id="render-done" />
+        </div>
+      );
+    }
+  };
+
+  ReactDOM.render(<PerfTestScenarioWrapper />, div);
+} else {
+  // TODO: This seems to increase React (unstable_runWithPriority) render consumption from 4% to 72%!
+  // const ScenarioContent = Array.from({ length: iterations }, () => scenarios[scenario]);
+
+  // TODO: Using React Fragments increases React (unstable_runWithPriority) render consumption from 4% to 26%.
+  // It'd be interesting to root cause why at some point.
+  // ReactDOM.render(<>{Array.from({ length: iterations }, () => (scenarios[scenario]))}</>, div);
+  ReactDOM.render(
+    <div>
+      {Array.from({ length: iterations }, () => (
+        <PerfTestScenario />
+      ))}
+    </div>,
+    div,
+    () => div.appendChild(renderFinishedMarker),
+  );
+}

--- a/apps/perf-test/src/index.scenarios.tsx
+++ b/apps/perf-test/src/index.scenarios.tsx
@@ -25,7 +25,7 @@ const renderType = queryParams.renderType;
 
 const PerfTestScenario = scenarios[scenario];
 
-if (renderType === 'VirtualRerender') {
+if (renderType === 'virtual-renderer') {
   const PerfTestScenarioWrapper: React.FunctionComponent = () => {
     const [renderCount, setRenderCounter] = React.useState(0);
     React.useEffect(() => {

--- a/apps/perf-test/src/index.scenarios.tsx
+++ b/apps/perf-test/src/index.scenarios.tsx
@@ -25,7 +25,7 @@ const renderType = queryParams.renderType;
 
 const PerfTestScenario = scenarios[scenario];
 
-if (renderType === 'virtual-renderer') {
+if (renderType === 'virtual-rerender') {
   const PerfTestScenarioWrapper: React.FunctionComponent = () => {
     const [renderCount, setRenderCounter] = React.useState(0);
     React.useEffect(() => {

--- a/apps/perf-test/src/index.scenarios.tsx
+++ b/apps/perf-test/src/index.scenarios.tsx
@@ -25,7 +25,7 @@ const renderType = queryParams.renderType;
 
 const PerfTestScenario = scenarios[scenario];
 
-if (renderType === 'rerender') {
+if (renderType === 'VirtualRerender') {
   const PerfTestScenarioWrapper: React.FunctionComponent = () => {
     const [renderCount, setRenderCounter] = React.useState(0);
     React.useEffect(() => {

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -8,8 +8,8 @@
  * memoization logic help avoid certain code paths.
  */
 
-const AllRenderTypes = ['mount', 'rerender'];
-const DefaultRenderTypes = ['mount'];
+const AllRenderTypes = ['Mount', 'VirtualRerender'];
+const DefaultRenderTypes = ['Mount'];
 
 const scenarioRenderTypes = {
   // TODO: uncomment to enable re-render tests

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -5,18 +5,19 @@ const AllRenderTypes = ['mount', 'rerender'];
 const DefaultRenderTypes = ['mount'];
 
 const scenarioRenderTypes = {
-  Checkbox: AllRenderTypes,
-  CheckboxNext: AllRenderTypes,
-  PrimaryButton: AllRenderTypes,
-  DefaultButton: AllRenderTypes,
-  ButtonNext: AllRenderTypes,
-  Link: AllRenderTypes,
-  LinkNext: AllRenderTypes,
-  Slider: AllRenderTypes,
-  SliderNext: AllRenderTypes,
-  Pivot: AllRenderTypes,
-  PivotNext: AllRenderTypes,
-  ThemeProvider: AllRenderTypes,
+  // TODO: uncomment to enable re-render tests
+  // Checkbox: AllRenderTypes,
+  // CheckboxNext: AllRenderTypes,
+  // PrimaryButton: AllRenderTypes,
+  // DefaultButton: AllRenderTypes,
+  // ButtonNext: AllRenderTypes,
+  // Link: AllRenderTypes,
+  // LinkNext: AllRenderTypes,
+  // Slider: AllRenderTypes,
+  // SliderNext: AllRenderTypes,
+  // Pivot: AllRenderTypes,
+  // PivotNext: AllRenderTypes,
+  // ThemeProvider: AllRenderTypes,
 };
 
 module.exports = {

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -2,6 +2,7 @@
 // you want their render types to differ from the default (mount only).
 
 const AllRenderTypes = ['mount', 'rerender'];
+const DefaultRenderTypes = ['mount'];
 
 const scenarioRenderTypes = {
   Checkbox: AllRenderTypes,
@@ -15,4 +16,7 @@ const scenarioRenderTypes = {
   SliderNext: AllRenderTypes,
 };
 
-module.exports = scenarioRenderTypes;
+module.exports = {
+  scenarioRenderTypes,
+  DefaultRenderTypes,
+};

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -1,0 +1,18 @@
+// You don't have to add scenarios to this structure unless
+// you want their render types to differ from the default (mount only).
+
+const AllRenderTypes = ['mount', 'rerender'];
+
+const scenarioRenderTypes = {
+  Checkbox: AllRenderTypes,
+  CheckboxNext: AllRenderTypes,
+  PrimaryButton: AllRenderTypes,
+  DefaultButton: AllRenderTypes,
+  ButtonNext: AllRenderTypes,
+  Link: AllRenderTypes,
+  LinkNext: AllRenderTypes,
+  Slider: AllRenderTypes,
+  SliderNext: AllRenderTypes,
+};
+
+module.exports = scenarioRenderTypes;

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -3,17 +3,17 @@
  * you want their render types to differ from the default (mount only).
  *
  * Note:
- * You should not need to have re-render tests in most cases because mount test provides enough coverage.
+ * You should not need to have virtual-rerender tests in most cases because mount test provides enough coverage.
  * It is mostly usefual for cases where component has memoization logics. And in case of re-rendering,
  * memoization logic help avoid certain code paths.
  */
 
-const AllRenderTypes = ['Mount', 'VirtualRerender'];
-const DefaultRenderTypes = ['Mount'];
+const AllRenderTypes = ['mount', 'virtual-rerender'];
+const DefaultRenderTypes = ['mount'];
 
 const scenarioRenderTypes = {
   // TODO: uncomment to enable re-render tests
-  ThemeProvider: AllRenderTypes,
+  // ThemeProvider: AllRenderTypes,
 };
 
 module.exports = {

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -16,6 +16,7 @@ const scenarioRenderTypes = {
   SliderNext: AllRenderTypes,
   Pivot: AllRenderTypes,
   PivotNext: AllRenderTypes,
+  ThemeProvider: AllRenderTypes,
 };
 
 module.exports = {

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -1,22 +1,18 @@
-// You don't have to add scenarios to this structure unless
-// you want their render types to differ from the default (mount only).
+/**
+ * You don't have to add scenarios to this structure unless
+ * you want their render types to differ from the default (mount only).
+ *
+ * Note:
+ * You should not need to have re-render tests in most cases because mount test provides enough coverage.
+ * It is mostly usefual for cases where component has memoization logics. And in case of re-rendering,
+ * memoization logic help avoid certain code paths.
+ */
 
 const AllRenderTypes = ['mount', 'rerender'];
 const DefaultRenderTypes = ['mount'];
 
 const scenarioRenderTypes = {
   // TODO: uncomment to enable re-render tests
-  // Checkbox: AllRenderTypes,
-  // CheckboxNext: AllRenderTypes,
-  // PrimaryButton: AllRenderTypes,
-  // DefaultButton: AllRenderTypes,
-  // ButtonNext: AllRenderTypes,
-  // Link: AllRenderTypes,
-  // LinkNext: AllRenderTypes,
-  // Slider: AllRenderTypes,
-  // SliderNext: AllRenderTypes,
-  // Pivot: AllRenderTypes,
-  // PivotNext: AllRenderTypes,
   // ThemeProvider: AllRenderTypes,
 };
 

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -14,6 +14,8 @@ const scenarioRenderTypes = {
   LinkNext: AllRenderTypes,
   Slider: AllRenderTypes,
   SliderNext: AllRenderTypes,
+  Pivot: AllRenderTypes,
+  PivotNext: AllRenderTypes,
 };
 
 module.exports = {

--- a/apps/perf-test/src/scenarioRenderTypes.js
+++ b/apps/perf-test/src/scenarioRenderTypes.js
@@ -13,7 +13,7 @@ const DefaultRenderTypes = ['Mount'];
 
 const scenarioRenderTypes = {
   // TODO: uncomment to enable re-render tests
-  // ThemeProvider: AllRenderTypes,
+  ThemeProvider: AllRenderTypes,
 };
 
 module.exports = {

--- a/apps/perf-test/src/scenarios/BaseButton.tsx
+++ b/apps/perf-test/src/scenarios/BaseButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { BaseButton } from 'office-ui-fabric-react';
 
-const scenario = <BaseButton text="I am a button" styles={{ root: { background: 'red' } }} />;
+const styles = { root: { background: 'red' } };
+const Scenario = () => <BaseButton text="I am a button" styles={styles} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ButtonNext.tsx
+++ b/apps/perf-test/src/scenarios/ButtonNext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react-button';
 
-const scenario = <Button content="I am a button" icon="X" />;
+const Scenario = () => <Button content="I am a button" icon="X" />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Checkbox.tsx
+++ b/apps/perf-test/src/scenarios/Checkbox.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Checkbox } from 'office-ui-fabric-react';
 
-const scenario = <Checkbox label="I am a checkbox" styles={{ root: { background: 'red' } }} />;
+const styles = { root: { background: 'red' } };
+const Scenario = () => <Checkbox label="I am a checkbox" styles={styles} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/CheckboxBase.tsx
+++ b/apps/perf-test/src/scenarios/CheckboxBase.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { CheckboxBase } from 'office-ui-fabric-react';
 
-const scenario = <CheckboxBase />;
+const Scenario = () => <CheckboxBase />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/CheckboxNext.tsx
+++ b/apps/perf-test/src/scenarios/CheckboxNext.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Checkbox } from '@fluentui/react-next';
 
-const scenario = <Checkbox label="I am a checkbox" styles={{ root: { background: 'red' } }} />;
+const styles = { root: { background: 'red' } };
+const Scenario = () => <Checkbox label="I am a checkbox" styles={styles} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ChoiceGroup.tsx
+++ b/apps/perf-test/src/scenarios/ChoiceGroup.tsx
@@ -8,6 +8,6 @@ const options: IChoiceGroupOption[] = [
   { key: 'D', text: 'Option D' },
 ];
 
-const scenario = <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" required={true} />;
+const Scenario = () => <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" required={true} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ComboBox.tsx
+++ b/apps/perf-test/src/scenarios/ComboBox.tsx
@@ -17,7 +17,7 @@ const options: IComboBoxOption[] = [
   { key: 'J', text: 'Option J' },
 ];
 
-const scenario = (
+const Scenario = () => (
   <ComboBox
     multiSelect
     defaultSelectedKey={['C', 'E']}
@@ -28,4 +28,4 @@ const scenario = (
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/CommandBar.tsx
+++ b/apps/perf-test/src/scenarios/CommandBar.tsx
@@ -60,6 +60,6 @@ const _farItems: ICommandBarItemProps[] = [
   },
 ];
 
-const scenario = <CommandBar items={_items} overflowItems={_overflowItems} farItems={_farItems} />;
+const Scenario = () => <CommandBar items={_items} overflowItems={_overflowItems} farItems={_farItems} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ContextualMenu.tsx
+++ b/apps/perf-test/src/scenarios/ContextualMenu.tsx
@@ -46,5 +46,5 @@ const menuItems: IContextualMenuItem[] = [
   },
 ];
 
-const scenario = <ContextualMenu items={menuItems} hidden={false} />;
-export default scenario;
+const Scenario = () => <ContextualMenu items={menuItems} hidden={false} />;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/DefaultButton.tsx
+++ b/apps/perf-test/src/scenarios/DefaultButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react';
 
-const scenario = <DefaultButton text="I am a button" styles={{ root: { background: 'red' } }} />;
+const styles = { root: { background: 'red' } };
+const Scenario = () => <DefaultButton text="I am a button" styles={styles} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/DetailsRow.tsx
+++ b/apps/perf-test/src/scenarios/DetailsRow.tsx
@@ -20,7 +20,7 @@ const Columns: IColumn[] = [
   { key: 'c', name: 'Size', fieldName: 'size', minWidth: 300, maxWidth: 300 },
 ];
 
-const scenario = (
+const Scenario = () => (
   <DetailsRow
     itemIndex={0}
     item={Items[0]}
@@ -30,4 +30,4 @@ const scenario = (
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/DetailsRowFast.tsx
+++ b/apps/perf-test/src/scenarios/DetailsRowFast.tsx
@@ -20,7 +20,7 @@ const Columns: IColumn[] = [
   { key: 'c', name: 'Size', fieldName: 'size', minWidth: 300, maxWidth: 300 },
 ];
 
-const scenario = (
+const Scenario = () => (
   <DetailsRow
     itemIndex={0}
     item={Items[0]}
@@ -31,4 +31,4 @@ const scenario = (
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/DetailsRowNoStyles.tsx
+++ b/apps/perf-test/src/scenarios/DetailsRowNoStyles.tsx
@@ -22,7 +22,7 @@ const Columns: IColumn[] = [
 
 const defaultTheme = createTheme({});
 
-const scenario = (
+const Scenario = () => (
   <DetailsRowBase
     theme={defaultTheme}
     itemIndex={0}
@@ -33,4 +33,4 @@ const scenario = (
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Dialog.tsx
+++ b/apps/perf-test/src/scenarios/Dialog.tsx
@@ -8,7 +8,7 @@ const dialogContentProps: IDialogContentProps = {
   subText: 'Do you want to send this message without a subject?',
 };
 
-const DialogExample: React.FunctionComponent = () => {
+const Scenario: React.FunctionComponent = () => {
   return (
     <Dialog hidden={false} dialogContentProps={dialogContentProps}>
       <DialogFooter>Dialog Footer</DialogFooter>
@@ -16,6 +16,4 @@ const DialogExample: React.FunctionComponent = () => {
   );
 };
 
-const scenario = <DialogExample />;
-
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/DocumentCardTitle.tsx
+++ b/apps/perf-test/src/scenarios/DocumentCardTitle.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { DocumentCardTitle } from 'office-ui-fabric-react';
 
-const scenario = (
+const Scenario = () => (
   <DocumentCardTitle
     title="This is the Title of a Very Interesting Document That Everyone Wants to Read"
     shouldTruncate
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Dropdown.tsx
+++ b/apps/perf-test/src/scenarios/Dropdown.tsx
@@ -14,6 +14,6 @@ const options: IDropdownOption[] = [
   { key: 'lettuce', text: 'Lettuce' },
 ];
 
-const scenario = <Dropdown placeholder="Select an option" label="Basic uncontrolled example" options={options} />;
+const Scenario = () => <Dropdown placeholder="Select an option" label="Basic uncontrolled example" options={options} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/FocusZone.tsx
+++ b/apps/perf-test/src/scenarios/FocusZone.tsx
@@ -11,10 +11,10 @@ const FocusZoneContent: React.FunctionComponent = () => {
   return <>{items}</>;
 };
 
-const scenario = (
+const Scenario = () => (
   <FocusZone as="ul">
     <FocusZoneContent />
   </FocusZone>
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/IconButton.tsx
+++ b/apps/perf-test/src/scenarios/IconButton.tsx
@@ -19,14 +19,10 @@ const menuProps: IContextualMenuProps = {
   directionalHintFixed: true,
 };
 
-const scenario = (
-  <IconButton
-    menuProps={menuProps}
-    iconProps={emojiIcon}
-    title="Emoji"
-    ariaLabel="Emoji"
-    styles={{ root: { background: 'red' } }}
-  />
+const styles = { root: { background: 'red' } };
+
+const Scenario = () => (
+  <IconButton menuProps={menuProps} iconProps={emojiIcon} title="Emoji" ariaLabel="Emoji" styles={styles} />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Label.tsx
+++ b/apps/perf-test/src/scenarios/Label.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Label } from 'office-ui-fabric-react';
 
-const scenario = <Label>I'm a Label</Label>;
+const Scenario = () => <Label>I'm a Label</Label>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Link.tsx
+++ b/apps/perf-test/src/scenarios/Link.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from 'office-ui-fabric-react';
 
-const scenario = <Link href="https//www.bing.com">Bing</Link>;
+const Scenario = () => <Link href="https//www.bing.com">Bing</Link>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/LinkNext.tsx
+++ b/apps/perf-test/src/scenarios/LinkNext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Link } from '@fluentui/react-next';
 
-const scenario = <Link href="https//www.bing.com">Bing</Link>;
+const Scenario = () => <Link href="https//www.bing.com">Bing</Link>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/MenuButton.tsx
+++ b/apps/perf-test/src/scenarios/MenuButton.tsx
@@ -16,6 +16,6 @@ const menuProps = {
   ],
 };
 
-const scenario = <DefaultButton text="I am a button" menuProps={menuProps} />;
+const Scenario = () => <DefaultButton text="I am a button" menuProps={menuProps} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Nav.tsx
+++ b/apps/perf-test/src/scenarios/Nav.tsx
@@ -62,6 +62,6 @@ const groups = [
   },
 ];
 
-const scenario = <Nav selectedKey="key3" ariaLabel="Nav basic example" groups={groups} />;
+const Scenario = () => <Nav selectedKey="key3" ariaLabel="Nav basic example" groups={groups} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Panel.tsx
+++ b/apps/perf-test/src/scenarios/Panel.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
 
-const scenario = (
+const Scenario = () => (
   <Panel isOpen={true} headerText="Panel header" closeButtonAriaLabel="Close">
     <p>Content goes here.</p>
   </Panel>
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Persona.tsx
+++ b/apps/perf-test/src/scenarios/Persona.tsx
@@ -9,7 +9,7 @@ const examplePersona: IPersonaSharedProps = {
   optionalText: 'Available at 4:00pm',
 };
 
-const scenario = (
+const Scenario = () => (
   <Persona
     {...examplePersona}
     size={PersonaSize.size32}
@@ -19,4 +19,4 @@ const scenario = (
   />
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Pivot.tsx
+++ b/apps/perf-test/src/scenarios/Pivot.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
 
-const scenario = (
+const Scenario = () => (
   <Pivot aria-label="Basic Pivot Example">
     <PivotItem
       headerText="My Files"
@@ -21,4 +21,4 @@ const scenario = (
   </Pivot>
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/PivotNext.tsx
+++ b/apps/perf-test/src/scenarios/PivotNext.tsx
@@ -4,23 +4,23 @@ import { Pivot, PivotItem } from '@fluentui/react-next';
 const Scenario = () => {
   return (
     <Pivot aria-label="Basic Pivot Example">
-    <PivotItem
-      headerText="My Files"
-      headerButtonProps={{
-        'data-order': 1,
-        'data-title': 'My Files Title',
-      }}
-    >
-      <div>Pivot #1</div>
-    </PivotItem>
-    <PivotItem headerText="Recent">
-      <div>Pivot #2</div>
-    </PivotItem>
-    <PivotItem headerText="Shared with me">
-      <div>Pivot #3</div>
-    </PivotItem>
-  </Pivot>
-  )
+      <PivotItem
+        headerText="My Files"
+        headerButtonProps={{
+          'data-order': 1,
+          'data-title': 'My Files Title',
+        }}
+      >
+        <div>Pivot #1</div>
+      </PivotItem>
+      <PivotItem headerText="Recent">
+        <div>Pivot #2</div>
+      </PivotItem>
+      <PivotItem headerText="Shared with me">
+        <div>Pivot #3</div>
+      </PivotItem>
+    </Pivot>
+  );
 };
 
 export default Scenario;

--- a/apps/perf-test/src/scenarios/PivotNext.tsx
+++ b/apps/perf-test/src/scenarios/PivotNext.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { Pivot, PivotItem } from '@fluentui/react-next';
 
-const scenario = (
-  <Pivot aria-label="Basic Pivot Example">
+const Scenario = () => {
+  return (
+    <Pivot aria-label="Basic Pivot Example">
     <PivotItem
       headerText="My Files"
       headerButtonProps={{
@@ -19,6 +20,7 @@ const scenario = (
       <div>Pivot #3</div>
     </PivotItem>
   </Pivot>
-);
+  )
+};
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/PrimaryButton.tsx
+++ b/apps/perf-test/src/scenarios/PrimaryButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { PrimaryButton } from 'office-ui-fabric-react';
 
-const scenario = <PrimaryButton styles={{ root: { background: 'red' } }}>I am a button</PrimaryButton>;
+const styles = { root: { background: 'red' } };
+const Scenario = () => <PrimaryButton styles={styles}>I am a button</PrimaryButton>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/SearchBox.tsx
+++ b/apps/perf-test/src/scenarios/SearchBox.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SearchBox } from 'office-ui-fabric-react';
 
-const scenario = <SearchBox placeholder="Search" />;
+const Scenario = () => <SearchBox placeholder="Search" />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Slider.tsx
+++ b/apps/perf-test/src/scenarios/Slider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Slider } from 'office-ui-fabric-react';
 
-const scenario = <Slider />;
+const Scenario = () => <Slider />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/SliderNext.tsx
+++ b/apps/perf-test/src/scenarios/SliderNext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Slider } from '@fluentui/react-next';
 
-const scenario = <Slider />;
+const Scenario = () => <Slider />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Spinner.tsx
+++ b/apps/perf-test/src/scenarios/Spinner.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 
-const scenario = <Spinner size={SpinnerSize.medium} />;
+const Scenario = () => <Spinner size={SpinnerSize.medium} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/SplitButton.tsx
+++ b/apps/perf-test/src/scenarios/SplitButton.tsx
@@ -20,6 +20,6 @@ const menuProps = {
   ],
 };
 
-const scenario = <DefaultButton split={true} text="I am a button" onClick={alertClicked} menuProps={menuProps} />;
+const Scenario = () => <DefaultButton split={true} text="I am a button" onClick={alertClicked} menuProps={menuProps} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Stack.tsx
+++ b/apps/perf-test/src/scenarios/Stack.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Stack } from 'office-ui-fabric-react';
 
-const scenario = <Stack />;
+const Scenario = () => <Stack />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/StackWithIntrinsicChildren.tsx
+++ b/apps/perf-test/src/scenarios/StackWithIntrinsicChildren.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Stack } from 'office-ui-fabric-react';
 
-const scenario = (
+const Scenario = () => (
   <Stack>
     <p>I am a stack child</p>
     <p>I am a stack child</p>
@@ -16,4 +16,4 @@ const scenario = (
   </Stack>
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/StackWithTextChildren.tsx
+++ b/apps/perf-test/src/scenarios/StackWithTextChildren.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Stack, Text } from 'office-ui-fabric-react';
 
-const scenario = (
+const Scenario = () => (
   <Stack>
     <Text>I am a stack child</Text>
     <Text>I am a stack child</Text>
@@ -16,4 +16,4 @@ const scenario = (
   </Stack>
 );
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/TagPicker.tsx
+++ b/apps/perf-test/src/scenarios/TagPicker.tsx
@@ -7,6 +7,6 @@ const onResolveSuggestions = (filterText: string): ITag[] => {
   return filterText ? testTags.filter(tag => tag.name.toLowerCase().indexOf(filterText.toLowerCase()) === 0) : [];
 };
 
-const scenario = <TagPicker onResolveSuggestions={onResolveSuggestions} />;
+const Scenario = () => <TagPicker onResolveSuggestions={onResolveSuggestions} />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Text.tsx
+++ b/apps/perf-test/src/scenarios/Text.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Text } from 'office-ui-fabric-react';
 
-const scenario = <Text>I am text, hear me roar.</Text>;
+const Scenario = () => <Text>I am text, hear me roar.</Text>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/TextField.tsx
+++ b/apps/perf-test/src/scenarios/TextField.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react';
 
-const scenario = <TextField label="With placeholder" placeholder="Please enter text here" />;
+const Scenario = () => <TextField label="With placeholder" placeholder="Please enter text here" />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ThemeProvider.tsx
+++ b/apps/perf-test/src/scenarios/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ThemeProvider } from '@fluentui/react-next';
 
-const scenario = <ThemeProvider />;
+const Scenario = () => <ThemeProvider />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/Toggle.tsx
+++ b/apps/perf-test/src/scenarios/Toggle.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Toggle } from 'office-ui-fabric-react';
 
-const scenario = <Toggle checked />;
+const Scenario = () => <Toggle checked />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/ToggleNext.tsx
+++ b/apps/perf-test/src/scenarios/ToggleNext.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Toggle } from '@fluentui/react-next';
 
-const scenario = <Toggle checked />;
+const Scenario = () => <Toggle checked />;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/src/scenarios/button.tsx
+++ b/apps/perf-test/src/scenarios/button.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
 
-const scenario = <button>I am a button</button>;
+const Scenario = () => <button>I am a button</button>;
 
-export default scenario;
+export default Scenario;

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -242,7 +242,7 @@ module.exports = async function getPerfRegressions() {
       const testUrlParams = `?scenario=${scenarioName}&iterations=${iterations}&renderType=${renderType}`;
 
       scenarios[scenarioKey] = {
-        baseline: `${urlForMaster}${testUrlParams}`,
+        baseline: `${urlForDeploy}${testUrlParams}`,
         scenario: `${urlForDeploy}${testUrlParams}`,
       };
 
@@ -278,7 +278,7 @@ module.exports = async function getPerfRegressions() {
       await page.goto(options.url);
 
       // TODO: uncomment to enable re-render tests
-      // await page.waitForSelector('#render-done');
+      await page.waitForSelector('#render-done');
     },
   };
 

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -275,8 +275,9 @@ module.exports = async function getPerfRegressions() {
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      await page.goto(options.url);
+      page.setDefaultTimeout(60000); // set 60s timeout, default is 30s.
 
+      await page.goto(options.url);
       // TODO: uncomment to enable re-render tests
       await page.waitForSelector('#render-done');
     },

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -279,7 +279,7 @@ module.exports = async function getPerfRegressions() {
 
       await page.goto(options.url);
       // TODO: uncomment to enable re-render tests
-      await page.waitForSelector('#render-done');
+      // await page.waitForSelector('#render-done');
     },
   };
 
@@ -361,11 +361,10 @@ function createScenarioTable(scenarioSettings, testResults, showAll) {
       .map(key => {
         const testResult = testResults[key];
         const { scenarioName, iterations, renderType } = scenarioSettings[key] || {};
-        const renderTypeFriendlyName = renderType === 'VirtualRerender' ? 'Virtual re-render' : renderType;
 
         return `<tr>
             <td>${scenarioName}</td>
-            <td>${renderTypeFriendlyName}</td>
+            <td>${renderType}</td>
             ${getCell(testResult, true)}
             ${getCell(testResult, false)}
             <td>${iterations}</td>

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -242,7 +242,7 @@ module.exports = async function getPerfRegressions() {
       const testUrlParams = `?scenario=${scenarioName}&iterations=${iterations}&renderType=${renderType}`;
 
       scenarios[scenarioKey] = {
-        baseline: `${urlForDeploy}${testUrlParams}`, // TODO: revert before merging
+        baseline: `${urlForMaster}${testUrlParams}`,
         scenario: `${urlForDeploy}${testUrlParams}`,
       };
 
@@ -276,7 +276,9 @@ module.exports = async function getPerfRegressions() {
     tempDir,
     pageActions: async (page, options) => {
       await page.goto(options.url);
-      await page.waitForSelector('#render-done');
+
+      // TODO: uncomment to enable re-render tests
+      // await page.waitForSelector('#render-done');
     },
   };
 

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -360,10 +360,11 @@ function createScenarioTable(scenarioSettings, testResults, showAll) {
       .map(key => {
         const testResult = testResults[key];
         const { scenarioName, iterations, renderType } = scenarioSettings[key] || {};
+        const renderTypeFriendlyName = renderType === 'rerender' ? 'virtual re-render' : renderType;
 
         return `<tr>
             <td>${scenarioName}</td>
-            <td>${renderType}</td>
+            <td>${renderTypeFriendlyName}</td>
             ${getCell(testResult, true)}
             ${getCell(testResult, false)}
             <td>${iterations}</td>

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -360,7 +360,7 @@ function createScenarioTable(scenarioSettings, testResults, showAll) {
       .map(key => {
         const testResult = testResults[key];
         const { scenarioName, iterations, renderType } = scenarioSettings[key] || {};
-        const renderTypeFriendlyName = renderType === 'rerender' ? 'virtual re-render' : renderType;
+        const renderTypeFriendlyName = renderType === 'VirtualRerender' ? 'Virtual re-render' : renderType;
 
         return `<tr>
             <td>${scenarioName}</td>

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -242,7 +242,7 @@ module.exports = async function getPerfRegressions() {
       const testUrlParams = `?scenario=${scenarioName}&iterations=${iterations}&renderType=${renderType}`;
 
       scenarios[scenarioKey] = {
-        baseline: `${urlForDeploy}${testUrlParams}`,
+        baseline: `${urlForMaster}${testUrlParams}`,
         scenario: `${urlForDeploy}${testUrlParams}`,
       };
 

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -20,7 +20,7 @@
     "@types/react": "16.8.25",
     "@types/react-dom": "16.8.4",
     "@types/webpack-env": "1.15.1",
-    "flamegrill": "0.1.3",
+    "flamegrill": "0.2.0",
     "ignore-not-found-export-webpack-plugin": "^1.0.1",
     "just-scripts": "0.43.1",
     "node-fetch": "^2.6.0",

--- a/packages/fluentui/perf-test/tasks/perf-test.ts
+++ b/packages/fluentui/perf-test/tasks/perf-test.ts
@@ -1,9 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import fetch from 'node-fetch';
 import _ from 'lodash';
 import flamegrill, { CookResult, CookResults, ScenarioConfig, Scenarios } from 'flamegrill';
-
 import { generateUrl } from '@fluentui/digest';
 
 type ExtendedCookResult = CookResult & {
@@ -103,7 +101,14 @@ export default async function getPerfRegressions(baselineOnly: boolean = false) 
     });
   }
 
-  const scenarioConfig: ScenarioConfig = { outDir, tempDir };
+  const scenarioConfig: ScenarioConfig = {
+    outDir,
+    tempDir,
+    pageActions: async (page, options) => {
+      page.setDefaultTimeout(90000); // set 90s timeout, default is 30s.
+      await page.goto(options.url);
+    },
+  };
   const scenarioResults = await flamegrill.cook(scenarios, scenarioConfig);
 
   const extendedCookResults = extendCookResults(stories, scenarioResults);

--- a/packages/fluentui/perf-test/tasks/perf-test.ts
+++ b/packages/fluentui/perf-test/tasks/perf-test.ts
@@ -105,7 +105,7 @@ export default async function getPerfRegressions(baselineOnly: boolean = false) 
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      page.setDefaultTimeout(90000); // set 90s timeout, default is 30s.
+      page.setDefaultTimeout(0); // set no timeout
       await page.goto(options.url);
     },
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9637,10 +9637,10 @@ flamebearer@^1.1.3:
     concat-stream "^1.6.2"
     opn "^5.3.0"
 
-flamegrill@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/flamegrill/-/flamegrill-0.1.3.tgz#3a92a87b7ff259cae16175ac74ea7dcbda3b2539"
-  integrity sha512-9oyBxKgsU+tvoiI7/r4tasU8wIbN91h+kwx+bZTPag01LwshqmEVwVANzBTTWtzeaeXw/2IGXi44D5kVTE8keQ==
+flamegrill@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/flamegrill/-/flamegrill-0.2.0.tgz#efee7e75800741a708d6e532a763ae851af3e293"
+  integrity sha512-p4TMMR47KjZCYy+rLucMfoVOXFPAwxvF+NmNKmDJV0bPzKM3Q19txSiHzIsOuCF9WDWrbTgyA97RT1HI+exQ1g==
   dependencies:
     concat-stream "^2.0.0"
     flamebearer "^1.1.3"


### PR DESCRIPTION
#### Description of changes
**This PR includes:**
- Add support to "Fabric" perf-test to test virtual re-renders. That is, we re-render the component by the number of defined iterations with exact same set of props with no layout/styling changes.
- ONLY enabled re-render tests for components we are currently working on for V8 as a starter.
- Upgrade `flamegrill` to include fix https://github.com/microsoft/flamegrill/pull/17. In this change I removed logic which sets no timeout for all tests. As a result, I need to `setDefaultTimeout` in FluentUI perf-test. 

**Note**: 
1. I understand we have 2 perf-test scripts in the repo. If I have time i would have converged them then add this feature. But I am having trouble find that time now. I still want to add the support since we are actively developing V8 and I want perf test coverage for re-render scenarios
2. master tests do not have latest `index.scenarios.ts` code so master will not work for re-render cases. I need to stage this change to 2 steps:
    - revert tests to only test mount and merge this change
    - merge another change that re-enable the tests for re-render

This iteration of perf results contain the re-rendering tests:
![image](https://user-images.githubusercontent.com/1207059/83905807-2bd9c580-a717-11ea-88b3-fade74eef375.png)
