### PR TITLE
useMergedRefs should return an immutable function

### DIFF
--- a/change/@uifabric-react-hooks-2020-06-19-12-26-25-fix-button-fixes.json
+++ b/change/@uifabric-react-hooks-2020-06-19-12-26-25-fix-button-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "useMergedRefs: Merging refs should produce an immutable ref object.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-19T19:26:25.030Z"
+}

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -6,6 +6,7 @@
 
 import { Async } from '@uifabric/utilities';
 import * as React from 'react';
+import { Ref } from 'react';
 
 // @public (undocumented)
 export type ChangeCallback<TElement extends HTMLElement, TValue> = (ev: React.FormEvent<TElement> | undefined, newValue: TValue | undefined) => void;
@@ -42,7 +43,7 @@ export function useForceUpdate(): () => void;
 export function useId(prefix?: string, providedId?: string): string;
 
 // @public
-export function useMergedRefs<T>(...refs: React.Ref<T>[]): (instance: T) => void;
+export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void;
 
 // @public
 export function useOnEvent<TElement extends Element, TEvent extends Event>(element: React.RefObject<TElement | undefined | null> | TElement | Window | undefined | null, eventName: string, callback: (ev: TEvent) => void, useCapture?: boolean): void;

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -1,8 +1,31 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { useMergedRefs } from './useMergedRefs';
 
 describe('useMergedRefs', () => {
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    wrapper?.unmount();
+    wrapper = undefined;
+  });
+
+  it('always returns the same ref (refs should be immutable)', () => {
+    let lastMergedRef;
+
+    const TestComponent: React.FunctionComponent = () => {
+      lastMergedRef = useMergedRefs<boolean>(() => ({}));
+      return null;
+    };
+
+    wrapper = mount(<TestComponent />);
+    const ref1 = lastMergedRef;
+    wrapper.setProps({});
+    const ref2 = lastMergedRef;
+
+    expect(ref1).toBe(ref2);
+  });
+
   it('updates all provided refs', () => {
     const refObject: React.RefObject<boolean> = React.createRef<boolean>();
     let refValue: boolean | null = null;
@@ -11,7 +34,7 @@ describe('useMergedRefs', () => {
       mergedRef(true);
       return null;
     };
-    mount(<TestComponent />);
+    wrapper = mount(<TestComponent />);
 
     expect(refObject.current).toBe(true);
     expect(refValue).toBe(true);
@@ -29,7 +52,7 @@ describe('useMergedRefs', () => {
       return null;
     };
 
-    const wrapper = mount(<TestComponent />);
+    wrapper = mount(<TestComponent />);
 
     const firstRefCallback = refCallback;
 
@@ -51,7 +74,7 @@ describe('useMergedRefs', () => {
       return null;
     };
 
-    const wrapper = mount(<TestComponent />);
+    wrapper = mount(<TestComponent />);
 
     let secondRefValue: boolean | null = null;
     refValueFunc = (val: boolean) => (secondRefValue = val);

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, Ref, MutableRefObject } from 'react';
+import { useRef, useCallback, Ref, MutableRefObject } from 'react';
 
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -8,10 +8,9 @@ import { useRef, useCallback, Ref, MutableRefObject } from 'react';
 export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
   const state = useRef<(Ref<T> | undefined)[]>();
 
-  // Update refs list in immutatable state object.
+  // Update refs list.
   state.current = refs;
 
-  // Return cached callback which refers to mutable refs array within the immutable state.
   return useCallback((value: T) => {
     for (const ref of state.current!) {
       if (typeof ref === 'function') {

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -5,11 +5,11 @@ import { useRef, useCallback, Ref, MutableRefObject } from 'react';
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refObjects: Ref<T>[]): (instance: T) => void {
+export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
   const state = useRef<(Ref<T> | undefined)[]>();
 
   // Update refs list in immutatable state object.
-  state.current = refObjects;
+  state.current = refs;
 
   // Return cached callback which refers to mutable refs array within the immutable state.
   return useCallback((value: T) => {

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -8,7 +8,7 @@ import { useState, useCallback, Ref, MutableRefObject } from 'react';
 export function useMergedRefs<T>(...refObjects: React.Ref<T>[]): (instance: T) => void {
   const [state] = useState<{ refs: (Ref<T> | undefined)[] }>({ refs: [] });
 
-  // Cache refs in immutatable state object.
+  // Update refs list in immutatable state object.
   state.refs = refObjects;
 
   // Return cached callback which refers to mutable refs array within the immutable state.

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,19 +1,27 @@
-import * as React from 'react';
+import { useState, useCallback, Ref, MutableRefObject } from 'react';
 
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: React.Ref<T>[]): (instance: T) => void {
-  return React.useCallback((value: T) => {
-    refs.forEach(ref => {
+export function useMergedRefs<T>(...refObjects: React.Ref<T>[]): (instance: T) => void {
+  const [state] = useState<{ refs: (Ref<T> | undefined)[] }>({ refs: [] });
+
+  // Cache refs in immutatable state object.
+  state.refs = refObjects;
+
+  // Return cached callback which refers to mutable refs array within the immutable state.
+  return useCallback((value: T) => {
+    const { refs } = state;
+
+    for (const ref of refs) {
       if (typeof ref === 'function') {
         ref(value);
       } else if (ref) {
         // work around the immutability of the React.Ref type
-        ((ref as unknown) as React.MutableRefObject<T>).current = value;
+        ((ref as unknown) as MutableRefObject<T>).current = value;
       }
-    });
-  }, refs);
+    }
+  }, []);
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,21 +1,19 @@
-import { useState, useCallback, Ref, MutableRefObject } from 'react';
+import { useState, useRef, useCallback, Ref, MutableRefObject } from 'react';
 
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refObjects: React.Ref<T>[]): (instance: T) => void {
-  const [state] = useState<{ refs: (Ref<T> | undefined)[] }>({ refs: [] });
+export function useMergedRefs<T>(...refObjects: Ref<T>[]): (instance: T) => void {
+  const state = useRef<(Ref<T> | undefined)[]>();
 
   // Update refs list in immutatable state object.
-  state.refs = refObjects;
+  state.current = refObjects;
 
   // Return cached callback which refers to mutable refs array within the immutable state.
   return useCallback((value: T) => {
-    const { refs } = state;
-
-    for (const ref of refs) {
+    for (const ref of state.current!) {
       if (typeof ref === 'function') {
         ref(value);
       } else if (ref) {


### PR DESCRIPTION
```tsx
const ref1 = React.useRef();
const ref2 = React.useRef();

return <div ref={useMergedRefs(ref1, ref2)} />;
```

In the current code, the ref function mutates every time, causing prop mutation unnecessarily. Tweaking the function to return the same function every time.
