### PR TITLE
Fix Picker action button screen reader issue by updating activedescendant

### DIFF
--- a/change/office-ui-fabric-react-2020-06-16-12-21-54-picker-actions-a11y.json
+++ b/change/office-ui-fabric-react-2020-06-16-12-21-54-picker-actions-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix screen reader behavior on picker action buttons (#13291)",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-16T19:21:54.171Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.test.tsx
@@ -462,4 +462,51 @@ describe('BasePicker', () => {
 
     expect(getSuggestions(document)).toBeTruthy();
   });
+
+  it('navigates to search for more button', () => {
+    jest.useFakeTimers();
+    document.body.appendChild(root);
+
+    const picker = React.createRef<IBasePicker<ISimple>>();
+    const onValidateInput = () => {
+      return ValidationState.valid;
+    };
+
+    const createGenericItem = (str: string): ISimple => {
+      return {
+        key: str,
+        name: str,
+      };
+    };
+
+    ReactDOM.render(
+      <BasePickerWithType
+        onResolveSuggestions={onResolveSuggestions}
+        onRenderItem={onRenderItem}
+        onRenderSuggestionsItem={basicSuggestionRenderer}
+        componentRef={picker}
+        createGenericItem={createGenericItem}
+        onValidateInput={onValidateInput}
+        pickerSuggestionsProps={{
+          searchForMoreText: 'More Options',
+        }}
+      />,
+      root,
+    );
+
+    const input = document.querySelector('.ms-BasePicker-input') as HTMLInputElement;
+    input.focus();
+    input.value = 'b';
+    ReactTestUtils.Simulate.input(input);
+    jest.runAllTimers();
+
+    expect(getSuggestions(document)).toBeDefined();
+
+    const moreButton = document.querySelector('[data-automationid=sug-searchForMore]') as HTMLElement;
+    expect(moreButton).toBeTruthy();
+    ReactTestUtils.Simulate.keyDown(input, { which: KeyCodes.up });
+
+    expect(moreButton.id).toEqual('sug-selectedAction');
+    expect(input.getAttribute('aria-activedescendant')).toEqual('sug-selectedAction');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -661,6 +661,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
           ) {
             ev.preventDefault();
             ev.stopPropagation();
+            this.forceUpdate();
           } else {
             if (
               this.suggestionElement.current &&
@@ -691,6 +692,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
           ) {
             ev.preventDefault();
             ev.stopPropagation();
+            this.forceUpdate();
           } else {
             if (
               this.suggestionElement.current &&
@@ -855,6 +857,11 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
 
   protected getActiveDescendant() {
     const currentIndex = this.suggestionStore.currentIndex;
+
+    if (currentIndex < 0 && this.suggestionElement.current && this.suggestionElement.current.hasSuggestedAction()) {
+      return 'sug-selectedAction';
+    }
+
     return currentIndex > -1 && !this.state.suggestionsLoading ? 'sug-' + currentIndex : undefined;
   }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -856,8 +856,12 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
   };
 
   protected getActiveDescendant() {
-    const currentIndex = this.suggestionStore.currentIndex;
+    if (this.state.suggestionsLoading) {
+      return undefined;
+    }
 
+    const currentIndex = this.suggestionStore.currentIndex;
+    // if the suggestions element has actions and the currentIndex does not point to a suggestion, return the action id
     if (currentIndex < 0 && this.suggestionElement.current && this.suggestionElement.current.hasSuggestedAction()) {
       return 'sug-selectedAction';
     }

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -166,6 +166,11 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
     const divProps: React.HtmlHTMLAttributes<HTMLDivElement> =
       hasNoSuggestions || isLoading ? { role: 'dialog', id: suggestionsListId } : {};
 
+    const forceResolveId =
+      this.state.selectedActionType === SuggestionActionType.forceResolve ? 'sug-selectedAction' : undefined;
+    const searchForMoreId =
+      this.state.selectedActionType === SuggestionActionType.searchMore ? 'sug-selectedAction' : undefined;
+
     return (
       <div className={this._classNames.root} {...divProps}>
         <Announced message={this._getAlertText()} aria-live="polite" />
@@ -175,6 +180,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
           <CommandButton
             componentRef={this._forceResolveButton}
             className={this._classNames.forceResolveButton}
+            id={forceResolveId}
             onClick={this._forceResolve}
             data-automationid={'sug-forceResolve'}
           >
@@ -192,6 +198,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
             componentRef={this._searchForMoreButton}
             className={this._classNames.searchForMoreButton}
             iconProps={{ iconName: 'Search' }}
+            id={searchForMoreId}
             onClick={this._getMoreResults}
           >
             {searchForMoreText}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -200,6 +200,7 @@ export class Suggestions<T> extends React.Component<ISuggestionsProps<T>, ISugge
             iconProps={{ iconName: 'Search' }}
             id={searchForMoreId}
             onClick={this._getMoreResults}
+            data-automationid={'sug-searchForMore'}
           >
             {searchForMoreText}
           </CommandButton>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13291 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There were two separate issues happening:
1. The action buttons in the Suggestions component (search for more and force resolve) did not have `id` attributes, and the picker input's `aria-activedescendant` attribute didn't point to them
2. The picker didn't rerender when use up/down arrows to move from an action button back to the suggestions list

This PR adds the id `sug-selectedAction` to the currently highlighted action button (managed by the Suggestions component). `BasePicker` is updated to set `aria-activedescendant` to `sug-selectedAction` when appropriate. It also adds an additional `this.forceUpdate()` to cause `activedescedant` to be recalculated and re-rendered when focus moves from the action button back to the options.