### PR TITLE
fix(FormPrototype): fix IE11

### DIFF
--- a/scripts/webpack/webpack.config.ts
+++ b/scripts/webpack/webpack.config.ts
@@ -118,6 +118,7 @@ const webpackConfig: webpack.Configuration = {
     alias: {
       ...lernaAliases(),
       src: paths.packageSrc('react-northstar'),
+      'react-hook-form': 'react-hook-form/dist/react-hook-form.ie11',
     },
   },
   optimization: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

[`react-hook-form` is not compatible with ie11](https://github.com/react-hook-form/react-hook-form/issues/56). This PR adds the alias for webpack suggested as solution.

#### Focus areas to test

(optional)
