### PR TITLE
getId: no need to resetIds when Stylesheet resets

### DIFF
--- a/change/@uifabric-utilities-2020-06-08-14-56-58-xgao-getId.json
+++ b/change/@uifabric-utilities-2020-06-08-14-56-58-xgao-getId.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "getId: no need to resetIds when Stylesheet resets",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-08T21:56:58.865Z"
+}

--- a/packages/utilities/src/getId.ts
+++ b/packages/utilities/src/getId.ts
@@ -1,5 +1,4 @@
 import { getWindow } from './dom/getWindow';
-import { Stylesheet } from '@uifabric/merge-styles';
 
 // Initialize global window id.
 const CURRENT_ID_PROPERTY = '__currentId__';
@@ -12,24 +11,12 @@ if (_global[CURRENT_ID_PROPERTY] === undefined) {
   _global[CURRENT_ID_PROPERTY] = 0;
 }
 
-let _initializedStylesheetResets = false;
-
 /**
  * Generates a unique id in the global scope (this spans across duplicate copies of the same library.)
  *
  * @public
  */
 export function getId(prefix?: string): string {
-  if (!_initializedStylesheetResets) {
-    // Configure ids to reset on stylesheet resets.
-    const stylesheet = Stylesheet.getInstance();
-
-    if (stylesheet && stylesheet.onReset) {
-      stylesheet.onReset(resetIds);
-    }
-    _initializedStylesheetResets = true;
-  }
-
   let index = _global[CURRENT_ID_PROPERTY]++;
 
   return (prefix || DEFAULT_ID_STRING) + index;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
I don't think there is a need to `resetIds` when Stylesheet resets. If so we should remove the logic so we don't take dependency on `Stylesheet` from `getId`.

#### Focus areas to test

(optional)
