### PR TITLE
Fix bug: ContextualMenu doesn't honor the focusZoneProps prop

### DIFF
--- a/change/office-ui-fabric-react-2020-07-04-06-52-11-focusZone.json
+++ b/change/office-ui-fabric-react-2020-07-04-06-52-11-focusZone.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Apply focusZone props to ContextualMenu.",
+  "packageName": "office-ui-fabric-react",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-04T13:52:11.021Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -374,10 +374,10 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
             {title && <div className={this._classNames.title}> {title} </div>}
             {items && items.length ? (
               <FocusZone
-                {...this._adjustedFocusZoneProps}
                 className={this._classNames.root}
                 isCircularNavigation={true}
                 handleTabKey={FocusZoneTabbableElements.all}
+                {...this._adjustedFocusZoneProps}
               >
                 {onRenderMenuList(
                   {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13923 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In `ContextualMenu` component, the `focusZoneProps` prop should override any default behavior. This is achieved by moving the spread operator to the end. 

#### Focus areas to test

Manual test