### PR TITLE
CalendarDayGrid: migrate component to function component

### DIFF
--- a/change/@uifabric-date-time-2020-06-25-16-55-17-functional-date-time-CaledarDayGrid.json
+++ b/change/@uifabric-date-time-2020-06-25-16-55-17-functional-date-time-CaledarDayGrid.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "CalendarDayGrid: migrate component to function component",
+  "packageName": "@uifabric/date-time",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-25T16:55:17.563Z"
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import {
-  KeyCodes,
-  css,
-  getRTL,
-  getRTLSafeKeyCode,
-  format,
-  classNamesFunction,
-  findIndex,
-  initializeComponentRef,
-} from '@uifabric/utilities';
+import { KeyCodes, css, getRTL, getRTLSafeKeyCode, format, classNamesFunction, findIndex } from '@uifabric/utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import {
   addDays,
@@ -458,12 +449,6 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
         this._navigateMonthEdge(ev, originalDate, weekIndex, dayIndex);
       }
     };
-  };
-
-  private _onClose = (): void => {
-    if (this.props.onDismiss) {
-      this.props.onDismiss();
-    }
   };
 
   /**

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -370,90 +370,48 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
         >
           <tbody>
             <CalendarDayMonthHeaderRow {...this.props} classNames={classNames} />
-            {this.renderRow(
-              classNames,
-              weeks![0],
-              -1,
-              weekCorners,
-              classNames.firstTransitionWeek,
-              'presentation',
-              true /*aria-hidden*/,
-            )}
-            {weeks!
-              .slice(1, weeks!.length - 1)
-              .map((week: IDayInfo[], weekIndex: number) =>
-                this.renderRow(classNames, week, weekIndex, weekCorners, classNames.weekRow),
-              )}
-            {this.renderRow(
-              classNames,
-              weeks![weeks!.length - 1],
-              -2,
-              weekCorners,
-              classNames.lastTransitionWeek,
-              'presentation',
-              true /*aria-hidden*/,
-            )}
+            <CalendarDayGridRow
+              {...this.props}
+              classNames={classNames}
+              week={weeks[0]}
+              weekIndex={-1}
+              weekCorners={weekCorners}
+              rowClassName={classNames.firstTransitionWeek}
+              ariaRole="presentation"
+              ariaHidden={true}
+              getDayInfosInRangeOfDay={this.getDayInfosInRangeOfDay}
+              getRefsFromDayInfos={this.getRefsFromDayInfos}
+            />
+            {weeks!.slice(1, weeks!.length - 1).map((week: IDayInfo[], weekIndex: number) => (
+              <CalendarDayGridRow
+                {...this.props}
+                key={weekIndex}
+                classNames={classNames}
+                week={week}
+                weekIndex={weekIndex}
+                weekCorners={weekCorners}
+                rowClassName={classNames.weekRow}
+                getDayInfosInRangeOfDay={this.getDayInfosInRangeOfDay}
+                getRefsFromDayInfos={this.getRefsFromDayInfos}
+              />
+            ))}
+            <CalendarDayGridRow
+              {...this.props}
+              classNames={classNames}
+              week={weeks![weeks!.length - 1]}
+              weekIndex={-2}
+              weekCorners={weekCorners}
+              rowClassName={classNames.lastTransitionWeek}
+              ariaRole="presentation"
+              ariaHidden={true}
+              getDayInfosInRangeOfDay={this.getDayInfosInRangeOfDay}
+              getRefsFromDayInfos={this.getRefsFromDayInfos}
+            />
           </tbody>
         </table>
       </FocusZone>
     );
   }
