### PR TITLE
Perf-test: set no timeout for puppeteer page action

### DIFF
--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -275,8 +275,8 @@ module.exports = async function getPerfRegressions() {
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      // temporarily removing the timeout
-      // while investigating what the correct timeout should be.
+      // Occasionally during our CI, page takes unexpected amount of time to navigate (unsure about the root cause).
+      // Removing the timeout to avoid perf-test failures but be cautious about long test runs.
       page.setDefaultTimeout(0);
 
       await page.goto(options.url);

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -275,7 +275,9 @@ module.exports = async function getPerfRegressions() {
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      page.setDefaultTimeout(0); // set no timeout
+      // temporarily removing the timeout
+      // while investigating what the correct timeout should be.
+      page.setDefaultTimeout(0);
 
       await page.goto(options.url);
       await page.waitForSelector('#render-done');

--- a/apps/perf-test/tasks/perf-test.ts
+++ b/apps/perf-test/tasks/perf-test.ts
@@ -275,7 +275,7 @@ module.exports = async function getPerfRegressions() {
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      page.setDefaultTimeout(60000); // set 60s timeout, default is 30s.
+      page.setDefaultTimeout(0); // set no timeout
 
       await page.goto(options.url);
       await page.waitForSelector('#render-done');

--- a/packages/fluentui/perf-test/tasks/perf-test.ts
+++ b/packages/fluentui/perf-test/tasks/perf-test.ts
@@ -105,7 +105,10 @@ export default async function getPerfRegressions(baselineOnly: boolean = false) 
     outDir,
     tempDir,
     pageActions: async (page, options) => {
-      page.setDefaultTimeout(0); // set no timeout
+      // Occasionally during our CI, page takes unexpected amount of time to navigate (unsure about the root cause).
+      // Removing the timeout to avoid perf-test failures but be cautious about long test runs.
+      page.setDefaultTimeout(0);
+
       await page.goto(options.url);
     },
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
remove timeout for page action.
Perf tests are currently timing out occasionally with 60s timeout set:
https://uifabric.visualstudio.com/fabricpublic/_build?definitionId=146&_a=summary

#### Focus areas to test

(optional)
