### PR TITLE
Fix width of header cells in TilesList

### DIFF
--- a/change/@uifabric-experiments-2020-06-18-21-37-27-tile-group.json
+++ b/change/@uifabric-experiments-2020-06-18-21-37-27-tile-group.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix width of header rows in TilesList",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-19T04:37:27.094Z"
+}

--- a/packages/experiments/src/components/TilesList/TilesList.scss
+++ b/packages/experiments/src/components/TilesList/TilesList.scss
@@ -33,6 +33,10 @@
   visibility: hidden;
 }
 
+.header {
+  display: block;
+}
+
 .grid {
   display: flex;
   flex-direction: row;
@@ -45,6 +49,10 @@
 .row {
   display: flex;
   width: 100%;
+
+  &.headerRow {
+    display: block;
+  }
 }
 
 .shimmeredList {

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -474,7 +474,9 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
           finalOnRenderRow({
             cellElements: currentRowCells,
             divProps: {
-              className: TilesListStyles.row,
+              className: css(TilesListStyles.row, {
+                [TilesListStyles.headerRow]: grid.mode === TilesGridMode.none,
+              }),
               role: 'presentation',
             },
           }),


### PR DESCRIPTION
Fixed a regression in `TilesList` were cells in a grid with type `'none'` were not taking up the full allocated width, causing content to be condensed. The solution is to mark header 'rows' so they are not `display: flex` like other rows.