-
-  private renderRow = (
-    classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
-    week: IDayInfo[],
-    weekIndex: number,
-    weekCorners?: IWeekCorners,
-    rowClassName?: string,
-    ariaRole?: string,
-    ariaHidden?: boolean,
-  ): JSX.Element => {
-    const {
-      showWeekNumbers,
-      firstDayOfWeek,
-      firstWeekOfYear,
-      navigatedDate,
-      strings,
-      hoisted: { weeks },
-    } = this.props;
-    const weekNumbers = showWeekNumbers
-      ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate)
-      : null;
-
-    const titleString = weekNumbers
-      ? strings.weekNumberFormatString && format(strings.weekNumberFormatString, weekNumbers[weekIndex])
-      : '';
-
-    return (
-      <tr role={ariaRole} className={rowClassName} key={weekIndex + '_' + week[0].key}>
-        {showWeekNumbers && weekNumbers && (
-          <th
-            className={classNames.weekNumberCell}
-            key={weekIndex}
-            title={titleString}
-            aria-label={titleString}
-            scope="row"
-          >
-            <span>{weekNumbers[weekIndex]}</span>
-          </th>
-        )}
-        {week.map((day: IDayInfo, dayIndex: number) => (
-          <CalendarGridDayCell
-            {...this.props}
-            key={day.key}
-            classNames={classNames}
-            day={day}
-            dayIndex={dayIndex}
-            weekIndex={weekIndex}
-            weekCorners={weekCorners}
-            ariaHidden={ariaHidden}
-            getDayInfosInRangeOfDay={this.getDayInfosInRangeOfDay}
-            getRefsFromDayInfos={this.getRefsFromDayInfos}
-          />
-        ))}
-      </tr>
-    );
-  };
 
   /**
    *
@@ -496,15 +454,63 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
   };
 }
 
-interface ICalendarDayGridDayCellProps extends ICalendarDayGridClassProps {
+interface ICalendarDayGridRowProps extends ICalendarDayGridClassProps {
   classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
-  day: IDayInfo;
-  dayIndex: number;
+  week: IDayInfo[];
   weekIndex: number;
   weekCorners?: IWeekCorners;
   ariaHidden?: boolean;
+  rowClassName?: string;
+  ariaRole?: string;
   getDayInfosInRangeOfDay(dayToCompare: IDayInfo): IDayInfo[];
   getRefsFromDayInfos(dayInfosInRange: IDayInfo[]): (HTMLElement | null)[];
+}
+
+const CalendarDayGridRow = (props: ICalendarDayGridRowProps): JSX.Element => {
+  const {
+    classNames,
+    week,
+    weekIndex,
+    rowClassName,
+    ariaRole,
+    showWeekNumbers,
+    firstDayOfWeek,
+    firstWeekOfYear,
+    navigatedDate,
+    strings,
+    hoisted: { weeks },
+  } = props;
+  const weekNumbers = showWeekNumbers
+    ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate)
+    : null;
+
+  const titleString = weekNumbers
+    ? strings.weekNumberFormatString && format(strings.weekNumberFormatString, weekNumbers[weekIndex])
+    : '';
+
+  return (
+    <tr role={ariaRole} className={rowClassName} key={weekIndex + '_' + week[0].key}>
+      {showWeekNumbers && weekNumbers && (
+        <th
+          className={classNames.weekNumberCell}
+          key={weekIndex}
+          title={titleString}
+          aria-label={titleString}
+          scope="row"
+        >
+          <span>{weekNumbers[weekIndex]}</span>
+        </th>
+      )}
+      {week.map((day: IDayInfo, dayIndex: number) => (
+        <CalendarGridDayCell {...props} key={day.key} day={day} dayIndex={dayIndex} />
+      ))}
+    </tr>
+  );
+};
+
+interface ICalendarDayGridDayCellProps extends ICalendarDayGridRowProps {
+  day: IDayInfo;
+  dayIndex: number;
 }
 
 const CalendarGridDayCell = ({

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -334,7 +334,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
         )}
         ref={(element: HTMLTableCellElement) => {
           this.props.customDayCellRef && this.props.customDayCellRef(element, day.originalDate, classNames);
-          this._setDayCellRef(element, day, isNavigatedDate);
+          this._setDayCellRef(element, day);
         }}
         aria-hidden={ariaHidden}
         onClick={day.isInBounds && !ariaHidden ? day.onSelected : undefined}
@@ -347,7 +347,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
           key={day.key + 'button'}
           aria-hidden={ariaHidden}
           className={css(classNames.dayButton, day.isToday && classNames.dayIsToday)}
-          onKeyDown={!ariaHidden ? this._onDayKeyDown(day.originalDate, weekIndex, dayIndex) : undefined}
+          onKeyDown={!ariaHidden ? this._onDayKeyDown(day.originalDate) : undefined}
           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
           id={isNavigatedDate ? activeDescendantId : undefined}
           aria-selected={day.isInBounds ? day.isSelected : undefined}
@@ -366,16 +366,11 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
     );
   };
 
-  private _setDayCellRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
+  private _setDayCellRef(element: HTMLElement | null, day: IDayInfo): void {
     this.days[day.key] = element;
   }
 
-  private _navigateMonthEdge(
-    ev: React.KeyboardEvent<HTMLElement>,
-    date: Date,
-    weekIndex: number,
-    dayIndex: number,
-  ): void {
+  private _navigateMonthEdge(ev: React.KeyboardEvent<HTMLElement>, date: Date): void {
     let targetDate: Date | undefined = undefined;
     let direction = 1; // by default search forward
     const { restrictedDates, minDate, maxDate } = this.props;
@@ -437,16 +432,12 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
     }
   }
 
-  private _onDayKeyDown = (
-    originalDate: Date,
-    weekIndex: number,
-    dayIndex: number,
-  ): ((ev: React.KeyboardEvent<HTMLElement>) => void) => {
+  private _onDayKeyDown = (originalDate: Date): ((ev: React.KeyboardEvent<HTMLElement>) => void) => {
     return (ev: React.KeyboardEvent<HTMLElement>): void => {
       if (ev.which === KeyCodes.enter) {
         this.props.hoisted.onSelectDate(originalDate);
       } else {
-        this._navigateMonthEdge(ev, originalDate, weekIndex, dayIndex);
+        this._navigateMonthEdge(ev, originalDate);
       }
     };
   };

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -585,7 +585,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
     } = this.props;
 
     // The hover state looks weird with non-contiguous days in work week view. In work week, show week hover state
-    const dateRangeHoverType = this.getDateRangeTypeToUse(dateRangeType, workWeekDays);
+    const dateRangeHoverType = getDateRangeTypeToUse(dateRangeType, workWeekDays);
 
     // gets all the dates for the given date range type that are in the same date range as the given day
     const dateRange = getDateRangeArray(
@@ -701,32 +701,6 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
       });
     };
   };
-
-  /**
-   * When given work week, if the days are non-contiguous, the hover states look really weird. So for non-contiguous
-   * work weeks, we'll just show week view instead.
-   */
-  private getDateRangeTypeToUse = (
-    dateRangeType: DateRangeType,
-    workWeekDays: DayOfWeek[] | undefined,
-  ): DateRangeType => {
-    if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
-      const sortedWWDays = workWeekDays.slice().sort();
-      let isContiguous = true;
-      for (let i = 1; i < sortedWWDays.length; i++) {
-        if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
-          isContiguous = false;
-          break;
-        }
-      }
-
-      if (!isContiguous || workWeekDays.length === 0) {
-        return DateRangeType.Week;
-      }
-    }
-
-    return dateRangeType;
-  };
 }
 
 const CalendarDayMonthHeaderRow = (
@@ -770,3 +744,26 @@ const CalendarDayMonthHeaderRow = (
     </tr>
   );
 };
