### PR TITLE
merge-styles: allowing css variables to be registered without being kebabcased.

### DIFF
--- a/change/@uifabric-charting-2020-06-22-18-55-04-feat-merge-styles-css-variables.json
+++ b/change/@uifabric-charting-2020-06-22-18-55-04-feat-merge-styles-css-variables.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing some unneeded mergeStyles usage in examples.",
+  "packageName": "@uifabric/charting",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T01:54:34.621Z"
+}

--- a/change/@uifabric-merge-styles-2020-06-22-18-55-04-feat-merge-styles-css-variables.json
+++ b/change/@uifabric-merge-styles-2020-06-22-18-55-04-feat-merge-styles-css-variables.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Loosening typings to allow for css variables. Removing kebab casing for css values which start with dashes.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T01:55:04.347Z"
+}

--- a/change/@uifabric-tslint-rules-2020-06-22-23-17-48-feat-merge-styles-css-variables.json
+++ b/change/@uifabric-tslint-rules-2020-06-22-23-17-48-feat-merge-styles-css-variables.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing style prop ban.",
+  "packageName": "@uifabric/tslint-rules",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-23T06:17:48.113Z"
+}

--- a/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
@@ -3,11 +3,6 @@ import { GroupedVerticalBarChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
-interface IRootStyles {
-  height: string;
-  width: string;
-}
-
 export class GroupedVerticalBarChartBasicExample extends React.Component<Readonly<{}>, {}> {
   public render(): React.ReactNode {
     const data = [
@@ -148,10 +143,10 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
       },
     ];
 
-    const rootStyle: IRootStyles = { width: '650px', height: '400px' };
+    const rootStyle = mergeStyles({ width: '650px', height: '400px' });
 
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div className={rootStyle}>
         <GroupedVerticalBarChart data={data} height={400} width={650} showYAxisGridLines />
       </div>
     );

--- a/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Styled.Example.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Styled.Example.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { GroupedVerticalBarChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 export class GroupedVerticalBarChartStyledExample extends React.Component<Readonly<{}>, {}> {
   public render(): React.ReactNode {
@@ -82,10 +76,8 @@ export class GroupedVerticalBarChartStyledExample extends React.Component<Readon
       },
     ];
 
-    const rootStyle: IRootStyles = { width: '650px', height: '400px' };
-
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={{ width: '650px', height: '400px' }}>
         <GroupedVerticalBarChart
           data={data}
           width={650}

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -1,13 +1,7 @@
 import * as React from 'react';
 import { IChartProps, ILineChartProps, LineChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 import * as d3 from 'd3-format';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 interface ILineChartBasicState {
   width: number;
@@ -116,14 +110,16 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
         },
       ],
     };
-    const rootStyle: IRootStyles = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+
     return (
       <>
         <label>change Width:</label>
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
-        <div className={mergeStyles(rootStyle)}>
+        <div style={rootStyle}>
           <LineChart
             data={data}
             legendsOverflowText={'Overflow Items'}

--- a/packages/charting/src/components/LineChart/examples/LineChart.Events.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Events.Example.tsx
@@ -9,11 +9,6 @@ const calloutItemStyle = mergeStyles({
   padding: '3px',
 });
 
-interface IRootStyles {
-  height: string;
-  width: string;
-}
-
 interface ILineChartEventsExampleState {
   width: number;
   height: number;
@@ -121,12 +116,14 @@ export class LineChartEventsExample extends React.Component<{}, ILineChartEvents
         },
       ],
     };
