### PR TITLE
ContextualMenu: Fix several issue with focus

### DIFF
--- a/change/office-ui-fabric-react-2020-06-25-22-59-46-minor-focus-fixes.json
+++ b/change/office-ui-fabric-react-2020-06-25-22-59-46-minor-focus-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Fix issue where focus would not return to button. Also fix issue where error might occur if the previously focused element didn't have a focus method.",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T05:59:46.400Z"
+}

--- a/change/office-ui-fabric-react-2020-06-25-22-59-46-minor-focus-fixes.json
+++ b/change/office-ui-fabric-react-2020-06-25-22-59-46-minor-focus-fixes.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "ContextualMenu: Fix issue where focus would not return to button. Also fix issue where error might occur if the previously focused element didn't have a focus method.",
+  "comment": "ContextualMenu: Fixing issue where focus would not return to previously focused element and issue where error might occur if said previously focused element didn't have a focus method.",
   "packageName": "office-ui-fabric-react",
   "email": "joschect@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1215,7 +1215,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
       this.dismiss(ev, true);
 
       // This should be removed whenever possible.
-      // This ensures that the hidden dismissal behavior maintains the same.
+      // This ensures that the hidden dismissal action maintains the same behavior.
       // If the menu is being dismissed then the previously focused element should
       // get focused since the dismiss was triggered by a user click on an item
       // Rather than focus being lost.

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -452,6 +452,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
     if (options && options.containsFocus && this._previousActiveElement) {
       // Make sure that the focus method actually exists
       // In some cases the object might exist but not be a real element.
+      // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.
       if (this._previousActiveElement.focus) {
         this._previousActiveElement && this._previousActiveElement.focus();
       }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -454,7 +454,7 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
       // In some cases the object might exist but not be a real element.
       // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.
       if (this._previousActiveElement.focus) {
-        this._previousActiveElement && this._previousActiveElement.focus();
+        this._previousActiveElement.focus();
       }
     }
   };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1040,7 +1040,7 @@ describe('ContextualMenu', () => {
       expect(document.querySelector('.SubMenuClass')).toEqual(null);
     });
 
-    it('Menu should correctly return focus to button when dismissed', () => {
+    it('Menu should correctly return focus to previously focused element when dismissed', () => {
       const temp = ReactTestUtils.renderIntoDocument<HTMLDivElement>(
         <div>
           <DefaultButton menuProps={{ items: menu }} text="but" id="btn" />

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1039,6 +1039,36 @@ describe('ContextualMenu', () => {
       button.current!.openMenu();
       expect(document.querySelector('.SubMenuClass')).toEqual(null);
     });
+
+    it('Menu should correctly return focus to button when dismissed', () => {
+      const temp = ReactTestUtils.renderIntoDocument<HTMLDivElement>(
+        <div>
+          <DefaultButton menuProps={{ items: menu }} text="but" id="btn" />
+        </div>,
+      ) as HTMLElement;
+
+      // Get and make sure that the button is the active element
+      const btn = temp.querySelector('#btn')! as HTMLElement;
+      expect(btn).not.toEqual(null);
+      btn.focus();
+      expect(document.activeElement).toEqual(btn);
+
+      // Click the button and make sure that the menu has opened
+      ReactTestUtils.Simulate.click(btn);
+      const cm = document.querySelector('.ms-ContextualMenu-Callout');
+      expect(cm).not.toEqual(null);
+
+      // Get an item from the menu and make sure it's focused
+      const menuList = document.querySelector('ul.ms-ContextualMenu-list') as HTMLUListElement;
+      const menuItem = menuList.querySelector('button');
+      menuItem!.focus();
+      expect(document.activeElement).toEqual(menuItem);
+      ReactTestUtils.Simulate.keyDown(menuList, { which: KeyCodes.escape });
+
+      // Ensure that the Menu has closed and that focus has returned to the button
+      expect(document.querySelector('.ms-ContextualMenu-Callout')).toBeNull();
+      expect(document.activeElement).toEqual(btn);
+    });
   });
 
   describe('canAnyMenuItemsCheck', () => {

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -175,6 +175,7 @@ function defaultFocusRestorer(options: { originalElement?: HTMLElement | Window;
   if (originalElement && containsFocus && originalElement !== window) {
     // Make sure that the focus method actually exists
     // In some cases the object might exist but not be a real element.
+    // This is primarily for IE 11 and should be removed once IE 11 is no longer in use.
     if (originalElement.focus) {
       originalElement.focus();
     }

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -173,6 +173,10 @@ function defaultFocusRestorer(options: { originalElement?: HTMLElement | Window;
   const { originalElement, containsFocus } = options;
 
   if (originalElement && containsFocus && originalElement !== window) {
-    originalElement.focus();
+    // Make sure that the focus method actually exists
+    // In some cases the object might exist but not be a real element.
+    if (originalElement.focus) {
+      originalElement.focus();
+    }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix 2 issues:
1. Fix an issue where focus would not return to the previously focused element if the contextualmenu was hidden instead of being removed from the dom.
2. Fix an issue where an error could sometimes throw if the previously focused element was removed from the dom before the contextualmenu was dismissed.

#### Focus areas to test

(optional)