+
+/**
+ * When given work week, if the days are non-contiguous, the hover states look really weird. So for non-contiguous
+ * work weeks, we'll just show week view instead.
+ */
+function getDateRangeTypeToUse(dateRangeType: DateRangeType, workWeekDays: DayOfWeek[] | undefined): DateRangeType {
+  if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
+    const sortedWWDays = workWeekDays.slice().sort();
+    let isContiguous = true;
+    for (let i = 1; i < sortedWWDays.length; i++) {
+      if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
+        isContiguous = false;
+        break;
+      }
+    }
+
+    if (!isContiguous || workWeekDays.length === 0) {
+      return DateRangeType.Week;
+    }
+  }
+
+  return dateRangeType;
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -238,7 +238,7 @@ function useWeekCornerStyles(props: ICalendarDayGridProps) {
 }
 
 export const CalendarDayGridBase = React.forwardRef(
-  (props: ICalendarDayGridProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+  (props: ICalendarDayGridProps, forwardedRef: React.Ref<FocusZone>) => {
     const navigatedDayRef = React.useRef<HTMLButtonElement>(null);
 
     const activeDescendantId = useId();
@@ -352,7 +352,7 @@ export const CalendarDayGridBase = React.forwardRef(
     } as const;
 
     return (
-      <FocusZone className={classNames.wrapper}>
+      <FocusZone className={classNames.wrapper} ref={forwardedRef}>
         <table
           className={classNames.table}
           aria-readonly="true"

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -191,7 +191,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
           role="grid"
         >
           <tbody>
-            {this.renderMonthHeaderRow(classNames)}
+            <CalendarDayMonthHeaderRow {...this.props} classNames={classNames} />
             {this.renderRow(
               classNames,
               weeks![0],
@@ -220,45 +220,6 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
       </FocusZone>
     );
   }
-
-  private renderMonthHeaderRow = (classNames: IProcessedStyleSet<ICalendarDayGridStyles>): JSX.Element => {
-    const {
-      showWeekNumbers,
-      strings,
-      firstDayOfWeek,
-      allFocusable,
-      weeksToShow,
-      hoisted: { weeks },
-    } = this.props;
-    const dayLabels = strings.shortDays.slice();
-    const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);
-    if (weeksToShow === 1 && firstOfMonthIndex >= 0) {
-      // if we only show one week, replace the header with short month name
-      dayLabels[firstOfMonthIndex] = strings.shortMonths[weeks![1][firstOfMonthIndex].originalDate.getMonth()];
-    }
-
-    return (
-      <tr>
-        {showWeekNumbers && <th className={classNames.dayCell} />}
-        {dayLabels.map((val: string, index: number) => {
-          const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
-          const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
-          return (
-            <th
-              className={css(classNames.dayCell, classNames.weekDayLabelCell)}
-              scope="col"
-              key={dayLabels[i] + ' ' + index}
-              title={label}
-              aria-label={label}
-              data-is-focusable={allFocusable ? true : undefined}
-            >
-              {dayLabels[i]}
-            </th>
-          );
-        })}
-      </tr>
-    );
-  };
 
   private renderRow = (
     classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
@@ -752,3 +713,45 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
     return dateRangeType;
   };
 }
+
+const CalendarDayMonthHeaderRow = (
+  props: ICalendarDayGridClassProps & { classNames: IProcessedStyleSet<ICalendarDayGridStyles> },
+) => {
+  const {
+    showWeekNumbers,
+    strings,
+    firstDayOfWeek,
+    allFocusable,
+    weeksToShow,
+    hoisted: { weeks },
+    classNames,
+  } = props;
+  const dayLabels = strings.shortDays.slice();
+  const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);
+  if (weeksToShow === 1 && firstOfMonthIndex >= 0) {
+    // if we only show one week, replace the header with short month name
+    dayLabels[firstOfMonthIndex] = strings.shortMonths[weeks![1][firstOfMonthIndex].originalDate.getMonth()];
+  }
+
+  return (
+    <tr>
+      {showWeekNumbers && <th className={classNames.dayCell} />}
+      {dayLabels.map((val: string, index: number) => {
+        const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
+        const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
+        return (
+          <th
+            className={css(classNames.dayCell, classNames.weekDayLabelCell)}
+            scope="col"
+            key={dayLabels[i] + ' ' + index}
+            title={label}
+            aria-label={label}
+            data-is-focusable={allFocusable ? true : undefined}
+          >
+            {dayLabels[i]}
+          </th>
+        );
+      })}
+    </tr>
+  );
+};

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -68,9 +68,11 @@ function useAnimateBackwards({ navigatedDate }: ICalendarDayGridProps): boolean 
 
 export const CalendarDayGridBase = React.forwardRef(
   (props: ICalendarDayGridProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+    const navigatedDayRef = React.useRef<HTMLButtonElement>(null);
+
     const animateBackwards = useAnimateBackwards(props);
 
-    return <CalendarDayGridBaseClass {...props} hoisted={{ animateBackwards }} />;
+    return <CalendarDayGridBaseClass {...props} hoisted={{ animateBackwards, navigatedDayRef }} />;
   },
 );
 CalendarDayGridBase.displayName = 'CalendarDayGridBase';
@@ -78,11 +80,11 @@ CalendarDayGridBase.displayName = 'CalendarDayGridBase';
 interface ICalendarDayGridClassProps extends ICalendarDayGridProps {
   hoisted: {
     animateBackwards: boolean;
+    navigatedDayRef: React.RefObject<HTMLButtonElement>;
   };
 }
 
 class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProps, ICalendarDayGridState> {
-  private navigatedDay: HTMLElement | null;
   private days: { [key: string]: HTMLElement | null } = {};
   private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 
@@ -177,10 +179,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
   }
 
   public focus(): void {
-    if (this.navigatedDay) {
-      this.navigatedDay.tabIndex = 0;
-      this.navigatedDay.focus();
-    }
+    this.props.hoisted.navigatedDayRef.current?.focus();
   }
 
   private renderMonthHeaderRow = (classNames: IProcessedStyleSet<ICalendarDayGridStyles>): JSX.Element => {
@@ -297,24 +296,19 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
           id={isNavigatedDate ? activeDescendantId : undefined}
           aria-selected={day.isInBounds ? day.isSelected : undefined}
           data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
-          ref={(element: HTMLButtonElement) => this._setDayRef(element, day, isNavigatedDate)}
+          ref={isNavigatedDate ? this.props.hoisted.navigatedDayRef : undefined}
           disabled={!allFocusable && !day.isInBounds}
           aria-disabled={!ariaHidden && !day.isInBounds}
           type="button"
           role="gridcell" // create grid structure
           aria-readonly={true} // prevent grid from being "editable"
+          tabIndex={isNavigatedDate ? 0 : undefined}
         >
           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
         </button>
       </td>
     );
   };
