### PR TITLE
Toggle: remove double label for

### DIFF
--- a/change/@fluentui-react-next-2020-07-01-17-10-39-t-dama-remove_double_LabelFor.json
+++ b/change/@fluentui-react-next-2020-07-01-17-10-39-t-dama-remove_double_LabelFor.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "repeat fix in useToggle.ts",
+  "packageName": "@fluentui/react-next",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-01T21:10:39.501Z"
+}

--- a/change/office-ui-fabric-react-2020-06-30-19-54-07-t-dama-remove_double_LabelFor.json
+++ b/change/office-ui-fabric-react-2020-06-30-19-54-07-t-dama-remove_double_LabelFor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combine labelId and StateTextId in labelledById and update tests",
+  "packageName": "office-ui-fabric-react",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-06-30T23:54:07.330Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -109,7 +109,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
         labelledById = labelId;
       }
       if (stateText) {
-        labelledById = labelledById ? (labelledById += ' ' + stateTextId) : stateTextId;
+        labelledById = labelledById ? labelledById + ' ' + stateTextId : stateTextId;
       }
     }
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -146,8 +146,8 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
         {(keytipAttributes: any): JSX.Element => renderPill(keytipAttributes)}
       </KeytipData>
     ) : (
-      renderPill()
-    );
+        renderPill()
+      );
 
     return (
       <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -101,14 +101,15 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
     // The following properties take priority for what Narrator should read:
     // 1. ariaLabel
     // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
-    // 3. label
-    // 4. onText (if checked) or offText (if not checked)
+    // 3. label AND stateText, if existent
+
     let labelledById: string | undefined = undefined;
     if (!ariaLabel && !badAriaLabel) {
       if (label) {
         labelledById = labelId;
-      } else if (stateText) {
-        labelledById = stateTextId;
+      }
+      if (stateText) {
+        labelledById = labelledById ? (labelledById += ' ' + stateTextId) : stateTextId;
       }
     }
 
@@ -159,6 +160,8 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
         <div className={classNames.container}>
           {pillContent}
           {stateText && (
+            // This second "htmlFor" property is needed to allow the
+            // toggle's stateText to also trigger a state change when clicked.
             <Label htmlFor={this._id} className={classNames.text} id={stateTextId}>
               {stateText}
             </Label>

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -109,7 +109,7 @@ export class ToggleBase extends React.Component<IToggleProps, IToggleState> impl
         labelledById = labelId;
       }
       if (stateText) {
-        labelledById = labelledById ? labelledById + ' ' + stateTextId : stateTextId;
+        labelledById = labelledById ? `${labelledById} ${stateTextId}` : stateTextId;
       }
     }
 

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.test.tsx
@@ -143,7 +143,7 @@ describe('Toggle', () => {
       </form>,
     );
     const button: any = wrapper.find('button');
-    // simulate to change toggle state
+    // Simulate to change toggle state.
     button.simulate('click');
     expect((component as React.Component<any, any>).state.checked).toEqual(true);
     expect(onSubmit.called).toEqual(false);
@@ -186,8 +186,8 @@ describe('Toggle', () => {
       ).toBe('ToggleId-stateText');
     });
 
-    it('is labelled by the state text element if no aria labels are provided and no label is provided', () => {
-      const component = mount(<Toggle onText="On" offText="Off" id="ToggleId" />);
+    it('is labelled by the label AND state text elements if no aria labels are provided', () => {
+      const component = mount(<Toggle label="Label" onText="On" offText="Off" id="ToggleId" />);
 
       expect(
         component
@@ -195,7 +195,7 @@ describe('Toggle', () => {
           .first()
           .getDOMNode()
           .getAttribute('aria-labelledby'),
-      ).toBe('ToggleId-stateText');
+      ).toBe('ToggleId-label ToggleId-stateText');
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -558,7 +558,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
-      aria-labelledby="Toggle4-label"
+      aria-labelledby="Toggle4-label Toggle4-stateText"
       className=
           ms-Toggle-background
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -87,7 +87,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle0-label"
+          aria-labelledby="Toggle0-label Toggle0-stateText"
           checked={false}
           className=
               ms-Toggle-background
@@ -261,7 +261,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle1-label"
+          aria-labelledby="Toggle1-label Toggle1-stateText"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -67,7 +67,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
       >
         <button
           aria-checked={true}
-          aria-labelledby="Toggle0-label"
+          aria-labelledby="Toggle0-label Toggle0-stateText"
           checked={true}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label"
+        aria-labelledby="Toggle0-label Toggle0-stateText"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle0-label"
+          aria-labelledby="Toggle0-label Toggle0-stateText"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -280,7 +280,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle3-label"
+            aria-labelledby="Toggle3-label Toggle3-stateText"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -280,7 +280,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle3-label"
+            aria-labelledby="Toggle3-label Toggle3-stateText"
             checked={false}
             className=
                 ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
       >
         <button
           aria-checked={false}
-          aria-labelledby="Toggle0-label"
+          aria-labelledby="Toggle0-label Toggle0-stateText"
           checked={false}
           className=
               ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -98,7 +98,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         >
           <button
             aria-checked={false}
-            aria-labelledby="Toggle0-label"
+            aria-labelledby="Toggle0-label Toggle0-stateText"
             checked={false}
             className=
                 ms-Toggle-background
@@ -428,7 +428,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             >
               <button
                 aria-checked={false}
-                aria-labelledby="Toggle4-label"
+                aria-labelledby="Toggle4-label Toggle4-stateText"
                 checked={false}
                 className=
                     ms-Toggle-background
@@ -758,7 +758,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 >
                   <button
                     aria-checked={false}
-                    aria-labelledby="Toggle8-label"
+                    aria-labelledby="Toggle8-label Toggle8-stateText"
                     checked={false}
                     className=
                         ms-Toggle-background
@@ -1101,7 +1101,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 >
                   <button
                     aria-checked={false}
-                    aria-labelledby="Toggle12-label"
+                    aria-labelledby="Toggle12-label Toggle12-stateText"
                     checked={false}
                     className=
                         ms-Toggle-background
@@ -1456,7 +1456,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             >
               <button
                 aria-checked={false}
-                aria-labelledby="Toggle16-label"
+                aria-labelledby="Toggle16-label Toggle16-stateText"
                 checked={false}
                 className=
                     ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -55,7 +55,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label"
+        aria-labelledby="Toggle0-label Toggle0-stateText"
         checked={false}
         className=
             ms-Toggle-background

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -76,7 +76,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-labelledby="Toggle0-label"
+        aria-labelledby="Toggle0-label Toggle0-stateText"
         className=
             ms-Toggle-background
             {
@@ -250,7 +250,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle1-label"
+        aria-labelledby="Toggle1-label Toggle1-stateText"
         className=
             ms-Toggle-background
             {
@@ -424,7 +424,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={true}
         aria-disabled={true}
-        aria-labelledby="Toggle2-label"
+        aria-labelledby="Toggle2-label Toggle2-stateText"
         className=
             ms-Toggle-background
             {
@@ -593,7 +593,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
-        aria-labelledby="Toggle3-label"
+        aria-labelledby="Toggle3-label Toggle3-stateText"
         className=
             ms-Toggle-background
             {
@@ -759,7 +759,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle4-label"
+        aria-labelledby="Toggle4-label Toggle4-stateText"
         className=
             ms-Toggle-background
             {
@@ -935,7 +935,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       <button
         aria-checked={false}
         aria-disabled={true}
-        aria-labelledby="Toggle5-label"
+        aria-labelledby="Toggle5-label Toggle5-stateText"
         className=
             ms-Toggle-background
             {
@@ -1355,7 +1355,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
     >
       <button
         aria-checked={true}
-        aria-labelledby="Toggle8-label"
+        aria-labelledby="Toggle8-label Toggle8-stateText"
         className=
             ms-Toggle-background
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -108,7 +108,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle0-label"
+        aria-labelledby="Toggle0-label Toggle0-stateText"
         className=
             ms-Toggle-background
             {
@@ -313,7 +313,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
     >
       <button
         aria-checked={false}
-        aria-labelledby="Toggle2-label"
+        aria-labelledby="Toggle2-label Toggle2-stateText"
         className=
             ms-Toggle-background
             {

--- a/packages/react-next/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react-next/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -232,7 +232,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
-      aria-labelledby="id__0-label"
+      aria-labelledby="id__0-label id__0-stateText"
       className="ms-Toggle-background"
       data-is-focusable={true}
       id="id__0"

--- a/packages/react-next/src/components/Toggle/useToggle.ts
+++ b/packages/react-next/src/components/Toggle/useToggle.ts
@@ -62,14 +62,15 @@ export const useToggle = (
   // The following properties take priority for what Narrator should read:
   // 1. ariaLabel
   // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
-  // 3. label
-  // 4. onText (if checked) or offText (if not checked)
+  // 3. label AND stateText, if existent
+
   let labelledById: string | undefined = undefined;
   if (!ariaLabel && !badAriaLabel) {
     if (label) {
       labelledById = labelId;
-    } else if (stateText) {
-      labelledById = stateTextId;
+    }
+    if (stateText) {
+      labelledById = labelledById ? `${labelledById} ${stateTextId}` : stateTextId;
     }
   }
 


### PR DESCRIPTION
Fixes #12708 

#### Description of changes

Removed mutual exclusivity of LABELID and STATETEXTID in LABELLEDBYID in the toggle component.

Previous behavior: If both LABEL and STATETEXT were present, LABELLEDBYID would only store LABELID, causing the STATETEXT to be ignored by the screen reader.

Current behavior: LABELID and STATETEXTID are no longer mutually exclusive; a screen reader will now read the extant properties, no longer omitting STATETEXT. 

Behavioral note: Now that the screen reader will read both LABEL and STATETEXT if present, the narrator (on Edge at least) will read LABEL and STATETEXT as well as "ON" or "OFF" depending on the checked state of the toggle.

Note: The initial fix pointed out that there are two "Label forhtml" in toggle, but they are both required so that clicking on either will toggle a state change. Discussed further in #8597