### PR TITLE
Charting: LineChart - callout not visible when graph more dense issue resovled.

### DIFF
--- a/change/@uifabric-charting-2020-07-07-19-01-04-user-v-jasha-bug#4272739-LineChart.json
+++ b/change/@uifabric-charting-2020-07-07-19-01-04-user-v-jasha-bug#4272739-LineChart.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "linechart-callout not visible in dense graph issue resolved",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-07-07T13:31:04.672Z"
 }

--- a/change/@uifabric-charting-2020-07-07-19-01-04-user-v-jasha-bug#4272739-LineChart.json
+++ b/change/@uifabric-charting-2020-07-07-19-01-04-user-v-jasha-bug#4272739-LineChart.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "linechart-callout not visible in dense graph issue resolved",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-07-07T13:31:04.672Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -105,8 +105,14 @@ export class LineChartBase extends React.Component<
     /** note that height and width are not used to resize or set as dimesions of the chart,
      * fitParentContainer is responisble for setting the height and width or resizing of the svg/chart
      */
-    if (prevProps.height !== this.props.height || prevProps.width !== this.props.width) {
+    if (
+      prevProps.height !== this.props.height ||
+      prevProps.width !== this.props.width ||
+      prevProps.data !== this.props.data
+    ) {
       this._fitParentContainer();
+      this._points = this.props.data.lineChartData ? this.props.data.lineChartData : [];
+      this._calloutPoints = this.CalloutData(this._points) ? this.CalloutData(this._points) : [];
     }
   }
 
@@ -230,6 +236,7 @@ export class LineChartBase extends React.Component<
                       index: number,
                     ) => (
                       <div
+                        id={`${index}_${xValue.y}`}
                         className={mergeStyles(this._classNames.calloutBlockContainer, {
                           borderLeft: `4px solid ${xValue.color}`,
                         })}
@@ -571,17 +578,6 @@ export class LineChartBase extends React.Component<
           }
         } else {
           lines.push(
-            <circle
-              id={circleId}
-              key={lineId + 1}
-              r={5}
-              cx={this._xAxisScale(x1)}
-              cy={this._yAxisScale(y1)}
-              opacity={0.1}
-              fill={lineColor}
-            />,
-          );
-          lines.push(
             <line
               id={lineId}
               key={lineId}
@@ -595,19 +591,6 @@ export class LineChartBase extends React.Component<
               opacity={0.1}
             />,
           );
-          if (j + 1 === this._points[i].data.length) {
-            lines.push(
-              <circle
-                id={circleId}
-                key={lineId + 2}
-                r={5}
-                cx={this._xAxisScale(x2)}
-                cy={this._yAxisScale(y2)}
-                fill={lineColor}
-                opacity={0.1}
-              />,
-            );
-          }
         }
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/13932
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
When one legend selected, remaining lines need show in blur. In this case no need to add circle at edges of lines. In this case, removed circles and updated component did update. When prop data changed, render data not updating immediately. So added prop update in this method.

#### Focus areas to test

Line chart

### Before fix
![image](https://user-images.githubusercontent.com/20105532/86790203-c2d2ce00-c085-11ea-8807-f012de4d9853.png)


### After fix
![image](https://user-images.githubusercontent.com/20105532/86790123-ae8ed100-c085-11ea-9116-da3183d71543.png)
