### PR TITLE
@fluentui/react-next jest moduleNameMapper fix

### DIFF
--- a/change/@fluentui-react-next-2020-06-17-15-59-04-react-next-fix.json
+++ b/change/@fluentui-react-next-2020-06-17-15-59-04-react-next-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "changing office-ui-fabric-react's path in react-next module mapper",
+  "packageName": "@fluentui/react-next",
+  "email": "esteban.230@hotmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-06-17T21:59:04.439Z"
+}

--- a/packages/react-next/jest.config.js
+++ b/packages/react-next/jest.config.js
@@ -9,9 +9,9 @@ const config = createConfig({
     '@fluentui/react-focus/lib/(.*)$': '@fluentui/react-focus/lib-commonjs/$1',
     '@uifabric/react-hooks/lib/(.*)$': '@uifabric/react-hooks/lib-commonjs/$1',
     '@uifabric/utilities/lib/(.*)$': '@uifabric/utilities/lib-commonjs/$1',
-    // These mappings allow Jest to run snapshot tests against Example files.
     'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
     'office-ui-fabric-react$': 'office-ui-fabric-react/lib-commonjs/',
+    // These mappings allow Jest to run snapshot tests against Example files.
     '@fluentui/react-next/lib/(.*)$': '<rootDir>/src/$1',
     '@fluentui/react-next$': '<rootDir>/src/',
   },

--- a/packages/react-next/jest.config.js
+++ b/packages/react-next/jest.config.js
@@ -9,8 +9,11 @@ const config = createConfig({
     '@fluentui/react-focus/lib/(.*)$': '@fluentui/react-focus/lib-commonjs/$1',
     '@uifabric/react-hooks/lib/(.*)$': '@uifabric/react-hooks/lib-commonjs/$1',
     '@uifabric/utilities/lib/(.*)$': '@uifabric/utilities/lib-commonjs/$1',
+    // These mappings allow Jest to run snapshot tests against Example files.
     'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
     'office-ui-fabric-react$': 'office-ui-fabric-react/lib-commonjs/',
+    '@fluentui/react-next/lib/(.*)$': '<rootDir>/src/$1',
+    '@fluentui/react-next$': '<rootDir>/src/',
   },
 
   snapshotSerializers: [resolveMergeStylesSerializer()],

--- a/packages/react-next/jest.config.js
+++ b/packages/react-next/jest.config.js
@@ -9,7 +9,6 @@ const config = createConfig({
     '@fluentui/react-focus/lib/(.*)$': '@fluentui/react-focus/lib-commonjs/$1',
     '@uifabric/react-hooks/lib/(.*)$': '@uifabric/react-hooks/lib-commonjs/$1',
     '@uifabric/utilities/lib/(.*)$': '@uifabric/utilities/lib-commonjs/$1',
-    // These mappings allow Jest to run snapshot tests against Example files.
     'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
     'office-ui-fabric-react$': 'office-ui-fabric-react/lib-commonjs/',
   },

--- a/packages/react-next/jest.config.js
+++ b/packages/react-next/jest.config.js
@@ -10,8 +10,8 @@ const config = createConfig({
     '@uifabric/react-hooks/lib/(.*)$': '@uifabric/react-hooks/lib-commonjs/$1',
     '@uifabric/utilities/lib/(.*)$': '@uifabric/utilities/lib-commonjs/$1',
     // These mappings allow Jest to run snapshot tests against Example files.
-    'office-ui-fabric-react/lib/(.*)$': '<rootDir>/../office-ui-fabric-react/src/$1',
-    'office-ui-fabric-react$': '<rootDir>/../office-ui-fabric-react/src/',
+    'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
+    'office-ui-fabric-react$': 'office-ui-fabric-react/lib-commonjs/',
   },
 
   snapshotSerializers: [resolveMergeStylesSerializer()],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changed the `office-ui-fabric-react` paths in the `moduleNameMapper` that caused `yarn test` to run indefinitely without finishing any tests. 
