### PR TITLE
Scrollable Pane: Fix pointer events

### DIFF
--- a/change/office-ui-fabric-react-2020-06-22-14-24-21-edwl-2020-06-fixScrollablePaneClick.json
+++ b/change/office-ui-fabric-react-2020-06-22-14-24-21-edwl-2020-06-fixScrollablePaneClick.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ScrollablePane: fix pointer events on sticky'd elements",
+  "packageName": "office-ui-fabric-react",
+  "email": "edwl@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-22T21:24:21.560Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.styles.ts
@@ -13,7 +13,7 @@ export const getStyles = (props: IScrollablePaneStyleProps): IScrollablePaneStyl
 
   const AboveAndBelowStyles: IStyle = {
     position: 'absolute',
-    pointerEvents: 'auto',
+    pointerEvents: 'none',
   };
 
   const positioningStyle: IStyle = {

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/__snapshots__/ScrollablePane.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`ScrollablePane renders correctly 1`] = `
     className=
 
         {
-          pointer-events: auto;
+          pointer-events: none;
           position: absolute;
           top: 0px;
           z-index: 1;
@@ -60,7 +60,7 @@ exports[`ScrollablePane renders correctly 1`] = `
 
         {
           bottom: 0px;
-          pointer-events: auto;
+          pointer-events: none;
           position: absolute;
         }
         @media screen and (-ms-high-contrast: active){& {
@@ -80,7 +80,7 @@ exports[`ScrollablePane renders correctly 1`] = `
 
           {
             bottom: 0px;
-            pointer-events: auto;
+            pointer-events: none;
             position: absolute;
             width: 100%;
           }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7673
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Change `pointer-events` from `none` to `auto` for ScrollablePane's sticky above/below region

#### Focus areas to test

(optional)
