### PR TITLE
Update buildto to accept multiple packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "a11ytest": "cd apps && cd a11y-tests && npm run test",
     "build": "lerna run build --stream",
     "build:fluentui:docs": "gulp build:docs",
-    "build:min": "yarn buildto @fluentui/react-next --min && yarn buildto @fluentui/react-northstar --min",
+    "build:min": "yarn buildto @fluentui/react-next @fluentui/react-northstar --min",
     "build:prod": "lerna run build --stream -- --production",
     "buildci": "yarn build && yarn test && yarn lint && yarn bundle",
     "buildci:prod": "yarn build:prod && yarn test && yarn lint && yarn bundle:prod",

--- a/scripts/monorepo/buildTo.js
+++ b/scripts/monorepo/buildTo.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const { spawnSync } = require('child_process');
 const lernaBin = require.resolve('lerna/cli.js');
 const getAllPackageInfo = require('./getAllPackageInfo');
@@ -8,29 +10,38 @@ const argv = process.argv.slice(2);
 if (argv.length < 1) {
   console.log(`Usage:
 
-  yarn buildto [packagename]
+  yarn buildto <packagename1> [<packagename2> ...] [<args>]
 
-This command builds all packages up to and including "packagename". The package name can actually be a substring.
-If multiple packages matched the pattern, they will all be built (along with their dependencies).`);
+This command builds all packages up to and including "packagename1" (and "packagename2" etc).
+The package name can be a substring.
+If multiple packages match a pattern, they will all be built (along with their dependencies).
+`);
 
   process.exit(0);
 }
 
-const [project, ...rest] = argv;
+const restIndex = argv.findIndex(arg => arg.startsWith('--'));
+const projects = restIndex === -1 ? argv : argv.slice(0, restIndex);
+const rest = restIndex === -1 ? [] : argv.slice(argv[restIndex] === '--' ? restIndex + 1 : restIndex);
 
 // This script matches substrings of the input for one more many projects
 const allPackages = getAllPackageInfo();
 
-let foundProjects = [project];
+const foundProjects = /** @type {string[]} */ ([]);
 
-if (!allPackages[project]) {
-  foundProjects = Object.keys(allPackages).filter(name => name.includes(project));
-  if (foundProjects.length === 0) {
-    console.log(`There is no project matching "${project}" in this repo`);
-  } else if (foundProjects.length > 1) {
-    console.log(`More than one project matched: "${foundProjects.join('", "')}"`);
+for (const project of projects) {
+  if (allPackages[project]) {
+    foundProjects.push(project);
   } else {
-    console.log(`Found a matching project named "${foundProjects[0]}"`);
+    const packagesForProject = Object.keys(allPackages).filter(name => name.includes(project));
+    if (packagesForProject.length === 0) {
+      console.log(`There is no project matching "${project}" in this repo`);
+    } else if (packagesForProject.length > 1) {
+      console.log(`More than one project matched: "${packagesForProject.join('", "')}"`);
+    } else {
+      console.log(`Found a matching project named "${packagesForProject[0]}"`);
+    }
+    foundProjects.push(...packagesForProject);
   }
 }
 


### PR DESCRIPTION
Update the buildto script to accept multiple package names. This way we can do `build:min` in one command and not duplicate work.