### PR TITLE
Convert KeytipTransitionModifier enum to type to save bytes

### DIFF
--- a/change/office-ui-fabric-react-2020-06-26-09-05-44-keco-keytips-enum.json
+++ b/change/office-ui-fabric-react-2020-06-26-09-05-44-keco-keytips-enum.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Convert KeytipTransitionModifier to type",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T16:05:44.937Z"
+}

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.base.tsx
@@ -12,6 +12,7 @@ import {
   EventGroup,
   Async,
   initializeComponentRef,
+  KeyCodes,
 } from '../../Utilities';
 import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { KeytipTree } from './KeytipTree';
@@ -38,7 +39,7 @@ export interface IKeytipLayerState {
 // Default sequence is Alt-Windows (Alt-Meta) in Windows, Option-Control (Alt-Control) in Mac
 const defaultStartSequence: IKeytipTransitionKey = {
   key: isMac() ? 'Control' : 'Meta',
-  modifierKeys: [KeytipTransitionModifier.alt],
+  modifierKeys: [KeyCodes.alt],
 };
 
 // Default exit sequence is the same as the start sequence
@@ -436,18 +437,18 @@ export class KeytipLayerBase extends React.Component<IKeytipLayerProps, IKeytipL
    * @returns List of ModifierKeyCodes that were pressed
    */
   private _getModifierKey(key: string, ev: React.KeyboardEvent<HTMLElement>): KeytipTransitionModifier[] | undefined {
-    const modifierKeys = [];
+    const modifierKeys: KeytipTransitionModifier[] = [];
     if (ev.altKey && key !== 'Alt') {
-      modifierKeys.push(KeytipTransitionModifier.alt);
+      modifierKeys.push(KeyCodes.alt);
     }
     if (ev.ctrlKey && key !== 'Control') {
-      modifierKeys.push(KeytipTransitionModifier.ctrl);
+      modifierKeys.push(KeyCodes.ctrl);
     }
     if (ev.shiftKey && key !== 'Shift') {
-      modifierKeys.push(KeytipTransitionModifier.shift);
+      modifierKeys.push(KeyCodes.shift);
     }
     if (ev.metaKey && key !== 'Meta') {
-      modifierKeys.push(KeytipTransitionModifier.meta);
+      modifierKeys.push(KeyCodes.leftWindow);
     }
     return modifierKeys.length ? modifierKeys : undefined;
   }

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -3,10 +3,9 @@ import { KeytipManager } from '../../utilities/keytips/KeytipManager';
 import { mount, ReactWrapper } from 'enzyme';
 import { KeytipLayerBase } from './KeytipLayer.base';
 import { IKeytipProps } from '../../Keytip';
-import { find } from '../../Utilities';
+import { find, KeyCodes } from '../../Utilities';
 import { KeytipTree } from './KeytipTree';
 import { KTP_FULL_PREFIX, KTP_SEPARATOR } from '../../utilities/keytips/KeytipConstants';
-import { KeytipTransitionModifier } from '../../utilities/keytips/IKeytipTransitionKey';
 
 describe('KeytipLayer', () => {
   const ktpMgr = KeytipManager.getInstance();
@@ -183,13 +182,13 @@ describe('KeytipLayer', () => {
         });
 
         it('calls on enter keytip mode when we process alt + left win', () => {
-          layerValue.processTransitionInput({ key: 'Meta', modifierKeys: [KeytipTransitionModifier.alt] });
+          layerValue.processTransitionInput({ key: 'Meta', modifierKeys: [KeyCodes.alt] });
           expect(onEnter).toBeCalled();
         });
 
         it('calls on exit keytip mode when we process alt + left win', () => {
           ktpTree.currentKeytip = ktpTree.root;
-          layerValue.processTransitionInput({ key: 'Meta', modifierKeys: [KeytipTransitionModifier.alt] });
+          layerValue.processTransitionInput({ key: 'Meta', modifierKeys: [KeyCodes.alt] });
           expect(onExit).toBeCalled();
         });
 

--- a/packages/office-ui-fabric-react/src/utilities/keytips/IKeytipTransitionKey.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/IKeytipTransitionKey.test.ts
@@ -1,9 +1,5 @@
-import {
-  IKeytipTransitionKey,
-  transitionKeysAreEqual,
-  transitionKeysContain,
-  KeytipTransitionModifier,
-} from './IKeytipTransitionKey';
+import { IKeytipTransitionKey, transitionKeysAreEqual, transitionKeysContain } from './IKeytipTransitionKey';
+import { KeyCodes } from '@uifabric/utilities';
 
 describe('IKeytipTransitionKey', () => {
   describe('transitionKeysAreEqual', () => {
@@ -17,16 +13,16 @@ describe('IKeytipTransitionKey', () => {
     });
 
     it('key and modifier equality', () => {
-      const key1: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeytipTransitionModifier.alt] };
+      const key1: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeyCodes.alt] };
       const key2: IKeytipTransitionKey = { key: 'a' };
-      const key3: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeytipTransitionModifier.ctrl] };
+      const key3: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeyCodes.ctrl] };
       const key4: IKeytipTransitionKey = {
         key: 'a',
-        modifierKeys: [KeytipTransitionModifier.alt, KeytipTransitionModifier.shift],
+        modifierKeys: [KeyCodes.alt, KeyCodes.shift],
       };
       const key5: IKeytipTransitionKey = {
         key: 'a',
-        modifierKeys: [KeytipTransitionModifier.shift, KeytipTransitionModifier.alt],
+        modifierKeys: [KeyCodes.shift, KeyCodes.alt],
       };
 
       expect(transitionKeysAreEqual(key1, key2)).toEqual(false);
@@ -51,13 +47,13 @@ describe('IKeytipTransitionKey', () => {
     });
 
     it('key and modifier', () => {
-      const key1: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeytipTransitionModifier.alt] };
+      const key1: IKeytipTransitionKey = { key: 'a', modifierKeys: [KeyCodes.alt] };
 
-      const keys1: IKeytipTransitionKey[] = [{ key: 'a', modifierKeys: [KeytipTransitionModifier.alt] }];
-      const keys2: IKeytipTransitionKey[] = [{ key: 'b', modifierKeys: [KeytipTransitionModifier.alt] }];
+      const keys1: IKeytipTransitionKey[] = [{ key: 'a', modifierKeys: [KeyCodes.alt] }];
+      const keys2: IKeytipTransitionKey[] = [{ key: 'b', modifierKeys: [KeyCodes.alt] }];
       const keys3: IKeytipTransitionKey[] = [
-        { key: 'a', modifierKeys: [KeytipTransitionModifier.alt, KeytipTransitionModifier.ctrl] },
-        { key: 'a', modifierKeys: [KeytipTransitionModifier.alt] },
+        { key: 'a', modifierKeys: [KeyCodes.alt, KeyCodes.ctrl] },
+        { key: 'a', modifierKeys: [KeyCodes.alt] },
       ];
 
       expect(transitionKeysContain(keys1, key1)).toEqual(true);

--- a/packages/office-ui-fabric-react/src/utilities/keytips/IKeytipTransitionKey.ts
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/IKeytipTransitionKey.ts
@@ -1,11 +1,10 @@
 import { find, KeyCodes } from '../../Utilities';
 
-export enum KeytipTransitionModifier {
-  shift = KeyCodes.shift,
-  ctrl = KeyCodes.ctrl,
-  alt = KeyCodes.alt,
-  meta = KeyCodes.leftWindow,
-}
+export type KeytipTransitionModifier =
+  | typeof KeyCodes.shift
+  | typeof KeyCodes.ctrl
+  | typeof KeyCodes.alt
+  | typeof KeyCodes.leftWindow;
 
 export interface IKeytipTransitionKey {
   key: string;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Converting enum to type should save some bytes. Currently, a lone import of Checkbox costs an SPFx WebPart **20kB**.

![image](https://user-images.githubusercontent.com/706967/85877873-acc33480-b78c-11ea-97d7-15b892bed836.png)

Another candidate for refactor: https://github.com/microsoft/fluentui/blob/c1b5549c28e14941aaa0922efdacbf11a44cff85/packages/office-ui-fabric-react/src/utilities/keytips/KeytipConstants.ts#L10

#### Focus areas to test

(optional)
