### PR TITLE
Add props and state typings  type for Sidebar component

### DIFF
--- a/packages/fluentui/docs/src/components/DocsLayout.tsx
+++ b/packages/fluentui/docs/src/components/DocsLayout.tsx
@@ -69,7 +69,7 @@ class DocsLayout extends React.Component<any, any> {
 
   renderChildren() {
     const { children, render } = this.props;
-    const sidebarWidth = '270';
+    const sidebarWidth = 270;
 
     const treeSectionStyle = {
       fontWeight: 700,

--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -18,9 +18,8 @@ import Logo from '../Logo/Logo';
 import { getComponentPathname } from '../../utils';
 import { getCode, keyboardKey } from '@fluentui/keyboard-key';
 import * as _ from 'lodash';
-import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { NavLink, NavLinkProps, withRouter } from 'react-router-dom';
+import { NavLink, NavLinkProps, withRouter, RouteComponentProps } from 'react-router-dom';
 import { SearchIcon, TriangleDownIcon, TriangleUpIcon, FilesTxtIcon, EditIcon } from '@fluentui/react-icons-northstar';
 
 type ComponentMenuItem = { displayName: string; type: string };
@@ -36,13 +35,11 @@ interface SidebarState {
   activeCategoryIndex: number | number[];
 }
 
-class Sidebar extends React.Component<any, SidebarState> {
-  static propTypes = {
-    match: PropTypes.object.isRequired,
-    location: PropTypes.object.isRequired,
-    history: PropTypes.object.isRequired,
-    style: PropTypes.object,
-  };
+interface SidebarProps {
+  width: number;
+  treeItemStyle: React.CSSProperties;
+}
+class Sidebar extends React.Component<SidebarProps & RouteComponentProps, SidebarState> {
   state = { query: '', activeCategoryIndex: 0 };
   searchInputRef = React.createRef<HTMLInputElement>();
 

--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -31,14 +31,19 @@ const behaviorMenu: ComponentMenuItem[] = require('../../behaviorMenu');
 
 const componentsBlackList = ['Debug', 'Design'];
 
-class Sidebar extends React.Component<any, any> {
+interface SidebarState {
+  query: string;
+  activeCategoryIndex: number | number[];
+}
+
+class Sidebar extends React.Component<any, SidebarState> {
   static propTypes = {
     match: PropTypes.object.isRequired,
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
     style: PropTypes.object,
   };
-  state: any = { query: '', activeCategoryIndex: 0 };
+  state = { query: '', activeCategoryIndex: 0 };
   searchInputRef = React.createRef<HTMLInputElement>();
 
   componentDidMount() {


### PR DESCRIPTION
#### Pull request checklist

#### Description of changes

Create `SidebarState` and `SidebarProps` interfaces to replace the Sidebar's state and props `any` types.
