### PR TITLE
 PivotItem: Fixing typing error in headerButtonProps

### DIFF
--- a/change/@fluentui-react-next-2020-06-10-14-14-47-pivotItemHeaderButtonType.json
+++ b/change/@fluentui-react-next-2020-06-10-14-14-47-pivotItemHeaderButtonType.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "PivotItem: Fixing typing error in headerButtonProps.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-10T21:14:47.890Z"
+}

--- a/change/office-ui-fabric-react-2020-06-10-14-10-47-pivotItemHeaderButtonType.json
+++ b/change/office-ui-fabric-react-2020-06-10-14-10-47-pivotItemHeaderButtonType.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "PivotItem: Fixing typing error in headerButtonProps.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-10T21:10:47.119Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6283,7 +6283,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     alwaysRender?: boolean;
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
-    headerButtonProps?: IButtonProps & {
+    headerButtonProps?: IButtonProps | {
         [key: string]: string | number | boolean;
     };
     headerText?: string;

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -27,7 +27,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Props for the header command button. This provides a way to pass in native props, such as data-* and aria-*,
    * for each pivot header/link element.
    */
-  headerButtonProps?: IButtonProps & { [key: string]: string | number | boolean };
+  headerButtonProps?: IButtonProps | { [key: string]: string | number | boolean };
 
   /**
    * An required key to uniquely identify a pivot item.

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -421,7 +421,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     alwaysRender?: boolean;
     ariaLabel?: string;
     componentRef?: IRefObject<{}>;
-    headerButtonProps?: IButtonProps & {
+    headerButtonProps?: IButtonProps | {
         [key: string]: string | number | boolean;
     };
     headerText?: string;
@@ -1114,10 +1114,10 @@ export const Toggle: React.FunctionComponent<IToggleProps>;
 export const ToggleBase: import("@fluentui/react-compose").ComponentWithAs<"div", IToggleProps>;
 
 // @public
-export const useLink: (props: ILinkProps, options: ComposePreparedOptions<{}, {}>) => any;
+export const useLink: (props: ILinkProps, options: ComposePreparedOptions<{}, any, {}>) => any;
 
 // @public (undocumented)
-export const useToggle: (props: IToggleProps, options: ComposePreparedOptions<{}, {}>) => any;
+export const useToggle: (props: IToggleProps, options: ComposePreparedOptions<{}, any, {}>) => any;
 
 
 export * from "office-ui-fabric-react/lib/ActivityItem";

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -1114,10 +1114,10 @@ export const Toggle: React.FunctionComponent<IToggleProps>;
 export const ToggleBase: import("@fluentui/react-compose").ComponentWithAs<"div", IToggleProps>;
 
 // @public
-export const useLink: (props: ILinkProps, options: ComposePreparedOptions<{}, any, {}>) => any;
+export const useLink: (props: ILinkProps, options: ComposePreparedOptions<{}, {}>) => any;
 
 // @public (undocumented)
-export const useToggle: (props: IToggleProps, options: ComposePreparedOptions<{}, any, {}>) => any;
+export const useToggle: (props: IToggleProps, options: ComposePreparedOptions<{}, {}>) => any;
 
 
 export * from "office-ui-fabric-react/lib/ActivityItem";

--- a/packages/react-next/src/components/Pivot/PivotItem.types.ts
+++ b/packages/react-next/src/components/Pivot/PivotItem.types.ts
@@ -27,7 +27,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Props for the header command button. This provides a way to pass in native props, such as data-* and aria-*,
    * for each pivot header/link element.
    */
-  headerButtonProps?: IButtonProps & { [key: string]: string | number | boolean };
+  headerButtonProps?: IButtonProps | { [key: string]: string | number | boolean };
 
   /**
    * An required key to uniquely identify a pivot item.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

#13128 aimed to expand the typings of `headerButtonProps` to accept `IButtonProps` but there was a bug in the type introduced. This PR fixes that bug.

#### Focus areas to test

(optional)
