### PR TITLE
fix(SplitButton): Fix primary hover styles

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13682](https://github.com/microsoft/fluentui/pull/13682))
 - Fix the order of callbacks in `Dropdown` @layershifter ([#13707](https://github.com/microsoft/fluentui/pull/13707))
 - Fix merging of `inputRef` on `searchInput` shorthand in `Dropdown` @layershifter ([#13711](https://github.com/microsoft/fluentui/pull/13711))
-- Fix primary hover styles for `SplitButton` @assuncaocharles ([#13726](https://github.com/microsoft/fluentui/pull/13726))
+- Fix primary styles for `SplitButton` hover @assuncaocharles ([#13726](https://github.com/microsoft/fluentui/pull/13726))
 
 ### Features
 - Add Emotion as an optional CSS-in-JS renderer @layershifter ([#13547](https://github.com/microsoft/fluentui/pull/13547))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Avatar` initials when the input only contains whitespace @rymeskar ([#13682](https://github.com/microsoft/fluentui/pull/13682))
 - Fix the order of callbacks in `Dropdown` @layershifter ([#13707](https://github.com/microsoft/fluentui/pull/13707))
 - Fix merging of `inputRef` on `searchInput` shorthand in `Dropdown` @layershifter ([#13711](https://github.com/microsoft/fluentui/pull/13711))
+- Fix primary hover styles for `SplitButton` @assuncaocharles ([#13726](https://github.com/microsoft/fluentui/pull/13726))
 
 ### Features
 - Add Emotion as an optional CSS-in-JS renderer @layershifter ([#13547](https://github.com/microsoft/fluentui/pull/13547))

--- a/packages/fluentui/docs/src/examples/components/SplitButton/Types/SplitButtonExamplePrimary.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/SplitButton/Types/SplitButtonExamplePrimary.shorthand.steps.ts
@@ -1,0 +1,11 @@
+import { splitButtonToggleClassName } from '@fluentui/react-northstar';
+
+const selectors = {
+  triggerButton: `.${splitButtonToggleClassName}`,
+};
+
+const config: ScreenerTestsConfig = {
+  steps: [builder => builder.hover(selectors.triggerButton).snapshot('Hover primary trigger')],
+};
+
+export default config;

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonToggleStyles.ts
@@ -84,7 +84,7 @@ const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonToggleStyl
       ':focus-visible': {
         backgroundColor: v.toggleButtonBackgroundColorFocus,
         borderColor: v.toggleButtonBorderColorFocus,
-        color: v.toggleButtonColorFocus,
+        // color: v.toggleButtonColorFocus,
         borderWidth,
 
         ':hover': {
@@ -108,6 +108,11 @@ const splitButtonToggleStyles: ComponentSlotStylesPrepared<SplitButtonToggleStyl
         ':focus': borderFocusStyles[':focus'],
         ':focus-visible': {
           backgroundColor: v.toggleButtonPrimaryBackgroundColorFocus,
+        },
+
+        ':hover': {
+          color: v.toggleButtonPrimaryHoverColor,
+          backgroundColor: v.toggleButtonPrimaryHoverBackgroundColor,
         },
       }),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/SplitButton/splitButtonVariables.ts
@@ -33,6 +33,8 @@ export interface SplitButtonVariables {
   toggleButtonColorFocus: string;
 
   toggleButtonPrimaryColor: string;
+  toggleButtonPrimaryHoverBackgroundColor: string;
+  toggleButtonPrimaryHoverColor: string;
   toggleButtonPrimaryBackgroundColor: string;
   toggleButtonPrimaryBorderColor: string;
   toggleButtonPrimaryBoxShadow: string;
@@ -83,6 +85,8 @@ export default (siteVars: SiteVariablesPrepared): SplitButtonVariables => {
     toggleButtonBorderColorFocus: undefined,
     toggleButtonColorFocus: undefined,
 
+    toggleButtonPrimaryHoverBackgroundColor: siteVars.colorScheme.brand.backgroundHover,
+    toggleButtonPrimaryHoverColor: siteVars.colorScheme.brand.foregroundHover1,
     toggleButtonPrimaryColor: siteVars.colorScheme.brand.foreground4,
     toggleButtonPrimaryBackgroundColor: siteVars.colorScheme.brand.background,
     toggleButtonPrimaryBorderColor: 'transparent',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13623
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix primary hover styles for `SplitButton`:

![ezgif-4-1e2a9d682c2b](https://user-images.githubusercontent.com/8545105/85192588-5acd6b00-b2c3-11ea-9f47-546e32e059db.gif)

#### Focus areas to test

(optional)
