### PR TITLE
Dialog: min height for title to ensure subtext doesn't overlap 'close' button.

### DIFF
--- a/change/office-ui-fabric-react-2020-06-05-15-01-14-dialog-missing-text.json
+++ b/change/office-ui-fabric-react-2020-06-05-15-01-14-dialog-missing-text.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Dialog: min height for title to ensure subtext doesn't overlap 'close' button.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-05T22:01:14.473Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -108,6 +108,7 @@ export const getStyles = (props: IDialogContentStyleProps): IDialogContentStyles
       {
         color: semanticColors.bodyText,
         margin: '0',
+        minHeight: fonts.xLarge.fontSize,
         padding: '16px 46px 20px 24px',
         lineHeight: 'normal',
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -192,6 +192,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
                         margin-left: 0;
                         margin-right: 0;
                         margin-top: 0;
+                        min-height: 20px;
                         padding-bottom: 20px;
                         padding-left: 24px;
                         padding-right: 46px;
@@ -500,6 +501,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
                         margin-left: 0;
                         margin-right: 0;
                         margin-top: 0;
+                        min-height: 20px;
                         padding-bottom: 20px;
                         padding-left: 24px;
                         padding-right: 46px;
@@ -808,6 +810,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
                         margin-left: 0;
                         margin-right: 0;
                         margin-top: 0;
+                        min-height: 20px;
                         padding-bottom: 20px;
                         padding-left: 24px;
                         padding-right: 46px;
@@ -1249,6 +1252,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
                         margin-left: 0;
                         margin-right: 0;
                         margin-top: 0;
+                        min-height: 20px;
                         padding-bottom: 20px;
                         padding-left: 24px;
                         padding-right: 46px;

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
             margin-left: 0;
             margin-right: 0;
             margin-top: 0;
+            min-height: 20px;
             padding-bottom: 20px;
             padding-left: 24px;
             padding-right: 46px;
@@ -142,6 +143,7 @@ exports[`Dialog renders Dialog with a jsx title 1`] = `
             margin-left: 0;
             margin-right: 0;
             margin-top: 0;
+            min-height: 20px;
             padding-bottom: 20px;
             padding-left: 24px;
             padding-right: 46px;
@@ -260,6 +262,7 @@ exports[`Dialog renders DialogContent with titleProps 1`] = `
             margin-left: 0;
             margin-right: 0;
             margin-top: 0;
+            min-height: 20px;
             padding-bottom: 20px;
             padding-left: 24px;
             padding-right: 46px;


### PR DESCRIPTION
- [X] Addresses an existing issue: Fixes #13458
- [X] Include a change request file using `$ yarn change`

