### PR TITLE
fix storybook dev server hardsource errors

### DIFF
--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -77,7 +77,21 @@ module.exports = ({ config }) => {
 
   config.resolve.alias = getResolveAlias();
 
-  config.plugins.push(new HardSourceWebpackPlugin(), new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }));
+  config.plugins.push(
+    new HardSourceWebpackPlugin(),
+    new HardSourceWebpackPlugin.ExcludeModulePlugin([
+      {
+        // HardSource works with mini-css-extract-plugin but due to how
+        // mini-css emits assets, assets are not emitted on repeated builds with
+        // mini-css and hard-source together. Ignoring the mini-css loader
+        // modules, but not the other css loader modules, excludes the modules
+        // that mini-css needs rebuilt to output assets every time.
+        // https://github.com/mzgoddard/hard-source-webpack-plugin/issues/416
+        test: /mini-css-extract-plugin[\\/]dist[\\/]loader/,
+      },
+    ]),
+    new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }),
+  );
 
   config.optimization.minimize = false;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Fix errors which happens occasionally while running storybook dev server:
```
...
[hardsource:75dd4623] Could not freeze ./src/components/SpinButton/SpinButton.classNames.ts: Cannot read property 'hash' of undefined
[hardsource:75dd4623] Could not freeze ./src/components/SpinButton/SpinButton.styles.ts: Cannot read property 'hash' of undefined
[hardsource:75dd4623] Could not freeze ./src/components/SpinButton/SpinButton.tsx: Cannot read property 'hash' of undefined
[hardsource:75dd4623] Could not freeze ./src/components/SpinButton/SpinButton.types.ts: Cannot read property 'hash' of undefined
...
```

See issue: https://github.com/mzgoddard/hard-source-webpack-plugin/issues/416

#### Focus areas to test

(optional)
