### PR TITLE
ensure theme.ts is always included when importing from styling package

### DIFF
--- a/change/@uifabric-styling-2020-06-09-14-30-19-xgao-fix-styling-sideeffects.json
+++ b/change/@uifabric-styling-2020-06-09-14-30-19-xgao-fix-styling-sideeffects.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ensure theme.ts is already included when importing from styling package",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-09T21:30:19.143Z"
+}

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -11,8 +11,7 @@
   "module": "lib/index.js",
   "sideEffects": [
     "lib/version.js",
-    "lib/index.js",
-    "lib/styles/theme.js"
+    "lib/index.js"
   ],
   "typings": "lib/index.d.ts",
   "scripts": {

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -11,6 +11,7 @@
   "module": "lib/index.js",
   "sideEffects": [
     "lib/version.js",
+    "lib/index.js",
     "lib/styles/theme.js"
   ],
   "typings": "lib/index.d.ts",

--- a/packages/styling/src/index.ts
+++ b/packages/styling/src/index.ts
@@ -4,4 +4,7 @@ export * from './utilities/index';
 export * from './interfaces/index';
 export * from './MergeStyles';
 import './version';
+
+// This file contains logic to initialize default theme.
+// Unfortunately we need to ensure this file is always imported when this package is referenced.
 import './styles/theme';

--- a/packages/styling/src/index.ts
+++ b/packages/styling/src/index.ts
@@ -3,8 +3,9 @@ export * from './styles/index';
 export * from './utilities/index';
 export * from './interfaces/index';
 export * from './MergeStyles';
+
 import './version';
 
-// This file contains logic to initialize default theme.
-// Unfortunately we need to ensure this file is always imported when this package is referenced.
-import './styles/theme';
+// Ensure theme is initialized when this package is referenced.
+import { initializeThemeInCustomizations } from './styles/theme';
+initializeThemeInCustomizations();

--- a/packages/styling/src/index.ts
+++ b/packages/styling/src/index.ts
@@ -4,3 +4,4 @@ export * from './utilities/index';
 export * from './interfaces/index';
 export * from './MergeStyles';
 import './version';
+import './styles/theme';

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -18,16 +18,20 @@ let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
 
 export const ThemeSettingName = 'theme';
 
-if (!Customizations.getSettings([ThemeSettingName]).theme) {
-  const win: any = getWindow(); // tslint:disable-line:no-any
+export function initializeThemeInCustomizations(): void {
+  if (!Customizations.getSettings([ThemeSettingName]).theme) {
+    const win: any = getWindow(); // tslint:disable-line:no-any
 
-  if (win?.FabricConfig?.theme) {
-    _theme = createTheme(win.FabricConfig.theme);
+    if (win?.FabricConfig?.theme) {
+      _theme = createTheme(win.FabricConfig.theme);
+    }
+
+    // Set the default theme.
+    Customizations.applySettings({ [ThemeSettingName]: _theme });
   }
-
-  // Set the default theme.
-  Customizations.applySettings({ [ThemeSettingName]: _theme });
 }
+
+initializeThemeInCustomizations();
 
 /**
  * Gets the theme object


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fix regression from #13422.
This fix ensure when styling package is being imported (no matter which code path user is importing), `theme.ts` is always included

#### Focus areas to test
doing imports such as:
```
import { FontSizes } from 'office-ui-fabric-react/lib/Styling';
import { registerIcons } from 'office-ui-fabric-react/lib/Styling';
import { FontSizes } from '@uifabric/styling';
import { registerIcons } from '@uifabric/styling';
```
includes `theme` 