### PR TITLE
Scrub and pre-commit fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,9 +3,12 @@
 const fs = require('fs');
 const path = require('path');
 
-// If someone updates from master but doesn't run yarn, by default they'd be unable to commit
-// with some cryptic error. Explicitly detect that condition and show a helpful error.
-if (!fs.existsSync(path.resolve(__dirname, '../node_modules/lint-staged/bin/lint-staged.js'))) {
+if (!fs.existsSync(path.resolve(__dirname, '../node_modules/lint-staged'))) {
+  console.error('lint-staged is not installed. Please run `yarn` then try again.');
+  process.exit(1);
+} else if (!fs.existsSync(path.resolve(__dirname, '../node_modules/lint-staged/bin/lint-staged.js'))) {
+  // If someone updates from master but doesn't run yarn, by default they'd be unable to commit
+  // with some cryptic error. Explicitly detect that condition and show a helpful error.
   console.error('lint-staged version is out of date! Please run `yarn` to update dependencies.');
   process.exit(1);
 }

--- a/scripts/scrub.js
+++ b/scripts/scrub.js
@@ -2,6 +2,7 @@
 
 const child_process = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 // This script MUST NOT have any deps aside from Node built-ins, because it deletes all node_modules!
 
@@ -53,8 +54,11 @@ function deleteNodeModulesSymlinks(packagePath, failedPaths) {
     return;
   }
   // Check node_modules for symlinks and manually remove those
+  // (odd way of iterating is since we're adding more modules to the list as we go)
   const modules = fs.readdirSync(nodeModulesPath);
-  for (const mod of modules) {
+  /** @type {string} */
+  let mod;
+  while ((mod = modules.pop())) {
     const modulePath = path.join(nodeModulesPath, mod);
     if (mod[0] === '@' && !/[/\\]/.test(mod)) {
       // Add any scoped modules to the list of things to check
@@ -77,10 +81,13 @@ function getChildren(parentFolder) {
  * @param {string[]} args
  */
 function spawn(cmd, args) {
-  return new Promise((resolve, reject) => {
-    const child = child_process.spawn(cmd, args, { stdio: 'inherit' });
-    child.on('exit', code => (code ? reject(new Error('Command failed')) : resolve()));
-  });
+  const maxBuffer = 1024 * 1024 * 10; // default is 1024 * 1024
+  const result = child_process.spawnSync(cmd, args, { stdio: 'inherit', maxBuffer });
+  if (result.error) {
+    throw result.error;
+  } else if (result.status) {
+    throw new Error('Command failed');
+  }
 }
 
 async function run() {
@@ -115,7 +122,7 @@ async function run() {
 
   // do these before deleting node_nodules
   console.log('\nClearing Jest cache...');
-  await spawn('npx', ['jest', '--clearCache']);
+  spawn(os.platform() === 'win32' ? 'npx.cmd' : 'npx', ['jest', '--clearCache']);
   try {
     console.log('\nAttempting to clear gulp-cache...');
     const cache = require('gulp-cache');
@@ -128,7 +135,14 @@ async function run() {
   const failedPaths = [];
 
   console.log("\nDeleting symlinks from packages' node_modules and rush temp files...");
-  const folders = [...getChildren('apps'), ...getChildren('packages'), 'scripts', 'common/temp'];
+  const folders = [
+    '.',
+    ...getChildren('apps'),
+    ...getChildren('packages'),
+    ...getChildren('packages/fluentui'),
+    'scripts',
+    'common/temp',
+  ];
   for (const folder of folders) {
     deleteNodeModulesSymlinks(folder, failedPaths);
   }
@@ -141,10 +155,10 @@ async function run() {
   }
 
   console.log('\nRunning "git clean -fdx" to remove all untracked files/folders (this may take awhile)...');
-  await spawn('git', ['clean', '-fdx']);
+  spawn('git', ['clean', '-fdx']);
 
   console.log('\nRunning "git reset --hard"...');
-  await spawn('git', ['reset', '--hard']);
+  spawn('git', ['reset', '--hard']);
 
   console.log('\nDone!');
 }

--- a/scripts/scrub.js
+++ b/scripts/scrub.js
@@ -54,7 +54,7 @@ function deleteNodeModulesSymlinks(packagePath, failedPaths) {
     return;
   }
   // Check node_modules for symlinks and manually remove those
-  // (odd way of iterating is since we're adding more modules to the list as we go)
+  // (using this odd way of iterating since we're adding more modules to the list as we go)
   const modules = fs.readdirSync(nodeModulesPath);
   /** @type {string} */
   let mod;


### PR DESCRIPTION
The scrub script needed a few fixes to work better on Windows:
- Use `npx.cmd` not `npx` on Windows
- Check `./node_modules` and `packages/fluentui/*/node_modules` for symlinks before running `git clean`

Also add another case to the pre-commit error message for if lint-staged isn't installed at all (because they need to run `yarn`).