### PR TITLE
chore: remove React from @fluentui/styles dependencies

### DIFF
--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -7,8 +7,7 @@
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "csstype": "^2.6.7",
-    "lodash": "^4.17.15",
-    "react": "16.8.6"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.51.0",


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13921

#### Description of changes

This change was done in #13602, in #13616 I moved out files that have React dependency to a separate package.
