### PR TITLE
Update Details and Grouped List chevron to rotate in the correct direction for RTL

### DIFF
--- a/change/office-ui-fabric-react-2020-06-08-13-20-35-bcoard-FixGroupedListRotation.json
+++ b/change/office-ui-fabric-react-2020-06-08-13-20-35-bcoard-FixGroupedListRotation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Details and Grouped list chevron to rotate in the correct direction for RTL.",
+  "packageName": "office-ui-fabric-react",
+  "email": "bcoard@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-08T20:20:35.175Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -8,7 +8,7 @@ import {
   hiddenContentStyle,
   ITheme,
 } from '../../Styling';
-import { IsFocusVisibleClassName } from '../../Utilities';
+import { getRTL, IsFocusVisibleClassName } from '../../Utilities';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 import { ICellStyleProps } from './DetailsRow.types';
 // For every group level there is a GroupSpacer added. Importing this const to have the source value in one place.
@@ -259,7 +259,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
             },
           ]
         : {
-            transform: 'rotate(90deg)',
+            transform: getRTL(theme) ? 'rotate(-90deg)' : 'rotate(90deg)',
           },
     ],
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.styles.ts
@@ -7,7 +7,7 @@ import {
   FontWeights,
   IconFontSizes,
 } from '../../Styling';
-import { IsFocusVisibleClassName } from '../../Utilities';
+import { getRTL, IsFocusVisibleClassName } from '../../Utilities';
 import { DEFAULT_CELL_STYLE_PROPS } from '../DetailsList/DetailsRow.styles';
 import { CHECK_CELL_WIDTH } from '../DetailsList/DetailsRowCheck.styles';
 // For every group level there is a GroupSpacer added. Importing this const to have the source value in one place.
@@ -180,7 +180,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
             },
           ]
         : {
-            transform: 'rotate(90deg)',
+            transform: getRTL(theme) ? 'rotate(-90deg)' : 'rotate(90deg)',
             transformOrigin: '50% 50%',
             transition: 'transform .1s linear',
           },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13512
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently all Details List headers and Grouped List headers chevrons rotate 90 degrees when expanded, regardless of RTL. With this change, if the user is in RTL, the chevron will rotate -90 degrees instead of 90 degrees.

#### Focus areas to test

Details Grouped List headers and Grouped List headers.
