### PR TITLE
Button color on expand

### DIFF
--- a/change/@uifabric-azure-themes-2020-07-01-14-38-23-button-color-on-expand.json
+++ b/change/@uifabric-azure-themes-2020-07-01-14-38-23-button-color-on-expand.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed primary button color on expand",
+  "packageName": "@uifabric/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-01T06:38:23.269Z"
+}

--- a/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DefaultButton.styles.ts
@@ -11,17 +11,14 @@ export const DefaultButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       fontSize: FontSizes.size13,
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorder}`,
       color: semanticColors.buttonText,
-      selectors: {
-        // standard button
-        '&.is-expanded': {
-          color: semanticColors.buttonText,
-        },
-      },
     },
     rootDisabled: {
       backgroundColor: semanticColors.buttonBackgroundDisabled,
       color: semanticColors.buttonTextDisabled,
       border: `0px`,
+    },
+    rootExpanded: {
+      color: semanticColors.buttonText,
     },
     rootHovered: {
       border: `${StyleConstants.borderWidth} solid ${semanticColors.inputBorderHovered}`,

--- a/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
+++ b/packages/azure-themes/src/azure/styles/PrimaryButton.styles.ts
@@ -15,6 +15,9 @@ export const PrimaryButtonStyles = (theme: ITheme): Partial<IButtonStyles> => {
       backgroundColor: semanticColors.primaryButtonBackgroundDisabled,
       color: semanticColors.primaryButtonTextDisabled,
     },
+    rootExpanded: {
+      color: semanticColors.primaryButtonText,
+    },
     rootFocused: {
       color: semanticColors.primaryButtonText,
       borderColor: semanticColors.primaryButtonBorder,

--- a/packages/azure-themes/src/stories/components/contextualMenu.tsx
+++ b/packages/azure-themes/src/stories/components/contextualMenu.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ContextualMenu, DefaultButton, IContextualMenuProps, IIconProps } from 'office-ui-fabric-react';
+import { ContextualMenu, DefaultButton, IContextualMenuProps, IIconProps, PrimaryButton } from 'office-ui-fabric-react';
 
 export interface IButtonExampleProps {
   // These are set based on the toggles shown above the examples (not needed in real code)
@@ -33,22 +33,26 @@ const addIcon: IIconProps = { iconName: 'Add' };
 export const ButtonContextualMenuExample: React.FunctionComponent<IButtonExampleProps> = props => {
   const { disabled, checked } = props;
 
+  const buttonProps = {
+    text: 'New item',
+    iconProps: addIcon,
+    menuProps: menuProps,
+    // Optional callback to customize menu rendering
+    menuAs: _getMenu,
+    // Optional callback to do other actions (besides opening the menu) on click
+    // onMenuClick={_onMenuClick}
+    // By default, the ContextualMenu is re-created each time it's shown and destroyed when closed.
+    // Uncomment the next line to hide the ContextualMenu but persist it in the DOM instead.
+    // persistMenu={true}
+    allowDisabledFocus: true,
+    disabled: disabled,
+    checked: checked,
+  };
   return (
-    <DefaultButton
-      text="New item"
-      iconProps={addIcon}
-      menuProps={menuProps}
-      // Optional callback to customize menu rendering
-      menuAs={_getMenu}
-      // Optional callback to do other actions (besides opening the menu) on click
-      // onMenuClick={_onMenuClick}
-      // By default, the ContextualMenu is re-created each time it's shown and destroyed when closed.
-      // Uncomment the next line to hide the ContextualMenu but persist it in the DOM instead.
-      // persistMenu={true}
-      allowDisabledFocus
-      disabled={disabled}
-      checked={checked}
-    />
+    <>
+      <DefaultButton {...buttonProps} />
+      <PrimaryButton {...buttonProps} />
+    </>
   );
 };
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Azure theme provided on-expand color style for DefaultButton, but didn't for PrimaryButton, causing PrimaryButton showing DefaultButton color on expand.
![image](https://user-images.githubusercontent.com/67673432/86214865-5d2aa180-bbae-11ea-8ecd-973cd24c0f78.png)

Other fixes:
1. Added PrimaryButton to ButtonContextualMenuExample
2. Replaced selector with rootExpanded for DefaultButton. DefaultButton's selector bypassed PrimaryButton's rootExpanded.

After fix
![image](https://user-images.githubusercontent.com/67673432/86215096-c01c3880-bbae-11ea-9a1f-e196f8b6d1cf.png)

Verified DefaultButton's on-expand color is not effected.
![image](https://user-images.githubusercontent.com/67673432/86215221-e641d880-bbae-11ea-8031-d198b532957a.png)


#### Focus areas to test

(optional)
