### PR TITLE
docs: fix required version of CSB package, improve dependency generation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Documentation
+- Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))
+
 <!--------------------------------[ v0.50.0 ]------------------------------- -->
 ## [v0.50.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.50.0) (2020-06-16)
 [Compare changes](https://github.com/OfficeDev/office-ui-fabric-react/compare/@fluentui/react-northstar_v0.49.0..@fluentui/react-northstar_v0.50.0)

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/ComponentControlsCodeSandbox.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/ComponentControlsCodeSandbox.tsx
@@ -91,7 +91,7 @@ class ComponentControlsCodeSandbox extends React.Component<
           name={exampleName}
           providedFiles={{
             [main]: { content: appTemplate },
-            'package.json': createPackageJson(main, exampleLanguage),
+            'package.json': createPackageJson(main, exampleCode, exampleLanguage),
           }}
           skipRedirect
           ref={this.codeSandboxerRef}

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
@@ -13,8 +13,6 @@ function createDependencies(code: string) {
     (declaration, name) => declaration.required || new RegExp(`from ['|"]${name}['|"]`).exec(code),
   );
 
-  console.log(filteredPackages);
-
   return {
     ..._.mapValues(filteredPackages, pkg => pkg.version),
     // required to enable all features due old templates in https://github.com/codesandbox/codesandbox-importers

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentControls/ComponentControlsCodeSandbox/createPackageJson.ts
@@ -5,21 +5,32 @@ import { ComponentSourceManagerLanguage } from '../../ComponentSourceManager';
 
 const name = 'fluent-ui-example';
 const description = 'An exported example from Fluent UI React, https://aka.ms/fluent-ui/';
-const dependencies = {
-  ..._.mapValues(imports, pkg => pkg.version),
-  // required to enable all features due old templates in https://github.com/codesandbox/codesandbox-importers
-  // https://github.com/microsoft/fluent-ui-react/issues/1519
-  'react-scripts': 'latest',
-};
 
-const createPackageJson = (mainFilename: string, language: ComponentSourceManagerLanguage) => ({
+function createDependencies(code: string) {
+  // Will include only required packages intentionally like "react" or required by a current example
+  const filteredPackages = _.pickBy(
+    imports,
+    (declaration, name) => declaration.required || new RegExp(`from ['|"]${name}['|"]`).exec(code),
+  );
+
+  console.log(filteredPackages);
+
+  return {
+    ..._.mapValues(filteredPackages, pkg => pkg.version),
+    // required to enable all features due old templates in https://github.com/codesandbox/codesandbox-importers
+    // https://github.com/microsoft/fluent-ui-react/issues/1519
+    'react-scripts': 'latest',
+  };
+}
+
+const createPackageJson = (mainFilename: string, code: string, language: ComponentSourceManagerLanguage) => ({
   content: JSON.stringify(
     {
       name,
       version: '1.0.0',
       description,
       main: mainFilename,
-      dependencies,
+      dependencies: createDependencies(code),
     },
     null,
     2,

--- a/packages/fluentui/docs/src/components/Playground/renderConfig.ts
+++ b/packages/fluentui/docs/src/components/Playground/renderConfig.ts
@@ -4,6 +4,7 @@ import * as Bindings from '@fluentui/react-bindings';
 import * as DocsComponent from '@fluentui/docs-components';
 import * as FluentUI from '@fluentui/react-northstar';
 import * as FluentUIIcons from '@fluentui/react-icons-northstar';
+import * as ReactFela from 'react-fela';
 import * as _ from 'lodash';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -24,13 +25,13 @@ export const babelConfig = {
   presets: ['es2015'],
 };
 
-type Import = {
+type CodeSandboxImport = {
   module: any;
   version: string;
   required: boolean;
 };
 
-export const imports: Record<string, Import> = {
+export const imports: Record<string, CodeSandboxImport> = {
   '@fluentui/accessibility': {
     version: accessibilityPackageJson.version,
     module: Accessibility,
@@ -80,6 +81,11 @@ export const imports: Record<string, Import> = {
     version: projectPackageJson.peerDependencies['react-dom'],
     module: ReactDOM,
     required: true,
+  },
+  'react-fela': {
+    version: projectPackageJson.dependencies['react-fela'],
+    module: ReactFela,
+    required: false,
   },
   prettier: {
     version: docsComponentsPackageJson.peerDependencies['prettier'],

--- a/packages/fluentui/docs/src/components/Playground/renderConfig.ts
+++ b/packages/fluentui/docs/src/components/Playground/renderConfig.ts
@@ -4,7 +4,6 @@ import * as Bindings from '@fluentui/react-bindings';
 import * as DocsComponent from '@fluentui/docs-components';
 import * as FluentUI from '@fluentui/react-northstar';
 import * as FluentUIIcons from '@fluentui/react-icons-northstar';
-import * as ReactFela from 'react-fela';
 import * as _ from 'lodash';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -13,6 +12,7 @@ import * as Classnames from 'classnames';
 const accessibilityPackageJson = require('@fluentui/accessibility/package.json');
 const docsComponentsPackageJson = require('@fluentui/docs-components/package.json');
 const projectPackageJson = require('@fluentui/react-northstar/package.json');
+const sandboxPackageJson = require('@fluentui/code-sandbox/package.json');
 
 export const babelConfig = {
   plugins: [
@@ -24,54 +24,67 @@ export const babelConfig = {
   presets: ['es2015'],
 };
 
-export const imports: Record<string, { version: string; module: any }> = {
+type Import = {
+  module: any;
+  version: string;
+  required: boolean;
+};
+
+export const imports: Record<string, Import> = {
   '@fluentui/accessibility': {
     version: accessibilityPackageJson.version,
     module: Accessibility,
+    required: false,
   },
   '@fluentui/code-sandbox': {
-    version: 'latest',
+    version: sandboxPackageJson.version,
     module: CodeSandbox,
+    required: true,
   },
   '@fluentui/docs-components': {
     version: docsComponentsPackageJson.version,
     module: DocsComponent,
+    required: true,
   },
   '@fluentui/react-icons-northstar': {
     version: projectPackageJson.version,
     module: FluentUIIcons,
+    required: false,
   },
   '@fluentui/react-northstar': {
     version: projectPackageJson.version,
     module: FluentUI,
+    required: true,
   },
   '@fluentui/react-bindings': {
     version: projectPackageJson.dependencies['@fluentui/react-bindings'],
     module: Bindings,
+    required: false,
   },
   classnames: {
     version: projectPackageJson.dependencies['classnames'],
     module: Classnames,
+    required: false,
   },
   lodash: {
     version: projectPackageJson.dependencies['lodash'],
     module: _,
+    required: false,
   },
   react: {
     version: projectPackageJson.peerDependencies['react'],
     module: React,
+    required: true,
   },
   'react-dom': {
     version: projectPackageJson.peerDependencies['react-dom'],
     module: ReactDOM,
-  },
-  'react-fela': {
-    version: projectPackageJson.dependencies['react-fela'],
-    module: ReactFela,
+    required: true,
   },
   prettier: {
     version: docsComponentsPackageJson.peerDependencies['prettier'],
     module: null, // no need to use it in our examples
+    required: true,
   },
 };
 
@@ -79,5 +92,6 @@ export const importResolver = importName => {
   if (imports[importName]) {
     return imports[importName].module;
   }
+
   throw new Error(`Module '${importName}' was not found. Please check renderConfig.ts`);
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR is related to Fluent v0 docs.

- uses the actual version `@fluentui/code-sandbox` package instead of latest
- adds filtering of exported dependencies as not all examples depend on `@fluentui/react-icons-northstar` for example

#### Focus areas to test

(optional)
