### PR TITLE
Fix build: yarn.lock is out of sync

### DIFF
--- a/apps/codesandbox-react-template/package.json
+++ b/apps/codesandbox-react-template/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@uifabric/set-version": "^7.0.15",
     "@microsoft/load-themed-styles": "^1.10.26",
-    "@fluentui/react": "7.121.7",
+    "@fluentui/react": "^7.121.7",
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,15 +1182,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@fluentui/react@7.121.4":
-  version "7.121.4"
-  resolved "https://registry.yarnpkg.com/@fluentui/react/-/react-7.121.4.tgz#f069161a8ecac006a7e931cada1ec7591be79ca3"
-  integrity sha512-df2sWMC3wGbo/k1Ilyf9JEIdReUz9lOkjqkqjx9bI1eh4WTM2pAay/RFnt2wcgZcowb/FkCVyNPgbVja7BvYtg==
-  dependencies:
-    "@uifabric/set-version" "^7.0.15"
-    office-ui-fabric-react "^7.121.4"
-    tslib "^1.10.0"
-
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Here is i saw what happened:

1. This change seems unexpected, it's referencing a wrong version of `@fluentui/react`: https://github.com/microsoft/fluentui/commit/acc9cc976871838be5967d6d303ebee44f557f24#diff-8ee2343978836a779dc9f8d6b794c3b2

2. Then when we apply package updates which fixed the package version, which caused `yarn.lock` to be out of sync: https://github.com/microsoft/fluentui/commit/4252ec8288267f4330a6344eadbf9093fd423704

#### Focus areas to test

(optional)
