### PR TITLE
Use correct target window for ResizeGroup animation frame callback

### DIFF
--- a/change/office-ui-fabric-react-2020-06-27-10-06-13-resize-group-animation.json
+++ b/change/office-ui-fabric-react-2020-06-27-10-06-13-resize-group-animation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure ResizeGroup uses correct window for animation frame",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-27T17:06:13.621Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -438,7 +438,7 @@ export class ResizeGroupBase extends React.Component<IResizeGroupProps, IResizeG
       if (nextState) {
         this.setState(nextState);
       }
-    });
+    }, this._root.current);
   }
 
   private _onResize(): void {


### PR DESCRIPTION
Fixed an issue where `targetElement` was not passed to `Async.requestAnimationFrame` by `ResizeGroup`. The result is that in Electron apps with cross-window rendering, the animation frame would not be called back.