### PR TITLE
Button: Adding pointer-events: none to :after focus rectangle

### DIFF
--- a/change/@fluentui-react-button-2020-06-18-17-43-50-buttonFocusAfterPointerEventsNone.json
+++ b/change/@fluentui-react-button-2020-06-18-17-43-50-buttonFocusAfterPointerEventsNone.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Button: Adding pointer-events: none to :after focus rectangle.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-19T00:43:50.885Z"
+}

--- a/packages/react-button/src/components/Button/Button.scss
+++ b/packages/react-button/src/components/Button/Button.scss
@@ -277,4 +277,5 @@
   border-radius: var(--button-borderRadius);
   border: var(--button-focus-width, 2px) solid var(--button-focusColor);
   box-shadow: 0 0 0 var(--button-focus-innerWidth, 1px) var(--button-focusInnerColor) inset;
+  pointer-events: none;
 }

--- a/packages/react-button/src/components/Button/Button.stories.tsx
+++ b/packages/react-button/src/components/Button/Button.stories.tsx
@@ -56,17 +56,6 @@ export const ButtonCss = () => (
   </Stack>
 );
 
-export const ButtonTest = () => (
-  <Button
-    content={{
-      children: 'Foo',
-      onClick: () => {
-        console.log(222);
-      },
-    }}
-  />
-);
-
 export const ButtonTokens = () => (
   <Stack gap={20}>
     <Text variant="xLarge">A button can be colored using inline tokens.</Text>

--- a/packages/react-button/src/components/Button/Button.stories.tsx
+++ b/packages/react-button/src/components/Button/Button.stories.tsx
@@ -56,6 +56,17 @@ export const ButtonCss = () => (
   </Stack>
 );
 
+export const ButtonTest = () => (
+  <Button
+    content={{
+      children: 'Foo',
+      onClick: () => {
+        console.log(222);
+      },
+    }}
+  />
+);
+
 export const ButtonTokens = () => (
   <Stack gap={20}>
     <Text variant="xLarge">A button can be colored using inline tokens.</Text>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13668
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `pointer-events: none` to the styling of the `:after` focus rectangle in the button so that it doesn't eat up the click events.

#### Focus areas to test

(optional)