-    const rootStyle: IRootStyles = {
+
+    const rootStyle = {
       width: `${this.state.width}px`,
       height: `${this.state.height}px`,
     };
+
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={rootStyle}>
         <LineChart
           data={data}
           legendsOverflowText={'Overflow Items'}

--- a/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 interface ILineChartMultipleExampleState {
   width: number;
@@ -102,7 +96,7 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
       chartTitle: 'Line Chart',
       lineChartData: points,
     };
-    const rootStyle: IRootStyles = { width: `${this.state.width}px`, height: `${this.state.height}px` };
+    const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
     const timeFormat = '%m/%d';
     // Passing tick values is optional, for more control.
     // If you do not pass them the line chart will render them for you based on D3's standard.
@@ -115,7 +109,7 @@ export class LineChartMultipleExample extends React.Component<{}, ILineChartMult
       new Date('06-01-2018'),
     ];
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={rootStyle}>
         <LineChart
           data={data}
           strokeWidth={4}

--- a/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Styled.Example.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 interface IStyledLineChartExampleState {
   width: number;
@@ -53,7 +47,7 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
       chartTitle: 'Line Chart',
       lineChartData: points,
     };
-    const rootStyle: IRootStyles = {
+    const rootStyle = {
       width: `${this.state.width}px`,
       height: `${this.state.height}px`,
     };
@@ -63,7 +57,7 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
-        <div className={mergeStyles(rootStyle)}>
+        <div style={rootStyle}>
           <LineChart
             data={data}
             strokeWidth={4}

--- a/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Basic.Example.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { VerticalBarChart, IVerticalBarChartProps } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 export class VerticalBarChartBasicExample extends React.Component<IVerticalBarChartProps, {}> {
   constructor(props: IVerticalBarChartProps) {
@@ -82,10 +76,8 @@ export class VerticalBarChartBasicExample extends React.Component<IVerticalBarCh
       },
     ];
 
-    const rootStyle: IRootStyles = { width: '650px', height: '400px' };
-
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={{ width: '650px', height: '400px' }}>
         <VerticalBarChart data={points} width={650} height={400} chartLabel={'Basic Chart with Numeric Axes'} />
       </div>
     );

