### PR TITLE
Addressing min:build to get codesandbox working.

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,10 +2,10 @@
   "buildCommand": "build:min",
   "packages": [
     "packages/react-button",
-    "@fluentui/react-northstar",
+    "packages/fluentui/react-northstar",
     "packages/office-ui-fabric-react",
-    "@fluentui/react-next",
-    "@fluentui/react-icons"
+    "packages/react-next",
+    "packages/react-icons"
   ],  
   "sandboxes": ["u0e3w"]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "a11ytest": "cd apps && cd a11y-tests && npm run test",
     "build": "lerna run build --stream",
     "build:fluentui:docs": "gulp build:docs",
-    "build:min": "lerna run build --stream --no-private -- --min",
+    "build:min": "yarn buildto @fluentui/react-next --min && yarn buildto @fluentui/react-northstar --min",
     "build:prod": "lerna run build --stream -- --production",
     "buildci": "yarn build && yarn test && yarn lint && yarn bundle",
     "buildci:prod": "yarn build:prod && yarn test && yarn lint && yarn bundle:prod",


### PR DESCRIPTION
This change reduces the minbuild to only build to `react-next` and `react-northstar` packages, which should include enough dependencies to support the codesandbox build, but avoid things like vr tests and doc sites.