### PR TITLE
fix height and width check in the image component

### DIFF
--- a/change/@fluentui-react-next-2020-06-10-14-15-55-qihuang-fixImageCoverStyleIssue.json
+++ b/change/@fluentui-react-next-2020-06-10-14-15-55-qihuang-fixImageCoverStyleIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "fix height and width check in the image component",
+  "packageName": "@fluentui/react-next",
+  "email": "nif_tony@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-10T06:15:55.621Z"
+}

--- a/change/office-ui-fabric-react-2020-06-10-14-15-55-qihuang-fixImageCoverStyleIssue.json
+++ b/change/office-ui-fabric-react-2020-06-10-14-15-55-qihuang-fixImageCoverStyleIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix height and width check in the image component",
+  "packageName": "office-ui-fabric-react",
+  "email": "nif_tony@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-10T06:15:53.961Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -165,8 +165,13 @@ export class ImageBase extends React.Component<IImageProps, IImageState> {
       // Determine the desired ratio using the width and height props.
       // If those props aren't available, measure measure the frame.
       let desiredRatio;
-      if (!!width && !!height && imageFit !== ImageFit.centerContain && imageFit !== ImageFit.centerCover) {
-        desiredRatio = (width as number) / (height as number);
+      if (
+        typeof width === 'number' &&
+        typeof height === 'number' &&
+        imageFit !== ImageFit.centerContain &&
+        imageFit !== ImageFit.centerCover
+      ) {
+        desiredRatio = width / height;
       } else {
         desiredRatio = this._frameElement.current.clientWidth / this._frameElement.current.clientHeight;
       }

--- a/packages/react-next/src/components/Image/Image.base.tsx
+++ b/packages/react-next/src/components/Image/Image.base.tsx
@@ -179,8 +179,13 @@ function computeCoverStyle(
     // Determine the desired ratio using the width and height props.
     // If those props aren't available, measure measure the frame.
     let desiredRatio;
-    if (!!width && !!height && imageFit !== ImageFit.centerContain && imageFit !== ImageFit.centerCover) {
-      desiredRatio = (width as number) / (height as number);
+    if (
+      typeof width === 'number' &&
+      typeof height === 'number' &&
+      imageFit !== ImageFit.centerContain &&
+      imageFit !== ImageFit.centerCover
+    ) {
+      desiredRatio = width / height;
     } else {
       desiredRatio = frameElement.current.clientWidth / frameElement.current.clientHeight;
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13543
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`width as number` and `height as number` are too dangerous. There are chances that caller is providing 100% to the width and height. At that point, the coverStyle will fail

#### Focus areas to test

Image Component