### PR TITLE
Combobox: Fix open onKeyboardFocus so it actually works as intended

### DIFF
--- a/change/office-ui-fabric-react-2020-06-08-17-07-03-fix-combobox-focus.json
+++ b/change/office-ui-fabric-react-2020-06-08-17-07-03-fix-combobox-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Fix openOnKeyboard prop to work as expected",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T00:07:03.206Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2812,7 +2812,7 @@ export interface IComboBoxState {
     currentPendingValue?: string;
     currentPendingValueValidIndex: number;
     currentPendingValueValidIndexOnHover: number;
-    focused?: boolean;
+    focusState?: 'none' | 'focused' | 'focusing';
     isOpen?: boolean;
     selectedIndices?: number[];
     suggestedDisplayValue?: string;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -486,6 +486,7 @@ describe('ComboBox', () => {
     );
     const comboBoxRoot = wrapper.find('.ms-ComboBox-Input').find('input');
     comboBoxRoot.simulate('focus');
+    comboBoxRoot.simulate('keyup');
     expect(onMenuOpenMock.mock.calls.length).toBe(1);
   });
 
@@ -851,13 +852,13 @@ describe('ComboBox', () => {
       />,
     );
     const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS], [0, 1, 2]);
     inputElement.simulate('focus');
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS], [0, 1, 2]);
     inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], [0, 1, 2]);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS], [0, 1, 2]);
     inputElement.simulate('blur');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [0, 1, 2, 3]);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [0, 1, 2, 3]);
   });
 
   // Adds currentPendingValue to options and makes it selected onBlur
@@ -873,19 +874,20 @@ describe('ComboBox', () => {
       <ComboBox multiSelect options={DEFAULT_OPTIONS} allowFreeform={true} componentRef={componentRef} />,
     );
     const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], []);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('focus');
-    expect((componentRef.current as ComboBox).state.focused).toEqual(true);
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    inputElement.simulate('keyup', { which: 10 });
+    expect((componentRef.current as ComboBox).state.focusState).toEqual('focused');
+    _verifyStateVariables(componentRef, 'focused', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    _verifyStateVariables(componentRef, 'focused', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('blur');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
 
     inputElement.simulate('focus');
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
     inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
 
     // This should toggle the checkbox off. With multi-select the currentPendingValue is not reset on input change
     // because it would break keyboard accessibility
@@ -897,7 +899,7 @@ describe('ComboBox', () => {
     inputElement.simulate('blur');
     _verifyStateVariables(
       componentRef,
-      false,
+      'none',
       [
         ...DEFAULT_OPTIONS,
         {
@@ -919,32 +921,32 @@ describe('ComboBox', () => {
     };
     wrapper = mount(<ComboBox options={DEFAULT_OPTIONS} allowFreeform={true} componentRef={componentRef} />);
     const inputElement: InputElementWrapper = wrapper.find('.ms-ComboBox input');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS], []);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('focus');
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('input', { target: { value: 'ManuallyEnteredValue' } });
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS], []);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS], []);
     inputElement.simulate('blur');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
 
     inputElement.simulate('focus');
-    _verifyStateVariables(componentRef, true, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
+    _verifyStateVariables(componentRef, 'focusing', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [3]);
     const buttonElement: any = wrapper.find('.ms-ComboBox button')! as any;
     buttonElement.simulate('click');
     const secondItem = document.querySelector('.ms-ComboBox-option[data-index="2"]')!;
     ReactTestUtils.Simulate.click(secondItem);
 
     inputElement.simulate('blur');
-    _verifyStateVariables(componentRef, false, [...DEFAULT_OPTIONS, { ...comboBoxOption }], [2]);
+    _verifyStateVariables(componentRef, 'none', [...DEFAULT_OPTIONS, { ...comboBoxOption }], [2]);
   });
 
   function _verifyStateVariables(
     componentRef: React.RefObject<any>,
-    isFocused: boolean,
+    focusState: 'none' | 'focused' | 'focusing',
     currentOptions: IComboBoxOption[],
     selectedIndices?: number[],
   ): void {
-    expect((componentRef.current as ComboBox).state.focused).toEqual(isFocused);
+    expect((componentRef.current as ComboBox).state.focusState).toEqual(focusState);
     expect((componentRef.current as ComboBox).state.selectedIndices).toEqual(selectedIndices);
     expect((componentRef.current as ComboBox).state.currentOptions).toEqual(currentOptions);
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -267,7 +267,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
 
   public componentDidUpdate(prevProps: IComboBoxProps, prevState: IComboBoxState) {
     const { allowFreeform, text, onMenuOpen, onMenuDismissed } = this.props;
-    const { isOpen, focusState, selectedIndices, currentPendingValueValidIndex } = this.state;
+    const { isOpen, selectedIndices, currentPendingValueValidIndex } = this.state;
 
     // If we are newly open or are open and the pending valid index changed,
     // make sure the currently selected/pending option is scrolled into view
@@ -360,7 +360,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
       iconButtonProps,
       multiSelect,
     } = this.props;
-    const { isOpen, focusState: focused, suggestedDisplayValue } = this.state;
+    const { isOpen, suggestedDisplayValue } = this.state;
     this._currentVisibleValue = this._getVisibleValue();
 
     // Single select is already accessible since the whole text is selected
@@ -382,7 +382,9 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
     // to correct the behavior where the input is cleared so the user can type. If a full refactor is done, then this
     // should be removed and the multiselect combobox should behave like a picker.
     const placeholder =
-      focused && this.props.multiSelect && multiselectAccessibleText ? multiselectAccessibleText : placeholderProp;
+      this._hasFocus() && this.props.multiSelect && multiselectAccessibleText
+        ? multiselectAccessibleText
+        : placeholderProp;
 
     this._classNames = this.props.getClassNames
       ? this.props.getClassNames(
@@ -390,7 +392,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           !!isOpen,
           !!disabled,
           !!required,
-          !!focused,
+          !!this._hasFocus(),
           !!allowFreeform,
           !!hasErrorMessage,
           className,
@@ -401,7 +403,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           !!isOpen,
           !!disabled,
           !!required,
-          !!focused,
+          !!this._hasFocus(),
           !!allowFreeform,
           !!hasErrorMessage,
         );
@@ -454,7 +456,7 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
                   this._onShouldSelectFullInputValueInAutofillComponentDidUpdate
                 }
                 title={title}
-                preventValueSelection={!focused}
+                preventValueSelection={!this._hasFocus()}
                 placeholder={placeholder}
                 tabIndex={tabIndex}
                 {...autofill}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #13495
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Steps towards a better handling on focus, now there are several states which help determine if the combobox should open when focused.

#### Focus areas to test

(optional)
