### PR TITLE
Partially Port #5536 to calculate aria-posinset and aria-setsize in CommandBar.tsx to skip ContextualMenuItemType which is equal to Divider or Header in office-ui-fabric-react/5.0

### DIFF
--- a/common/changes/office-ui-fabric-react/hotfix_1-office-ui-fabric-react-5.0_2020-06-18-12-33.json
+++ b/common/changes/office-ui-fabric-react/hotfix_1-office-ui-fabric-react-5.0_2020-06-18-12-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "CommandBar: Caculate aria-posinset and aria-setsize to skip ContextualMenuItemType which is equal to Divider or Header",
+      "type": "minor"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "xianwang@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../Utilities';
 import { ICommandBar, ICommandBarProps, ICommandBarItemProps } from './CommandBar.types';
 import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
-import { ContextualMenu, IContextualMenuProps, IContextualMenuItem } from '../../ContextualMenu';
+import { ContextualMenu, IContextualMenuProps, IContextualMenuItem, ContextualMenuItemType } from '../../ContextualMenu';
 import { hasSubmenu } from '../../utilities/contextualMenu/index';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import {
@@ -116,7 +116,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
       );
     }
     // Total # of menu items is regular items + far items + 1 for the ellipsis, if necessary
-    const setSize = renderedItems!.length + renderedFarItems!.length + (renderedOverflowItems && renderedOverflowItems.length > 0 ? 1 : 0);
+    const setSize = this._getTotalFocusedItemCount(renderedItems) + this._getTotalFocusedItemCount(renderedFarItems) + (renderedOverflowItems && renderedOverflowItems.length > 0 ? 1 : 0);
     let posInSet = 1;
 
     return (
@@ -125,7 +125,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
         <FocusZone componentRef={ this._focusZone } className={ styles.container } direction={ FocusZoneDirection.horizontal } role='menubar' >
           <div className={ css('ms-CommandBar-primaryCommands', styles.primaryCommands) } ref={ this._commandSurface }>
             { renderedItems!.map(item => (
-              this._renderItemInCommandBar(item, posInSet++, setSize, expandedMenuItemKey!)
+              this._renderItemInCommandBar(item, this._needReviseAriaPosinset(item, posInSet) ? posInSet++ : posInSet, setSize, expandedMenuItemKey!)
             )).concat((renderedOverflowItems && renderedOverflowItems.length) ? [
               <div className={ css('ms-CommandBarItem', styles.item) } key={ OVERFLOW_KEY } ref={ this._overflow }>
                 <button
@@ -150,7 +150,7 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
           </div>
           <div className={ css('ms-CommandBar-sideCommands', styles.sideCommands) } ref={ this._farCommandSurface }>
             { renderedFarItems!.map(item => (
-              this._renderItemInCommandBar(item, posInSet++, setSize, expandedMenuItemKey!, true)
+              this._renderItemInCommandBar(item, this._needReviseAriaPosinset(item, posInSet) ? posInSet++ : posInSet, setSize, expandedMenuItemKey!, true)
             )) }
           </div>
         </FocusZone>
@@ -537,5 +537,28 @@ export class CommandBar extends BaseComponent<ICommandBarProps, ICommandBarState
 
   private _getContextualMenuPropsFromItem(item: IContextualMenuItem): IContextualMenuProps | undefined {
     return item.subMenuProps || (item.items && { items: item.items });
+  }
+
+  private _getTotalFocusedItemCount(items?: IContextualMenuItem[]): number {
+    let totalItemCount = 0;
+    if (items && items.length > 0) {
+      for (const item of items) {
+        if (item.itemType === ContextualMenuItemType.Divider || item.itemType === ContextualMenuItemType.Header) {
+          continue;
+        }
+
+        ++totalItemCount;
+      }
+    }
+
+    return totalItemCount;
+  }
+
+  private _needReviseAriaPosinset(item: IContextualMenuItem, indexCorrection: number): boolean {
+    if (item.itemType === ContextualMenuItemType.Divider || item.itemType === ContextualMenuItemType.Header) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/data-nonFocusable.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/data-nonFocusable.ts
@@ -1,8 +1,10 @@
+import { ContextualMenuItemType } from '../../ContextualMenu';
 export const itemsNonFocusable = [
   {
     key: 'newItem',
     name: 'New',
     icon: 'Add',
+    itemType: ContextualMenuItemType.Normal,
     ariaLabel: 'New. Use left and right arrow keys to navigate',
     onClick: () => { return; },
     items: [
@@ -22,6 +24,7 @@ export const itemsNonFocusable = [
     key: 'upload',
     name: 'Upload',
     icon: 'Upload',
+    itemType: ContextualMenuItemType.Normal,
     onClick: () => { return; },
     ['data-automation-id']: 'uploadNonFocusButton'
   }
@@ -32,12 +35,14 @@ export const farItemsNonFocusable = [
     key: 'saveStatus',
     name: 'Your page has been saved',
     icon: 'CheckMark',
+    itemType: ContextualMenuItemType.Header,
     ['data-automation-id']: 'saveStatusCheckMark'
   },
   {
     key: 'publish',
     name: 'Publish',
     icon: 'ReadingMode',
+    itemType: ContextualMenuItemType.Normal,
     onClick: () => { return; }
   }
 ];


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ rush change`

#### Description of changes

CommandBar: Caculate aria-posinset and aria-setsize to skip ContextualMenuItemType which is equal to Divider or Header

#### Focus areas to test

(optional)
