### PR TITLE
getGlobalClassNames: correct return type

### DIFF
--- a/change/@uifabric-styling-2020-06-05-17-26-47-xgao-globalClassName.json
+++ b/change/@uifabric-styling-2020-06-05-17-26-47-xgao-globalClassName.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "getGlobalClassNames: correct return type",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-06T00:26:47.017Z"
+}

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -139,7 +139,7 @@ export function getFocusStyle(theme: ITheme, options?: IGetFocusStylesOptions): 
 export function getFocusStyle(theme: ITheme, inset?: number, position?: 'relative' | 'absolute', highContrastStyle?: IRawStyle | undefined, borderColor?: string, outlineColor?: string, isFocusedOnly?: boolean): IRawStyle;
 
 // @public
-export function getGlobalClassNames<T>(classNames: GlobalClassNames<T>, theme: ITheme, disableGlobalClassNames?: boolean): Partial<GlobalClassNames<T>>;
+export function getGlobalClassNames<T>(classNames: GlobalClassNames<T>, theme: ITheme, disableGlobalClassNames?: boolean): GlobalClassNames<T>;
 
 // @public
 export function getIcon(name?: string): IIconRecord | undefined;

--- a/packages/styling/src/styles/getGlobalClassNames.ts
+++ b/packages/styling/src/styles/getGlobalClassNames.ts
@@ -9,7 +9,7 @@ export type GlobalClassNames<IStyles> = Record<keyof IStyles, string>;
  * disable boolean. These immutable values can be memoized.
  */
 const _getGlobalClassNames = memoizeFunction(
-  <T>(classNames: GlobalClassNames<T>, disableGlobalClassNames?: boolean): Partial<GlobalClassNames<T>> => {
+  <T>(classNames: GlobalClassNames<T>, disableGlobalClassNames?: boolean): GlobalClassNames<T> => {
     const styleSheet = Stylesheet.getInstance();
 
     if (disableGlobalClassNames) {
@@ -17,7 +17,7 @@ const _getGlobalClassNames = memoizeFunction(
       return (Object.keys(classNames) as (keyof T)[]).reduce((acc, className) => {
         acc[className] = styleSheet.getClassName(classNames[className]);
         return acc;
-      }, {} as Partial<GlobalClassNames<T>>);
+      }, {} as GlobalClassNames<T>);
     }
 
     // use global classnames
@@ -38,7 +38,7 @@ export function getGlobalClassNames<T>(
   classNames: GlobalClassNames<T>,
   theme: ITheme,
   disableGlobalClassNames?: boolean,
-): Partial<GlobalClassNames<T>> {
+): GlobalClassNames<T> {
   return _getGlobalClassNames(
     classNames,
     disableGlobalClassNames !== undefined ? disableGlobalClassNames : theme.disableGlobalClassNames,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
correct return type. getGlobalClassNames either return the passed classNames or make them dynamic if `disabled`. so return type should be the same as input

#### Focus areas to test

(optional)
