### PR TITLE
Fixing jest environment path to be preserved, unbreaks `jest test`

### DIFF
--- a/scripts/tasks/jest.js
+++ b/scripts/tasks/jest.js
@@ -8,6 +8,7 @@ exports.jest = () =>
     ...(process.env.TF_BUILD && { runInBand: true }),
     ...(argv().u || argv().updateSnapshot ? { updateSnapshot: true } : undefined),
     env: {
+      ...process.env,
       NODE_ENV: 'test',
     },
   });


### PR DESCRIPTION
Expected:
Running `jest test` should not throw watchman errors.

Resulted:
It's not in the path errors.

Fix:
Path is preserved.
