### PR TITLE
Fix issue When the mouse is over the data point on the second chart, the vertical line appears on the first chart

### DIFF
--- a/change/@uifabric-charting-2020-06-24-21-25-37-user-v-gorraj-Bug_4248966.json
+++ b/change/@uifabric-charting-2020-06-24-21-25-37-user-v-gorraj-Bug_4248966.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix issue When the mouse is over the data point on the second chart, the vertical line appears on the first chart.",
+  "packageName": "@uifabric/charting",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-24T15:55:37.026Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -60,8 +60,9 @@ export class LineChartBase extends React.Component<
   private chartContainer: HTMLDivElement;
   private legendContainer: HTMLDivElement;
   private _calloutId: string;
+  private _verticalLine: string;
   // These margins are necessary for d3Scales to appear without cutting off
-  private margins = { top: 20, right: 20, bottom: 35, left: 65 };
+  private margins = { top: 20, right: 20, bottom: 35, left: 40 };
   private minLegendContainerHeight: number = 32;
   private eventLabelHeight: number = 36;
   constructor(props: ILineChartProps) {
@@ -85,6 +86,7 @@ export class LineChartBase extends React.Component<
     this._points = this.props.data.lineChartData ? this.props.data.lineChartData : [];
     this._calloutPoints = this.CalloutData(this._points) ? this.CalloutData(this._points) : [];
     this._calloutId = getId('callout');
+    this._verticalLine = getId('verticalLine');
     this._uniqLineText =
       '_line_' +
       Math.random()
@@ -177,7 +179,7 @@ export class LineChartBase extends React.Component<
               ref={(e: SVGElement | null) => {
                 this.yAxisElement = e;
               }}
-              transform={`translate(65, 0)`}
+              transform={`translate(${this.margins.left}, 0)`}
               className={this._classNames.yAxis}
             />
             <g>
@@ -187,7 +189,7 @@ export class LineChartBase extends React.Component<
                 x2={0}
                 y2={svgDimensions.height}
                 stroke={'steelblue'}
-                className={'verticalLine'}
+                id={this._verticalLine}
                 visibility={'hidden'}
                 strokeDasharray={'5,5'}
               />
@@ -464,8 +466,8 @@ export class LineChartBase extends React.Component<
     const yAxis = d3AxisLeft(yAxisScale)
       .tickSize(-(this.state.containerWidth - this.margins.left - this.margins.right))
       .tickPadding(12)
-      .tickValues(domainValues)
-      .tickFormat(yAxisTickFormat);
+      .tickValues(domainValues);
+    yAxisTickFormat ? yAxis.tickFormat(yAxisTickFormat) : yAxis.ticks(4, 's');
     this.yAxisElement
       ? d3Select(this.yAxisElement)
           .call(yAxis)
@@ -636,7 +638,7 @@ export class LineChartBase extends React.Component<
     d3Select('#' + circleId)
       .attr('fill', '#fff')
       .attr('r', 8);
-    d3Select('.verticalLine')
+    d3Select(`#${this._verticalLine}`)
       .attr('transform', () => `translate(${_this._xAxisScale(x)}, 0)`)
       .attr('visibility', 'visibility');
     this.state.refArray.map((obj: IRefArrayData) => {
@@ -667,7 +669,7 @@ export class LineChartBase extends React.Component<
     d3Select('#' + keyVal)
       .attr('fill', '#fff')
       .attr('r', 8);
-    d3Select('.verticalLine')
+    d3Select(`#${this._verticalLine}`)
       .attr('transform', () => `translate(${_this._xAxisScale(x)}, 0)`)
       .attr('visibility', 'visibility');
     const found = find(this._calloutPoints, (element: { x: string | number }) => element.x === formattedData);
@@ -700,7 +702,7 @@ export class LineChartBase extends React.Component<
     d3Select('#' + keyVal)
       .attr('fill', lineColor)
       .attr('r', 0.2);
-    d3Select('.verticalLine').attr('visibility', 'hidden');
+    d3Select(`#${this._verticalLine}`).attr('visibility', 'hidden');
     this.setState({
       isCalloutVisible: false,
     });

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { IChartProps, ILineChartProps, LineChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
-import * as d3 from 'd3-format';
 
 interface IRootStyles {
   height: string;
@@ -129,7 +128,6 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
             legendsOverflowText={'Overflow Items'}
             yMinValue={200}
             yMaxValue={301}
-            yAxisTickFormat={d3.format('$,')}
             height={this.state.height}
             width={this.state.width}
           />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Fix issue When the mouse is over the data point on the second chart, the vertical line appears on the first chart

#### Focus areas to test
multiple Line charts in same page 
