### PR TITLE
drawing focus border around the arc in dount chart

### DIFF
--- a/change/@uifabric-charting-2020-06-15-14-03-02-user-v-sivsar-donutChartFocusIssue.json
+++ b/change/@uifabric-charting-2020-06-15-14-03-02-user-v-sivsar-donutChartFocusIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding focus border functionality to donut chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-15T08:33:02.763Z"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.styles.ts
@@ -2,13 +2,22 @@ import { IArcProps, IArcStyles } from './Arc.types';
 import { DefaultPalette, FontSizes } from 'office-ui-fabric-react/lib/Styling';
 
 export const getStyles = (props: IArcProps): IArcStyles => {
-  const { color, href } = props;
+  const { color, href, theme } = props;
   return {
     root: {
       fill: color,
       cursor: href ? 'pointer' : 'default',
       stroke: DefaultPalette.white,
-      strokeWidth: 2,
+      outline: 'transparent',
+      selectors: {
+        '::-moz-focus-inner': {
+          border: '0',
+        },
+      },
+    },
+    focusRing: {
+      stroke: theme.semanticColors.focusBorder,
+      strokeWidth: 4,
     },
     insideDonutString: {
       fontSize: FontSizes.large,

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -26,18 +26,21 @@ export class Arc extends React.Component<IArcProps, IArcState> {
   }
 
   public render(): JSX.Element {
-    const { color, arc, href, valueInsideDonut } = this.props;
+    const { color, arc, href, valueInsideDonut, theme, focusedArcId } = this.props;
     const getClassNames = classNamesFunction<IArcProps, IArcStyles>();
-    const classNames = getClassNames(getStyles, { color, href });
+    const classNames = getClassNames(getStyles, { color, href, theme });
     const id = this.props.uniqText! + this.props.data!.data.legend!.replace(/\s+/, '') + this.props.data!.data.data;
     const opacity: number =
       this.props.activeArc === this.props.data!.data.legend || this.props.activeArc === '' ? 1 : 0.1;
     return (
       <g ref={this.currentRef}>
+        {!!focusedArcId && focusedArcId === id && (
+          <path id={id + 'focusRing'} d={arc(this.props.focusData)} className={classNames.focusRing} />
+        )}
         <path
           id={id}
           d={arc(this.props.data)}
-          onFocus={this._onFocus.bind(this, this.props.data!.data)}
+          onFocus={this._onFocus.bind(this, this.props.data!.data, id)}
           className={classNames.root}
           data-is-focusable={true}
           onMouseOver={this._hoverOn.bind(this, this.props.data!.data)}
@@ -55,9 +58,9 @@ export class Arc extends React.Component<IArcProps, IArcState> {
     );
   }
 
-  private _onFocus(data: IChartDataPoint): void {
+  private _onFocus(data: IChartDataPoint, id: string): void {
     if (this.props.activeArc === this.props.data!.data.legend || this.props.activeArc === '') {
-      this.props.onFocusCallback!(data, this.currentRef.current);
+      this.props.onFocusCallback!(data, id, this.currentRef.current);
     }
   }
 

--- a/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.types.ts
@@ -1,11 +1,24 @@
-import { IStyle } from 'office-ui-fabric-react/lib/Styling';
+import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IChartDataPoint } from '../index';
 export interface IArcProps {
+  /**
+   * Theme
+   */
+  theme: ITheme;
   /**
    * Data to render in the Arc.
    */
   data?: IArcData;
 
+  /**
+   * Data to render focused Arc
+   */
+  focusData?: IArcData;
+
+  /**
+   * id of the focused arc
+   */
+  focusedArcId?: string;
   /**
    * shape for  Arc.
    */
@@ -110,4 +123,9 @@ export interface IArcStyles {
    * Style set for the inside donut string
    */
   insideDonutString: IStyle;
+
+  /**
+   * styles for the focus
+   */
+  focusRing: IStyle;
 }

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -23,6 +23,7 @@ interface IDonutChartState {
   isLegendSelected?: boolean;
   xCalloutValue?: string;
   yCalloutValue?: string;
+  focusedArcId?: string;
 }
 
 export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChartState> {
@@ -116,9 +117,11 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
                 uniqText={this._uniqText}
                 onBlurCallback={this._onBlur}
                 activeArc={this.state.activeLegend}
+                focusedArcId={this.state.focusedArcId || ''}
                 href={href}
                 calloutId={this._calloutId}
                 valueInsideDonut={valueInsideDonut}
+                theme={theme!}
               />
             </svg>
           </div>
@@ -215,7 +218,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     return legends;
   }
 
-  private _focusCallback = (data: IChartDataPoint, element: SVGPathElement): void => {
+  private _focusCallback = (data: IChartDataPoint, id: string, element: SVGPathElement): void => {
     this._currentHoverElement = element;
     this.setState({
       showHover: true,
@@ -224,6 +227,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       color: data.color!,
       xCalloutValue: data.xAxisCalloutData!,
       yCalloutValue: data.yAxisCalloutData!,
+      focusedArcId: id,
     });
   };
 
@@ -239,7 +243,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     });
   };
   private _onBlur = (): void => {
-    this.setState({ showHover: false });
+    this.setState({ showHover: false, focusedArcId: '' });
   };
 
   private _hoverLeave(): void {

--- a/packages/charting/src/components/DonutChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.tsx
@@ -6,7 +6,7 @@ import { IArcData } from '../Arc/Arc.types';
 import { IChartDataPoint } from '../index';
 
 export class Pie extends React.Component<IPieProps, {}> {
-  public static defaultProps = {
+  public static defaultProps: Partial<IPieProps> = {
     pie: shape
       .pie()
       .sort(null)

--- a/packages/charting/src/components/DonutChart/Pie/Pie.tsx
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.tsx
@@ -6,26 +6,36 @@ import { IArcData } from '../Arc/Arc.types';
 import { IChartDataPoint } from '../index';
 
 export class Pie extends React.Component<IPieProps, {}> {
-  public static defaultProps: Partial<IPieProps> = {
+  public static defaultProps = {
     pie: shape
       .pie()
       .sort(null)
       // tslint:disable:no-any
       .value((d: any) => {
         return d.data;
-      }),
+      })
+      .padAngle(0.02),
   };
+  // tslint:disable-next-line:no-any
+  private _pieForFocusRing: any;
   constructor(props: IPieProps) {
     super(props);
     this._hoverCallback = this._hoverCallback.bind(this);
+    this._pieForFocusRing = shape
+      .pie()
+      .sort(null)
+      // tslint:disable-next-line:no-any
+      .value((d: any) => d.data)
+      .padAngle(0);
   }
 
-  public arcGenerator = (d: IArcData, i: number, href?: string): JSX.Element => {
+  public arcGenerator = (d: IArcData, i: number, focusData: IArcData, href?: string): JSX.Element => {
     const color = d && d.data && d.data.color;
     return (
       <Arc
         key={i}
         data={d}
+        focusData={focusData}
         innerRadius={this.props.innerRadius}
         outerRadius={this.props.outerRadius}
         color={color!}
@@ -38,21 +48,26 @@ export class Pie extends React.Component<IPieProps, {}> {
         href={href}
         calloutId={this.props.calloutId}
         valueInsideDonut={this.props.valueInsideDonut}
+        theme={this.props.theme!}
+        focusedArcId={this.props.focusedArcId}
       />
     );
   };
 
   public render(): JSX.Element {
     const { pie, data, width, height, href } = this.props;
-
+    const focusData = this._pieForFocusRing(data);
     const piechart = pie(data),
       translate = `translate(${width / 2}, ${height / 2})`;
-
-    return <g transform={translate}>{piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i, href))}</g>;
+    return (
+      <g transform={translate}>
+        {piechart.map((d: IArcData, i: number) => this.arcGenerator(d, i, focusData[i], href))}
+      </g>
+    );
   }
 
-  private _focusCallback = (data: IChartDataPoint, e: SVGPathElement): void => {
-    this.props.onFocusCallback!(data, e);
+  private _focusCallback = (data: IChartDataPoint, id: string, e: SVGPathElement): void => {
+    this.props.onFocusCallback!(data, id, e);
   };
 
   private _hoverCallback(data: IChartDataPoint, e: React.MouseEvent<SVGPathElement>): void {

--- a/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
+++ b/packages/charting/src/components/DonutChart/Pie/Pie.types.ts
@@ -1,7 +1,11 @@
-import { IStyle } from 'office-ui-fabric-react/lib/Styling';
+import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IChartDataPoint } from '../index';
 
 export interface IPieProps {
+  /**
+   * Theme
+   */
+  theme: ITheme;
   /**
    * Width of the Pie.
    */
@@ -66,6 +70,11 @@ export interface IPieProps {
    * props for inside donut value
    */
   valueInsideDonut?: string | number;
+
+  /**
+   * id of the focused arc
+   */
+  focusedArcId?: string;
 }
 
 export interface IPieStyles {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://office.visualstudio.com/OC/_queries/edit/4221185/
- [x] Include a change request file using `$ yarn change`

#### Description of changes

i have added the focus border functionality to the arc in donut chart when it get's focused

to achieve this. i am first removing the `stroke-width` to the arc which is responsible for spaces between the arc. and adding the `padAngle(0.02)` to achieve the spacing functionality .

similar to the pie data. i constructed one more `arc` array with `padAngle` `0` and sending it to arc from `pie` component. so whenever the `arc` get focused i am taking it's id and setting it to state in `donutchart.base` and sending it down to the `arc` component again, so whenever the state id in donut and arc is equal i am drawing the another `arc` behind the focused `arc` with color `focusBorder` and greater `stroke-width` so in this way users we get border like feeling  around the arc.

**before fix video**
https://drive.google.com/file/d/14SuBLyCTrN5FRI6YgJjU6vGWEMKZHcHC/view?usp=sharing

**after fix video**
https://drive.google.com/file/d/1EJrfG7md7J1GmwT7cRtIqp2HUFDOe8bm/view?usp=sharing

**before fix snap**
![image](https://user-images.githubusercontent.com/33802398/84637103-f4d39300-af12-11ea-98e3-d7b9be6e7395.png)

**after fix snap**
![image](https://user-images.githubusercontent.com/33802398/84637197-0b79ea00-af13-11ea-90f9-96c57d145df9.png)

**before fix without focus border**
![image](https://user-images.githubusercontent.com/33802398/84637348-35cba780-af13-11ea-9912-c685094bea31.png)

**after fix without focus border**
![image](https://user-images.githubusercontent.com/33802398/84637273-1e8cba00-af13-11ea-9ac8-e835acf6ab81.png)



#### Focus areas to test

Donut chart
