### PR TITLE
chore: move shorthandConfig to compose()

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentAction.tsx
@@ -1,11 +1,11 @@
 import { buttonBehavior } from '@fluentui/accessibility';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Button, { ButtonProps, ButtonStylesProps } from '../Button/Button';
 
-interface AttachmentActionOwnProps {}
+export interface AttachmentActionOwnProps {}
 export interface AttachmentActionProps extends AttachmentActionOwnProps, ButtonProps {
   text?: never;
   iconOnly?: never;
@@ -38,7 +38,11 @@ const AttachmentAction = compose<
   className: attachmentActionClassName,
   displayName: 'AttachmentAction',
   overrideStyles: true,
-}) as ComponentWithAs<'button', AttachmentActionProps> & { shorthandConfig: ShorthandConfig<AttachmentActionProps> };
+
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 AttachmentAction.defaultProps = {
   accessibility: buttonBehavior,
@@ -57,10 +61,6 @@ AttachmentAction.propTypes = {
   onFocus: PropTypes.func,
   primary: customPropTypes.every([customPropTypes.disallow(['secondary']), PropTypes.bool]),
   secondary: customPropTypes.every([customPropTypes.disallow(['primary']), PropTypes.bool]),
-};
-
-AttachmentAction.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default AttachmentAction;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentBody.tsx
@@ -1,9 +1,9 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
-interface AttachmentBodyOwnProps {}
+export interface AttachmentBodyOwnProps {}
 export interface AttachmentBodyProps extends AttachmentBodyOwnProps, BoxProps {}
 
 export type AttachmentBodyStylesProps = never;
@@ -19,13 +19,12 @@ const AttachmentBody = compose<'div', AttachmentBodyOwnProps, AttachmentBodyStyl
     displayName: 'AttachmentBody',
 
     overrideStyles: true,
+    shorthandConfig: {
+      mappedProp: 'content',
+    },
   },
-) as ComponentWithAs<'div', AttachmentBodyProps> & { shorthandConfig: ShorthandConfig<AttachmentBodyProps> };
+);
 
 AttachmentBody.propTypes = commonPropTypes.createCommon();
-
-AttachmentBody.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default AttachmentBody;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentDescription.tsx
@@ -1,8 +1,8 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
-interface AttachmentDescriptionOwnProps {}
+export interface AttachmentDescriptionOwnProps {}
 export interface AttachmentDescriptionProps extends AttachmentDescriptionOwnProps, BoxProps {}
 
 export type AttachmentDescriptionStylesProps = never;
@@ -22,17 +22,14 @@ const AttachmentDescription = compose<
   displayName: 'AttachmentDescription',
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', AttachmentDescriptionProps> & {
-  shorthandConfig: ShorthandConfig<AttachmentDescriptionProps>;
-};
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 AttachmentDescription.defaultProps = {
   as: 'span',
 };
 AttachmentDescription.propTypes = commonPropTypes.createCommon();
-
-AttachmentDescription.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default AttachmentDescription;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentHeader.tsx
@@ -1,8 +1,8 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
-interface AttachmentHeaderOwnProps {}
+export interface AttachmentHeaderOwnProps {}
 export interface AttachmentHeaderProps extends AttachmentHeaderOwnProps, BoxProps {}
 
 export type AttachmentHeaderStylesProps = never;
@@ -22,16 +22,14 @@ const AttachmentHeader = compose<
   displayName: 'AttachmentHeader',
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', AttachmentHeaderProps> & {
-  shorthandConfig: ShorthandConfig<AttachmentHeaderProps>;
-};
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 AttachmentHeader.defaultProps = {
   as: 'span',
 };
 AttachmentHeader.propTypes = commonPropTypes.createCommon();
-AttachmentHeader.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default AttachmentHeader;

--- a/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Attachment/AttachmentIcon.tsx
@@ -1,8 +1,8 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
-interface AttachmentIconOwnProps {}
+export interface AttachmentIconOwnProps {}
 export interface AttachmentIconProps extends AttachmentIconOwnProps, BoxProps {}
 
 export type AttachmentIconStylesProps = never;
@@ -18,15 +18,15 @@ const AttachmentIcon = compose<'span', AttachmentIconOwnProps, AttachmentIconSty
     displayName: 'AttachmentIcon',
 
     overrideStyles: true,
