### PR TITLE
getNativeProps perf: adjusting indexOf lookup to object lookups.

### DIFF
--- a/change/@uifabric-experiments-2020-06-29-11-47-21-fix-getNativePropsPerf.json
+++ b/change/@uifabric-experiments-2020-06-29-11-47-21-fix-getNativePropsPerf.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating some typings.",
+  "packageName": "@uifabric/experiments",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T18:47:21.731Z"
+}

--- a/change/@uifabric-utilities-2020-06-29-10-46-43-fix-getNativePropsPerf.json
+++ b/change/@uifabric-utilities-2020-06-29-10-46-43-fix-getNativePropsPerf.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "getNativeProps: changed to object lookups rather than array searching to determine native props.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T17:46:43.577Z"
+}

--- a/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
@@ -55,7 +55,7 @@ export const ActionableView: IActionableComponent['view'] = (props, slots) => {
 
 interface IActionableRootType {
   htmlType: 'link' | 'button';
-  propertiesType: string[];
+  propertiesType: string[] | Record<string, number>;
 }
 
 function _deriveRootType(props: IActionableViewProps): IActionableRootType {

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -70,7 +70,7 @@ export const ButtonView: IButtonComponent['view'] = (props, slots) => {
 
 interface IButtonRootType {
   htmlType: 'link' | 'button';
-  propertiesType: string[];
+  propertiesType: string[] | Record<string, number>;
 }
 
 function _deriveRootType(props: IButtonViewProps): IButtonRootType {

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -24,7 +24,7 @@ export const allowOverscrollOnElement: (element: HTMLElement | null, events: Eve
 export const allowScrollOnElement: (element: HTMLElement | null, events: EventGroup) => void;
 
 // @public
-export const anchorProperties: string[];
+export const anchorProperties: Record<string, number>;
 
 // @public
 export function appendFunction(parent: any, ...functions: any[]): () => void;
@@ -71,7 +71,7 @@ export class Async {
     }
 
 // @public
-export const audioProperties: string[];
+export const audioProperties: Record<string, number>;
 
 // @public
 export class AutoScroll {
@@ -102,13 +102,13 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
 }
 
 // @public
-export const baseElementEvents: string[];
+export const baseElementEvents: Record<string, number>;
 
 // @public
-export const baseElementProperties: string[];
+export const baseElementProperties: Record<string, number>;
 
 // @public
-export const buttonProperties: string[];
+export const buttonProperties: Record<string, number>;
 
 // @public
 export function calculatePrecision(value: number | string): number;
@@ -117,10 +117,10 @@ export function calculatePrecision(value: number | string): number;
 export function classNamesFunction<TStyleProps extends {}, TStyleSet extends IStyleSet<TStyleSet>>(options?: IClassNamesFunctionOptions): (getStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet> | undefined, styleProps?: TStyleProps) => IProcessedStyleSet<TStyleSet>;
 
 // @public (undocumented)
-export const colGroupProperties: string[];
+export const colGroupProperties: Record<string, number>;
 
 // @public (undocumented)
-export const colProperties: string[];
+export const colProperties: Record<string, number>;
 
 // @public
 export function composeComponentAs<TProps>(outer: IComponentAs<TProps>, inner: IComponentAs<TProps>): IComponentAs<TProps>;
@@ -197,7 +197,7 @@ export class DelayedRender extends React.Component<IDelayedRenderProps, IDelayed
 export function disableBodyScroll(): void;
 
 // @public
-export const divProperties: string[];
+export const divProperties: Record<string, number>;
 
 // @public
 export function doesElementContainFocus(element: HTMLElement): boolean;
@@ -295,7 +295,7 @@ export const FocusRects: React.FunctionComponent<{
 export function format(s: string, ...values: any[]): string;
 
 // @public
-export const formProperties: string[];
+export const formProperties: Record<string, number>;
 
 // @public
 export function getChildren(parent: HTMLElement, allowVirtualChildren?: boolean): HTMLElement[];
@@ -337,7 +337,7 @@ export function getLastTabbable(rootElement: HTMLElement, currentElement: HTMLEl
 export function getNativeElementProps<TAttributes extends React.HTMLAttributes<any>>(tagName: keyof React.ReactHTML, props: {}, excludedPropNames?: string[]): TAttributes;
 
 // @public
-export function getNativeProps<T>(props: {}, allowedPropNames: string[], excludedPropNames?: string[]): T;
+export function getNativeProps<T extends Record<string, any>>(props: Record<string, any>, allowedPropNames: string[] | Record<string, number>, excludedPropNames?: string[]): T;
 
 // @public
 export function getNextElement(rootElement: HTMLElement, currentElement: HTMLElement | null, checkNode?: boolean, suppressParentTraversal?: boolean, suppressChildTraversal?: boolean, includeElementsInFocusZones?: boolean, allowFocusRoot?: boolean, tabbable?: boolean): HTMLElement | null;
@@ -404,7 +404,7 @@ export function hoistMethods(destination: any, source: any, exclusions?: string[
 export function hoistStatics<TSource extends Object, TDest>(source: TSource, dest: TDest): TDest;
 
 // @public
-export const htmlElementProperties: string[];
+export const htmlElementProperties: Record<string, number>;
 
 // @public (undocumented)
 export interface IAsAsyncOptions<TProps> {
@@ -582,13 +582,13 @@ export interface IFitContentToBoundsOptions {
 }
 
 // @public
-export const iframeProperties: string[];
+export const iframeProperties: Record<string, number>;
 
 // @public @deprecated (undocumented)
-export const imageProperties: string[];
+export const imageProperties: Record<string, number>;
 
 // @public
-export const imgProperties: string[];
+export const imgProperties: Record<string, number>;
 
 // @public
 export function initializeComponentRef<TProps extends IBaseProps, TState>(obj: React.Component<TProps, TState>): void;
@@ -597,7 +597,7 @@ export function initializeComponentRef<TProps extends IBaseProps, TState>(obj: R
 export function initializeFocusRects(window?: Window): void;
 
 // @public
-export const inputProperties: string[];
+export const inputProperties: Record<string, number>;
 
 // @public (undocumented)
 export interface IObjectWithKey {
@@ -937,10 +937,10 @@ export const KeyCodes: {
 export type KeyCodes = number;
 
 // @public
-export const labelProperties: string[];
+export const labelProperties: Record<string, number>;
 
 // @public
-export const liProperties: string[];
+export const liProperties: Record<string, number>;
 
 // @public
 export function mapEnumByName<T>(theEnum: any, callback: (name?: string, value?: string | number) => T | undefined): (T | undefined)[] | undefined;
@@ -976,7 +976,7 @@ export function modalize(target: HTMLElement): () => void;
 export function nullRender(): JSX.Element | null;
 
 // @public
-export const olProperties: string[];
+export const olProperties: Record<string, number>;
 
 export { Omit }
 
@@ -984,7 +984,7 @@ export { Omit }
 export function on(element: Element | Window, eventName: string, callback: (ev: Event) => void, options?: boolean): () => void;
 
 // @public (undocumented)
-export const optionProperties: string[];
+export const optionProperties: Record<string, number>;
 
 // @public
 export interface Point {
@@ -1125,7 +1125,7 @@ export enum SelectionMode {
 }
 
 // @public
-export const selectProperties: string[];
+export const selectProperties: Record<string, number>;
 
 // @public
 export function setBaseUrl(baseUrl: string): void;
@@ -1178,22 +1178,22 @@ export type StyleFunction<TStyleProps, TStyleSet> = IStyleFunctionOrObject<TStyl
 };
 
 // @public
-export const tableProperties: string[];
+export const tableProperties: Record<string, number>;
 
 // @public
-export const tdProperties: string[];
+export const tdProperties: Record<string, number>;
 
 // @public
-export const textAreaProperties: string[];
+export const textAreaProperties: Record<string, number>;
 
 // @public
-export const thProperties: string[];
+export const thProperties: Record<string, number>;
 
 // @public
 export function toMatrix<T>(items: T[], columnCount: number): T[][];
 
 // @public
-export const trProperties: string[];
+export const trProperties: Record<string, number>;
 
 // @public
 export function unhoistMethods(source: any, methodNames: string[]): void;
@@ -1208,7 +1208,7 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void;
 export function values<T>(obj: any): T[];
 
 // @public
-export const videoProperties: string[];
+export const videoProperties: Record<string, number>;
 
 // @public
 export function warn(message: string): void;

--- a/packages/utilities/src/getNativeElementProps.ts
+++ b/packages/utilities/src/getNativeElementProps.ts
@@ -24,7 +24,7 @@ import {
 } from './properties';
 import * as React from 'react';
 
-const nativeElementMap: Record<string, string[]> = {
+const nativeElementMap: Record<string, Record<string, number>> = {
   label: labelProperties,
   audio: audioProperties,
   video: videoProperties,

--- a/packages/utilities/src/properties.ts
+++ b/packages/utilities/src/properties.ts
@@ -1,11 +1,23 @@
-import { filteredAssign } from './object';
+const toObjectMap = (...items: (string[] | Record<string, number>)[]) => {
+  const result: Record<string, number> = {};
+
+  for (const item of items) {
+    const keys = Array.isArray(item) ? item : Object.keys(item);
+
+    for (const key of keys) {
+      result[key] = 1;
+    }
+  }
+
+  return result;
+};
 
 /**
  * An array of events that are allowed on every html element type.
  *
  * @public
  */
-export const baseElementEvents = [
+export const baseElementEvents = toObjectMap([
   'onCopy',
   'onCut',
   'onPaste',
@@ -85,14 +97,14 @@ export const baseElementEvents = [
   'onPointerUp',
   'onGotPointerCapture',
   'onLostPointerCapture',
-];
+]);
 
 /**
  * An array of element attributes which are allowed on every html element type.
  *
  * @public
  */
-export const baseElementProperties = [
+export const baseElementProperties = toObjectMap([
   'accessKey', // global
   'children', // global
   'className', // global
@@ -110,30 +122,30 @@ export const baseElementProperties = [
   'translate', // global
   'spellCheck', // global
   'name', // global
-];
+]);
 
 /**
  * An array of HTML element properties and events.
  *
  * @public
  */
-export const htmlElementProperties = baseElementProperties.concat(baseElementEvents);
+export const htmlElementProperties = toObjectMap(baseElementProperties, baseElementEvents);
 
 /**
  * An array of LABEL tag properties and events.
  *
  * @public
  */
-export const labelProperties = htmlElementProperties.concat([
+export const labelProperties = toObjectMap(htmlElementProperties, [
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
 ]);
 
 /**
  * An array of AUDIO tag properties and events.
- *
+
  * @public
  */
-export const audioProperties = htmlElementProperties.concat([
+export const audioProperties = toObjectMap(htmlElementProperties, [
   'height', // canvas, embed, iframe, img, input, object, video
   'loop', // audio, video
   'muted', // audio, video
@@ -147,7 +159,7 @@ export const audioProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const videoProperties = audioProperties.concat([
+export const videoProperties = toObjectMap(audioProperties, [
   'poster', // video
 ]);
 
@@ -156,7 +168,7 @@ export const videoProperties = audioProperties.concat([
  *
  * @public
  */
-export const olProperties = htmlElementProperties.concat([
+export const olProperties = toObjectMap(htmlElementProperties, [
   'start', // ol
 ]);
 
@@ -165,7 +177,7 @@ export const olProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const liProperties = htmlElementProperties.concat([
+export const liProperties = toObjectMap(htmlElementProperties, [
   'value', // button, input, li, option, meter, progress, param
 ]);
 
@@ -174,7 +186,7 @@ export const liProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const anchorProperties = htmlElementProperties.concat([
+export const anchorProperties = toObjectMap(htmlElementProperties, [
   'download', // a, area
   'href', // a, area, base, link
   'hrefLang', // a, area, link
@@ -189,7 +201,7 @@ export const anchorProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const buttonProperties = htmlElementProperties.concat([
+export const buttonProperties = toObjectMap(htmlElementProperties, [
   'autoFocus', // button, input, select, textarea
   'disabled', // button, fieldset, input, optgroup, option, select, textarea
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
@@ -207,7 +219,7 @@ export const buttonProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const inputProperties = buttonProperties.concat([
+export const inputProperties = toObjectMap(buttonProperties, [
   'accept', // input
   'alt', // area, img, input
   'autoCapitalize', // input, textarea
@@ -239,7 +251,7 @@ export const inputProperties = buttonProperties.concat([
  *
  * @public
  */
-export const textAreaProperties = buttonProperties.concat([
+export const textAreaProperties = toObjectMap(buttonProperties, [
   'autoCapitalize', // input, textarea
   'cols', // textarea
   'dirname', // input, textarea
@@ -257,13 +269,13 @@ export const textAreaProperties = buttonProperties.concat([
  *
  * @public
  */
-export const selectProperties = buttonProperties.concat([
+export const selectProperties = toObjectMap(buttonProperties, [
   'form', // button, fieldset, input, label, meter, object, output, select, textarea
   'multiple', // input, select
   'required', // input, select, textarea
 ]);
 
-export const optionProperties = htmlElementProperties.concat([
+export const optionProperties = toObjectMap(htmlElementProperties, [
   'selected', // option
   'value', // button, input, li, option, meter, progress, param
 ]);
@@ -273,7 +285,7 @@ export const optionProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const tableProperties = htmlElementProperties.concat([
+export const tableProperties = toObjectMap(htmlElementProperties, [
   'cellPadding', // table
   'cellSpacing', // table
 ]);
@@ -290,7 +302,7 @@ export const trProperties = htmlElementProperties;
  *
  * @public
  */
-export const thProperties = htmlElementProperties.concat([
+export const thProperties = toObjectMap(htmlElementProperties, [
   'rowSpan', // td, th
   'scope', // th
 ]);
@@ -300,18 +312,18 @@ export const thProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const tdProperties = htmlElementProperties.concat([
+export const tdProperties = toObjectMap(htmlElementProperties, [
   'colSpan', // td
   'headers', // td
   'rowSpan', // td, th
   'scope', // th
 ]);
 
-export const colGroupProperties = htmlElementProperties.concat([
+export const colGroupProperties = toObjectMap(htmlElementProperties, [
   'span', // col, colgroup
 ]);
 
-export const colProperties = htmlElementProperties.concat([
+export const colProperties = toObjectMap(htmlElementProperties, [
   'span', // col, colgroup
 ]);
 
@@ -320,7 +332,7 @@ export const colProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const formProperties = htmlElementProperties.concat([
+export const formProperties = toObjectMap(htmlElementProperties, [
   'acceptCharset', // form
   'action', // form
   'encType', // form
@@ -335,7 +347,7 @@ export const formProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const iframeProperties = htmlElementProperties.concat([
+export const iframeProperties = toObjectMap(htmlElementProperties, [
   'allow', // iframe
   'allowFullScreen', // iframe
   'allowPaymentRequest', // iframe
@@ -355,7 +367,7 @@ export const iframeProperties = htmlElementProperties.concat([
  *
  * @public
  */
-export const imgProperties = htmlElementProperties.concat([
+export const imgProperties = toObjectMap(htmlElementProperties, [
   'alt', // area, img, input
   'crossOrigin', // img
   'height', // canvas, embed, iframe, img, input, object, video
@@ -388,23 +400,39 @@ export const divProperties = htmlElementProperties;
  *
  * @public
  * @param props - The unfiltered input props
- * @param allowedPropsNames-  The array of allowed propnames.
+ * @param allowedPropsNames - The array or record of allowed prop names.
  * @returns The filtered props
  */
-export function getNativeProps<T>(props: {}, allowedPropNames: string[], excludedPropNames?: string[]): T {
+// tslint:disable-next-line: no-any
+export function getNativeProps<T extends Record<string, any>>(
+  // tslint:disable-next-line:no-any
+  props: Record<string, any>,
+  allowedPropNames: string[] | Record<string, number>,
+  excludedPropNames?: string[],
+): T {
   // It'd be great to properly type this while allowing 'aria-` and 'data-' attributes like TypeScript does for
   // JSX attributes, but that ability is hardcoded into the TS compiler with no analog in TypeScript typings.
   // Then we'd be able to enforce props extends native props (including aria- and data- attributes), and then
   // return native props.
   // We should be able to do this once this PR is merged: https://github.com/microsoft/TypeScript/pull/26797
-  return filteredAssign(
-    (propName: string) => {
-      return (
-        (!excludedPropNames || excludedPropNames.indexOf(propName) < 0) &&
-        (propName.indexOf('data-') === 0 || propName.indexOf('aria-') === 0 || allowedPropNames.indexOf(propName) >= 0)
-      );
-    },
-    {},
-    props,
-  ) as T;
+
+  const isArray = Array.isArray(allowedPropNames);
+  // tslint:disable-next-line:no-any
+  const result: Record<string, any> = {};
+  const keys = Object.keys(props);
+
+  for (const key of keys) {
+    const isNativeProp =
+      (!isArray && (allowedPropNames as Record<string, number>)[key]) ||
+      (isArray && (allowedPropNames as string[]).indexOf(key) >= 0) ||
+      key.indexOf('data-') === 0 ||
+      key.indexOf('aria-') === 0;
+
+    if (isNativeProp && (!excludedPropNames || excludedPropNames?.indexOf(key) === -1)) {
+      // tslint:disable-next-line:no-any
+      result[key] = props![key] as any;
+    }
+  }
+
+  return result as T;
 }


### PR DESCRIPTION
This change is backwards compatible with the current implementation, but changes all property sets to object maps for faster lookups and props resolution.

Before `divProperties` (the second argument) would be an array, which internally would use `indexOf` to find matches:
```tsx
getNativeProps({...props}, divProperties /* which is an array of strings */, excludedProperties)
```

After, `divProperties` is an object map, where we use `divProperties[key]` to find matches:
```tsx
getNativeProps({...props}, divProperties /* which is Record<string, number> */, excludedProperties)
```

This should result in far less overhead in using the helper.
