### PR TITLE
Icons warnings for wrong usage

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Accordion/AccordionTitle.tsx
@@ -13,6 +13,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   rtlTextContainer,
+  assertValidIconValue,
 } from '../../utils';
 import {
   WithAsProp,
@@ -149,6 +150,8 @@ const AccordionTitle: React.FC<WithAsProp<AccordionTitleProps>> &
     }),
     rtl: context.rtl,
   });
+
+  assertValidIconValue(indicator, 'indicator');
 
   const handleClick = (e: React.SyntheticEvent) => {
     if (!disabled) {

--- a/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
+++ b/packages/fluentui/react-northstar/src/components/Alert/Alert.tsx
@@ -11,6 +11,7 @@ import {
   commonPropTypes,
   childrenExist,
   createShorthandFactory,
+  assertValidIconValue,
 } from '../../utils';
 import {
   ComponentEventHandler,
@@ -193,6 +194,8 @@ const Alert: React.FC<WithAsProp<AlertProps>> &
     }),
     rtl: context.rtl,
   });
+
+  assertValidIconValue(icon);
 
   const handleDismissOverrides = (predefinedProps: ButtonProps) => ({
     onClick: (e: React.SyntheticEvent, buttonProps: ButtonProps) => {

--- a/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/Attachment.tsx
@@ -24,6 +24,7 @@ import {
   ChildrenComponentProps,
   createShorthand,
   ShorthandFactory,
+  assertValidIconValue,
 } from '../../utils';
 import AttachmentAction, { AttachmentActionProps } from './AttachmentAction';
 import AttachmentBody, { AttachmentBodyProps } from './AttachmentBody';
@@ -130,6 +131,8 @@ const Attachment = compose<'div', AttachmentProps, AttachmentStylesProps, {}, {}
 
     const ElementType = getElementType(props);
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    assertValidIconValue(icon);
 
     const handleClick = (e: React.KeyboardEvent | React.MouseEvent) => {
       if (disabled) {

--- a/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Avatar/Avatar.tsx
@@ -17,7 +17,13 @@ import {
   FluentComponentStaticProps,
   ProviderContextPrepared,
 } from '../../types';
-import { createShorthandFactory, UIComponentProps, commonPropTypes, SizeValue } from '../../utils';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  commonPropTypes,
+  SizeValue,
+  assertValidIconValue,
+} from '../../utils';
 
 export interface AvatarProps extends UIComponentProps {
   /**
@@ -91,6 +97,8 @@ const Avatar: React.FC<WithAsProp<AvatarProps>> & FluentComponentStaticProps<Ava
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Avatar.handledProps, props);
+
+  assertValidIconValue(icon);
 
   const imageElement = Image.create(image, {
     defaultProps: () =>

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -26,6 +26,7 @@ import {
   SizeValue,
   ShorthandFactory,
   createShorthand,
+  assertValidIconValue,
 } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 import Loader, { LoaderProps } from '../Loader/Loader';
@@ -188,6 +189,8 @@ const Button = compose<'button', ButtonProps, ButtonStylesProps, {}, {}>(
 
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
     const ElementType = getElementType(props);
+
+    assertValidIconValue(icon);
 
     const renderIcon = () => {
       return createShorthand(composeOptions.slots.icon, icon, {

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
@@ -12,6 +12,7 @@ import {
   rtlTextContainer,
   ContentComponentProps,
   ChildrenComponentProps,
+  assertValidIconValue,
 } from '../../utils';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
@@ -104,6 +105,8 @@ const CarouselNavigationItem: React.FC<WithAsProp<CarouselNavigationItemProps>> 
   } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(CarouselNavigationItem.handledProps, props);
+
+  assertValidIconValue(indicator, 'indicator');
 
   const getA11yProps = useAccessibility(props.accessibility, {
     debugName: CarouselNavigationItem.displayName,

--- a/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Checkbox/Checkbox.tsx
@@ -15,7 +15,13 @@ import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import { createShorthandFactory, ChildrenComponentProps, commonPropTypes, UIComponentProps } from '../../utils';
+import {
+  createShorthandFactory,
+  ChildrenComponentProps,
+  commonPropTypes,
+  UIComponentProps,
+  assertValidIconValue,
+} from '../../utils';
 import {
   ComponentEventHandler,
   WithAsProp,
@@ -136,6 +142,8 @@ const Checkbox: React.FC<WithAsProp<CheckboxProps>> & FluentComponentStaticProps
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Checkbox.handledProps, props);
+
+  assertValidIconValue(indicator, 'indicator');
 
   const handleChange = (e: React.ChangeEvent) => {
     if (!disabled) {

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -34,6 +34,7 @@ import {
   UIComponentProps,
   isFromKeyboard,
   createShorthand,
+  assertValidIconValue,
 } from '../../utils';
 import List, { ListProps } from '../List/List';
 import DropdownItem, { DropdownItemProps } from './DropdownItem';
@@ -463,6 +464,10 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       headerMessage,
     } = this.props;
     const { highlightedIndex, open, searchQuery, value } = this.state;
+
+    assertValidIconValue(toggleIndicator, 'toggleIndicator');
+    assertValidIconValue(clearIndicator, 'toggleIndicator');
+    assertValidIconValue(props.checkableIndicator, 'checkableIndicator');
 
     return (
       <ElementType className={classes.root} onChange={this.handleChange} {...unhandledProps}>

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownItem.tsx
@@ -8,7 +8,7 @@ import { ThemeContext } from 'react-fela';
 import { getElementType, useUnhandledProps, useStyles, useTelemetry } from '@fluentui/react-bindings';
 import cx from 'classnames';
 
-import { createShorthandFactory, commonPropTypes } from '../../utils';
+import { createShorthandFactory, commonPropTypes, assertValidIconValue } from '../../utils';
 import {
   ShorthandValue,
   ComponentEventHandler,
@@ -116,6 +116,8 @@ const DropdownItem: React.FC<WithAsProp<DropdownItemProps> & { index: number }> 
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DropdownItem.handledProps, props);
+
+  assertValidIconValue(checkableIndicator, 'checkableIndicator');
 
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     _.invoke(props, 'onClick', e, props);

--- a/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/DropdownSelectedItem.tsx
@@ -20,7 +20,7 @@ import {
   ProviderContextPrepared,
 } from '../../types';
 import { UIComponentProps } from '../../utils/commonPropInterfaces';
-import { createShorthandFactory, commonPropTypes } from '../../utils';
+import { createShorthandFactory, commonPropTypes, assertValidIconValue } from '../../utils';
 import Image, { ImageProps } from '../Image/Image';
 import Box, { BoxProps } from '../Box/Box';
 import { useUnhandledProps, useStyles, useTelemetry, getElementType, useAccessibility } from '@fluentui/react-bindings';
@@ -128,6 +128,8 @@ const DropdownSelectedItem: React.FC<WithAsProp<DropdownSelectedItemProps>> &
       rtl: context.rtl,
     },
   );
+
+  assertValidIconValue(icon);
 
   const handleClick = (e: React.SyntheticEvent) => {
     _.invoke(props, 'onClick', e, props);

--- a/packages/fluentui/react-northstar/src/components/Input/Input.tsx
+++ b/packages/fluentui/react-northstar/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ import {
   ChildrenComponentProps,
   commonPropTypes,
   createShorthandFactory,
+  assertValidIconValue,
 } from '../../utils';
 import { SupportedIntrinsicInputProps } from '../../utils/htmlPropsUtils';
 import {
@@ -159,6 +160,10 @@ const Input: React.FC<WithAsProp<InputProps>> & FluentComponentStaticProps<Input
     initialValue: '',
   });
   const hasValue: boolean = !!value && (value as string)?.length !== 0;
+
+  assertValidIconValue(icon);
+  assertValidIconValue(successIndicator, 'successIndicator');
+  assertValidIconValue(errorIndicator, 'errorIndicator');
 
   const isShowSuccessIndicatorUndefined = typeof showSuccessIndicator === 'undefined';
 

--- a/packages/fluentui/react-northstar/src/components/Label/Label.tsx
+++ b/packages/fluentui/react-northstar/src/components/Label/Label.tsx
@@ -16,6 +16,7 @@ import {
   commonPropTypes,
   ColorComponentProps,
   rtlTextContainer,
+  assertValidIconValue,
 } from '../../utils';
 
 import Image, { ImageProps } from '../Image/Image';
@@ -107,6 +108,8 @@ const Label: React.FC<WithAsProp<LabelProps>> & FluentComponentStaticProps = pro
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Label.handledProps, props);
+
+  assertValidIconValue(icon);
 
   if (childrenExist(children)) {
     const element = (

--- a/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Loader/Loader.tsx
@@ -16,6 +16,7 @@ import {
   commonPropTypes,
   SizeValue,
   getOrGenerateIdFromShorthand,
+  assertValidIconValue,
 } from '../../utils';
 import {
   WithAsProp,
@@ -119,6 +120,8 @@ const Loader: React.FC<WithAsProp<LoaderProps>> &
     }),
     rtl: context.rtl,
   });
+
+  assertValidIconValue(indicator, 'indicator');
 
   React.useEffect(() => {
     if (delay > 0) {

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -29,6 +29,7 @@ import {
   getKindProp,
   rtlTextContainer,
   ShorthandFactory,
+  assertValidIconValue,
 } from '../../utils';
 import MenuItem, { MenuItemProps } from './MenuItem';
 import MenuDivider, { MenuDividerProps } from './MenuDivider';
@@ -184,6 +185,8 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
     const dividerProps = useSlotProps('divider', slotProps);
 
     const unhandledProps = useUnhandledProps(composeOptions.handledProps, props);
+
+    assertValidIconValue(props.indicator, 'indicator');
 
     const getA11yProps = useAccessibility<MenuBehaviorProps>(props.accessibility, {
       debugName: composeOptions.displayName,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -27,6 +27,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   isFromKeyboard as isEventFromKeyboard,
+  assertValidIconValue,
 } from '../../utils';
 import Menu, { MenuProps, MenuShorthandKinds } from './Menu';
 import MenuItemIcon, { MenuItemIconProps } from './MenuItemIcon';
@@ -227,6 +228,9 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       value: props.menuOpen,
       initialValue: false,
     });
+
+    assertValidIconValue(icon);
+    assertValidIconValue(indicator, 'indicator');
 
     const [isFromKeyboard, setIsFromKeyboard] = React.useState(false);
 

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -4,7 +4,13 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
-import { createShorthandFactory, UIComponentProps, ChildrenComponentProps, commonPropTypes } from '../../utils';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  ChildrenComponentProps,
+  commonPropTypes,
+  assertValidIconValue,
+} from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 import {
   ComponentEventHandler,
@@ -113,6 +119,8 @@ const RadioGroupItem: React.FC<WithAsProp<RadioGroupItemProps>> &
   React.useEffect(() => {
     if (checked && shouldFocus) elementRef.current.focus();
   }, [checked, shouldFocus]);
+
+  assertValidIconValue(indicator, 'indicator');
 
   const { classes, styles: resolvedStyles } = useStyles<RadioGroupItemStylesProps>(RadioGroupItem.displayName, {
     className: radioGroupItemClassName,

--- a/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Reaction/Reaction.tsx
@@ -10,6 +10,7 @@ import {
   rtlTextContainer,
   createShorthandFactory,
   ContentComponentProps,
+  assertValidIconValue,
 } from '../../utils';
 import { Accessibility } from '@fluentui/accessibility';
 
@@ -81,6 +82,8 @@ const Reaction: React.FC<WithAsProp<ReactionProps>> &
     }),
     rtl: context.rtl,
   });
+
+  assertValidIconValue(icon);
 
   const element = (
     <ElementType

--- a/packages/fluentui/react-northstar/src/components/Status/Status.tsx
+++ b/packages/fluentui/react-northstar/src/components/Status/Status.tsx
@@ -6,7 +6,13 @@ import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import { createShorthandFactory, UIComponentProps, commonPropTypes, SizeValue } from '../../utils';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  commonPropTypes,
+  SizeValue,
+  assertValidIconValue,
+} from '../../utils';
 import {
   WithAsProp,
   ShorthandValue,
@@ -63,6 +69,8 @@ const Status: React.FC<WithAsProp<StatusProps>> & FluentComponentStaticProps = p
   });
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Status.handledProps, props);
+
+  assertValidIconValue(icon);
 
   const iconElement = Box.create(icon, {
     defaultProps: () =>

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -27,6 +27,7 @@ import {
   ContentComponentProps,
   commonPropTypes,
   childrenExist,
+  assertValidIconValue,
 } from '../../utils';
 import { ComponentEventHandler, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
 import { getPopperPropsFromShorthand, Popper, PopperShorthandProps } from '../../utils/positioner';
@@ -139,6 +140,8 @@ const ToolbarItem = compose<'button', ToolbarItemProps, ToolbarItemStylesProps, 
 
     const parentVariables = React.useContext(ToolbarVariablesContext);
     const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
+
+    assertValidIconValue(icon);
 
     const { menuSlot } = (useContextSelectors(ToolbarMenuContext, {
       menuSlot: v => v.slots.menu,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenu.tsx
@@ -28,6 +28,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   ContentComponentProps,
+  assertValidIconValue,
 } from '../../utils';
 
 import { ComponentEventHandler, ShorthandCollection, ShorthandValue, ProviderContextPrepared } from '../../types';
@@ -90,6 +91,8 @@ const ToolbarMenu = compose<'ul', ToolbarMenuProps, ToolbarMenuStylesProps, {}, 
     const parentVariables = React.useContext(ToolbarVariablesContext);
     const mergedVariables = mergeVariablesOverrides(parentVariables, variables);
     const slotProps = composeOptions.resolveSlotProps<ToolbarMenuProps>(props);
+
+    assertValidIconValue(submenuIndicator, 'submenuIndicator');
 
     const getA11yProps = useAccessibility(accessibility, {
       debugName: composeOptions.displayName,

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuItem.tsx
@@ -36,6 +36,7 @@ import {
   UIComponentProps,
   childrenExist,
   doesNodeContainClick,
+  assertValidIconValue,
 } from '../../utils';
 import { ComponentEventHandler, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
 import { getPopperPropsFromShorthand, Popper, PopperShorthandProps } from '../../utils/positioner';
@@ -201,6 +202,10 @@ const ToolbarMenuItem = compose<'button', ToolbarMenuItemProps, ToolbarMenuItemS
       },
       rtl: context.rtl,
     });
+
+    assertValidIconValue(icon);
+    assertValidIconValue(activeIndicator, 'activeIndicator');
+    assertValidIconValue(submenuIndicator, 'submenuIndicator');
 
     const { classes, styles: resolvedStyles } = useStyles<ToolbarMenuItemStylesProps>(composeOptions.displayName, {
       className: composeOptions.className,

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -15,6 +15,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   rtlTextContainer,
+  assertValidIconValue,
 } from '../../utils';
 import {
   ComponentEventHandler,
@@ -197,6 +198,8 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> & FluentComponentStaticProps
     mapPropsToInlineStyles: () => ({ className, design, styles, variables }),
     rtl: context.rtl,
   });
+
+  assertValidIconValue(selectionIndicator, 'selectionIndicator');
 
   const handleSelection = e => {
     onTitleClick(e, props, true);

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -17,6 +17,7 @@ import {
   ChildrenComponentProps,
   ContentComponentProps,
   rtlTextContainer,
+  assertValidIconValue,
 } from '../../utils';
 import {
   ComponentEventHandler,
@@ -158,6 +159,9 @@ const TreeTitle: React.FC<WithAsProp<TreeTitleProps>> & FluentComponentStaticPro
 
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(TreeTitle.handledProps, props);
+
+  assertValidIconValue(selectionIndicator, 'selectionIndicator');
+
   const handleClick = e => {
     _.invoke(props, 'onClick', e, props);
   };

--- a/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
+++ b/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
@@ -1,0 +1,25 @@
+import { ShorthandValue } from '../../types';
+import inconsistentIconNames from './inconsistentIconNames';
+import { BoxProps } from '../../components/Box/Box';
+
+const assertValidIconValue = (iconShorthand: ShorthandValue<BoxProps>, propName = 'icon') => {
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof iconShorthand === 'string' || (typeof iconShorthand === 'object' && !!(iconShorthand as any).name)) {
+      const name = typeof iconShorthand === 'string' ? iconShorthand : (iconShorthand as any).name;
+      const wrongUsage =
+        typeof iconShorthand === 'string'
+          ? `${propName}="${iconShorthand}"`
+          : `${propName}="{${JSON.stringify(iconShorthand)}}`;
+      const correctUsage = inconsistentIconNames[name]
+        ? `<${inconsistentIconNames[name]} />`
+        : name.length > 0
+        ? `<${name[0].toUpperCase() + name.slice(1)}Icon />`
+        : 'some icon component';
+      console.error(
+        `FluentUI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component`,
+      );
+    }
+  }
+};
+
+export default assertValidIconValue;

--- a/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
+++ b/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
@@ -16,7 +16,7 @@ const assertValidIconValue = (iconShorthand: ShorthandValue<BoxProps>, propName 
         ? `<${name[0].toUpperCase() + name.slice(1)}Icon />`
         : 'some icon component';
       console.error(
-        `FluentUI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component`,
+        `FluentUI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component.`,
       );
     }
   }

--- a/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
+++ b/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
@@ -1,4 +1,5 @@
 import { ShorthandValue } from '../../types';
+import * as _ from 'lodash';
 import inconsistentIconNames from './inconsistentIconNames';
 import { BoxProps } from '../../components/Box/Box';
 
@@ -6,6 +7,8 @@ const assertValidIconValue = (iconShorthand: ShorthandValue<BoxProps>, propName 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof iconShorthand === 'string' || (typeof iconShorthand === 'object' && !!(iconShorthand as any).name)) {
       const name = typeof iconShorthand === 'string' ? iconShorthand : (iconShorthand as any).name;
+      const camelCaseName = _.camelCase(name);
+      const iconComponentName = camelCaseName[0].toUpperCase() + camelCaseName.slice(1);
       const wrongUsage =
         typeof iconShorthand === 'string'
           ? `${propName}="${iconShorthand}"`
@@ -13,10 +16,10 @@ const assertValidIconValue = (iconShorthand: ShorthandValue<BoxProps>, propName 
       const correctUsage = inconsistentIconNames[name]
         ? `<${inconsistentIconNames[name]} />`
         : name.length > 0
-        ? `<${name[0].toUpperCase() + name.slice(1)}Icon />`
+        ? `<${iconComponentName}Icon />`
         : 'some icon component';
-      console.warn(
-        `FluentUI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component.`,
+      console.error(
+        `Fluent UI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component.`,
       );
     }
   }

--- a/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
+++ b/packages/fluentui/react-northstar/src/utils/assertions/assertValidIconValue.ts
@@ -15,7 +15,7 @@ const assertValidIconValue = (iconShorthand: ShorthandValue<BoxProps>, propName 
         : name.length > 0
         ? `<${name[0].toUpperCase() + name.slice(1)}Icon />`
         : 'some icon component';
-      console.error(
+      console.warn(
         `FluentUI - you are using the icon shorthand in a wrong way. Please replace ${wrongUsage} with ${correctUsage} and move all properties except the name on the new component.`,
       );
     }

--- a/packages/fluentui/react-northstar/src/utils/assertions/inconsistentIconNames.ts
+++ b/packages/fluentui/react-northstar/src/utils/assertions/inconsistentIconNames.ts
@@ -1,0 +1,35 @@
+const inconsistentIconNames: Record<string, string> = {};
+
+inconsistentIconNames['chevron-right-medium'] = 'ChevronEndMediumIcon';
+inconsistentIconNames['triangle-right'] = 'TriangleEndIcon';
+inconsistentIconNames['onenote'] = 'OneNoteIcon';
+inconsistentIconNames['onenote-color'] = 'OneNoteColorIcon';
+inconsistentIconNames['onedrive'] = 'OneDriveIcon';
+inconsistentIconNames['powerpoint'] = 'PowerPointIcon';
+inconsistentIconNames['powerpoint-color'] = 'PowerPointColorIcon';
+
+inconsistentIconNames['icon-circle'] = 'CircleIcon';
+inconsistentIconNames['icon-checkmark'] = 'AcceptIcon';
+inconsistentIconNames['icon-circle'] = 'CircleIcon';
+inconsistentIconNames['icon-close'] = 'CloseIcon';
+inconsistentIconNames['icon-arrow-up'] = 'TriangleUpIcon';
+inconsistentIconNames['icon-arrow-down'] = 'TriangleDownIcon';
+inconsistentIconNames['icon-arrow-end'] = 'TriangleEndIcon';
+inconsistentIconNames['icon-menu-arrow-down'] = 'ChevronDownMediumIcon';
+inconsistentIconNames['icon-menu-arrow-end'] = 'ChevronEndMediumIcon';
+inconsistentIconNames['icon-pause'] = 'PauseIcon';
+inconsistentIconNames['icon-play'] = 'PlayIcon';
+
+inconsistentIconNames['stardust-circle'] = 'CircleIcon';
+inconsistentIconNames['stardust-checkmark'] = 'AcceptIcon';
+inconsistentIconNames['stardust-circle'] = 'CircleIcon';
+inconsistentIconNames['stardust-close'] = 'CloseIcon';
+inconsistentIconNames['stardust-arrow-up'] = 'TriangleUpIcon';
+inconsistentIconNames['stardust-arrow-down'] = 'TriangleDownIcon';
+inconsistentIconNames['stardust-arrow-end'] = 'TriangleEndIcon';
+inconsistentIconNames['stardust-menu-arrow-down'] = 'ChevronDownMediumIcon';
+inconsistentIconNames['stardust-menu-arrow-end'] = 'ChevronEndMediumIcon';
+inconsistentIconNames['stardust-pause'] = 'PauseIcon';
+inconsistentIconNames['stardust-play'] = 'PlayIcon';
+
+export default inconsistentIconNames;

--- a/packages/fluentui/react-northstar/src/utils/index.ts
+++ b/packages/fluentui/react-northstar/src/utils/index.ts
@@ -23,6 +23,8 @@ export { default as createComponent } from './createComponent';
 export { getKindProp } from './getKindProp';
 export * from './whatInput';
 
+export { default as assertValidIconValue } from './assertions/assertValidIconValue';
+
 export * from './commonPropInterfaces';
 export { screenReaderContainerStyles } from './accessibility/Styles/accessibilityStyles';
 // work around api-extractor limitation


### PR DESCRIPTION
```tsx
<Button icon="book" />
```
will create the following error:
```
FluentUI - you are using the icon shorthand in a wrong way. Please replace icon="book" with <BookIcon /> and move all properties except the name on the new component
```

```tsx
<Button icon={{name: 'book'}} />
```

will create the following error:
```
FluentUI - you are using the icon shorthand in a wrong way. Please replace icon="{{"name":"book"}} with <BookIcon /> and move all properties except the name on the new component.
```