### PR TITLE
fix(components): Fix input and menu styles for IE11

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -107,6 +107,7 @@ const themeOverrides = {
     MenuItemBlue: {
       root: {
         backgroundColor: 'lightblue',
+        height: '100%',
       },
     },
     MenuItemIconGreen: {
@@ -122,8 +123,6 @@ const themeOverrides = {
     MenuitemIndicatorSaturated: {
       root: {
         filter: 'saturate(8)',
-        height: '20px',
-        width: '20px',
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -122,6 +122,7 @@ const themeOverrides = {
     MenuitemIndicatorSaturated: {
       root: {
         filter: 'saturate(8)',
+        backgroundSize: '20px',
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -14,6 +14,7 @@ import {
   MenuItemProps,
   MenuItemStylesProps,
 } from '@fluentui/react-northstar';
+import { FloatProperty } from 'csstype';
 
 const MenuItemWrapperDashed = compose(MenuItemWrapper, {
   displayName: 'MenuItemWrapperDashed',
@@ -126,7 +127,7 @@ const themeOverrides = {
         backgroundSize: '20px',
         height: '20px',
         width: '20px',
-        float: 'right',
+        float: 'right' as FloatProperty,
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -122,8 +122,6 @@ const themeOverrides = {
     MenuitemIndicatorSaturated: {
       root: {
         filter: 'saturate(8)',
-        height: '20px',
-        width: '20px',
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -107,6 +107,7 @@ const themeOverrides = {
     MenuItemBlue: {
       root: {
         backgroundColor: 'lightblue',
+        overflow: 'visible',
       },
     },
     MenuItemIconGreen: {
@@ -123,6 +124,9 @@ const themeOverrides = {
       root: {
         filter: 'saturate(8)',
         backgroundSize: '20px',
+        height: '20px',
+        width: '20px',
+        float: 'right',
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExampleCompose.shorthand.tsx
@@ -107,7 +107,6 @@ const themeOverrides = {
     MenuItemBlue: {
       root: {
         backgroundColor: 'lightblue',
-        height: '100%',
       },
     },
     MenuItemIconGreen: {
@@ -123,6 +122,8 @@ const themeOverrides = {
     MenuitemIndicatorSaturated: {
       root: {
         filter: 'saturate(8)',
+        height: '20px',
+        width: '20px',
       },
     },
     MenuItemWrapperDashed: {

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertStyles.ts
@@ -111,8 +111,9 @@ const alertStyles: ComponentSlotStylesPrepared<AlertStylesProps, AlertVariables>
     flexGrow: 1,
   }),
 
-  content: (): ICSSInJSStyle => ({
+  content: ({ variables: v }): ICSSInJSStyle => ({
     flexGrow: 1,
+    lineHeight: v.minHeight,
   }),
 
   icon: ({ variables: v }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Alert/alertStyles.ts
@@ -111,9 +111,8 @@ const alertStyles: ComponentSlotStylesPrepared<AlertStylesProps, AlertVariables>
     flexGrow: 1,
   }),
 
-  content: ({ variables: v }): ICSSInJSStyle => ({
+  content: (): ICSSInJSStyle => ({
     flexGrow: 1,
-    lineHeight: v.minHeight,
   }),
 
   icon: ({ variables: v }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
@@ -58,6 +58,10 @@ const inputStyles: ComponentSlotStylesPrepared<InputStylesProps, InputVariables>
     ...(p.hasIcon && {
       padding: p.iconPosition === 'start' ? v.inputPaddingWithIconAtStart : v.inputPaddingWithIconAtEnd,
     }),
+
+    '::-ms-clear ': {
+      display: 'none',
+    },
   }),
 
   icon: ({ props: p, variables: v }): ICSSInJSStyle => ({

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
@@ -67,6 +67,7 @@ const inputStyles: ComponentSlotStylesPrepared<InputStylesProps, InputVariables>
     alignItems: 'center',
     justifyContent: 'center',
     position: v.iconPosition as PositionProperty,
+    top: pxToRem(8),
     ...(p.error && { color: v.colorError }),
     ...(p.requiredAndSuccessful && {
       color: v.successfulColor,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Input/inputStyles.ts
@@ -67,7 +67,8 @@ const inputStyles: ComponentSlotStylesPrepared<InputStylesProps, InputVariables>
     alignItems: 'center',
     justifyContent: 'center',
     position: v.iconPosition as PositionProperty,
-    top: pxToRem(8),
+    top: 0,
+    bottom: 0,
     ...(p.error && { color: v.colorError }),
     ...(p.requiredAndSuccessful && {
       color: v.successfulColor,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
@@ -8,7 +8,7 @@ const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStyl
   root: ({ props: p, variables: v, rtl }) => {
     return {
       position: 'relative',
-      verticalAlign: 'top',
+      float: 'right',
       left: pxToRem(12),
       userSelect: 'none',
       marginRight: pxToRem(4),
@@ -24,10 +24,11 @@ const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStyl
         transform: `scaleX(-1)`,
       }),
       content: '" "',
-      display: 'inline-block',
+      display: 'block',
       overflow: 'hidden',
-      height: pxToRem(16),
+      height: pxToRem(14),
       width: pxToRem(16),
+      backgroundSize: pxToRem(16),
 
       backgroundImage: submenuIndicatorUrl(v.indicatorColor, p.vertical),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
@@ -8,7 +8,7 @@ const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStyl
   root: ({ props: p, variables: v, rtl }) => {
     return {
       position: 'relative',
-      float: 'right',
+      verticalAlign: 'top',
       left: pxToRem(12),
       userSelect: 'none',
       marginRight: pxToRem(4),
@@ -24,7 +24,7 @@ const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStyl
         transform: `scaleX(-1)`,
       }),
       content: '" "',
-      display: 'block',
+      display: 'inline-block',
       overflow: 'hidden',
       height: pxToRem(16),
       width: pxToRem(16),

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemIndicatorStyles.ts
@@ -26,7 +26,7 @@ const menuItemIndicatorStyles: ComponentSlotStylesPrepared<MenuItemIndicatorStyl
       content: '" "',
       display: 'block',
       overflow: 'hidden',
-      height: pxToRem(14),
+      height: pxToRem(16),
       width: pxToRem(16),
       backgroundSize: pxToRem(16),
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -140,6 +140,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, MenuVaria
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        overflow: 'visible',
       }),
 
       // active styles

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -116,7 +116,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, MenuVaria
 
     return {
       color: 'inherit',
-      display: 'block',
+      display: 'flex',
       cursor: 'pointer',
       whiteSpace: 'nowrap',
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -116,7 +116,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, MenuVaria
 
     return {
       color: 'inherit',
-      display: 'flex',
+      display: 'block',
       cursor: 'pointer',
       whiteSpace: 'nowrap',
 

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -119,7 +119,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemStylesProps, MenuVaria
       display: 'block',
       cursor: 'pointer',
       whiteSpace: 'nowrap',
-
+      overflow: 'hidden',
       ...(pointing &&
         vertical && {
           border: '1px solid transparent',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

[Deployed Site](http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/13901/merge/react-northstar)

This PR fixes styles for `Input` and `Menu` in IE11

`Input` before:

<img width="446" alt="Screenshot 2020-07-07 at 09 28 44" src="https://user-images.githubusercontent.com/8545105/86745164-71e9b800-c03a-11ea-8b11-4431c05bb070.png">

after: 

<img width="420" alt="Screenshot 2020-07-07 at 10 12 04" src="https://user-images.githubusercontent.com/8545105/86745199-79a95c80-c03a-11ea-958d-d3f6f218b875.png">

`Menu` before:

<img width="325" alt="Screenshot 2020-07-07 at 09 29 48" src="https://user-images.githubusercontent.com/8545105/86745266-84fc8800-c03a-11ea-908b-26558b5e69ba.png">

after:

<img width="330" alt="Screenshot 2020-07-07 at 10 11 26" src="https://user-images.githubusercontent.com/8545105/86745290-8a59d280-c03a-11ea-8774-134d5954c811.png">



#### Focus areas to test

(optional)
