### PR TITLE
Partially Port #5536 to calculate aria-posinset and aria-setsize in CommandBar.tsx to skip ContextualMenuItemType which is equal to Divider or Header in office-ui-fabric-react/5.79.1

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_5-office-ui-fabric-react-5.79.1_2020-06-16-11-41.json
+++ b/common/changes/office-ui-fabric-react/hotfix_5-office-ui-fabric-react-5.79.1_2020-06-16-11-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Caculate aria-posinset and aria-setsize to skip ContextualMenuItemType which is equal to Divider or Header",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/data-nonFocusable.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/data-nonFocusable.ts
@@ -1,8 +1,10 @@
+import { ContextualMenuItemType } from '../../ContextualMenu';
 export const itemsNonFocusable = [
   {
     key: 'newItem',
     name: 'New',
     icon: 'Add',
+    itemType: ContextualMenuItemType.Normal,
     ariaLabel: 'New. Use left and right arrow keys to navigate',
     onClick: () => { return; },
     items: [
@@ -22,6 +24,7 @@ export const itemsNonFocusable = [
     key: 'upload',
     name: 'Upload',
     icon: 'Upload',
+    itemType: ContextualMenuItemType.Normal,
     onClick: () => { return; },
     ['data-automation-id']: 'uploadNonFocusButton'
   }
@@ -32,12 +35,14 @@ export const farItemsNonFocusable = [
     key: 'saveStatus',
     name: 'Your page has been saved',
     icon: 'CheckMark',
+    itemType: ContextualMenuItemType.Header,
     ['data-automation-id']: 'saveStatusCheckMark'
   },
   {
     key: 'publish',
     name: 'Publish',
     icon: 'ReadingMode',
+    itemType: ContextualMenuItemType.Normal,
     onClick: () => { return; }
   }
 ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ rush change`

#### Description of changes

Partially Port #5536 to calculate aria-posinset and aria-setsize in CommandBar.tsx to skip ContextualMenuItemType which is equal to Divider or Header in office-ui-fabric-react/5.79.1.

By default aria-posinset and aria-setsize are calculated regardless of ContextualMenuItemType. But in some case, we will encounter accessibility bugs about enumerating errors if ContextualMenu contains ContextualMenuItemType.Divider or ContextualMenuItemType.Header.

#### Focus areas to test

(optional)
