### PR TITLE
resolveSlotProps: when slot/shorthand prop has JSX element as children, slot should be completely replaced by it

### DIFF
--- a/change/@fluentui-react-compose-2020-06-26-11-31-26-xgao-compose-fix.json
+++ b/change/@fluentui-react-compose-2020-06-26-11-31-26-xgao-compose-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "resolveSlotProps: when slot/shorthand prop has JSX element as children, slot should be completely replace by it.",
+  "comment": "resolveSlotProps: Making change so that if slot/shorthand prop has JSX element as children, slot is completely replaced by it.",
   "packageName": "@fluentui/react-compose",
   "email": "xgao@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-compose-2020-06-26-11-31-26-xgao-compose-fix.json
+++ b/change/@fluentui-react-compose-2020-06-26-11-31-26-xgao-compose-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "resolveSlotProps: when slot/shorthand prop has JSX element as children, slot should be completely replace by it.",
+  "packageName": "@fluentui/react-compose",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-26T18:31:26.152Z"
+}

--- a/packages/react-compose/src/resolveSlotProps.test.tsx
+++ b/packages/react-compose/src/resolveSlotProps.test.tsx
@@ -66,7 +66,10 @@ describe('resolveSlotProps', () => {
         defaultOptionsWithSlots,
       ),
     ).toEqual({
-      ...getDefaultSlots(),
+      slots: {
+        ...getDefaultSlots().slots,
+        slot1: React.Fragment,
+      },
       state,
       slotProps: {
         root: {},

--- a/packages/react-compose/src/resolveSlotProps.ts
+++ b/packages/react-compose/src/resolveSlotProps.ts
@@ -40,12 +40,15 @@ export function resolveSlotProps<TProps, TState = TProps>(
         (slot && slot.shorthandConfig && slot.shorthandConfig.mappedProp) || defaultMappedProps[slot],
       );
 
-      if (typeof mergedSlotProp.children === 'function') {
+      const isChildrenFunction = typeof mergedSlotProp.children === 'function';
+      if (isChildrenFunction || React.isValidElement(mergedSlotProp.children)) {
         const { children, ...restProps } = slotProp;
-        // If the children is a function, replace the slot.
+
         slots[slotName] = React.Fragment;
         slotProps[slotName] = {
-          children: slotProp.children(slot, { ...slotProps[slotName], ...restProps }),
+          children: isChildrenFunction
+            ? mergedSlotProp.children(slot, { ...slotProps[slotName], ...restProps })
+            : mergedSlotProp.children,
         };
       } else {
         slotProps[slotName] = mergedSlotProp;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
In case we have
```
<Button icon={<MyIcon>} />
```
we should have icon slot completely replaced by `<MyIcon>`, not 
```
<ParentIconSlot>
  <MyIcon>
</ParentIconSlot>
```

In case if you do want to keep the `<ParentIconSlot>` wrapper, you should do
```
<Button icon={{
  children: (Component, props) => (
    <Component>
      <MyIcon>
    </Component>
  )
}} />
```

#### Focus areas to test

(optional)
