### PR TITLE
HoverCard: Expose Optional native props for the host div of HoverCard

### DIFF
--- a/change/office-ui-fabric-react-2020-06-26-17-04-04-HostNativePropsForHoverCard.json
+++ b/change/office-ui-fabric-react-2020-06-26-17-04-04-HostNativePropsForHoverCard.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Expose Optional native props for the host div of HoverCard",
   "packageName": "office-ui-fabric-react",
   "email": "v-gorraj@microsoft.com",

--- a/change/office-ui-fabric-react-2020-06-26-17-04-04-HostNativePropsForHoverCard.json
+++ b/change/office-ui-fabric-react-2020-06-26-17-04-04-HostNativePropsForHoverCard.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Expose Optional native props for the host div of HoverCard",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T11:34:04.337Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -535,7 +535,7 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
     // (undocumented)
     readonly indeterminate: boolean;
     render(): JSX.Element;
-}
+    }
 
 // @public (undocumented)
 export enum CheckboxVisibility {
@@ -4998,6 +4998,7 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement> {
     eventListenerTarget?: HTMLElement | string | null;
     expandedCardOpenDelay?: number;
     expandingCardProps?: IExpandingCardProps;
+    hostNativeProps?: React.HTMLAttributes<HTMLDivElement>;
     instantOpenOnClick?: boolean;
     onCardExpand?: () => void;
     onCardHide?: () => void;
@@ -8104,7 +8105,7 @@ export class LinkBase extends React.Component<ILinkProps, {}> implements ILink {
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
-}
+    }
 
 // @public
 export class List<T = any> extends React.Component<IListProps<T>, IListState<T>> implements IList {

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.base.tsx
@@ -138,6 +138,7 @@ export class HoverCardBase extends React.Component<IHoverCardProps, IHoverCardSt
       plainCardProps,
       trapFocus,
       setInitialFocus,
+      hostNativeProps,
     } = this.props;
     const { isHoverCardVisible, mode, openMode } = this.state;
     const hoverCardId = id || getId('hoverCard');
@@ -167,6 +168,7 @@ export class HoverCardBase extends React.Component<IHoverCardProps, IHoverCardSt
         ref={this._hoverCard}
         aria-describedby={setAriaDescribedBy && isHoverCardVisible ? hoverCardId : undefined}
         data-is-focusable={!Boolean(this.props.target)}
+        {...(hostNativeProps && { ...getNativeProps(hostNativeProps!, divProperties) })}
       >
         {children}
         {isHoverCardVisible &&

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.types.ts
@@ -98,6 +98,12 @@ export interface IHoverCardProps extends React.HTMLAttributes<HTMLDivElement> {
   onCardExpand?: () => void;
 
   /**
+   * Optional Native props (s) for the host div of HoverCard
+   */
+
+  hostNativeProps?: React.HTMLAttributes<HTMLDivElement>;
+
+  /**
    * Set to true to set focus on the first focusable element in the card. Works in pair with the 'trapFocus' prop.
    * @defaultvalue false
    */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

HoverCard: Expose Optional native props for the host div of HoverCard

 Need to pass accessibility props for host like role and aria-label and aria expanded to resolve this issue https://office.visualstudio.com/OC/_workitems/edit/4221810 in this bug 7 more is the outer host element i want pass aria props for this host element.

example :
`<HoverCard
        type={HoverCardType.plain}
        plainCardProps={plainCardProps}
        instantOpenOnClick={true}
        onCardHide={onHoverCardHideHandler}
        setInitialFocus={true}
        trapFocus={true}
        onCardVisible={this._hoverCardVisible}
        styles={classNames.subComponentStyles.hoverCardStyles}
        cardDismissDelay={300}
      >
        <div
          role={'combobox'}
          aria-expanded={this.state.isHoverCardVisible}
          aria-label={`${items.length} ${overflowString}`}
          data-is-focusable={true}
        >
          <div className={classNames.overflowIndicationTextStyle}>
            {items.length} {overflowString}
          </div>
        </div>
      </HoverCard>`

Here i have added role aria-expanded and aria-label but since it is wrapped with hover card host i am unable to use this as expected. 

#### Focus areas to test
Hover card 
        https://github.com/microsoft/fluentui/blob/fb9e9f54a7a5ef35e56bc9962c20e6f2dedebf86/packages/charting/src/components/Legends/Legends.base.tsx#L243