### PR TITLE
chore: update Webpack config for bundle size task in v0

### DIFF
--- a/scripts/webpack/webpack.config.stats.ts
+++ b/scripts/webpack/webpack.config.stats.ts
@@ -5,6 +5,7 @@ import webpack from 'webpack';
 import config from '../config';
 import glob from 'glob';
 import * as _ from 'lodash';
+import TerserWebpackPlugin from 'terser-webpack-plugin';
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const { paths } = config;
@@ -59,7 +60,22 @@ const makeConfig = (srcPath: string, name: string): webpack.Configuration => ({
     'react-dom': 'reactDOM',
   },
   optimization: {
-    concatenateModules: false,
+    minimizer: [
+      new TerserWebpackPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: false,
+
+        terserOptions: {
+          mangle: false,
+          output: {
+            beautify: true,
+            comments: true,
+            preserve_annotations: true,
+          },
+        },
+      }),
+    ],
   },
   plugins: [
     new CleanWebpackPlugin([paths.base('stats')], {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR changes `webpack.config` for bundle size measurements in v0:
![image](https://user-images.githubusercontent.com/14183168/86127643-88df5600-bae0-11ea-9c74-e26cbff8ff6f.png)

There are two changes:
- enable `concatenateModules` as actually all tree-shaking in Webpack based on this
- update settings for `TerserWebpackPlugin` to easier debug possible concatenation bailouts. This will make numbers potentially inaccurate as the code will not be fully minified

#### Focus areas to test

(optional)