--- a/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Dynamic.Example.tsx
+++ b/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Dynamic.Example.tsx
@@ -2,12 +2,6 @@ import * as React from 'react';
 import { VerticalBarChart, IVerticalBarChartProps, IDataPoint } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 export interface IExampleState {
   dynamicData: IDataPoint[];
@@ -47,10 +41,8 @@ export class VerticalBarChartDynamicExample extends React.Component<IVerticalBar
   }
 
   public render(): JSX.Element {
-    const rootStyle: IRootStyles = { width: '650px', height: '400px' };
-
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={{ width: '650px', height: '400px' }}>
         <VerticalBarChart
           data={this.state.dynamicData}
           colors={this.state.colors}

--- a/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Styled.Example.tsx
+++ b/packages/charting/src/components/VerticalBarChart/examples/VerticalBarChart.Styled.Example.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import { VerticalBarChart, IVerticalBarChartProps } from '@uifabric/charting';
 import { DefaultPalette, DefaultFontStyles } from 'office-ui-fabric-react/lib/Styling';
-import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-
-interface IRootStyles {
-  height: string;
-  width: string;
-}
 
 export class VerticalBarChartStyledExample extends React.Component<IVerticalBarChartProps, {}> {
   constructor(props: IVerticalBarChartProps) {
@@ -14,7 +8,6 @@ export class VerticalBarChartStyledExample extends React.Component<IVerticalBarC
   }
 
   public render(): JSX.Element {
-    const rootStyle: IRootStyles = { width: '800px', height: '400px' };
     const points = [
       { x: 'One', y: 20 },
       { x: 'Two', y: 48 },
@@ -59,7 +52,7 @@ export class VerticalBarChartStyledExample extends React.Component<IVerticalBarC
     const customColors = [DefaultPalette.greenLight, DefaultPalette.green, DefaultPalette.greenDark];
 
     return (
-      <div className={mergeStyles(rootStyle)}>
+      <div style={{ width: '800px', height: '400px' }}>
         <VerticalBarChart
           data={points}
           width={800}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -102,6 +102,8 @@ export interface IRawFontStyle {
 
 // @public
 export interface IRawStyle extends IRawStyleBase {
+    // (undocumented)
+    [key: string]: string | number | undefined | Record<string, IStyle>;
     displayName?: string;
     selectors?: {
         [key: string]: IStyle;

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -7,6 +7,8 @@ import { IRawStyleBase } from './IRawStyleBase';
  * {@docCategory IRawStyle}
  */
 export interface IRawStyle extends IRawStyleBase {
+  [key: string]: string | number | undefined | Record<string, IStyle>;
+
   /**
    * Display name for the style.
    */

--- a/packages/merge-styles/src/mergeStyles.test.ts
+++ b/packages/merge-styles/src/mergeStyles.test.ts
@@ -30,6 +30,11 @@ describe('mergeStyles', () => {
     expect(_stylesheet.getRules()).toEqual('.css-0{right:10px;}');
   });
 
+  it('can register a css variable', () => {
+    mergeStyles({ '--fooBar': 'baz' });
+    expect(_stylesheet.getRules()).toEqual('.css-0{--fooBar:baz;}');
+  });
+
   it('can re-register rules when rtl is flipped', () => {
     const result1 = mergeStyles({ left: 10 });
     expect(_stylesheet.getRules()).toEqual('.css-0{left:10px;}');

--- a/packages/merge-styles/src/transforms/kebabRules.test.ts
+++ b/packages/merge-styles/src/transforms/kebabRules.test.ts
@@ -16,4 +16,12 @@ describe('kebabRules', () => {
 
     expect(rules).toEqual(['-webkit-font-smoothing', 'antialiased']);
   });
+
+  it('can avoid kebabing css variables', () => {
+    const rules = ['--fooBar', 'test'];
+
+    kebabRules(rules, 0);
+
+    expect(rules).toEqual(['--fooBar', 'test']);
+  });
 });

--- a/packages/merge-styles/src/transforms/kebabRules.test.ts
+++ b/packages/merge-styles/src/transforms/kebabRules.test.ts
@@ -24,4 +24,12 @@ describe('kebabRules', () => {
 
     expect(rules).toEqual(['--fooBar', 'test']);
   });
+
+  it('can leave webkit prefix intact', () => {
+    const rules = ['-webkit-font-smoothing', 'antialiased'];
+
+    kebabRules(rules, 0);
+
+    expect(rules).toEqual(['-webkit-font-smoothing', 'antialiased']);
+  });
 });

--- a/packages/merge-styles/src/transforms/kebabRules.ts
+++ b/packages/merge-styles/src/transforms/kebabRules.ts
@@ -3,5 +3,7 @@ const rules: { [key: string]: string } = {};
 export function kebabRules(rulePairs: (string | number)[], index: number): void {
   const rule: string = rulePairs[index] as string;
 
-  rulePairs[index] = rules[rule] = rules[rule] || rule.replace(/([A-Z])/g, '-$1').toLowerCase();
+  if (rule.charAt(0) !== '-') {
+    rulePairs[index] = rules[rule] = rules[rule] || rule.replace(/([A-Z])/g, '-$1').toLowerCase();
+  }
 }

--- a/packages/tslint-rules/tslint.json
+++ b/packages/tslint-rules/tslint.json
@@ -29,13 +29,6 @@
     "jsx-self-close": true,
     "jsx-no-multiline-js": false, // override tslint-react
     "jsx-no-string-ref": true,
-    "jsx-ban-props": [
-      true,
-      [
-        "style",
-        "Use className and provide css rules instead of using inline styles."
-      ]
-    ],
     "no-duplicate-variable": true,
     "use-isnan": true,
     "triple-equals": [


### PR DESCRIPTION
Updating `merge-styles` to allow for css variable registration without kebab casing:

Before, type error and erroneous output:
```tsx
mergeStyles({ '--button-borderColor': 'red' }) // output: .css-0{--button-border-color: 'red'}
```
After, no red squiggles, correct output:

```tsx
mergeStyles({ '--button-borderColor': 'red' }) // output: .css-0{--button-borderColor: 'red'}
```
