### PR TITLE
fix: Remove named exports of components in react-northstar

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Accordion/Accordion.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/Accordion.tsx
@@ -105,7 +105,7 @@ export const accordionSlotClassNames: AccordionSlotClassNames = {
   title: `${accordionClassName}__title`,
 };
 
-export const Accordion: React.FC<WithAsProp<AccordionProps>> &
+const Accordion: React.FC<WithAsProp<AccordionProps>> &
   FluentComponentStaticProps<AccordionProps> & {
     Title: typeof AccordionTitle;
     Content: typeof AccordionContent;

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionContent.tsx
@@ -48,7 +48,7 @@ export const accordionContentClassName = 'ui-accordion__content';
 
 export type AccordionContentStylesProps = Required<Pick<AccordionContentProps, 'active'>>;
 
-export const AccordionContent: React.FC<WithAsProp<AccordionContentProps>> &
+const AccordionContent: React.FC<WithAsProp<AccordionContentProps>> &
   FluentComponentStaticProps<AccordionContentProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(AccordionContent.displayName, context.telemetry);

--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -89,7 +89,7 @@ export type AccordionTitleStylesProps = Required<Pick<AccordionTitleProps, 'disa
   content: boolean;
 };
 
-export const AccordionTitle: React.FC<WithAsProp<AccordionTitleProps>> &
+const AccordionTitle: React.FC<WithAsProp<AccordionTitleProps>> &
   FluentComponentStaticProps<AccordionTitleProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(AccordionTitle.displayName, context.telemetry);

--- a/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
+++ b/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
@@ -124,7 +124,7 @@ export const alertSlotClassNames: AlertSlotClassNames = {
   body: `${alertClassName}__body`,
 };
 
