### PR TITLE
User/v sivar/linechart remove resize

### DIFF
--- a/change/@uifabric-charting-2020-06-08-10-47-38-user-v-sivar-linechartRemoveResize.json
+++ b/change/@uifabric-charting-2020-06-08-10-47-38-user-v-sivar-linechartRemoveResize.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "removing resize event from chart and resizing the chart in CDU based on changes in height and width prop",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-08T05:17:38.066Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -98,11 +98,19 @@ export class LineChartBase extends React.Component<
 
   public componentDidMount(): void {
     this._fitParentContainer();
-    window.addEventListener('resize', this._fitParentContainer);
   }
 
   public componentWillUnmount(): void {
     cancelAnimationFrame(this._reqID);
+  }
+
+  public componentDidUpdate(prevProps: ILineChartProps): void {
+    /** note that height and width are not used to resize or set as dimesions of the chart,
+     * fitParentContainer is responisble for setting the height and width or resizing of the svg/chart
+     */
+    if (prevProps.height !== this.props.height || prevProps.width !== this.props.width) {
+      this._fitParentContainer();
+    }
   }
 
   public render(): JSX.Element {

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -9,14 +9,30 @@ interface IRootStyles {
   width: string;
 }
 
-export class LineChartBasicExample extends React.Component<{}, {}> {
+interface ILineChartBasicState {
+  width: number;
+  height: number;
+}
+
+export class LineChartBasicExample extends React.Component<{}, ILineChartBasicState> {
   constructor(props: ILineChartProps) {
     super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
   }
 
   public render(): JSX.Element {
     return <div>{this._basicExample()}</div>;
   }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
 
   private _basicExample(): JSX.Element {
     const data: IChartProps = {
@@ -100,17 +116,25 @@ export class LineChartBasicExample extends React.Component<{}, {}> {
         },
       ],
     };
-    const rootStyle: IRootStyles = { width: '700px', height: '300px' };
+    const rootStyle: IRootStyles = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     return (
-      <div className={mergeStyles(rootStyle)}>
-        <LineChart
-          data={data}
-          legendsOverflowText={'Overflow Items'}
-          yMinValue={200}
-          yMaxValue={301}
-          yAxisTickFormat={d3.format('$,')}
-        />
-      </div>
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div className={mergeStyles(rootStyle)}>
+          <LineChart
+            data={data}
+            legendsOverflowText={'Overflow Items'}
+            yMinValue={200}
+            yMaxValue={301}
+            yAxisTickFormat={d3.format('$,')}
+            height={this.state.height}
+            width={this.state.width}
+          />
+        </div>
+      </>
     );
   }
 }

--- a/packages/charting/src/components/LineChart/examples/LineChart.Events.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Events.Example.tsx
@@ -14,14 +14,38 @@ interface IRootStyles {
   width: string;
 }
 
-export class LineChartEventsExample extends React.Component<{}, {}> {
+interface ILineChartEventsExampleState {
+  width: number;
+  height: number;
+}
+
+export class LineChartEventsExample extends React.Component<{}, ILineChartEventsExampleState> {
   constructor(props: ILineChartProps) {
     super(props);
+    this.state = {
+      width: 700,
+      height: 330,
+    };
   }
 
   public render(): JSX.Element {
-    return <div>{this._basicExample()}</div>;
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div>{this._basicExample()}</div>
+      </>
+    );
   }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
 
   private _basicExample(): JSX.Element {
     const data: IChartProps = {
@@ -97,7 +121,10 @@ export class LineChartEventsExample extends React.Component<{}, {}> {
         },
       ],
     };
-    const rootStyle: IRootStyles = { width: '700px', height: '330px' };
+    const rootStyle: IRootStyles = {
+      width: `${this.state.width}px`,
+      height: `${this.state.height}px`,
+    };
     return (
       <div className={mergeStyles(rootStyle)}>
         <LineChart
@@ -150,6 +177,8 @@ export class LineChartEventsExample extends React.Component<{}, {}> {
             labelWidth: 50,
             mergedLabel: (count: number) => `${count} events`,
           }}
+          height={this.state.height}
+          width={this.state.width}
         />
       </div>
     );

--- a/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
@@ -8,13 +8,30 @@ interface IRootStyles {
   width: string;
 }
 
-export class LineChartMultipleExample extends React.Component<{}, {}> {
+interface ILineChartMultipleExampleState {
+  width: number;
+  height: number;
+}
+
+export class LineChartMultipleExample extends React.Component<{}, ILineChartMultipleExampleState> {
   constructor(props: ILineChartProps) {
     super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
   }
 
   public render(): JSX.Element {
-    return <div>{this._styledExample()}</div>;
+    return (
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div>{this._styledExample()}</div>
+      </>
+    );
   }
 
   private _onLegendClickHandler = (selectedLegend: string | null): void => {
@@ -85,7 +102,7 @@ export class LineChartMultipleExample extends React.Component<{}, {}> {
       chartTitle: 'Line Chart',
       lineChartData: points,
     };
-    const rootStyle: IRootStyles = { width: '700px', height: '300px' };
+    const rootStyle: IRootStyles = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     const timeFormat = '%m/%d';
     // Passing tick values is optional, for more control.
     // If you do not pass them the line chart will render them for you based on D3's standard.
@@ -105,8 +122,17 @@ export class LineChartMultipleExample extends React.Component<{}, {}> {
           tickFormat={timeFormat}
           tickValues={tickValues}
           enabledLegendsWrapLines={true}
+          height={this.state.height}
+          width={this.state.width}
         />
       </div>
     );
   }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
 }

--- a/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
@@ -8,14 +8,30 @@ interface IRootStyles {
   width: string;
 }
 
-export class LineChartStyledExample extends React.Component<{}, {}> {
+interface IStyledLineChartExampleState {
+  width: number;
+  height: number;
+}
+
+export class LineChartStyledExample extends React.Component<{}, IStyledLineChartExampleState> {
   constructor(props: ILineChartProps) {
     super(props);
+    this.state = {
+      width: 700,
+      height: 300,
+    };
   }
 
   public render(): JSX.Element {
     return <div>{this._styledExample()}</div>;
   }
+
+  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ width: parseInt(e.target.value, 10) });
+  };
+  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ height: parseInt(e.target.value, 10) });
+  };
 
   private _styledExample(): JSX.Element {
     const points: ILineChartPoints[] = [
@@ -37,11 +53,27 @@ export class LineChartStyledExample extends React.Component<{}, {}> {
       chartTitle: 'Line Chart',
       lineChartData: points,
     };
-    const rootStyle: IRootStyles = { width: '700px', height: '300px' };
+    const rootStyle: IRootStyles = {
+      width: `${this.state.width}px`,
+      height: `${this.state.height}px`,
+    };
     return (
-      <div className={mergeStyles(rootStyle)}>
-        <LineChart data={data} strokeWidth={4} yMaxValue={90} hideLegend={true} />
-      </div>
+      <>
+        <label>change Width:</label>
+        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
+        <label>change Height:</label>
+        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div className={mergeStyles(rootStyle)}>
+          <LineChart
+            data={data}
+            strokeWidth={4}
+            yMaxValue={90}
+            hideLegend={true}
+            height={this.state.height}
+            width={this.state.width}
+          />
+        </div>
+      </>
     );
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13404
- [x] Include a change request file using `$ yarn change`

#### Description of changes

removing the resize event on the chart and adding resize functionality in CDU if height and width prop changes..

#### Focus areas to test

line chart


#### after fix film

[video of responsiveness](https://drive.google.com/file/d/11DgmasB8Mb2TUkmWYqvYV5J_J4WDczGW/view?usp=sharing)
