### PR TITLE
Slider: Fix High Contrast bug in Slider #13869

### DIFF
--- a/change/office-ui-fabric-react-2020-07-08-09-49-12-a11y-slider.json
+++ b/change/office-ui-fabric-react-2020-07-08-09-49-12-a11y-slider.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix slider styles",
+  "comment": "Slider: Fixing High Contrast styles.",
   "packageName": "office-ui-fabric-react",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-07-08-09-49-12-a11y-slider.json
+++ b/change/office-ui-fabric-react-2020-07-08-09-49-12-a11y-slider.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix slider styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-08T16:49:12.360Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -1,5 +1,11 @@
 import { ISliderStyleProps, ISliderStyles } from './Slider.types';
-import { getGlobalClassNames, HighContrastSelector, AnimationVariables, getFocusStyle } from '../../Styling';
+import {
+  getGlobalClassNames,
+  HighContrastSelector,
+  AnimationVariables,
+  getFocusStyle,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+} from '../../Styling';
 import { getRTL } from '@uifabric/utilities';
 
 const GlobalClassNames = {
@@ -141,6 +147,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
           [`:hover .${classNames.thumb}`]: slideBoxActiveThumbStyles,
           [`:active .${classNames.zeroTick}`]: slideBoxActiveZeroTickStyles,
           [`:hover .${classNames.zeroTick}`]: slideBoxActiveZeroTickStyles,
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       vertical

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -141,6 +141,9 @@ exports[`Slider renders correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
             background-color: Highlight;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       data-is-focusable={true}
       id="Slider0"
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -325,6 +325,9 @@ Array [
               @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           data-is-focusable={true}
           id="Slider3"
           onKeyDown={[Function]}
@@ -585,6 +588,9 @@ Array [
               }
               @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
+              }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           data-is-focusable={true}
           id="Slider4"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -764,6 +764,9 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           data-is-focusable={true}
           id="Slider7"
           onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -868,6 +868,9 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                 background-color: Highlight;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           data-is-focusable={true}
           id="Slider7"
           onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -134,6 +134,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}
@@ -395,6 +398,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider1"
         onKeyDown={[Function]}
@@ -613,6 +619,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               right: 1px;
               top: 1px;
               z-index: 1;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={false}
         id="Slider2"
@@ -882,6 +891,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider3"
         onKeyDown={[Function]}
@@ -1143,6 +1155,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider4"
         onKeyDown={[Function]}
@@ -1403,6 +1418,9 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Slider5"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
@@ -170,6 +170,9 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}
@@ -406,6 +409,9 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               right: 1px;
               top: 1px;
               z-index: 1;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={false}
         id="Slider1"
@@ -693,6 +699,9 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider2"
         onKeyDown={[Function]}
@@ -972,6 +981,9 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider3"
         onKeyDown={[Function]}
@@ -1250,6 +1262,9 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             }
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Slider4"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -218,6 +218,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider0"
               onKeyDown={[Function]}
@@ -1212,6 +1215,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                       background-color: Highlight;
                     }
+                    @media screen and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
                 data-is-focusable={true}
                 id="Slider5"
                 onKeyDown={[Function]}
@@ -1533,6 +1539,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider6"
               onKeyDown={[Function]}
@@ -1793,6 +1802,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider7"
@@ -2092,6 +2104,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider8"
               onKeyDown={[Function]}
@@ -2352,6 +2367,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider9"
@@ -2651,6 +2669,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider10"
               onKeyDown={[Function]}
@@ -2911,6 +2932,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider11"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -198,6 +198,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                   background-color: Highlight;
                 }
+                @media screen and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             data-is-focusable={true}
             id="Slider0"
             onKeyDown={[Function]}
@@ -474,6 +477,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 }
                 @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                   background-color: Highlight;
+                }
+                @media screen and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             data-is-focusable={true}
             id="Slider1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -219,6 +219,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider0"
               onKeyDown={[Function]}
@@ -1137,6 +1140,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     top: 1px;
                     z-index: 1;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={false}
               id="Slider5"
               role="slider"
@@ -1635,6 +1641,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider7"
@@ -2780,6 +2789,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider14"
               onKeyDown={[Function]}
@@ -3040,6 +3052,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider15"
@@ -3340,6 +3355,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
                   }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               data-is-focusable={true}
               id="Slider16"
               onKeyDown={[Function]}
@@ -3600,6 +3618,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
                   @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                     background-color: Highlight;
+                  }
+                  @media screen and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               data-is-focusable={true}
               id="Slider17"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -198,6 +198,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                   background-color: Highlight;
                 }
+                @media screen and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             data-is-focusable={true}
             id="Slider0"
             onKeyDown={[Function]}
@@ -474,6 +477,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 }
                 @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
                   background-color: Highlight;
+                }
+                @media screen and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             data-is-focusable={true}
             id="Slider1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
@@ -162,6 +162,9 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
             @media screen and (-ms-high-contrast: active){&:hover .ms-Slider-zeroTick {
               background-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         data-is-focusable={true}
         id="Slider0"
         onKeyDown={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13869 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

-  Fix Slider styles in High Contrast mode in Edge Chromium.
- Main files to review is Slider.styles. Rest is snapshots update

**Screenshots**

Before:
![image](https://user-images.githubusercontent.com/66456876/86951790-d96d3980-c106-11ea-9031-1336ca730e5e.png)

After:
![image](https://user-images.githubusercontent.com/66456876/86952413-ceff6f80-c107-11ea-97ff-04c288981051.png)


#### Focus areas to test

(optional)
