### PR TITLE
fix(build): match only main react-northstar package tag when saving stats

### DIFF
--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -88,7 +88,7 @@ steps:
 
   # HEADS UP: also see tag-version-prefix in fluentui-publish.js
   - script: |
-      yarn stats:save --tag=`git tag --points-at HEAD | grep -o 'northstar_v.*'`
+      yarn stats:save --tag=`git tag --points-at HEAD | grep ^@fluentui/react-northstar_v | grep -o 'northstar_v.*'`
     condition: ne(variables.buildReason, 'PullRequest')
     displayName: Save Statistics to DB (master only)
     env:


### PR DESCRIPTION
#### Description of changes

When v0 perf stats are saved for a git commit which contains tag for the v0 main package (`@fluentui/react-northstar`), a version from the tag should be saved to the stats db.

This fix saves the version only for the main package and ignores tag for other packages (like `@fluentui/react-icons-northstar_v0.50.0`).
