### PR TITLE
fix(Avatar): Fixing name initials bug in Avatar component.

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
+- Fix `Avatar` initials when the input only contains whitespace, @rymeskar ([#13619](https://github.com/microsoft/fluentui/issues/13619))
 
 ### Documentation
 - Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
-- Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13619](https://github.com/microsoft/fluentui/pull/13682))
+- Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13682](https://github.com/microsoft/fluentui/pull/13682))
 
 ### Documentation
 - Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
-- Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13619](https://github.com/microsoft/fluentui/issues/13619))
+- Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13619](https://github.com/microsoft/fluentui/pull/13682))
 
 ### Documentation
 - Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
-- Fix `Avatar` initials when the input only contains whitespace, @rymeskar ([#13619](https://github.com/microsoft/fluentui/issues/13619))
+- Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13619](https://github.com/microsoft/fluentui/issues/13619))
 
 ### Documentation
 - Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -151,6 +151,7 @@ Avatar.defaultProps = {
     }
 
     const reducedName = name
+      .replace(/\s+/g, ' ')
       .replace(/\s*\(.*?\)\s*/g, ' ')
       .replace(/\s*{.*?}\s*/g, ' ')
       .replace(/\s*\[.*?]\s*/g, ' ');
@@ -159,7 +160,7 @@ Avatar.defaultProps = {
       .split(' ')
       .filter(item => item !== '')
       .map(item => item.charAt(0))
-      .reduce((accumulator, currentValue) => accumulator + currentValue);
+      .reduce((accumulator, currentValue) => accumulator + currentValue, '');
 
     if (initials.length > 2) {
       return initials.charAt(0) + initials.charAt(initials.length - 1);

--- a/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
@@ -50,17 +50,17 @@ describe('Avatar', () => {
     });
 
     it('calculates an expected initials with a hypen', () => {
-      let result = getInitials('David Zearing-Goff');
+      const result = getInitials('David Zearing-Goff');
       expect(result).toEqual('DZ');
     });
 
     it('calculates an expected initials with numbers', () => {
-      let result = getInitials('4lex 5loo');
+      const result = getInitials('4lex 5loo');
       expect(result).toEqual('45');
     });
 
     it('calculates an expected initials with multiple parentheses, extra spaces, and unwanted characters', () => {
-      let result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ');
+      const result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ');
       expect(result).toEqual('!G');
     });
 
@@ -79,7 +79,7 @@ describe('Avatar', () => {
     });
 
     it('calculates an expected initials for Arabic names', () => {
-      let result = getInitials('خسرو رحیمی');
+      const result = getInitials('خسرو رحیمی');
       expect(result).toEqual('خر');
     });
 

--- a/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Avatar/Avatar-test.tsx
@@ -24,5 +24,96 @@ describe('Avatar', () => {
       expect(getInitials('John Doe {Working position}')).toEqual('JD');
       expect(getInitials('John Doe [Working position]')).toEqual('JD');
     });
+
+    it('handles null inputs', () => {
+      let result = getInitials(null);
+      expect(result).toEqual('');
+
+      result = getInitials(undefined);
+      expect(result).toEqual('');
+    });
+
+    it('handles whitespace input', () => {
+      let result = getInitials('    ');
+      expect(result).toEqual('');
+
+      result = getInitials('\t\n');
+      expect(result).toEqual('');
+    });
+
+    it('calculates an expected initials for non-ASCII characters', () => {
+      let result = getInitials('Írissa Þórðardóttir');
+      expect(result).toEqual('ÍÞ');
+
+      result = getInitials('Øyvind Åsen');
+      expect(result).toEqual('ØÅ');
+    });
+
+    it('calculates an expected initials with a hypen', () => {
+      let result = getInitials('David Zearing-Goff');
+      expect(result).toEqual('DZ');
+    });
+
+    it('calculates an expected initials with numbers', () => {
+      let result = getInitials('4lex 5loo');
+      expect(result).toEqual('45');
+    });
+
+    it('calculates an expected initials with multiple parentheses, extra spaces, and unwanted characters', () => {
+      let result = getInitials(' !@#$%^&*()=+ (Alpha) David   (The man) `~<>,./?[]{}|   Goff   (Gamma)    ');
+      expect(result).toEqual('!G');
+    });
+
+    it('calculates an expected initials for names with multiple components', () => {
+      let result = getInitials('A');
+      expect(result).toEqual('A');
+
+      result = getInitials('A B');
+      expect(result).toEqual('AB');
+
+      result = getInitials('A B C');
+      expect(result).toEqual('AC');
+
+      result = getInitials('A B C D');
+      expect(result).toEqual('AD');
+    });
+
+    it('calculates an expected initials for Arabic names', () => {
+      let result = getInitials('خسرو رحیمی');
+      expect(result).toEqual('خر');
+    });
+
+    it('calculates an expected initials for Chinese names', () => {
+      let result = getInitials('桂英');
+      expect(result).toEqual('桂');
+
+      result = getInitials('佳');
+      expect(result).toEqual('佳');
+
+      result = getInitials('宋智洋');
+      expect(result).toEqual('宋');
+    });
+
+    it('calculates an expected initials for Korean names', () => {
+      let result = getInitials('강현');
+      expect(result).toEqual('강');
+
+      result = getInitials('최종래');
+      expect(result).toEqual('최');
+
+      result = getInitials('남궁 성종');
+      expect(result).toEqual('남성');
+    });
+
+    it('calculates an expected initials for Japanese names', () => {
+      let result = getInitials('松田');
+      expect(result).toEqual('松');
+
+      result = getInitials('海野');
+      expect(result).toEqual('海');
+
+      result = getInitials('かり');
+      expect(result).toEqual('か');
+    });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13619
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The changes focus on allowing an input of whitespace characters to construct proper initials. This is achieved through passing an initial value to the accumulator function.

#### Focus areas to test

The Avatar tests were extended to include broader ranges of inputs; specifically focusing on corner cases. Some of the test cases were taken from the FabricUI [initials utilities tests](https://github.com/microsoft/fluentui/blob/78a6692613ae3b445e785a4062ae3a704fb3ae4c/packages/utilities/src/initials.test.ts).