-
-  private _setDayRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
-    if (isNavigatedDate) {
-      this.navigatedDay = element;
-    }
-  }
 
   private _setDayCellRef(element: HTMLElement | null, day: IDayInfo, isNavigatedDate: boolean): void {
     this.days[day.key] = element;

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -563,7 +563,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
   };
 
   private _getHighlightedCornerStyle(weekCorners: IWeekCorners, dayIndex: number, weekIndex: number): string {
-    const cornerStyle = weekCorners[weekIndex + '_' + dayIndex] ? weekCorners[weekIndex + '_' + dayIndex] : '';
+    const cornerStyle = weekCorners[weekIndex + '_' + dayIndex] ?? '';
     return cornerStyle;
   }
 

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -86,10 +86,12 @@ function useWeeks(
  * Hook to determine whether to animate the CalendarDayGrid forwards or backwards
  * @returns true if the grid should animate backwards; false otherwise
  */
-function useAnimateBackwards(weeks: IDayInfo[][]): boolean {
+function useAnimateBackwards(weeks: IDayInfo[][]): boolean | undefined {
   const previousNavigatedDate = usePrevious(weeks[0][0].originalDate);
 
-  if (!previousNavigatedDate || previousNavigatedDate <= weeks[0][0].originalDate) {
+  if (!previousNavigatedDate || previousNavigatedDate.getTime() === weeks[0][0].originalDate.getTime()) {
+    return undefined;
+  } else if (previousNavigatedDate <= weeks[0][0].originalDate) {
     return false;
   } else {
     return true;

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -309,7 +309,6 @@ interface ICalendarDayGridClassProps extends ICalendarDayGridProps {
 
 class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProps, {}> {
   private days: { [key: string]: HTMLElement | null } = {};
-  private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 
   public render(): JSX.Element {
     const {
@@ -324,7 +323,7 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
       hoisted: { animateBackwards, weeks, activeDescendantId },
     } = this.props;
 
-    this.classNames = getClassNames(styles, {
+    const classNames = getClassNames(styles, {
       theme: theme!,
       className: className,
       dateRangeType: dateRangeType,
@@ -334,7 +333,6 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
       animationDirection: animationDirection,
       animateBackwards: animateBackwards,
     });
-    const classNames = this.classNames;
 
     // When the month is highlighted get the corner dates so that styles can be added to them
     const weekCorners: IWeekCorners = this.props.hoisted.getWeekCornerStyles(classNames, weeks!);

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -52,12 +52,23 @@ export interface ICalendarDayGridState {
   animateBackwards?: boolean;
 }
 
-export class CalendarDayGridBase extends React.Component<ICalendarDayGridProps, ICalendarDayGridState> {
+export const CalendarDayGridBase = React.forwardRef(
+  (props: ICalendarDayGridProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+    return <CalendarDayGridBaseClass {...props} hoisted={{}} />;
+  },
+);
+CalendarDayGridBase.displayName = 'CalendarDayGridBase';
+
+interface ICalendarDayGridClassProps extends ICalendarDayGridProps {
+  hoisted: {};
+}
+
+class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProps, ICalendarDayGridState> {
   private navigatedDay: HTMLElement | null;
   private days: { [key: string]: HTMLElement | null } = {};
   private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 
-  public constructor(props: ICalendarDayGridProps) {
+  public constructor(props: ICalendarDayGridClassProps) {
     super(props);
 
     initializeComponentRef(this);
@@ -71,7 +82,7 @@ export class CalendarDayGridBase extends React.Component<ICalendarDayGridProps, 
   }
 
   // tslint:disable-next-line function-name
-  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarDayGridProps): void {
+  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarDayGridClassProps): void {
     const weeks = this._getWeeks(nextProps);
     let isBackwards = undefined;
 
@@ -425,7 +436,7 @@ export class CalendarDayGridBase extends React.Component<ICalendarDayGridProps, 
    * Initial parsing of the given props to generate IDayInfo two dimensional array, which contains a representation
    * of every day in the grid. Convenient for helping with conversions between day refs and Date objects in callbacks.
    */
-  private _getWeeks(propsToUse: ICalendarDayGridProps): IDayInfo[][] {
+  private _getWeeks(propsToUse: ICalendarDayGridClassProps): IDayInfo[][] {
     const {
       selectedDate,
       dateRangeType,

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -44,21 +44,7 @@ export interface ICalendarDayGridState {
   activeDescendantId?: string;
 }
 
-/**
- * Hook to determine whether to animate the CalendarDayGrid forwards or backwards
- * @returns true if the grid should animate backwards; false otherwise
- */
-function useAnimateBackwards({ navigatedDate }: ICalendarDayGridProps): boolean {
-  const previousNavigatedDate = usePrevious(navigatedDate);
-
-  if (!previousNavigatedDate || previousNavigatedDate <= navigatedDate) {
-    return false;
-  } else {
-    return true;
-  }
-}
-
-function useWeeks(props: ICalendarDayGridProps, onSelectDate: (date: Date) => void) {
+function useWeeks(props: ICalendarDayGridProps, onSelectDate: (date: Date) => void): IDayInfo[][] {
   /**
    * Initial parsing of the given props to generate IDayInfo two dimensional array, which contains a representation
    * of every day in the grid. Convenient for helping with conversions between day refs and Date objects in callbacks.
@@ -92,6 +78,20 @@ function useWeeks(props: ICalendarDayGridProps, onSelectDate: (date: Date) => vo
   }, [props]);
 
   return weeks;
+}
+
+/**
+ * Hook to determine whether to animate the CalendarDayGrid forwards or backwards
+ * @returns true if the grid should animate backwards; false otherwise
+ */
+function useAnimateBackwards(weeks: IDayInfo[][]): boolean {
+  const previousNavigatedDate = usePrevious(weeks[0][0].originalDate);
+
+  if (!previousNavigatedDate || previousNavigatedDate <= weeks[0][0].originalDate) {
+    return false;
+  } else {
+    return true;
+  }
 }
 
 export const CalendarDayGridBase = React.forwardRef(
@@ -128,7 +128,7 @@ export const CalendarDayGridBase = React.forwardRef(
     };
 
     const weeks = useWeeks(props, onSelectDate);
-    const animateBackwards = useAnimateBackwards(props);
+    const animateBackwards = useAnimateBackwards(weeks);
 
     return <CalendarDayGridBaseClass {...props} hoisted={{ animateBackwards, navigatedDayRef, weeks, onSelectDate }} />;
   },

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -127,6 +127,16 @@ export const CalendarDayGridBase = React.forwardRef(
     const weeks = useWeeks(props, onSelectDate);
     const animateBackwards = useAnimateBackwards(weeks);
 
+    React.useImperativeHandle(
+      props.componentRef,
+      () => ({
+        focus() {
+          navigatedDayRef.current?.focus?.();
+        },
+      }),
+      [],
+    );
+
     return (
       <CalendarDayGridBaseClass
         {...props}
@@ -150,14 +160,6 @@ interface ICalendarDayGridClassProps extends ICalendarDayGridProps {
 class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProps, {}> {
   private days: { [key: string]: HTMLElement | null } = {};
   private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
-
-  public constructor(props: ICalendarDayGridClassProps) {
-    super(props);
-
-    initializeComponentRef(this);
-
-    this._onClose = this._onClose.bind(this);
-  }
 
   public render(): JSX.Element {
     const {
@@ -226,10 +228,6 @@ class CalendarDayGridBaseClass extends React.Component<ICalendarDayGridClassProp
         </table>
       </FocusZone>
     );
-  }
-
-  public focus(): void {
-    this.props.hoisted.navigatedDayRef.current?.focus();
   }
 
   private renderMonthHeaderRow = (classNames: IProcessedStyleSet<ICalendarDayGridStyles>): JSX.Element => {

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import { KeyCodes, css, getRTLSafeKeyCode } from '@uifabric/utilities';
+import {
+  addDays,
+  addWeeks,
+  compareDates,
+  findAvailableDate,
+  IAvailableDateOptions,
+} from '@fluentui/date-time-utilities';
+import { DateRangeType } from '../Calendar/Calendar.types';
+import { IDayInfo } from './CalendarDayGrid.base';
+import { ICalendarGridRowProps } from './CalendarGridRow';
+
+export interface ICalendarGridDayCellProps extends ICalendarGridRowProps {
+  day: IDayInfo;
+  dayIndex: number;
+}
+
+export const CalendarGridDayCell = ({
+  navigatedDate,
+  dateTimeFormatter,
+  allFocusable,
+  strings,
+  activeDescendantId,
+  navigatedDayRef,
+  calculateRoundedStyles,
+  weeks,
+  classNames,
+  day,
+  dayIndex,
+  weekIndex,
+  weekCorners,
+  ariaHidden,
+  customDayCellRef,
+  dateRangeType,
+  daysToSelectInDayView,
+  onSelectDate,
+  restrictedDates,
+  minDate,
+  maxDate,
+  onNavigateDate,
+  getDayInfosInRangeOfDay,
+  getRefsFromDayInfos,
+}: ICalendarGridDayCellProps): JSX.Element => {
+  const cornerStyle = weekCorners?.[weekIndex + '_' + dayIndex] ?? '';
+  const isNavigatedDate = compareDates(navigatedDate, day.originalDate);
+
+  const navigateMonthEdge = (ev: React.KeyboardEvent<HTMLElement>, date: Date): void => {
+    let targetDate: Date | undefined = undefined;
+    let direction = 1; // by default search forward
+
+    if (ev.which === KeyCodes.up) {
+      targetDate = addWeeks(date, -1);
+      direction = -1;
+    } else if (ev.which === KeyCodes.down) {
+      targetDate = addWeeks(date, 1);
+    } else if (ev.which === getRTLSafeKeyCode(KeyCodes.left)) {
+      targetDate = addDays(date, -1);
+      direction = -1;
+    } else if (ev.which === getRTLSafeKeyCode(KeyCodes.right)) {
+      targetDate = addDays(date, 1);
+    }
+
+    if (!targetDate) {
+      // if we couldn't find a target date at all, do nothing
+      return;
+    }
+
+    const findAvailableDateOptions: IAvailableDateOptions = {
+      initialDate: date,
+      targetDate,
+      direction,
+      restrictedDates,
+      minDate,
+      maxDate,
+    };
+
+    // target date is restricted, search in whatever direction until finding the next possible date,
+    // stopping at boundaries
+    let nextDate = findAvailableDate(findAvailableDateOptions);
+
+    if (!nextDate) {
+      // if no dates available in initial direction, try going backwards
+      findAvailableDateOptions.direction = -direction;
+      nextDate = findAvailableDate(findAvailableDateOptions);
+    }
+
+    // if the nextDate is still inside the same focusZone area, let the focusZone handle setting the focus so we
+    // don't jump the view unnecessarily
+    const isInCurrentView =
+      weeks &&
+      nextDate &&
+      weeks.slice(1, weeks.length - 1).some((week: IDayInfo[]) => {
+        return week.some((dayToCompare: IDayInfo) => {
+          return compareDates(dayToCompare.originalDate, nextDate!);
+        });
+      });
+    if (isInCurrentView) {
+      return;
+    }
+
+    // else, fire navigation on the date to change the view to show it
+    if (nextDate) {
+      onNavigateDate(nextDate, true);
+      ev.preventDefault();
+    }
+  };
+
+  const onMouseOverDay = (ev: React.MouseEvent<HTMLElement>) => {
+    const dayInfos = getDayInfosInRangeOfDay(day);
+    const dayRefs = getRefsFromDayInfos(dayInfos);
+
+    dayRefs.forEach((dayRef: HTMLElement, index: number) => {
+      if (dayRef) {
+        dayRef.classList.add('ms-CalendarDay-hoverStyle');
+        if (
+          !dayInfos[index].isSelected &&
+          dateRangeType === DateRangeType.Day &&
+          daysToSelectInDayView &&
+          daysToSelectInDayView > 1
+        ) {
+          // remove the static classes first to overwrite them
+          dayRef.classList.remove(
+            classNames.bottomLeftCornerDate!,
+            classNames.bottomRightCornerDate!,
+            classNames.topLeftCornerDate!,
+            classNames.topRightCornerDate!,
+          );
+
+          const classNamesToAdd = calculateRoundedStyles(
+            classNames,
+            false,
+            false,
+            index > 0,
+            index < dayRefs.length - 1,
+          ).trim();
+          if (classNamesToAdd) {
+            dayRef.classList.add(...classNamesToAdd.split(' '));
+          }
+        }
+      }
+    });
+  };
+
+  const onMouseDownDay = (ev: React.MouseEvent<HTMLElement>) => {
+    const dayInfos = getDayInfosInRangeOfDay(day);
+    const dayRefs = getRefsFromDayInfos(dayInfos);
+
+    dayRefs.forEach((dayRef: HTMLElement) => {
+      if (dayRef) {
+        dayRef.classList.add('ms-CalendarDay-pressedStyle');
+      }
+    });
+  };
+
+  const onMouseUpDay = (ev: React.MouseEvent<HTMLElement>) => {
+    const dayInfos = getDayInfosInRangeOfDay(day);
+    const dayRefs = getRefsFromDayInfos(dayInfos);
+
+    dayRefs.forEach((dayRef: HTMLElement) => {
+      if (dayRef) {
+        dayRef.classList.remove('ms-CalendarDay-pressedStyle');
+      }
+    });
+  };
+
+  const onMouseOutDay = (ev: React.MouseEvent<HTMLElement>) => {
+    const dayInfos = getDayInfosInRangeOfDay(day);
+    const dayRefs = getRefsFromDayInfos(dayInfos);
+
+    dayRefs.forEach((dayRef: HTMLElement, index: number) => {
+      if (dayRef) {
+        dayRef.classList.remove('ms-CalendarDay-hoverStyle');
+        dayRef.classList.remove('ms-CalendarDay-pressedStyle');
+        if (
+          !dayInfos[index].isSelected &&
+          dateRangeType === DateRangeType.Day &&
+          daysToSelectInDayView &&
+          daysToSelectInDayView > 1
+        ) {
+          const classNamesToAdd = calculateRoundedStyles(
+            classNames,
+            false,
+            false,
+            index > 0,
+            index < dayRefs.length - 1,
+          ).trim();
+          if (classNamesToAdd) {
+            dayRef.classList.remove(...classNamesToAdd.split(' '));
+          }
+        }
+      }
+    });
+  };
+
+  const onDayKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
+    if (ev.which === KeyCodes.enter) {
+      onSelectDate?.(day.originalDate);
+    } else {
+      navigateMonthEdge(ev, day.originalDate);
+    }
+  };
+
+  return (
+    <td
+      className={css(
+        classNames.dayCell,
+        weekCorners && cornerStyle,
+        day.isSelected && classNames.daySelected,
+        !day.isInBounds && classNames.dayOutsideBounds,
+        !day.isInMonth && classNames.dayOutsideNavigatedMonth,
+      )}
+      ref={(element: HTMLTableCellElement) => {
+        customDayCellRef?.(element, day.originalDate, classNames);
+        day.setRef(element);
+      }}
+      aria-hidden={ariaHidden}
+      onClick={day.isInBounds && !ariaHidden ? day.onSelected : undefined}
+      onMouseOver={!ariaHidden ? onMouseOverDay : undefined}
+      onMouseDown={!ariaHidden ? onMouseDownDay : undefined}
+      onMouseUp={!ariaHidden ? onMouseUpDay : undefined}
+      onMouseOut={!ariaHidden ? onMouseOutDay : undefined}
+    >
+      <button
+        key={day.key + 'button'}
+        aria-hidden={ariaHidden}
+        className={css(classNames.dayButton, day.isToday && classNames.dayIsToday)}
+        onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
+        aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
+        id={isNavigatedDate ? activeDescendantId : undefined}
+        aria-selected={day.isInBounds ? day.isSelected : undefined}
+        data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
+        ref={isNavigatedDate ? navigatedDayRef : undefined}
+        disabled={!allFocusable && !day.isInBounds}
+        aria-disabled={!ariaHidden && !day.isInBounds}
+        type="button"
+        role="gridcell" // create grid structure
+        aria-readonly={true} // prevent grid from being "editable"
+        tabIndex={isNavigatedDate ? 0 : undefined}
+      >
+        <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>
+      </button>
+    </td>
+  );
+};

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarGridRow.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarGridRow.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { format } from '@uifabric/utilities';
+import { getWeekNumbersInMonth } from '@fluentui/date-time-utilities';
+import { ICalendarDayGridProps, ICalendarDayGridStyles } from './CalendarDayGrid.types';
+import { IProcessedStyleSet } from '@uifabric/styling';
+import { CalendarGridDayCell } from './CalendarGridDayCell';
+import { IDayInfo, IWeekCorners } from './CalendarDayGrid.base';
+
+export interface ICalendarGridRowProps extends ICalendarDayGridProps {
+  classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
+  weeks: IDayInfo[][];
+  week: IDayInfo[];
+  weekIndex: number;
+  weekCorners?: IWeekCorners;
+  ariaHidden?: boolean;
+  rowClassName?: string;
+  ariaRole?: string;
+  navigatedDayRef: React.RefObject<HTMLButtonElement>;
+  activeDescendantId: string;
+  calculateRoundedStyles(
+    classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
+    above: boolean,
+    below: boolean,
+    left: boolean,
+    right: boolean,
+  ): string;
+  getDayInfosInRangeOfDay(dayToCompare: IDayInfo): IDayInfo[];
+  getRefsFromDayInfos(dayInfosInRange: IDayInfo[]): (HTMLElement | null)[];
+}
+
+export const CalendarGridRow = (props: ICalendarGridRowProps): JSX.Element => {
+  const {
+    classNames,
+    week,
+    weeks,
+    weekIndex,
+    rowClassName,
+    ariaRole,
+    showWeekNumbers,
+    firstDayOfWeek,
+    firstWeekOfYear,
+    navigatedDate,
+    strings,
+  } = props;
+  const weekNumbers = showWeekNumbers
+    ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate)
+    : null;
+
+  const titleString = weekNumbers
+    ? strings.weekNumberFormatString && format(strings.weekNumberFormatString, weekNumbers[weekIndex])
+    : '';
+
+  return (
+    <tr role={ariaRole} className={rowClassName} key={weekIndex + '_' + week[0].key}>
+      {showWeekNumbers && weekNumbers && (
+        <th
+          className={classNames.weekNumberCell}
+          key={weekIndex}
+          title={titleString}
+          aria-label={titleString}
+          scope="row"
+        >
+          <span>{weekNumbers[weekIndex]}</span>
+        </th>
+      )}
+      {week.map((day: IDayInfo, dayIndex: number) => (
+        <CalendarGridDayCell {...props} key={day.key} day={day} dayIndex={dayIndex} />
+      ))}
+    </tr>
+  );
+};

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { css, findIndex } from '@uifabric/utilities';
+import { DAYS_IN_WEEK } from '@fluentui/date-time-utilities';
+import { ICalendarDayGridProps, ICalendarDayGridStyles } from './CalendarDayGrid.types';
+import { IProcessedStyleSet } from '@uifabric/styling';
+import { IDayInfo } from './CalendarDayGrid.base';
+
+export interface ICalendarDayMonthHeaderRowProps extends ICalendarDayGridProps {
+  weeks: IDayInfo[][];
+  classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
+}
+
+export const CalendarMonthHeaderRow = (props: ICalendarDayMonthHeaderRowProps) => {
+  const { showWeekNumbers, strings, firstDayOfWeek, allFocusable, weeksToShow, weeks, classNames } = props;
+  const dayLabels = strings.shortDays.slice();
+  const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);
+  if (weeksToShow === 1 && firstOfMonthIndex >= 0) {
+    // if we only show one week, replace the header with short month name
+    dayLabels[firstOfMonthIndex] = strings.shortMonths[weeks![1][firstOfMonthIndex].originalDate.getMonth()];
+  }
+
+  return (
+    <tr>
+      {showWeekNumbers && <th className={classNames.dayCell} />}
+      {dayLabels.map((val: string, index: number) => {
+        const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
+        const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
+        return (
+          <th
+            className={css(classNames.dayCell, classNames.weekDayLabelCell)}
+            scope="col"
+            key={dayLabels[i] + ' ' + index}
+            title={label}
+            aria-label={label}
+            data-is-focusable={allFocusable ? true : undefined}
+          >
+            {dayLabels[i]}
+          </th>
+        );
+      })}
+    </tr>
+  );
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Migrates CalendarDayGrid to (a set of) functional components, per the ongoing effort in `@fluentui/react-next` to make all components React Strict-mode-compliant. Since the OUFR version of Calendar/DateGrid are being deprecated by this package, I am migrating the components in place.

#### Focus areas to test

(optional)
