### PR TITLE
mergestyles: IStyle: loosening typings for objects embedded within the style.

### DIFF
--- a/change/@uifabric-merge-styles-2020-06-29-16-01-58-fix-merge-styles-typings.json
+++ b/change/@uifabric-merge-styles-2020-06-29-16-01-58-fix-merge-styles-typings.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Loosening typings in the `IStyle` interface.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-29T23:01:58.214Z"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -102,7 +102,7 @@ export interface IRawFontStyle {
 
 // @public
 export interface IRawStyle extends IRawStyleBase {
-    [key: string]: string | number | undefined | Record<string, any>;
+    [key: string]: any;
     displayName?: string;
     selectors?: {
         [key: string]: IStyle;

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -102,8 +102,7 @@ export interface IRawFontStyle {
 
 // @public
 export interface IRawStyle extends IRawStyleBase {
-    // (undocumented)
-    [key: string]: string | number | undefined | Record<string, IStyle>;
+    [key: string]: string | number | undefined | Record<string, any>;
     displayName?: string;
     selectors?: {
         [key: string]: IStyle;

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -7,7 +7,11 @@ import { IRawStyleBase } from './IRawStyleBase';
  * {@docCategory IRawStyle}
  */
 export interface IRawStyle extends IRawStyleBase {
-  [key: string]: string | number | undefined | Record<string, IStyle>;
+  /**
+   * Allow css variables, strings, objects. While we should have more strict typing
+   * here, partners are broken in many unpredictable cases.
+   */
+  [key: string]: string | number | undefined | Record<string, any>;
 
   /**
    * Display name for the style.

--- a/packages/merge-styles/src/IStyle.ts
+++ b/packages/merge-styles/src/IStyle.ts
@@ -9,9 +9,10 @@ import { IRawStyleBase } from './IRawStyleBase';
 export interface IRawStyle extends IRawStyleBase {
   /**
    * Allow css variables, strings, objects. While we should have more strict typing
-   * here, partners are broken in many unpredictable cases.
+   * here, partners are broken in many unpredictable cases where typescript can't infer
+   * the right typing. Loosening the typing to both allow for css variables and other things.
    */
-  [key: string]: string | number | undefined | Record<string, any>;
+  [key: string]: any;
 
   /**
    * Display name for the style.


### PR DESCRIPTION
The `IStyle` interface was recently tweaked to allow for CSS variables to be provided. The typings were too restrictive, loosening the indexer to make things more compatible with previous versions.

