### PR TITLE
Grouped bar chart Y axis tick values truncate issue resolved

### DIFF
--- a/change/@uifabric-charting-2020-06-16-16-08-34-user-v-jasha-GroupedChartYAxisIssues.json
+++ b/change/@uifabric-charting-2020-06-16-16-08-34-user-v-jasha-GroupedChartYAxisIssues.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Y axis ticks truncate issue resolved",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-06-16T10:38:34.326Z"
 }

--- a/change/@uifabric-charting-2020-06-16-16-08-34-user-v-jasha-GroupedChartYAxisIssues.json
+++ b/change/@uifabric-charting-2020-06-16-16-08-34-user-v-jasha-GroupedChartYAxisIssues.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Y axis ticks truncate issue resolved",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T10:38:34.326Z"
+}

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -103,7 +103,6 @@ export class GroupedVerticalBarChartBase extends React.Component<
 
   public componentDidMount(): void {
     this._fitParentContainer();
-    window.addEventListener('resize', this._fitParentContainer);
   }
 
   public componentWillUnmount(): void {
@@ -111,15 +110,20 @@ export class GroupedVerticalBarChartBase extends React.Component<
     d3Select('#firstGElementForBars').remove();
   }
 
-  public componentDidUpdate(): void {
+  public componentDidUpdate(prevProps: IGroupedVerticalBarChartProps): void {
     if (this._isGraphDraw) {
       // drawing graph after first update only to avoid multile g tags
       this._drawGraph();
       this._isGraphDraw = false;
     }
+    if (prevProps.height !== this.props.height || prevProps.width !== this.props.width) {
+      this._fitParentContainer();
+      this._drawGraph();
+    }
   }
 
   public render(): React.ReactNode {
+    this._adjustProps();
     const { theme, className, styles } = this.props;
 
     if (this.props.parentRef) {
@@ -493,7 +497,8 @@ export class GroupedVerticalBarChartBase extends React.Component<
       .domain([0, domains[domains.length - 1]])
       .range([this.state.containerHeight - this.margins.bottom, this.margins.top]);
     const yAxis = d3AxisLeft(yAxisScale)
-      .tickPadding(10)
+      .tickPadding(5)
+      .ticks(this._yAxisTickCount, 's')
       .tickValues(domains);
 
     this._showYAxisGridLines &&

--- a/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
@@ -16,7 +16,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
         series: [
           {
             key: 'series1',
-            data: 9,
+            data: 90000,
             color: DefaultPalette.accent,
             legend: 'MetaData1',
             xAxisCalloutData: '2020/04/30',
@@ -24,7 +24,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series2',
-            data: 85,
+            data: 85000,
             color: DefaultPalette.blueMid,
             legend: 'MetaData2',
             xAxisCalloutData: '2020/04/30',
@@ -32,7 +32,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series3',
-            data: 36,
+            data: 36000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData3',
             xAxisCalloutData: '2020/04/30',
@@ -40,7 +40,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series4',
-            data: 66,
+            data: 66000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
             xAxisCalloutData: '2020/04/30',
@@ -48,7 +48,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series5',
-            data: 34,
+            data: 34000,
             color: DefaultPalette.blueDark,
             legend: 'MetaData5',
             xAxisCalloutData: '2020/04/30',
@@ -61,7 +61,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
         series: [
           {
             key: 'series1',
-            data: 14,
+            data: 14000,
             color: DefaultPalette.accent,
             legend: 'MetaData1',
             xAxisCalloutData: '2020/04/30',
@@ -69,7 +69,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series2',
-            data: 50,
+            data: 50000,
             color: DefaultPalette.blueMid,
             legend: 'MetaData2',
             xAxisCalloutData: '2020/04/30',
@@ -77,7 +77,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series3',
-            data: 33,
+            data: 33000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData3',
             xAxisCalloutData: '2020/04/30',
@@ -85,7 +85,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series4',
-            data: 44,
+            data: 44000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
             xAxisCalloutData: '2020/04/30',
@@ -93,7 +93,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series5',
-            data: 72,
+            data: 72000,
             color: DefaultPalette.blueDark,
             legend: 'MetaData5',
             xAxisCalloutData: '2020/04/30',
@@ -106,7 +106,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
         series: [
           {
             key: 'series1',
-            data: 33,
+            data: 33000,
             color: DefaultPalette.accent,
             legend: 'MetaData1',
             xAxisCalloutData: '2020/04/30',
@@ -114,7 +114,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series2',
-            data: 3,
+            data: 3000,
             color: DefaultPalette.blueMid,
             legend: 'MetaData2',
             xAxisCalloutData: '2020/04/30',
@@ -122,7 +122,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series3',
-            data: 75,
+            data: 75000,
             color: DefaultPalette.blueLight,
             legend: 'MetaData3',
             xAxisCalloutData: '2020/04/30',
@@ -130,7 +130,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series4',
-            data: 29,
+            data: 29000,
             color: DefaultPalette.blue,
             legend: 'MetaData4',
             xAxisCalloutData: '2020/04/30',
@@ -138,7 +138,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
           },
           {
             key: 'series5',
-            data: 90,
+            data: 50000,
             color: DefaultPalette.blueDark,
             legend: 'MetaData5',
             xAxisCalloutData: '2020/04/30',
@@ -152,7 +152,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
 
     return (
       <div className={mergeStyles(rootStyle)}>
-        <GroupedVerticalBarChart data={data} showYAxisGridLines />
+        <GroupedVerticalBarChart data={data} height={400} width={650} showYAxisGridLines />
       </div>
     );
   }

--- a/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Styled.Example.tsx
@@ -88,11 +88,10 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<Readon
       <div className={mergeStyles(rootStyle)}>
         <GroupedVerticalBarChart
           data={data}
-          showXAxisGridLines
+          width={650}
+          height={400}
           showYAxisGridLines
           yAxisTickCount={10}
-          showXAxisPath
-          showYAxisPath
           barwidth={43}
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In grouped vertical bar chart graph, y axis tick truncate issue resolved by added ticks property to the axis and updating tick padding property. By this, SI Units will be added.

Minor changes made related to the automatically size changes when parent width or height changes.

#### Focus areas to test

Grouped vertical bar chart

## Before changes
![image](https://user-images.githubusercontent.com/20105532/84765202-86630380-afec-11ea-94b3-8738bea9d792.png)


## After changes
![image](https://user-images.githubusercontent.com/20105532/84765146-73503380-afec-11ea-886f-2110cc929644.png)
