### PR TITLE
Fix Special Folder Icons and Signals

### DIFF
--- a/change/@uifabric-experiments-2020-06-16-12-16-25-user-taenri-specialFolderIconFix.json
+++ b/change/@uifabric-experiments-2020-06-16-12-16-25-user-taenri-specialFolderIconFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix icon names for DesktopSignal, DocumentsSignal, and PicturesSignal. Update example page.",
+  "packageName": "@uifabric/experiments",
+  "email": "taenri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T19:16:19.097Z"
+}

--- a/change/@uifabric-file-type-icons-2020-06-16-12-16-25-user-taenri-specialFolderIconFix.json
+++ b/change/@uifabric-file-type-icons-2020-06-16-12-16-25-user-taenri-specialFolderIconFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add special folder icon names to FileTypeIconMap. Fix icon name for special documents folder.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "taenri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T19:16:25.597Z"
+}

--- a/packages/experiments/src/components/signals/Signals.tsx
+++ b/packages/experiments/src/components/signals/Signals.tsx
@@ -119,15 +119,15 @@ export const SharedSignal: Signal = (props: ISignalProps): JSX.Element => {
 };
 
 export const DesktopSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="desktopfolder" />;
+  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="TVMonitor" />;
 };
 
 export const DocumentsSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="documentsfolder" />;
+  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Page" />;
 };
 
 export const PicturesSignal: Signal = (props: ISignalProps): JSX.Element => {
-  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="picturesfolder" />;
+  return <IconSignal {...props} signalClass={SignalsStyles.folder} iconName="Photo2" />;
 };
 
 export const MalwareDetectedSignal: Signal = (props: ISignalProps): JSX.Element => {

--- a/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
+++ b/packages/experiments/src/components/signals/examples/Signals.Basic.Example.tsx
@@ -21,6 +21,9 @@ import {
   RecordSignal,
   NeedsRepublishingSignal,
   ItemScheduledSignal,
+  DesktopSignal,
+  DocumentsSignal,
+  PicturesSignal,
 } from '@uifabric/experiments';
 import { Checkbox, ChoiceGroup, IChoiceGroupOption, css } from 'office-ui-fabric-react';
 import { lorem } from '@uifabric/example-data';
@@ -123,6 +126,9 @@ export class SignalsBasicExample extends React.Component<{}, ISignalsBasicExampl
           <SignalExample name="Shared" signal={<SharedSignal />} />
           <SignalExample name="Needs Republishing" signal={<NeedsRepublishingSignal />} />
           <SignalExample name="Page Scheduled" signal={<ItemScheduledSignal />} />
+          <SignalExample name="Special Folder (Desktop)" signal={<DesktopSignal />} />
+          <SignalExample name="Special Folder (Documents)" signal={<DocumentsSignal />} />
+          <SignalExample name="Special Folder (Pictures)" signal={<PicturesSignal />} />
         </div>
       </div>
     );

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -256,7 +256,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   csv: {
     extensions: ['csv'],
   },
+  desktopfolder: {},
   docset: {},
+  documentfolder: {},
   docx: {
     extensions: ['doc', 'docm', 'docx', 'docb'],
   },
@@ -377,6 +379,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     ],
   },
   photo360: {},
+  picturesfolder: {},
   potx: {
     extensions: ['pot', 'potm', 'potx'],
   },

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -12,7 +12,7 @@ const MULTIPLE_ITEMS = 'multiple';
 const NEWS = 'sponews';
 const STREAM = 'stream';
 const DESKTOP_FOLDER = 'desktopfolder';
-const DOCUMENTS_FOLDER = 'documentsfolder';
+const DOCUMENTS_FOLDER = 'documentfolder';
 const PICTURES_FOLDER = 'picturesfolder';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes internal issue.
- [X] Include a change request file using `$ yarn change`

#### Description of changes

[@uifabric/experiments] Fix icon names for DesktopSignal, DocumentsSignal, and PicturesSignal. Update example page.

[@uifabric/file-type-icons] Add special folder icon names to FileTypeIconMap. Fix icon name for special documents folder.

#### Focus areas to test

(optional)
![image](https://user-images.githubusercontent.com/1110944/84907752-6d983380-b068-11ea-841e-0964a8b12f0e.png)

http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/13625/merge/experiments/dist/index.html#/examples/signals