### PR TITLE
GroupedVerticalBarChart - The second bar chart disappear when the number of charts are greater than 2 in one page -Issue fixed

### DIFF
--- a/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
+++ b/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Grouped chart - second chart disappear issue fixed",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-06-24T14:35:28.103Z"
+}

--- a/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
+++ b/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Grouped chart - second chart disappear issue fixed",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-06-24T14:35:28.103Z"
 }

--- a/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
+++ b/change/@uifabric-charting-2020-06-24-20-05-28-user-v-jasha-GroupedCHartNotVisibleIssus.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Grouped chart - second chart disappear issue fixed",
+  "comment": "Grouped veritcal bar chart - second chart disappear issue fixed",
   "packageName": "@uifabric/charting",
   "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -72,6 +72,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
   private _xScale0: any;
   // tslint:disable-next-line:no-any
   private _xScale1: any;
+  private _uniqLineText: string;
   private _dataset: IGVDataPoint[];
   private _keys: string[];
   private _isGraphDraw: boolean = true;
@@ -99,6 +100,11 @@ export class GroupedVerticalBarChartBase extends React.Component<
     };
     this._refArray = [];
     this._adjustProps();
+    this._uniqLineText =
+      '_GroupedBarChart_' +
+      Math.random()
+        .toString(36)
+        .substring(7);
   }
 
   public componentDidMount(): void {
@@ -156,12 +162,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
 
     return (
       <div
-        id="d3GroupedChart"
+        id={`d3GroupedChart_${this._uniqLineText}`}
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
         className={this._classNames.root}
       >
         <FocusZone direction={FocusZoneDirection.horizontal}>
-          <svg width={svgDimensions.width} height={svgDimensions.height}>
+          <svg width={svgDimensions.width} height={svgDimensions.height} id={this._uniqLineText}>
             <g
               id="xAxisGElement"
               ref={(node: SVGGElement | null) => this._setXAxis(node, x0Axis)}
@@ -174,10 +180,14 @@ export class GroupedVerticalBarChartBase extends React.Component<
               className={this._classNames.yAxis}
               transform={`translate(40, 0)`}
             />
-            <g id="barGElement" />
+            <g id={`barGElement_${this._uniqLineText}`} className="barGElement" />
           </svg>
         </FocusZone>
-        <div ref={(e: HTMLDivElement) => (this.legendContainer = e)} className={this._classNames.legendContainer}>
+        <div
+          ref={(e: HTMLDivElement) => (this.legendContainer = e)}
+          id={this._uniqLineText}
+          className={this._classNames.legendContainer}
+        >
           {legends}
         </div>
         {!this.props.hideTooltip && this.state.isCalloutVisible ? (
@@ -337,10 +347,11 @@ export class GroupedVerticalBarChartBase extends React.Component<
       .range([0, this.state.containerHeight - this.margins.bottom - this.margins.top]);
 
     // previous <g> - graph need to remove otherwise multile g elements will create
-    d3Select('#firstGElementForBars').remove();
-    const barContainer = d3Select('#barGElement')
+    d3Select(`#firstGElementForBars_${this._uniqLineText}_${this._yMax}`).remove();
+    const barContainer = d3Select(`#barGElement_${this._uniqLineText}`)
       .append('g')
-      .attr('id', 'firstGElementForBars');
+      .attr('class', 'firstGElementForBars')
+      .attr('id', `#firstGElementForBars_${this._uniqLineText}_${this._yMax}`);
     const seriesName = barContainer
       .selectAll('.name')
       .data(this._datasetForBars)

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -3,7 +3,7 @@ import { max as d3Max } from 'd3-array';
 import { axisLeft as d3AxisLeft, axisBottom as d3AxisBottom, Axis as D3Axis } from 'd3-axis';
 import { scaleBand as d3ScaleBand, scaleLinear as d3ScaleLinear } from 'd3-scale';
 import { select as d3Select, event as d3Event } from 'd3-selection';
-import { classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, getId } from 'office-ui-fabric-react/lib/Utilities';
 import { IProcessedStyleSet, IPalette } from 'office-ui-fabric-react/lib/Styling';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { ILegend, Legends } from '../Legends/index';
@@ -100,11 +100,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
     };
     this._refArray = [];
     this._adjustProps();
-    this._uniqLineText =
-      '_GroupedBarChart_' +
-      Math.random()
-        .toString(36)
-        .substring(7);
+    this._uniqLineText = getId('GroupedVerticalChart_');
   }
 
   public componentDidMount(): void {
@@ -539,7 +535,6 @@ export class GroupedVerticalBarChartBase extends React.Component<
   }
 
   private _onLegendHover(customMessage: string): void {
-    console.log('legend hover');
     if (this.state.isLegendSelected === false) {
       this.setState({
         isLegendHovered: true,

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -347,11 +347,11 @@ export class GroupedVerticalBarChartBase extends React.Component<
       .range([0, this.state.containerHeight - this.margins.bottom - this.margins.top]);
 
     // previous <g> - graph need to remove otherwise multile g elements will create
-    d3Select(`#firstGElementForBars_${this._uniqLineText}_${this._yMax}`).remove();
+    d3Select(`#firstGElementForBars_${this._yMax}_${this._uniqLineText}`).remove();
     const barContainer = d3Select(`#barGElement_${this._uniqLineText}`)
       .append('g')
       .attr('class', 'firstGElementForBars')
-      .attr('id', `#firstGElementForBars_${this._uniqLineText}_${this._yMax}`);
+      .attr('id', `firstGElementForBars_${this._yMax}_${this._uniqLineText}`);
     const seriesName = barContainer
       .selectAll('.name')
       .data(this._datasetForBars)
@@ -539,6 +539,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
   }
 
   private _onLegendHover(customMessage: string): void {
+    console.log('legend hover');
     if (this.state.isLegendSelected === false) {
       this.setState({
         isLegendHovered: true,

--- a/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/examples/GroupedVerticalBarChart.Basic.Example.tsx
@@ -153,6 +153,7 @@ export class GroupedVerticalBarChartBasicExample extends React.Component<Readonl
     return (
       <div className={mergeStyles(rootStyle)}>
         <GroupedVerticalBarChart data={data} height={400} width={650} showYAxisGridLines />
+        <GroupedVerticalBarChart data={data} height={400} width={650} showYAxisGridLines />
       </div>
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

ID's added to chart SVG and G elements.
When we have 2 charts on same page, because of same ID's second graph getting disappeared. By Adding unique ID's, issue resolved.

#### Focus areas to test

Grouped vertical bar chart

### Before fix
![image](https://user-images.githubusercontent.com/20105532/85591345-dc761d80-b662-11ea-82b1-98e0a3ec5816.png)


### After fix (adding 2 charts in same page)
![image](https://user-images.githubusercontent.com/20105532/85591431-ec8dfd00-b662-11ea-9604-4a8ce0c89d6d.png)
