### PR TITLE
Enable yarn start without build - Import _References.scss from office-ui-fabric-core module

### DIFF
--- a/change/office-ui-fabric-react-2020-06-15-13-23-43-jslone-sass-reference-build.json
+++ b/change/office-ui-fabric-react-2020-06-15-13-23-43-jslone-sass-reference-build.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "_common.scss: Update import statement to not depend on dist folder (which doesn't exist until full build)",
+  "packageName": "office-ui-fabric-react",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-15T20:23:43.312Z"
+}

--- a/packages/office-ui-fabric-react/src/common/_common.scss
+++ b/packages/office-ui-fabric-react/src/common/_common.scss
@@ -1,4 +1,4 @@
-@import '../../dist/sass/References';
+@import '~office-ui-fabric-core/dist/sass/References';
 @import './i18n';
 @import './themeOverrides';
 @import './focusBorder';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13607
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Import References from office-ui-fabric-core module instead of ../../dist folder.

_References.scss is not copied to the dist folder until after a build, this means that the first dev experience would require a full build to yarn start. With this change devs should be able to yarn start without first doing a build. 

#### Focus areas to test

Test that a clean repo builds after just:
```yarn```
```yarn start```
