### PR TITLE
Fixing React-Next's Toggle component focus border value

### DIFF
--- a/change/@fluentui-react-next-2020-06-24-17-32-48-feat-toggle-focus-fix.json
+++ b/change/@fluentui-react-next-2020-06-24-17-32-48-feat-toggle-focus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fixing React-Next's Toggle.scss focus value",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-25T00:32:48.311Z"
+}

--- a/packages/react-next/src/components/Toggle/Toggle.scss
+++ b/packages/react-next/src/components/Toggle/Toggle.scss
@@ -56,7 +56,7 @@ $DEFAULT_THUMB_SIZE: 12px;
   transition: all 0.1s ease;
   width: $DEFAULT_PILL_WIDTH;
 
-  @include focus-border($padding: -2);
+  @include focus-border($padding: -2px);
 
   &:hover {
     border-color: var($semanticColorsInputBorderHovered);


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Quick fix to React-Next's `Toggle` component styling, so that it can show a focus border.