-export const Alert: React.FC<WithAsProp<AlertProps>> &
+const Alert: React.FC<WithAsProp<AlertProps>> &
   FluentComponentStaticProps<AlertProps> & {
     DismissAction: typeof AlertDismissAction;
   } = props => {

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonGroup.tsx
@@ -43,8 +43,7 @@ export type ButtonGroupStylesProps = Required<Pick<ButtonGroupProps, 'circular'>
 
 export const buttonGroupClassName = 'ui-buttons';
 
-export const ButtonGroup: React.FC<WithAsProp<ButtonGroupProps>> &
-  FluentComponentStaticProps<ButtonGroupProps> = props => {
+const ButtonGroup: React.FC<WithAsProp<ButtonGroupProps>> & FluentComponentStaticProps<ButtonGroupProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(ButtonGroup.displayName, context.telemetry);
   setStart();

--- a/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/Carousel.tsx
@@ -128,7 +128,7 @@ export const carouselSlotClassNames: CarouselSlotClassNames = {
   navigation: `${carouselClassName}__navigation`,
 };
 
-export const Carousel: React.FC<WithAsProp<CarouselProps>> &
+const Carousel: React.FC<WithAsProp<CarouselProps>> &
   FluentComponentStaticProps<CarouselProps> & {
     Item: typeof CarouselItem;
     Navigation: typeof CarouselNavigation;

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselItem.tsx
@@ -46,8 +46,7 @@ export const carouselItemSlotClassNames: CarouselItemSlotClassNames = {
   itemPositionText: `${carouselItemClassName}__itemPositionText`,
 };
 
-export const CarouselItem: React.FC<WithAsProp<CarouselItemProps>> &
-  FluentComponentStaticProps<CarouselItemProps> = props => {
+const CarouselItem: React.FC<WithAsProp<CarouselItemProps>> & FluentComponentStaticProps<CarouselItemProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(CarouselItem.displayName, context.telemetry);
   setStart();

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigation.tsx
@@ -74,7 +74,7 @@ export type CarouselNavigationStylesProps = Required<
 
 export const carouselNavigationClassName = 'ui-carousel__navigation';
 
-export const CarouselNavigation: React.FC<WithAsProp<CarouselNavigationProps>> &
+const CarouselNavigation: React.FC<WithAsProp<CarouselNavigationProps>> &
   FluentComponentStaticProps<CarouselNavigationProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(CarouselNavigation.displayName, context.telemetry);

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
@@ -82,7 +82,7 @@ export const carouselNavigationItemSlotClassNames: CarouselNavigationItemSlotCla
   content: `${carouselNavigationItemClassName}__content`,
 };
 
-export const CarouselNavigationItem: React.FC<WithAsProp<CarouselNavigationItemProps>> &
+const CarouselNavigationItem: React.FC<WithAsProp<CarouselNavigationItemProps>> &
   FluentComponentStaticProps<CarouselNavigationItemProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(CarouselNavigationItem.displayName, context.telemetry);

--- a/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dialog/DialogFooter.tsx
@@ -24,8 +24,7 @@ export const dialogFooterClassName = 'ui-dialog__footer';
 
 export type DialogFooterStylesProps = never;
 
-export const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> &
-  FluentComponentStaticProps<DialogFooterProps> = props => {
+const DialogFooter: React.FC<WithAsProp<DialogFooterProps>> & FluentComponentStaticProps<DialogFooterProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DialogFooter.displayName, context.telemetry);
   setStart();

--- a/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Divider/Divider.tsx
@@ -48,7 +48,7 @@ export type DividerStylesProps = Required<
 
 export const dividerClassName = 'ui-divider';
 
-export const Divider: React.FC<WithAsProp<DividerProps>> & FluentComponentStaticProps<DividerProps> = props => {
+const Divider: React.FC<WithAsProp<DividerProps>> & FluentComponentStaticProps<DividerProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Divider.displayName, context.telemetry);
   setStart();

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSearchInput.tsx
@@ -81,7 +81,7 @@ export const dropdownSearchInputSlotClassNames: DropdownSearchInputSlotClassName
 
 export type DropdownSearchInputStylesProps = Required<Pick<DropdownSearchInputProps, 'inline'>>;
 
-export const DropdownSearchInput: React.FC<WithAsProp<DropdownSearchInputProps>> &
+const DropdownSearchInput: React.FC<WithAsProp<DropdownSearchInputProps>> &
   FluentComponentStaticProps<DropdownSearchInputProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(DropdownSearchInput.displayName, context.telemetry);

--- a/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
+++ b/packages/fluentui/react-northstar/src/components/Embed/Embed.tsx
@@ -83,7 +83,7 @@ export const embedSlotClassNames: EmbedSlotClassNames = {
 
 export type EmbedStylesProps = Required<Pick<EmbedProps, 'active'>> & { iframeLoaded: boolean };
 
-export const Embed: React.FC<WithAsProp<EmbedProps>> & FluentComponentStaticProps<EmbedProps> = props => {
+const Embed: React.FC<WithAsProp<EmbedProps>> & FluentComponentStaticProps<EmbedProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Embed.displayName, context.telemetry);
   setStart();

--- a/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
+++ b/packages/fluentui/react-northstar/src/components/SplitButton/SplitButton.tsx
@@ -107,7 +107,7 @@ export const splitButtonClassName = 'ui-splitbutton';
 
 export type SplitButtonStylesProps = Required<Pick<SplitButtonProps, 'size'>> & { isFromKeyboard: boolean };
 
-export const SplitButton: React.FC<WithAsProp<SplitButtonProps>> &
+const SplitButton: React.FC<WithAsProp<SplitButtonProps>> &
   FluentComponentStaticProps<SplitButtonProps> & {
     Toggle: typeof SplitButtonToggle;
   } = props => {

--- a/packages/fluentui/react-northstar/src/components/Table/Table.tsx
+++ b/packages/fluentui/react-northstar/src/components/Table/Table.tsx
@@ -62,7 +62,7 @@ export const tableSlotClassNames: TableSlotClassNames = {
 
 export type TableStylesProps = never;
 
-export const Table: React.FC<WithAsProp<TableProps>> &
+const Table: React.FC<WithAsProp<TableProps>> &
   FluentComponentStaticProps<TableProps> & {
     Cell: typeof TableCell;
     Row: typeof TableRow;

--- a/packages/fluentui/react-northstar/src/components/TextArea/TextArea.tsx
+++ b/packages/fluentui/react-northstar/src/components/TextArea/TextArea.tsx
@@ -56,7 +56,7 @@ export type TextAreaStylesProps = Required<Pick<TextAreaProps, 'inverted' | 'res
 
 export const textAreaClassName = 'ui-textarea';
 
-export const TextArea: React.FC<WithAsProp<TextAreaProps>> & FluentComponentStaticProps<TextAreaProps> = props => {
+const TextArea: React.FC<WithAsProp<TextAreaProps>> & FluentComponentStaticProps<TextAreaProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(TextArea.displayName, context.telemetry);
 

--- a/packages/fluentui/react-northstar/src/components/Video/Video.tsx
+++ b/packages/fluentui/react-northstar/src/components/Video/Video.tsx
@@ -38,7 +38,7 @@ export const videoClassName = 'ui-video';
 
 export type VideoStylesProps = Required<Pick<VideoProps, 'variables'>>;
 
-export const Video: React.FC<WithAsProp<VideoProps>> & FluentComponentStaticProps<VideoProps> = props => {
+const Video: React.FC<WithAsProp<VideoProps>> & FluentComponentStaticProps<VideoProps> = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Video.displayName, context.telemetry);
   setStart();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

react-northstar components are wrapped with `withSafeTypeForAs` and exported as default export. Those are then re-exported as named in index.ts:
```jsx
export * from './components/Accordion/Accordion';
export { default as Accordion } from './components/Accordion/Accordion';
```

If the component is exported as named, it is reexported by the first line and the name collides with the re-export on the second line.

Components should not be directly exported, I removed the exports.

