### PR TITLE
Revert "resolveSlotProps: when slot/shorthand prop has JSX element as children, slot should be completely replaced by it"

### DIFF
--- a/change/@fluentui-react-compose-2020-07-01-10-08-42-xgao-fix-slot-prop.json
+++ b/change/@fluentui-react-compose-2020-07-01-10-08-42-xgao-fix-slot-prop.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Revert \"resolveSlotProps: when slot/shorthand prop has JSX element as children, slot should be completely replaced by it (#13827)\"",
+  "packageName": "@fluentui/react-compose",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-01T17:08:42.245Z"
+}

--- a/packages/react-compose/src/resolveSlotProps.test.tsx
+++ b/packages/react-compose/src/resolveSlotProps.test.tsx
@@ -66,10 +66,7 @@ describe('resolveSlotProps', () => {
         defaultOptionsWithSlots,
       ),
     ).toEqual({
-      slots: {
-        ...getDefaultSlots().slots,
-        slot1: React.Fragment,
-      },
+      ...getDefaultSlots(),
       state,
       slotProps: {
         root: {},

--- a/packages/react-compose/src/resolveSlotProps.ts
+++ b/packages/react-compose/src/resolveSlotProps.ts
@@ -40,15 +40,12 @@ export function resolveSlotProps<TProps, TState = TProps>(
         (slot && slot.shorthandConfig && slot.shorthandConfig.mappedProp) || defaultMappedProps[slot],
       );
 
-      const isChildrenFunction = typeof mergedSlotProp.children === 'function';
-      if (isChildrenFunction || React.isValidElement(mergedSlotProp.children)) {
+      if (typeof mergedSlotProp.children === 'function') {
         const { children, ...restProps } = slotProp;
-
+        // If the children is a function, replace the slot.
         slots[slotName] = React.Fragment;
         slotProps[slotName] = {
-          children: isChildrenFunction
-            ? mergedSlotProp.children(slot, { ...slotProps[slotName], ...restProps })
-            : mergedSlotProp.children,
+          children: slotProp.children(slot, { ...slotProps[slotName], ...restProps }),
         };
       } else {
         slotProps[slotName] = mergedSlotProp;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Revert #13827. Chatted with David and this is not the behavior we want. For majority of the cases of changing slot, container element is needed. 

#### Focus areas to test

(optional)