+    shorthandConfig: {
+      mappedProp: 'content',
+    },
   },
-) as ComponentWithAs<'span', AttachmentIconProps> & { shorthandConfig: ShorthandConfig<AttachmentIconProps> };
+);
 
 AttachmentIcon.defaultProps = {
   as: 'span',
 };
 AttachmentIcon.propTypes = commonPropTypes.createCommon();
-AttachmentIcon.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default AttachmentIcon;

--- a/packages/fluentui/react-northstar/src/components/Button/Button.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/Button.tsx
@@ -266,7 +266,6 @@ const Button = compose<'button', ButtonProps, ButtonStylesProps, {}, {}>(
       icon: Box,
       loader: Loader,
     },
-
     slotProps: props => ({
       content: {
         size: props.size,
@@ -276,6 +275,9 @@ const Button = compose<'button', ButtonProps, ButtonStylesProps, {}, {}>(
       },
     }),
 
+    shorthandConfig: {
+      mappedProp: 'content',
+    },
     handledProps: [
       'accessibility',
       'as',
@@ -338,10 +340,6 @@ Button.propTypes = {
 
 Button.Group = ButtonGroup;
 Button.Content = ButtonContent;
-
-Button.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 Button.create = createShorthandFactory({ Component: Button, mappedProp: 'content' });
 

--- a/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Button/ButtonContent.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import { commonPropTypes, SizeValue } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
@@ -22,7 +22,10 @@ const ButtonContent = compose<'span', ButtonContentProps, ButtonContentStylesPro
   handledProps: ['size'],
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', ButtonContentProps> & { shorthandConfig: ShorthandConfig<ButtonContentProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 ButtonContent.defaultProps = {
   as: 'span',
@@ -30,9 +33,6 @@ ButtonContent.defaultProps = {
 ButtonContent.propTypes = {
   ...commonPropTypes.createCommon(),
   size: customPropTypes.size,
-};
-ButtonContent.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default ButtonContent;

--- a/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
@@ -1,4 +1,5 @@
-import { ComponentWithAs, compose, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 
@@ -20,12 +21,12 @@ const CardExpandableBox = compose<
 >(Box, {
   className: cardExpandableBoxClassName,
   displayName: 'CardExpandableBox',
-}) as ComponentWithAs<'div', CardExpandableBoxProps> & { shorthandConfig: ShorthandConfig<CardExpandableBoxProps> };
+
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 CardExpandableBox.propTypes = commonPropTypes.createCommon();
-
-CardExpandableBox.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default CardExpandableBox;

--- a/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
+++ b/packages/fluentui/react-northstar/src/components/Card/CardExpandableBox.tsx
@@ -1,5 +1,4 @@
 import { compose } from '@fluentui/react-bindings';
-import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps, BoxStylesProps } from '../Box/Box';
 

--- a/packages/fluentui/react-northstar/src/components/Form/FormMessage.tsx
+++ b/packages/fluentui/react-northstar/src/components/Form/FormMessage.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
 
@@ -18,18 +18,19 @@ export const formMessageClassName = 'ui-form__message';
 const FormMessage = compose<'span', FormMessageProps, FormMessageStylesProps, BoxProps, {}>(Box, {
   className: formMessageClassName,
   displayName: 'FormMessage',
+
   mapPropsToStylesProps: ({ error }) => ({ error }),
   handledProps: ['error'],
+
   overrideStyles: true,
-}) as ComponentWithAs<'span', FormMessageProps> & { shorthandConfig: ShorthandConfig<FormMessageProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 FormMessage.defaultProps = {
   as: 'span',
 };
 FormMessage.propTypes = commonPropTypes.createCommon();
-
-FormMessage.shorthandConfig = {
-  mappedProp: 'content',
-};
 
 export default FormMessage;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -153,10 +153,10 @@ const MenuDivider = compose<'li', MenuDividerProps, MenuDividerStylesProps, {}, 
       'secondary',
       'vertical',
     ],
+    shorthandConfig: { mappedProp: 'content' },
   },
 ) as ComponentWithAs<'li', MenuDividerProps> & {
   create: ShorthandFactory<MenuDividerProps>;
-  shorthandConfig: ShorthandConfig<MenuDividerProps>;
 };
 
 MenuDivider.defaultProps = {
@@ -173,6 +173,5 @@ MenuDivider.propTypes = {
 };
 
 MenuDivider.create = createShorthandFactory({ Component: MenuDivider, mappedProp: 'content' });
-MenuDivider.shorthandConfig = { mappedProp: 'content' };
 
 export default MenuDivider;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuDivider.tsx
@@ -8,7 +8,6 @@ import {
   useTelemetry,
   useStyles,
   useUnhandledProps,
-  ShorthandConfig,
 } from '@fluentui/react-bindings';
 import { useContextSelectors } from '@fluentui/react-context-selector';
 import * as PropTypes from 'prop-types';

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemContent.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
@@ -37,7 +37,10 @@ const MenuItemContent = compose<'span', MenuItemContentProps, MenuItemContentSty
   handledProps: ['hasMenu', 'hasIcon', 'vertical', 'inSubmenu'],
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', MenuItemContentProps> & { shorthandConfig: ShorthandConfig<MenuItemContentProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 MenuItemContent.defaultProps = {
   as: 'span',
@@ -48,9 +51,6 @@ MenuItemContent.propTypes = {
   hasMenu: PropTypes.bool,
   vertical: PropTypes.bool,
   inSubmenu: PropTypes.bool,
-};
-MenuItemContent.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default MenuItemContent;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIcon.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
 import Box, { BoxProps } from '../Box/Box';
@@ -26,7 +26,10 @@ const MenuItemIcon = compose<'span', MenuItemIconProps, MenuItemIconStylesProps,
   handledProps: ['hasContent', 'iconOnly'],
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', MenuItemIconProps> & { shorthandConfig: ShorthandConfig<MenuItemIconProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 MenuItemIcon.defaultProps = {
   as: 'span',
@@ -35,9 +38,6 @@ MenuItemIcon.propTypes = {
   ...commonPropTypes.createCommon(),
   hasContent: PropTypes.bool,
   iconOnly: PropTypes.bool,
-};
-MenuItemIcon.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default MenuItemIcon;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemIndicator.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import { indicatorBehavior } from '@fluentui/accessibility';
 import * as PropTypes from 'prop-types';
 
@@ -50,7 +50,10 @@ const MenuItemIndicator = compose<'span', MenuItemIndicatorProps, MenuItemIndica
   handledProps: ['iconOnly', 'vertical', 'inSubmenu', 'active', 'primary', 'underlined'],
 
   overrideStyles: true,
-}) as ComponentWithAs<'span', MenuItemIndicatorProps> & { shorthandConfig: ShorthandConfig<MenuItemIndicatorProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 MenuItemIndicator.defaultProps = {
   as: 'span',
@@ -64,9 +67,6 @@ MenuItemIndicator.propTypes = {
   active: PropTypes.bool,
   primary: PropTypes.bool,
   underlined: PropTypes.bool,
-};
-MenuItemIndicator.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default MenuItemIndicator;

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
@@ -1,4 +1,4 @@
-import { compose, ComponentWithAs, ShorthandConfig } from '@fluentui/react-bindings';
+import { compose } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import { commonPropTypes } from '../../utils';
@@ -90,7 +90,10 @@ const MenuItemWrapper = compose<'li', MenuItemWrapperProps, MenuItemWrapperStyle
   ],
 
   overrideStyles: true,
-}) as ComponentWithAs<'li', MenuItemWrapperProps> & { shorthandConfig: ShorthandConfig<MenuItemWrapperProps> };
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
 
 MenuItemWrapper.defaultProps = {
   as: 'li',
@@ -107,9 +110,6 @@ MenuItemWrapper.propTypes = {
   secondary: customPropTypes.every([customPropTypes.disallow(['primary']), PropTypes.bool]),
   underlined: PropTypes.bool,
   vertical: PropTypes.bool,
-};
-MenuItemWrapper.shorthandConfig = {
-  mappedProp: 'content',
 };
 
 export default MenuItemWrapper;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The support for `shorthandConfig` under `composeOptions` was added in #13240. This PR simply move the usage to `compose()` instead of statics. No user-facing changes.

#### Focus areas to test

(optional)
