### PR TITLE
chore(Grid): convert to be function component

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## BREAKING CHANGES
+- Restricted prop sets in the `Grid` component which are passed to styles functions @layershifter ([#13863](https://github.com/microsoft/fluentui/pull/13863))
+
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
 - Updating list item to use the Teams redlines @notandrew ([#13233](https://github.com/microsoft/fluentui/pull/13233))

--- a/packages/fluentui/accessibility/src/behaviors/Grid/gridBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Grid/gridBehavior.ts
@@ -17,4 +17,6 @@ const gridBehavior: Accessibility = () => ({
   },
 });
 
+export type GridBehaviorProps = never;
+
 export default gridBehavior;

--- a/packages/fluentui/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Grid/gridHorizontalBehavior.ts
@@ -1,5 +1,6 @@
 import { Accessibility } from '../../types';
 import { FocusZoneDirection } from '../../focusZone/types';
+import { GridBehaviorProps } from './gridBehavior';
 
 /**
  * @description
@@ -9,7 +10,7 @@ import { FocusZoneDirection } from '../../focusZone/types';
  * @specification
  * Provides arrow key navigation in bidirectionalDomOrder direction.
  */
-const gridHorizontalBehavior: Accessibility = () => ({
+const gridHorizontalBehavior: Accessibility<GridBehaviorProps> = () => ({
   attributes: {},
   focusZone: {
     props: {

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -75,6 +75,7 @@ export { default as chatMessageBehavior } from './Chat/chatMessageBehavior';
 export * from './Chat/chatMessageBehavior';
 export { default as formFieldBehavior } from './Form/formFieldBehavior';
 export * from './Form/formFieldBehavior';
+export * from './Grid/gridBehavior';
 export { default as gridBehavior } from './Grid/gridBehavior';
 export { default as gridHorizontalBehavior } from './Grid/gridHorizontalBehavior';
 export { default as hierarchicalTreeBehavior } from './HierarchicalTree/hierarchicalTreeBehavior';

--- a/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
+++ b/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
@@ -61,18 +61,16 @@ const Grid: React.FC<WithAsProp<GridProps>> & FluentComponentStaticProps<GridPro
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Grid.handledProps, props);
 
-  const element = (
-    <>
-      <ElementType
-        {...getA11yProps('root', {
-          className: classes.root,
-          ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
-          ...unhandledProps,
-        })}
-      >
-        {childrenExist(children) ? children : content}
-      </ElementType>
-    </>
+  const element = getA11yProps.unstable_wrapWithFocusZone(
+    <ElementType
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
+        ...unhandledProps,
+      })}
+    >
+      {childrenExist(children) ? children : content}
+    </ElementType>,
   );
   setEnd();
 

--- a/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
+++ b/packages/fluentui/react-northstar/src/components/Grid/Grid.tsx
@@ -1,25 +1,27 @@
-import { Accessibility } from '@fluentui/accessibility';
+import { Accessibility, GridBehaviorProps } from '@fluentui/accessibility';
+import { getElementType, useAccessibility, useStyles, useTelemetry, useUnhandledProps } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+
 import {
-  UIComponent,
   childrenExist,
-  RenderResultConfig,
   UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
   ContentComponentProps,
   rtlTextContainer,
 } from '../../utils';
-import { WithAsProp, withSafeTypeForAs } from '../../types';
+import { FluentComponentStaticProps, ProviderContextPrepared, WithAsProp, withSafeTypeForAs } from '../../types';
 
 export interface GridProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps {
   /**
    * Accessibility behavior if overridden by the user.
    * @available gridBehavior, gridHorizontalBehavior
    * */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<GridBehaviorProps>;
 
   /** The columns of the grid with a space-separated list of values. The values represent the track size, and the space between them represents the grid line. */
   columns?: number;
@@ -30,42 +32,67 @@ export interface GridProps extends UIComponentProps, ChildrenComponentProps, Con
 
 export const gridClassName = 'ui-grid';
 
-class Grid extends UIComponent<WithAsProp<GridProps>> {
-  static displayName = 'Grid';
+export type GridStylesProps = Pick<GridProps, 'columns' | 'rows'>;
 
-  static deprecated_className = gridClassName;
+const Grid: React.FC<WithAsProp<GridProps>> & FluentComponentStaticProps<GridProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(Grid.displayName, context.telemetry);
+  setStart();
 
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false,
+  const { accessibility, children, className, columns, content, design, rows, styles, variables } = props;
+
+  const getA11yProps = useAccessibility(accessibility, {
+    debugName: Grid.displayName,
+
+    rtl: context.rtl,
+  });
+  const { classes } = useStyles<GridStylesProps>(Grid.displayName, {
+    className: gridClassName,
+    mapPropsToStyles: () => ({ columns, rows }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
     }),
-    columns: PropTypes.number,
-    content: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([PropTypes.arrayOf(customPropTypes.nodeContent), customPropTypes.nodeContent]),
-    ]),
-    rows: PropTypes.number,
-  };
+    rtl: context.rtl,
+  });
 
-  static defaultProps: WithAsProp<GridProps> = {
-    as: 'div',
-  };
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(Grid.handledProps, props);
 
-  renderComponent({ accessibility, ElementType, classes, unhandledProps }: RenderResultConfig<any>): React.ReactNode {
-    const { children, content } = this.props;
-
-    return (
+  const element = (
+    <>
       <ElementType
-        className={classes.root}
-        {...rtlTextContainer.getAttributes({ forElements: [children, content] })}
-        {...accessibility.attributes.root}
-        {...unhandledProps}
+        {...getA11yProps('root', {
+          className: classes.root,
+          ...rtlTextContainer.getAttributes({ forElements: [children, content] }),
+          ...unhandledProps,
+        })}
       >
         {childrenExist(children) ? children : content}
       </ElementType>
-    );
-  }
-}
+    </>
+  );
+  setEnd();
+
+  return element;
+};
+
+Grid.displayName = 'Grid';
+
+Grid.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false,
+  }),
+  columns: PropTypes.number,
+  content: customPropTypes.every([
+    customPropTypes.disallow(['children']),
+    PropTypes.oneOfType([PropTypes.arrayOf(customPropTypes.nodeContent), customPropTypes.nodeContent]),
+  ]),
+  rows: PropTypes.number,
+};
+Grid.handledProps = Object.keys(Grid.propTypes) as any;
 
 /**
  * A Grid is a layout component that harmonizes negative space, by controlling both the row and column alignment.

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Grid/gridStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Grid/gridStyles.ts
@@ -1,12 +1,12 @@
 import { GridVariables } from './gridVariables';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
-import { GridProps } from '../../../../components/Grid/Grid';
+import { GridStylesProps } from '../../../../components/Grid/Grid';
 
 const getCSSTemplateValue = (template: number, gap: string = ''): string => {
   return Array.from({ length: template }, () => '1fr').join(` ${gap} `);
 };
 
-const gridStyles: ComponentSlotStylesPrepared<GridProps, GridVariables> = {
+const gridStyles: ComponentSlotStylesPrepared<GridStylesProps, GridVariables> = {
   root: ({ props, variables: { height, width, defaultColumnCount, gridGap, padding } }): ICSSInJSStyle => {
     const { rows, columns = !props.rows && defaultColumnCount } = props;
 

--- a/packages/fluentui/react-northstar/src/themes/teams/types.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/types.ts
@@ -40,7 +40,7 @@ import { FormStylesProps } from '../../components/Form/Form';
 import { FormFieldStylesProps } from '../../components/Form/FormField';
 import { FormLabelStylesProps } from '../../components/Form/FormLabel';
 import { FormMessageStylesProps } from '../../components/Form/FormMessage';
-import { GridProps } from '../../components/Grid/Grid';
+import { GridStylesProps } from '../../components/Grid/Grid';
 import { HeaderDescriptionStylesProps } from '../../components/Header/HeaderDescription';
 import { HeaderStylesProps } from '../../components/Header/Header';
 import { ImageStylesProps } from '../../components/Image/Image';
@@ -136,7 +136,7 @@ export type TeamsThemeStylesProps = {
   FormField: FormFieldStylesProps;
   FormLabel: FormLabelStylesProps;
   FormMessage: FormMessageStylesProps;
-  Grid: GridProps;
+  Grid: GridStylesProps;
   Header: HeaderStylesProps;
   HeaderDescription: HeaderDescriptionStylesProps;
   SvgIcon: SvgIconStylesProps;

--- a/packages/fluentui/react-northstar/test/specs/components/Grid/Grid-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Grid/Grid-test.tsx
@@ -3,5 +3,5 @@ import { isConformant } from 'test/specs/commonTests';
 import Grid from 'src/components/Grid/Grid';
 
 describe('Grid', () => {
-  isConformant(Grid);
+  isConformant(Grid, { constructorName: 'Grid' });
 });


### PR DESCRIPTION
# BREAKING CHANGES

This PR converts `Grid` component to be functional and restricts props set that will be passed to styles functions.

Related to #12237.

## Prop sets

| `Grid`    |
| --------- |
| `columns` |
| `rows` |
