### PR TITLE
Grouped vertical bar chart: Prop check added to update chart when props changed

### DIFF
--- a/change/@uifabric-charting-2020-06-30-11-14-54-user-v-jasha-GVBChartIssue.json
+++ b/change/@uifabric-charting-2020-06-30-11-14-54-user-v-jasha-GVBChartIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "prop check added",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T05:44:54.224Z"
+}

--- a/change/@uifabric-charting-2020-06-30-11-14-54-user-v-jasha-GVBChartIssue.json
+++ b/change/@uifabric-charting-2020-06-30-11-14-54-user-v-jasha-GVBChartIssue.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "prop check added",
+  "comment": "prop check added in Grouped vertical bar chart",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-06-30T05:44:54.224Z"
 }

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -115,7 +115,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
   }
 
   public componentDidUpdate(prevProps: IGroupedVerticalBarChartProps): void {
-    if (this._isGraphDraw) {
+    if (this._isGraphDraw || prevProps.data !== this.props.data) {
       // drawing graph after first update only to avoid multile g tags
       this._drawGraph();
       this._isGraphDraw = false;
@@ -345,11 +345,11 @@ export class GroupedVerticalBarChartBase extends React.Component<
       .range([0, this.state.containerHeight - this.margins.bottom - this.margins.top]);
 
     // previous <g> - graph need to remove otherwise multile g elements will create
-    d3Select(`#firstGElementForBars_${this._yMax}_${this._uniqLineText}`).remove();
+    d3Select(`#firstGElementForBars_${this._uniqLineText}`).remove();
     const barContainer = d3Select(`#barGElement_${this._uniqLineText}`)
       .append('g')
       .attr('class', 'firstGElementForBars')
-      .attr('id', `firstGElementForBars_${this._yMax}_${this._uniqLineText}`);
+      .attr('id', `firstGElementForBars_${this._uniqLineText}`);
     const seriesName = barContainer
       .selectAll('.name')
       .data(this._datasetForBars)

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -535,6 +535,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
         titleForHoverCard: customMessage,
       });
     }
+    this._isGraphDraw = true;
   }
 
   private _onLegendHover(customMessage: string): void {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: https://github.com/microsoft/fluentui/issues/13838
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

While changing the prop data, graph not re rendered. So added prop check in should update in base file. 

#### Focus areas to test

Grouped vertical bar chart

### Before fix
![image](https://user-images.githubusercontent.com/20105532/86088294-b073f580-bac3-11ea-9c64-2ad53af27902.png)

### After fix
![image](https://user-images.githubusercontent.com/20105532/86088343-c7b2e300-bac3-11ea-88c5-374d42fb8975.png)
