### PR TITLE
Port #10020 to remove role=presentation in FocusZone in office-ui-fabric-react/5.79.1

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_7-office-ui-fabric-react-5.79.1_2020-06-18-06-33.json
+++ b/common/changes/office-ui-fabric-react/hotfix_7-office-ui-fabric-react-5.79.1_2020-06-18-06-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "FocusZone: Remove role=presentation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`Breadcrumb renders breadcumb correctly 1`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="presentation"
       >
         <ol
           className="ms-Breadcrumb-list"
@@ -174,7 +173,6 @@ exports[`Breadcrumb renders breadcumb correctly 2`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="presentation"
       >
         <ol
           className="ms-Breadcrumb-list"
@@ -383,7 +381,6 @@ exports[`Breadcrumb renders breadcumb correctly 3`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="presentation"
       >
         <ol
           className="ms-Breadcrumb-list"

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <table
                 aria-activedescendant="DatePickerDay-active9"
@@ -961,7 +960,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-DatePicker-optionGrid"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -206,7 +206,6 @@ exports[`DetailsList renders List correctly 1`] = `
           onFocus={[Function]}
           onKeyDown={[Function]}
           onMouseDownCapture={[Function]}
-          role="presentation"
         >
           <div
             className="ms-SelectionZone"

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -129,7 +129,6 @@ export class FocusZone extends BaseComponent<IFocusZoneProps, {}> implements IFo
 
     return (
       <Tag
-        role='presentation'
         {
         ...divProps
         }

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -9,7 +9,6 @@ exports[`Nav renders Nav correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
   onMouseDownCapture={[Function]}
-  role="presentation"
 >
   <nav
     aria-label={undefined}

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`Pivot renders Pivot correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="presentation"
   >
     <ul
       className="ms-Pivot"

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`Rating Renders Rating correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="presentation"
     tabIndex={-1}
   >
     <button

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
   onFocus={[Function]}
   onKeyDown={[Function]}
   onMouseDownCapture={[Function]}
-  role="presentation"
 >
   <table
     aria-posinset={undefined}

--- a/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/__snapshots__/BasePicker.test.tsx.snap
@@ -13,7 +13,6 @@ exports[`Pickers BasePicker renders BasePicker correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="presentation"
   >
     <div
       aria-live="assertive"
@@ -80,7 +79,6 @@ exports[`Pickers TagPicker renders TagPicker correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    role="presentation"
   >
     <div
       aria-live="assertive"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ rush change`

#### Description of changes

Port #10020 to remove role=presentation in FocusZone in office-ui-fabric-react/5.79.1

#### Focus areas to test

(optional)
