### PR TITLE
Adding build:min step to reduce build times for codesandbox builds

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,4 +1,5 @@
 {
   "packages": ["packages/react-button"],
-  "sandboxes": ["u0e3w"]
+  "sandboxes": ["u0e3w"],
+  "build": "build:min"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "a11ytest": "cd apps && cd a11y-tests && npm run test",
     "build": "lerna run build --stream",
     "build:fluentui:docs": "gulp build:docs",
+    "build:min": "lerna run build --stream --no-private -- --min",
     "build:prod": "lerna run build --stream -- --production",
     "buildci": "yarn build && yarn test && yarn lint && yarn bundle",
     "buildci:prod": "yarn build:prod && yarn test && yarn lint && yarn bundle:prod",

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -81,7 +81,7 @@ module.exports = function preset() {
     return argv().commonjs
       ? 'ts:commonjs-only'
       : parallel(
-          'ts:commonjs',
+          condition('ts:commonjs', () => !argv().min),
           'ts:esm',
           condition('ts:amd', () => !!argv().production),
         );
@@ -104,7 +104,16 @@ module.exports = function preset() {
 
   task('build:node-lib', series('clean', 'copy', 'ts:commonjs-only')).cached();
 
-  task('build', series('clean', 'copy', 'sass', 'ts', 'api-extractor:verify')).cached();
+  task(
+    'build',
+    series(
+      'clean',
+      'copy',
+      'sass',
+      'ts',
+      condition('api-extractor:verify', () => !argv().min),
+    ),
+  ).cached();
 
   task(
     'bundle',


### PR DESCRIPTION
You can now do a build:min to only build ESM modules for non-private packages. Hooked up sandbox ci to use this command, so hopefully this improves the reliability.