### PR TITLE
Link: fix incorrect href in Link component's example page

### DIFF
--- a/change/office-ui-fabric-react-2020-06-08-12-01-42-tomi-first-issue.json
+++ b/change/office-ui-fabric-react-2020-06-08-12-01-42-tomi-first-issue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Link: fix broken href in examples",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-08T19:01:42.377Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/examples/Link.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/examples/Link.Basic.Example.tsx
@@ -6,9 +6,12 @@ export const LinkBasicExample: React.FunctionComponent = () => {
     <div>
       <p>
         When a link has an href,{' '}
-        <Link href="http://dev.office.com/fabric/components/link">it renders as an anchor tag.</Link> Without an href,{' '}
-        <Link>the link is rendered as a button</Link>. You can also use the disabled attribute to create a{' '}
-        <Link disabled={true} href="http://dev.office.com/fabric/components/link">
+        <Link href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link">
+          it renders as an anchor tag.
+        </Link>{' '}
+        Without an href, <Link>the link is rendered as a button</Link>. You can also use the disabled attribute to
+        create a{' '}
+        <Link disabled={true} href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link">
           disabled link.
         </Link>
       </p>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -44,13 +44,13 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           &:focus {
             color: #0078d4;
           }
-      href="http://dev.office.com/fabric/components/link"
+      href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link"
       onClick={[Function]}
     >
       it renders as an anchor tag.
     </a>
-     Without an href,
      
+    Without an href, 
     <button
       className=
           ms-Link


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13445 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update incorrect href in Link's example page to go to the right page

#### Focus areas to test

(optional)
