### PR TITLE
Keytips: storybook example fixes

### DIFF
--- a/change/@fluentui-react-next-2020-06-18-11-09-19-xgao-keytip-example-fixes.json
+++ b/change/@fluentui-react-next-2020-06-18-11-09-19-xgao-keytip-example-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Keytip: add KeytipLayer storybook decorator and fix missing handled prop for link",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-18T18:09:19.612Z"
+}

--- a/change/office-ui-fabric-react-2020-06-18-11-09-19-xgao-keytip-example-fixes.json
+++ b/change/office-ui-fabric-react-2020-06-18-11-09-19-xgao-keytip-example-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Keytip: add KeytipLayer storybook decorator and fix missing handled prop for link",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-18T18:08:14.477Z"
+}

--- a/packages/office-ui-fabric-react/.storybook/decorators/index.js
+++ b/packages/office-ui-fabric-react/.storybook/decorators/index.js
@@ -1,0 +1,1 @@
+export * from './withKeytipLayer';

--- a/packages/office-ui-fabric-react/.storybook/decorators/withKeytipLayer.js
+++ b/packages/office-ui-fabric-react/.storybook/decorators/withKeytipLayer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { KeytipLayer } from 'office-ui-fabric-react';
+
+export const withKeytipLayer = storyFn => {
+  return (
+    <>
+      <KeytipLayer content="Alt Windows" />
+      {storyFn()}
+    </>
+  );
+};

--- a/packages/office-ui-fabric-react/.storybook/preview.js
+++ b/packages/office-ui-fabric-react/.storybook/preview.js
@@ -3,9 +3,12 @@ import generateStoriesFromExamples from '@uifabric/build/storybook/generateStori
 import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { withPerformance } from 'storybook-addon-performance';
+import { withKeytipLayer } from './decorators';
 
 addDecorator(withA11y());
 addDecorator(withPerformance);
+addDecorator(withKeytipLayer);
+
 addParameters({
   a11y: {
     manual: true,

--- a/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.base.tsx
@@ -73,7 +73,19 @@ export class LinkBase extends React.Component<ILinkProps, {}> implements ILink {
     // Deconstruct the props so we remove props like `as`, `theme` and `styles`
     // as those will always be removed. We also take some props that are optional
     // based on the RootType.
-    const { children, as, disabled, target, href, theme, getStyles, styles, componentRef, ...restProps } = props;
+    const {
+      children,
+      as,
+      disabled,
+      target,
+      href,
+      theme,
+      getStyles,
+      styles,
+      componentRef,
+      keytipProps,
+      ...restProps
+    } = props;
 
     // RootType will be a string if we're dealing with an html component
     if (typeof RootType === 'string') {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1200,16 +1200,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               data-ktp-execute-target="ktp-a-2"
               data-ktp-target="ktp-a-2"
               href="http://www.bing.com"
-              keytipProps={
-                Object {
-                  "content": "2",
-                  "keySequences": Array [
-                    "a",
-                    "2",
-                  ],
-                  "onExecute": [Function],
-                }
-              }
               onClick={[Function]}
               target="_blank"
             >

--- a/packages/react-next/.storybook/decorators/index.js
+++ b/packages/react-next/.storybook/decorators/index.js
@@ -1,0 +1,2 @@
+export * from './withThemeProvider';
+export * from './withKeytipLayer';

--- a/packages/react-next/.storybook/decorators/withKeytipLayer.js
+++ b/packages/react-next/.storybook/decorators/withKeytipLayer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { KeytipLayer } from '@fluentui/react-next';
+
+export const withKeytipLayer = storyFn => {
+  return (
+    <>
+      <KeytipLayer content="Alt Windows" />
+      {storyFn()}
+    </>
+  );
+};

--- a/packages/react-next/.storybook/preview.js
+++ b/packages/react-next/.storybook/preview.js
@@ -4,12 +4,14 @@ import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { withPerformance } from 'storybook-addon-performance';
 import { withKnobs } from '@storybook/addon-knobs';
-import { withThemeProvider } from './decorators/withThemeProvider';
+import { withThemeProvider, withKeytipLayer } from './decorators';
 
 addDecorator(withA11y());
 addDecorator(withPerformance);
 addDecorator(withKnobs({ escapeHTML: false }));
 addDecorator(withThemeProvider);
+addDecorator(withKeytipLayer);
+
 addParameters({
   a11y: {
     manual: true,

--- a/packages/react-next/src/components/Link/useLink.ts
+++ b/packages/react-next/src/components/Link/useLink.ts
@@ -69,7 +69,7 @@ const adjustPropsForRootType = (
   // Deconstruct the props so we remove props like `as`, `theme` and `styles`
   // as those will always be removed. We also take some props that are optional
   // based on the RootType.
-  const { as, disabled, target, href, theme, getStyles, styles, componentRef, ...restProps } = props;
+  const { as, disabled, target, href, theme, getStyles, styles, componentRef, keytipProps, ...restProps } = props;
 
   // RootType will be a string if we're dealing with an html component
   if (typeof RootType === 'string') {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
1. Added render `KeytipLayer` using storybook decorator as Keytips are actually shown when using storybook examples
2. Added `keytipProps` as part of handled props for link

#### Focus areas to test

(optional)
