### PR TITLE
fix(ToolbarMenuItemActiveIndicator): Center indicator

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemActiveIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Toolbar/toolbarMenuItemActiveIndicatorStyles.ts
@@ -19,6 +19,7 @@ const toolbarMenuItemStyles: ComponentSlotStylesPrepared<
       height: '100%',
       position: 'absolute',
       right: pxToRem(7),
+      top: pxToRem(2),
     };
   },
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13265
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Center `ToolbarMenuItemActiveIndicator` on Toolbar

<img width="433" alt="Screenshot 2020-06-09 at 21 59 53" src="https://user-images.githubusercontent.com/8545105/84193962-9171dd00-aa9c-11ea-9840-3bd9fd93e74f.png">


#### Focus areas to test

(optional)
