### PR TITLE
fix(CommonPropInterfaces): add as prop to UIComponentProps

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExample.shorthand.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Input, FormProps } from '@fluentui/react-northstar';
 
-const fields = [
+const fields: FormProps['fields'] = [
   {
     label: 'First name',
     name: 'firstName',
@@ -26,7 +26,7 @@ const fields = [
   },
   {
     label: 'I agree to the Terms and Conditions',
-    control: { as: 'input' },
+    control: { as: 'input' as const },
     type: 'checkbox',
     id: 'conditions-shorthand',
     key: 'conditions',

--- a/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Form/Types/FormExampleInline.shorthand.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Form, Button, Input } from '@fluentui/react-northstar';
+import { Form, Button, Input, FormProps } from '@fluentui/react-northstar';
 
-const fields = [
+const fields: FormProps['fields'] = [
   {
     label: 'First name',
     name: 'firstName',

--- a/packages/fluentui/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Types/ToolbarExampleEditor.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Toolbar, Input, Button, Form } from '@fluentui/react-northstar';
+import { Toolbar, Input, Button, Form, FormProps } from '@fluentui/react-northstar';
 import { useBooleanKnob } from '@fluentui/docs-components';
 import {
   BoldIcon,
@@ -22,7 +22,7 @@ import {
   CodeSnippetIcon,
 } from '@fluentui/react-icons-northstar';
 
-const fields = [
+const fields: FormProps['fields'] = [
   {
     label: 'First name',
     name: 'firstName',

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -201,7 +201,7 @@ Provider.defaultProps = {
   theme: {},
 };
 Provider.propTypes = {
-  as: PropTypes.elementType,
+  as: PropTypes.elementType as PropTypes.Requireable<React.ElementType>,
   design: PropTypes.object,
   variables: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
   styles: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarMenuRadioGroup.tsx
@@ -110,7 +110,7 @@ const ToolbarMenuRadioGroup = compose<'ul', ToolbarMenuRadioGroupProps, ToolbarM
             createShorthand(ToolbarMenuItem, item, {
               defaultProps: () => ({
                 accessibility: toolbarMenuItemRadioBehavior,
-                as: 'li',
+                as: 'li' as const,
                 active: activeIndex === index,
                 index,
               }),

--- a/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
+++ b/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
@@ -15,7 +15,7 @@ export interface UIComponentProps<P = any, V = any> extends StyledComponentProps
   /** Additional CSS class name(s) to apply.  */
   className?: string;
   design?: ComponentDesignProp;
-  as?: React.ElementType<any>;
+  as?: React.ElementType;
 }
 
 export type SizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';

--- a/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
+++ b/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
@@ -15,7 +15,7 @@ export interface UIComponentProps<P = any, V = any> extends StyledComponentProps
   /** Additional CSS class name(s) to apply.  */
   className?: string;
   design?: ComponentDesignProp;
-  as?: React.ReactNode;
+  as?: React.ElementType<any>;
 }
 
 export type SizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';

--- a/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
+++ b/packages/fluentui/react-northstar/src/utils/commonPropInterfaces.ts
@@ -15,6 +15,7 @@ export interface UIComponentProps<P = any, V = any> extends StyledComponentProps
   /** Additional CSS class name(s) to apply.  */
   className?: string;
   design?: ComponentDesignProp;
+  as?: React.ReactNode;
 }
 
 export type SizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';

--- a/packages/fluentui/react-northstar/src/utils/commonPropTypes.ts
+++ b/packages/fluentui/react-northstar/src/utils/commonPropTypes.ts
@@ -26,7 +26,7 @@ export const createCommon = (config: CreateCommonConfig = {}) => {
       accessibility: customPropTypes.accessibility,
     }),
     ...(as && {
-      as: PropTypes.oneOf([PropTypes.elementType, PropTypes.string]),
+      as: PropTypes.elementType as PropTypes.Requireable<React.ElementType>,
     }),
     ...(children && {
       children: children === 'element' ? PropTypes.element : PropTypes.node,

--- a/packages/fluentui/react-northstar/src/utils/commonPropTypes.ts
+++ b/packages/fluentui/react-northstar/src/utils/commonPropTypes.ts
@@ -26,7 +26,7 @@ export const createCommon = (config: CreateCommonConfig = {}) => {
       accessibility: customPropTypes.accessibility,
     }),
     ...(as && {
-      as: PropTypes.elementType,
+      as: PropTypes.oneOf([PropTypes.elementType, PropTypes.string]),
     }),
     ...(children && {
       children: children === 'element' ? PropTypes.element : PropTypes.node,

--- a/packages/fluentui/react-northstar/test/specs/components/Form/FormField-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Form/FormField-test.tsx
@@ -15,7 +15,7 @@ const inputIconClassName = '.ui-input__icon';
 const formFieldImplementsShorthandProp = implementsShorthandProp(FormField);
 
 const getFormField = (control: React.ComponentType<any> | string) =>
-  mountWithProvider(<FormField control={{ as: control }} name="firstName" />).find('FormField');
+  mountWithProvider(<FormField control={{ as: control as React.ElementType }} name="firstName" />).find('FormField');
 
 describe('FormField', () => {
   isConformant(FormField, { constructorName: 'FormField' });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13716
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `as?: React.ReactNode;` to `UIComponentProps` so `as` prop would be valid in any wrapped component like:

```jsx

const StyledProvider: React.FC<ProviderProps> = ({ styles, ...rest }) => (
  <Provider {...rest} />
);

export default function App() {
  return (
    <StyledProvider as="main">
      <div className="App">
        <h1>Hello CodeSandbox</h1>
        <h2>Start editing to see some magic happen!</h2>
      </div>
    </StyledProvider>
  );
}
```

#### Focus areas to test

(optional)
