### PR TITLE
Screen Reader is not announcing the location list items twice.

### DIFF
--- a/change/office-ui-fabric-react-2020-06-15-13-43-56-user-v-satgar-ScreenReaderAnnouncingTwice.json
+++ b/change/office-ui-fabric-react-2020-06-15-13-43-56-user-v-satgar-ScreenReaderAnnouncingTwice.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing title for command bar",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-06-15T08:13:56.156Z"
+}

--- a/change/office-ui-fabric-react-2020-06-15-13-43-56-user-v-satgar-ScreenReaderAnnouncingTwice.json
+++ b/change/office-ui-fabric-react-2020-06-15-13-43-56-user-v-satgar-ScreenReaderAnnouncingTwice.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Removing title for command bar",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "v-satgar@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-06-15T08:13:56.156Z"
 }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1383,7 +1383,6 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           aria-selected={isSelected ? 'true' : 'false'}
           ariaLabel={this._getPreviewText(item)}
           disabled={item.disabled}
-          title={title}
         >
           {
             <span className={optionClassNames.optionTextWrapper} ref={isSelected ? this._selectedElement : undefined}>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removed title for the commandBar for the screen reader to announce the list item only once.

#### Focus areas to test

N/A
