### PR TITLE
[Date-Time] refactor date time examples

### DIFF
--- a/change/@uifabric-date-time-2020-07-08-15-51-08-lorejoh12-refactorDateTimeExamples.json
+++ b/change/@uifabric-date-time-2020-07-08-15-51-08-lorejoh12-refactorDateTimeExamples.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "refactoring the date time examples into separate files to fix storybook. Also fixing bug in Calendar where externally controlled date does not navigate the calendar when the date changes",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-08T22:50:52.897Z"
+}

--- a/change/office-ui-fabric-react-2020-07-08-15-51-08-lorejoh12-refactorDateTimeExamples.json
+++ b/change/office-ui-fabric-react-2020-07-08-15-51-08-lorejoh12-refactorDateTimeExamples.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "refactoring the date time examples into separate files to fix storybook. Also fixing bug in Calendar where externally controlled date does not navigate the calendar when the date changes",
+  "packageName": "office-ui-fabric-react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-08T22:51:08.435Z"
+}

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -22,6 +22,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev:storybook",
+    "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
     "update-snapshots": "just-scripts jest -u",
     "update-api": "just-scripts update-api"

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -81,14 +81,22 @@ const DEFAULT_PROPS: Partial<ICalendarProps> = {
 };
 
 function useDateState({ value, today = new Date(), onSelectDate }: ICalendarProps) {
+  /** The currently selected date in the calendar */
+  const [selectedDate = today, setSelectedDate] = useControllableValue(value, today);
+
   /** The currently focused date in the day picker, but not necessarily selected */
   const [navigatedDay = today, setNavigatedDay] = React.useState(value);
 
   /** The currently focused date in the month picker, but not necessarily selected */
   const [navigatedMonth = today, setNavigatedMonth] = React.useState(value);
 
-  /** The currently selected date in the calendar */
-  const [selectedDate = today, setSelectedDate] = useControllableValue(value, today);
+  /** If using a controlled value, when that value changes, navigate to that date */
+  const [lastSelectedDate = today, setLastSelectedDate] = React.useState(value);
+  if (value && lastSelectedDate.valueOf() !== value.valueOf()) {
+    setNavigatedDay(value);
+    setNavigatedMonth(value);
+    setLastSelectedDate(value);
+  }
 
   const navigateMonth = (date: Date) => {
     setNavigatedMonth(date);

--- a/packages/date-time/src/components/Calendar/CalendarPage.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarPage.tsx
@@ -1,16 +1,32 @@
 import * as React from 'react';
 import { ExampleCard, ComponentPage, PropertiesTableSet, Markdown } from '@uifabric/example-app-base';
-import { DateRangeType, DayOfWeek } from './Calendar.types';
 import { CalendarButtonExample } from './examples/Calendar.Button.Example';
+import { CalendarInlineContiguousWorkWeekDaysExample } from './examples/Calendar.Inline.ContiguousWorkWeekDays.Example';
+import { CalendarInlineCustomDayCellRefExample } from './examples/Calendar.Inline.CustomDayCellRef.Example';
+import { CalendarInlineDateBoundariesExample } from './examples/Calendar.Inline.DateBoundaries.Example';
 import { CalendarInlineExample } from './examples/Calendar.Inline.Example';
-import { addMonths, addYears, addDays } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
-import { IProcessedStyleSet } from '@uifabric/styling';
-import { ICalendarDayGridStyles } from '@uifabric/date-time';
+import { CalendarInlineMonthOnlyExample } from './examples/Calendar.Inline.MonthOnly.Example';
+import { CalendarInlineMultidayDayViewExample } from './examples/Calendar.Inline.MultidayDayView.Example';
+import { CalendarInlineNonContiguousWorkWeekDaysExample } from './examples/Calendar.Inline.NonContiguousWorkWeekDays.Example';
+import { CalendarInlineOverlayedMonthExample } from './examples/Calendar.Inline.OverlayedMonthPicker.Example';
+import { CalendarInlineSixWeeksExample } from './examples/Calendar.Inline.SixWeeks';
+import { CalendarInlineWeekNumbersExample } from './examples/Calendar.Inline.WeekNumbers.Example';
+import { CalendarInlineWeekSelectionExample } from './examples/Calendar.Inline.WeekSelection.Example';
+import { CalendarInlineMonthSelectionExample } from './examples/Calendar.Inline.MonthSelection.Example';
 
-const CalendarButtonExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx') as string;
-const CalendarInlineExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx') as string;
-
-const today = new Date(Date.now());
+const CalendarButtonExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Button.Example') as string;
+const CalendarInlineContiguousWorkWeekDaysExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.ContiguousWorkWeekDays.Example') as string;
+const CalendarInlineCustomDayCellRefExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.CustomDayCellRef.Example') as string;
+const CalendarInlineDateBoundariesExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.DateBoundaries.Example') as string;
+const CalendarInlineExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.Example') as string;
+const CalendarInlineMonthOnlyExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example') as string;
+const CalendarInlineMultidayDayViewExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example') as string;
+const CalendarInlineNonContiguousWorkWeekDaysExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.NonContiguousWorkWeekDays.Example') as string;
+const CalendarInlineOverlayedMonthExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.OverlayedMonthPicker.Example') as string;
+const CalendarInlineSixWeeksExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.SixWeeks') as string;
+const CalendarInlineWeekNumbersExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example') as string;
+const CalendarInlineWeekSelectionExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example') as string;
+const CalendarInlineMonthSelectionExampleCode = require('!raw-loader!@uifabric/date-time/src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example') as string;
 
 export class CalendarPage extends React.Component<{}, {}> {
   public render(): JSX.Element {
@@ -21,199 +37,73 @@ export class CalendarPage extends React.Component<{}, {}> {
         exampleCards={
           <div>
             <ExampleCard title="Inline Calendar" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                isMonthPickerVisible={false}
-                dateRangeType={DateRangeType.Day}
-                showGoToToday={true}
-              />
+              <CalendarInlineExample />
             </ExampleCard>
             <ExampleCard
               title="Inline Calendar with overlayed month picker when header is clicked"
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineOverlayedMonthExampleCode}
             >
-              <CalendarInlineExample
-                showMonthPickerAsOverlay={true}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                dateRangeType={DateRangeType.Day}
-                showGoToToday={false}
-              />
+              <CalendarInlineOverlayedMonthExample />
             </ExampleCard>
-            <ExampleCard title="Inline Calendar with month picker" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Day}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-              />
+            <ExampleCard title="Inline Calendar with week selection" code={CalendarInlineWeekSelectionExampleCode}>
+              <CalendarInlineWeekSelectionExample />
             </ExampleCard>
-            <ExampleCard title="Inline Calendar with week selection" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Week}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                showNavigateButtons={true}
-              />
+            <ExampleCard title="Inline Calendar with month selection" code={CalendarInlineMonthSelectionExampleCode}>
+              <CalendarInlineMonthSelectionExample />
             </ExampleCard>
-            <ExampleCard title="Inline Calendar with month selection" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Month}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                showNavigateButtons={true}
-              />
+            <ExampleCard title="Inline Calendar with week numbers" code={CalendarInlineWeekNumbersExampleCode}>
+              <CalendarInlineWeekNumbersExample />
             </ExampleCard>
-            <ExampleCard title="Inline Calendar with week numbers" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                isMonthPickerVisible={false}
-                dateRangeType={DateRangeType.Day}
-                showGoToToday={true}
-                showWeekNumbers={true}
-              />
+            <ExampleCard
+              title="Inline Calendar with 6 weeks display by default"
+              code={CalendarInlineSixWeeksExampleCode}
+            >
+              <CalendarInlineSixWeeksExample />
             </ExampleCard>
-            <ExampleCard title="Inline Calendar with 6 weeks display by default" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                isMonthPickerVisible={false}
-                dateRangeType={DateRangeType.Day}
-                showGoToToday={true}
-                showSixWeeksByDefault={true}
-              />
-            </ExampleCard>
-            <ExampleCard title="Inline Calendar with month picker and no day picker" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Month}
-                showGoToToday={true}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                isDayPickerVisible={false}
-              />
+            <ExampleCard
+              title="Inline Calendar with month picker and no day picker"
+              code={CalendarInlineMonthOnlyExampleCode}
+            >
+              <CalendarInlineMonthOnlyExample />
             </ExampleCard>
             <ExampleCard
               title="Inline Calendar with date boundary (minDate, maxDate) and disabled dates (restrictedDates)"
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineDateBoundariesExampleCode}
             >
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Day}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={false}
-                minDate={addMonths(today, -1)}
-                maxDate={addYears(today, 1)}
-                restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
-              />
+              <CalendarInlineDateBoundariesExample />
             </ExampleCard>
             <ExampleCard
               title={
                 'Calendar with selectableDays = [Monday, Tuesday, Wednesday, Thursday, Friday] provided, ' +
                 'first day of week = Sunday'
               }
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineContiguousWorkWeekDaysExampleCode}
             >
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.WorkWeek}
-                firstDayOfWeek={DayOfWeek.Sunday}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                workWeekDays={[
-                  DayOfWeek.Monday,
-                  DayOfWeek.Tuesday,
-                  DayOfWeek.Wednesday,
-                  DayOfWeek.Thursday,
-                  DayOfWeek.Friday,
-                ]}
-              />
+              <CalendarInlineContiguousWorkWeekDaysExample />
             </ExampleCard>
             <ExampleCard
               title={
                 'Calendar with selectableDays = [Tuesday, Wednesday, Friday, Saturday] provided, ' +
                 'first day of week = Monday'
               }
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineNonContiguousWorkWeekDaysExampleCode}
             >
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.WorkWeek}
-                firstDayOfWeek={DayOfWeek.Monday}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                workWeekDays={[DayOfWeek.Tuesday, DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Friday]}
-              />
+              <CalendarInlineNonContiguousWorkWeekDaysExample />
             </ExampleCard>
             <ExampleCard
               title="Calendar with multiday view using dateRangeType = Day and daysToSelectInDayView = 4"
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineMultidayDayViewExampleCode}
             >
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Day}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                calendarDayProps={{ daysToSelectInDayView: 4 }}
-                showDaysToSelectInDayViewDropdown={true}
-              />
+              <CalendarInlineMultidayDayViewExample />
             </ExampleCard>
             <ExampleCard
               title="Calendar with customDayCellRef applying a tooltip to each day and disabling weekends"
-              code={CalendarInlineExampleCode}
+              code={CalendarInlineCustomDayCellRefExampleCode}
             >
-              <CalendarInlineExample
-                dateRangeType={DateRangeType.Day}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                showGoToToday={true}
-                calendarDayProps={{
-                  customDayCellRef: (
-                    element: HTMLElement,
-                    date: Date,
-                    classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
-                  ) => {
-                    if (element) {
-                      element.title = 'custom title from customDayCellRef: ' + date.toString();
-                      if (date.getDay() === 0 || date.getDay() === 6) {
-                        classNames.dayOutsideBounds && element.classList.add(classNames.dayOutsideBounds);
-                        (element.children[0] as HTMLButtonElement).disabled = true;
-                      }
-                    }
-                  },
-                }}
-              />
+              <CalendarInlineCustomDayCellRefExample />
             </ExampleCard>
             <ExampleCard title="Calendar launched from a button" code={CalendarButtonExampleCode}>
               <CalendarButtonExample highlightCurrentMonth={true} />
-            </ExampleCard>
-            <ExampleCard title="Month picker launched from a button" code={CalendarButtonExampleCode}>
-              <CalendarButtonExample
-                isDayPickerVisible={false}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                buttonString={'Click for Month Picker'}
-              />
-            </ExampleCard>
-            <ExampleCard
-              title="Calendar with overlayed month picker launched from a button"
-              code={CalendarButtonExampleCode}
-            >
-              <CalendarButtonExample
-                showMonthPickerAsOverlay={true}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                buttonString={'Click for Overlayed Day Picker and Month Picker'}
-              />
-            </ExampleCard>
-            <ExampleCard
-              title="Calendar with overlayed month picker launched from a button without show go to today button"
-              code={CalendarButtonExampleCode}
-            >
-              <CalendarButtonExample
-                showMonthPickerAsOverlay={true}
-                showGoToToday={false}
-                highlightCurrentMonth={false}
-                highlightSelectedMonth={true}
-                buttonString={'Click for Overlayed Day Picker and Month Picker without go to today button'}
-              />
             </ExampleCard>
           </div>
         }

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -35,10 +35,6 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
       showCalendar: false,
       selectedDate: undefined,
     };
-
-    this._onClick = this._onClick.bind(this);
-    this._onDismiss = this._onDismiss.bind(this);
-    this._onSelectDate = this._onSelectDate.bind(this);
   }
 
   public render(): JSX.Element {
@@ -66,7 +62,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
                 onSelectDate={this._onSelectDate}
                 onDismiss={this._onDismiss}
                 isMonthPickerVisible={this.props.isMonthPickerVisible}
-                value={this.state.selectedDate!}
+                value={this.state.selectedDate}
                 firstDayOfWeek={DayOfWeek.Sunday}
                 strings={defaultDayPickerStrings}
                 isDayPickerVisible={this.props.isDayPickerVisible}
@@ -82,25 +78,25 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
     );
   }
 
-  private _onClick(): void {
+  private _onClick = (): void => {
     this.setState((prevState: ICalendarButtonExampleState) => {
       prevState.showCalendar = !prevState.showCalendar;
       return prevState;
     });
-  }
+  };
 
-  private _onDismiss(): void {
+  private _onDismiss = (): void => {
     this.setState((prevState: ICalendarButtonExampleState) => {
       prevState.showCalendar = false;
       return prevState;
     });
-  }
+  };
 
-  private _onSelectDate(date: Date): void {
+  private _onSelectDate = (date: Date): void => {
     this.setState((prevState: ICalendarButtonExampleState) => {
       prevState.showCalendar = false;
       prevState.selectedDate = date;
       return prevState;
     });
-  }
+  };
 }

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.ContiguousWorkWeekDays.Example.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+  selectedDateRange?: Date[];
+}
+
+export class CalendarInlineContiguousWorkWeekDaysExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+      selectedDateRange: undefined,
+    };
+  }
+
+  public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
+        <Calendar
+          dateRangeType={DateRangeType.WorkWeek}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          workWeekDays={[
+            DayOfWeek.Monday,
+            DayOfWeek.Tuesday,
+            DayOfWeek.Wednesday,
+            DayOfWeek.Thursday,
+            DayOfWeek.Friday,
+          ]}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+        />
+      </div>
+    );
+  }
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.CustomDayCellRef.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.CustomDayCellRef.Example.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import {
+  Calendar,
+  ICalendarDayGridStyles,
+  DateRangeType,
+  DayOfWeek,
+  defaultDayPickerStrings,
+} from '@uifabric/date-time';
+import { IProcessedStyleSet } from '@uifabric/styling';
+
+import * as styles from './Calendar.Example.scss';
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+}
+
+export class CalendarInlineCustomDayCellRefExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <Calendar
+          dateRangeType={DateRangeType.Day}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          calendarDayProps={{
+            customDayCellRef: (
+              element: HTMLElement,
+              date: Date,
+              classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
+            ) => {
+              if (element) {
+                element.title = 'custom title from customDayCellRef: ' + date.toString();
+                if (date.getDay() === 0 || date.getDay() === 6) {
+                  classNames.dayOutsideBounds && element.classList.add(classNames.dayOutsideBounds);
+                  (element.children[0] as HTMLButtonElement).disabled = true;
+                }
+              }
+            },
+          }}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+        />
+      </div>
+    );
+  }
+
+  private _onSelectDate = (date: Date): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.DateBoundaries.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.DateBoundaries.Example.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import { addMonths, addYears, addDays } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+const today = new Date();
+const minDate = addMonths(today, -1);
+const maxDate = addYears(today, 1);
+const restrictedDates = [addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)];
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+}
+
+export class CalendarInlineDateBoundariesExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: today,
+    };
+  }
+
+  public render(): JSX.Element {
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        {(minDate || maxDate) && (
+          <div>
+            Date boundary:
+            <span>
+              {' '}
+              {minDate ? minDate.toLocaleDateString() : 'Not set'}-{maxDate ? maxDate.toLocaleDateString() : 'Not set'}
+            </span>
+          </div>
+        )}
+        {restrictedDates && (
+          <div>
+            Disabled date(s):
+            <span>
+              {' '}
+              {restrictedDates.length > 0
+                ? restrictedDates.map((d: Date) => d.toLocaleDateString()).join(', ')
+                : 'Not set'}
+            </span>
+          </div>
+        )}
+        <Calendar
+          dateRangeType={DateRangeType.Day}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={false}
+          minDate={minDate}
+          maxDate={maxDate}
+          restrictedDates={restrictedDates}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+        />
+      </div>
+    );
+  }
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+import { Calendar, DayOfWeek, defaultDayPickerStrings, DateRangeType } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
-import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx
@@ -6,27 +6,43 @@ import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;
+  selectedDateRange?: Date[];
 }
 
-export class CalendarInlineExample extends React.Component<{}, ICalendarInlineExampleState> {
+export class CalendarInlineMonthOnlyExample extends React.Component<{}, ICalendarInlineExampleState> {
   public constructor(props: {}) {
     super(props);
 
     this.state = {
       selectedDate: new Date(),
+      selectedDateRange: undefined,
     };
   }
 
   public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
     return (
       <div className={styles.wrapper}>
         <div>
           Selected date(s):{' '}
           <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
         </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
         <Calendar
-          dateRangeType={DateRangeType.Day}
+          dateRangeType={DateRangeType.Month}
           showGoToToday={true}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          isDayPickerVisible={false}
           onSelectDate={this._onSelectDate}
           value={this.state.selectedDate}
           firstDayOfWeek={DayOfWeek.Sunday}
@@ -36,10 +52,11 @@ export class CalendarInlineExample extends React.Component<{}, ICalendarInlineEx
     );
   }
 
-  private _onSelectDate = (date: Date): void => {
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
     this.setState((prevState: ICalendarInlineExampleState) => {
       return {
         selectedDate: date,
+        selectedDateRange: dateRangeArray,
       };
     });
   };

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthOnly.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+import { Calendar, DayOfWeek, defaultDayPickerStrings, DateRangeType } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
-import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MonthSelection.Example.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react';
+import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+const dateRangeType = DateRangeType.Month;
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+  selectedDateRange?: Date[];
+}
+
+export class CalendarInlineMonthSelectionExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+      selectedDateRange: undefined,
+    };
+  }
+
+  public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
+        <Calendar
+          dateRangeType={dateRangeType}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+        />
+        <div>
+          <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+          <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+        </div>
+      </div>
+    );
+  }
+
+  private _goPrevious = (): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      const selectedDate = prevState.selectedDate || new Date();
+      const dateRangeArray = getDateRangeArray(selectedDate, dateRangeType, DayOfWeek.Sunday);
+
+      const subtractFrom = new Date(dateRangeArray[0].getFullYear(), dateRangeArray[0].getMonth(), 1);
+      const daysToSubtract = 1;
+
+      const newSelectedDate = addDays(subtractFrom, -daysToSubtract);
+
+      return {
+        selectedDate: newSelectedDate,
+      };
+    });
+  };
+
+  private _goNext = (): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      const selectedDate = prevState.selectedDate || new Date();
+      const dateRangeArray = getDateRangeArray(selectedDate, dateRangeType, DayOfWeek.Sunday);
+      const newSelectedDate = addDays(dateRangeArray.pop()!, 1);
+
+      return {
+        selectedDate: newSelectedDate,
+      };
+    });
+  };
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.MultidayDayView.Example.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+const initialDaysToSelectInDayView = 4;
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+  selectedDateRange?: Date[];
+  daysToSelectInDayView?: number;
+}
+
+export class CalendarInlineMultidayDayViewExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+      selectedDateRange: undefined,
+      daysToSelectInDayView: initialDaysToSelectInDayView,
+    };
+  }
+
+  public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
+        <Calendar
+          dateRangeType={DateRangeType.Day}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+          calendarDayProps={{
+            daysToSelectInDayView: this.state.daysToSelectInDayView,
+          }}
+        />
+        <div>
+          <Dropdown
+            className={styles.dropdown}
+            selectedKey={this.state.daysToSelectInDayView && this.state.daysToSelectInDayView}
+            label="Choose days to select"
+            options={[
+              { key: 1, text: '1' },
+              { key: 2, text: '2' },
+              { key: 3, text: '3' },
+              { key: 4, text: '4' },
+              { key: 5, text: '5' },
+              { key: 6, text: '6' },
+            ]}
+            onChange={this._onDaysToSelectInDayViewDropdownChange}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  private _onDaysToSelectInDayViewDropdownChange = (
+    ev: React.FormEvent<HTMLElement>,
+    option: IDropdownOption | undefined,
+  ): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        ...prevState,
+        daysToSelectInDayView: option && (option.key as number),
+      };
+    });
+  };
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        ...prevState,
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.NonContiguousWorkWeekDays.Example.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+  selectedDateRange?: Date[];
+}
+
+export class CalendarInlineNonContiguousWorkWeekDaysExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+      selectedDateRange: undefined,
+    };
+  }
+
+  public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
+        <Calendar
+          dateRangeType={DateRangeType.WorkWeek}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          workWeekDays={[DayOfWeek.Tuesday, DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Friday]}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Monday}
+          strings={defaultDayPickerStrings}
+        />
+      </div>
+    );
+  }
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.OverlayedMonthPicker.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.OverlayedMonthPicker.Example.tsx
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+import { Calendar, DayOfWeek, DateRangeType, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
-import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;
 }
 
-export class CalendarInlineExample extends React.Component<{}, ICalendarInlineExampleState> {
+export class CalendarInlineOverlayedMonthExample extends React.Component<{}, ICalendarInlineExampleState> {
   public constructor(props: {}) {
     super(props);
 
@@ -25,8 +24,11 @@ export class CalendarInlineExample extends React.Component<{}, ICalendarInlineEx
           <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
         </div>
         <Calendar
+          showMonthPickerAsOverlay={true}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
           dateRangeType={DateRangeType.Day}
-          showGoToToday={true}
+          showGoToToday={false}
           onSelectDate={this._onSelectDate}
           value={this.state.selectedDate}
           firstDayOfWeek={DayOfWeek.Sunday}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx
@@ -8,7 +8,7 @@ export interface ICalendarInlineExampleState {
   selectedDate?: Date;
 }
 
-export class CalendarInlineExample extends React.Component<{}, ICalendarInlineExampleState> {
+export class CalendarInlineSixWeeksExample extends React.Component<{}, ICalendarInlineExampleState> {
   public constructor(props: {}) {
     super(props);
 
@@ -25,6 +25,7 @@ export class CalendarInlineExample extends React.Component<{}, ICalendarInlineEx
           <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
         </div>
         <Calendar
+          showSixWeeksByDefault={true}
           dateRangeType={DateRangeType.Day}
           showGoToToday={true}
           onSelectDate={this._onSelectDate}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.SixWeeks.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+import { Calendar, DayOfWeek, defaultDayPickerStrings, DateRangeType } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
-import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+import { Calendar, DayOfWeek, defaultDayPickerStrings, DateRangeType } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
-import { DateRangeType } from '../../DatePicker';
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date;

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekNumbers.Example.tsx
@@ -8,7 +8,7 @@ export interface ICalendarInlineExampleState {
   selectedDate?: Date;
 }
 
-export class CalendarInlineExample extends React.Component<{}, ICalendarInlineExampleState> {
+export class CalendarInlineWeekNumbersExample extends React.Component<{}, ICalendarInlineExampleState> {
   public constructor(props: {}) {
     super(props);
 
@@ -27,6 +27,7 @@ export class CalendarInlineExample extends React.Component<{}, ICalendarInlineEx
         <Calendar
           dateRangeType={DateRangeType.Day}
           showGoToToday={true}
+          showWeekNumbers={true}
           onSelectDate={this._onSelectDate}
           value={this.state.selectedDate}
           firstDayOfWeek={DayOfWeek.Sunday}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.WeekSelection.Example.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react';
+import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { Calendar, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
+
+import * as styles from './Calendar.Example.scss';
+
+const dateRangeType = DateRangeType.Week;
+
+export interface ICalendarInlineExampleState {
+  selectedDate?: Date;
+  selectedDateRange?: Date[];
+}
+
+export class CalendarInlineWeekSelectionExample extends React.Component<{}, ICalendarInlineExampleState> {
+  public constructor(props: {}) {
+    super(props);
+
+    this.state = {
+      selectedDate: new Date(),
+      selectedDateRange: undefined,
+    };
+  }
+
+  public render(): JSX.Element {
+    let dateRangeString: string | null = null;
+    if (this.state.selectedDateRange) {
+      const rangeStart = this.state.selectedDateRange[0];
+      const rangeEnd = this.state.selectedDateRange[this.state.selectedDateRange.length - 1];
+      dateRangeString = rangeStart.toLocaleDateString() + '-' + rangeEnd.toLocaleDateString();
+    }
+
+    return (
+      <div className={styles.wrapper}>
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          Selected dates:
+          <span> {!dateRangeString ? 'Not set' : dateRangeString}</span>
+        </div>
+        <Calendar
+          dateRangeType={dateRangeType}
+          highlightCurrentMonth={false}
+          highlightSelectedMonth={true}
+          showGoToToday={true}
+          onSelectDate={this._onSelectDate}
+          value={this.state.selectedDate}
+          firstDayOfWeek={DayOfWeek.Sunday}
+          strings={defaultDayPickerStrings}
+        />
+        <div>
+          <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+          <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+        </div>
+      </div>
+    );
+  }
+
+  private _goPrevious = (): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      const selectedDate = prevState.selectedDate || new Date();
+      const dateRangeArray = getDateRangeArray(selectedDate, dateRangeType, DayOfWeek.Sunday);
+
+      const subtractFrom = dateRangeArray[0];
+      const daysToSubtract = dateRangeArray.length;
+
+      const newSelectedDate = addDays(subtractFrom, -daysToSubtract);
+
+      return {
+        selectedDate: newSelectedDate,
+      };
+    });
+  };
+
+  private _goNext = (): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      const selectedDate = prevState.selectedDate || new Date();
+      const dateRangeArray = getDateRangeArray(selectedDate, dateRangeType, DayOfWeek.Sunday);
+      const newSelectedDate = addDays(dateRangeArray.pop()!, 1);
+
+      return {
+        selectedDate: newSelectedDate,
+      };
+    });
+  };
+
+  private _onSelectDate = (date: Date, dateRangeArray: Date[]): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        selectedDate: date,
+        selectedDateRange: dateRangeArray,
+      };
+    });
+  };
+}

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPickerPage.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPickerPage.tsx
@@ -18,16 +18,10 @@ export class WeeklyDayPickerPage extends React.Component<{}, {}> {
               <WeeklyDayPickerInlineExample />
             </ExampleCard>
             <ExampleCard
-              title="Inline WeeklyDayPicker with externally controlled date"
-              code={WeeklyDayPickerInlineExampleCode}
-            >
-              <WeeklyDayPickerInlineExample showNavigateButtons={true} />
-            </ExampleCard>
-            <ExampleCard
               title="Inline WeeklyDayPicker that can be expanded to full month picker"
               code={WeeklyDayPickerInlineExpandableExampleCode}
             >
-              <WeeklyDayPickerInlineExpandableExample showExpandButton={true} weeksToShow={6} />
+              <WeeklyDayPickerInlineExpandableExample />
             </ExampleCard>
           </div>
         }

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  WeeklyDayPicker,
-  IWeeklyDayPickerProps,
-  DayOfWeek,
-  addDays,
-  defaultDayPickerStrings,
-} from '@uifabric/date-time';
+import { WeeklyDayPicker, DayOfWeek, addDays, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
@@ -14,80 +8,43 @@ export interface IWeeklyDayPickerInlineExampleState {
   selectedDate?: Date;
 }
 
-export interface IWeeklyDayPickerInlineExampleProps extends Omit<IWeeklyDayPickerProps, 'strings'> {
-  showNavigateButtons?: boolean;
-}
-
-export class WeeklyDayPickerInlineExample extends React.Component<
-  IWeeklyDayPickerInlineExampleProps,
-  IWeeklyDayPickerInlineExampleState
-> {
-  public constructor(props: IWeeklyDayPickerInlineExampleProps) {
+export class WeeklyDayPickerInlineExample extends React.Component<{}, IWeeklyDayPickerInlineExampleState> {
+  public constructor(props: {}) {
     super(props);
 
     this.state = {
       selectedDate: new Date(),
     };
-
-    this._onSelectDate = this._onSelectDate.bind(this);
   }
 
   public render(): JSX.Element {
     return (
       <div className={styles.wrapper}>
-        {
-          <div>
-            Selected date(s):{' '}
-            <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
-          </div>
-        }
-        {(this.props.minDate || this.props.maxDate) && (
-          <div>
-            Date boundary:
-            <span>
-              {' '}
-              {this.props.minDate ? this.props.minDate.toLocaleDateString() : 'Not set'}-
-              {this.props.maxDate ? this.props.maxDate.toLocaleDateString() : 'Not set'}
-            </span>
-          </div>
-        )}
-        {this.props.restrictedDates && (
-          <div>
-            Disabled date(s):
-            <span>
-              {' '}
-              {this.props.restrictedDates.length > 0
-                ? this.props.restrictedDates.map((d: Date) => d.toLocaleDateString()).join(', ')
-                : 'Not set'}
-            </span>
-          </div>
-        )}
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
         <WeeklyDayPicker
           onSelectDate={this._onSelectDate}
-          firstDayOfWeek={this.props.firstDayOfWeek ? this.props.firstDayOfWeek : DayOfWeek.Sunday}
+          firstDayOfWeek={DayOfWeek.Sunday}
           strings={defaultDayPickerStrings}
-          minDate={this.props.minDate}
-          maxDate={this.props.maxDate}
-          restrictedDates={this.props.restrictedDates}
           initialDate={this.state.selectedDate}
         />
-        {this.props.showNavigateButtons && (
-          <div>
-            <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-            <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-          </div>
-        )}
+        <div>
+          <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+          <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+        </div>
       </div>
     );
   }
 
-  private _onSelectDate(date: Date): void {
+  private _onSelectDate = (date: Date): void => {
     this.setState((prevState: IWeeklyDayPickerInlineExampleState) => {
       return {
         selectedDate: date,
       };
     });
-  }
+  };
 
   private _goPrevious = () => {
     if (this.state && this.state.selectedDate) {

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  WeeklyDayPicker,
-  DayOfWeek,
-  addDays,
-  IWeeklyDayPickerProps,
-  defaultDayPickerStrings,
-} from '@uifabric/date-time';
+import { WeeklyDayPicker, DayOfWeek, addDays, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
@@ -15,91 +9,57 @@ export interface IWeeklyDayPickerInlineExpandableExampleState {
   expanded?: boolean;
 }
 
-export interface IWeeklyDayPickerInlineExpandableExampleProps extends Omit<IWeeklyDayPickerProps, 'strings'> {
-  showExpandButton?: boolean;
-  showNavigateButtons?: boolean;
-}
-
 export class WeeklyDayPickerInlineExpandableExample extends React.Component<
-  IWeeklyDayPickerInlineExpandableExampleProps,
+  {},
   IWeeklyDayPickerInlineExpandableExampleState
 > {
-  public constructor(props: IWeeklyDayPickerInlineExpandableExampleProps) {
+  public constructor(props: {}) {
     super(props);
 
     this.state = {
       selectedDate: new Date(),
       expanded: false,
     };
-
-    this._onSelectDate = this._onSelectDate.bind(this);
   }
 
   public render(): JSX.Element {
     return (
       <div className={styles.wrapper}>
-        {
-          <div>
-            Selected date(s):{' '}
-            <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
-          </div>
-        }
-        {(this.props.minDate || this.props.maxDate) && (
-          <div>
-            Date boundary:
-            <span>
-              {' '}
-              {this.props.minDate ? this.props.minDate.toLocaleDateString() : 'Not set'}-
-              {this.props.maxDate ? this.props.maxDate.toLocaleDateString() : 'Not set'}
-            </span>
-          </div>
-        )}
-        {this.props.restrictedDates && (
-          <div>
-            Disabled date(s):
-            <span>
-              {' '}
-              {this.props.restrictedDates.length > 0
-                ? this.props.restrictedDates.map((d: Date) => d.toLocaleDateString()).join(', ')
-                : 'Not set'}
-            </span>
-          </div>
-        )}
-        {this.props.showExpandButton && (
-          <div>
-            <DefaultButton
-              className={styles.button}
-              onClick={this._expand}
-              text="Expand/collapse"
-              aria-expanded={this.state.expanded}
-            />
-          </div>
-        )}
+        <div>
+          Selected date(s):{' '}
+          <span>{!this.state.selectedDate ? 'Not set' : this.state.selectedDate.toLocaleString()}</span>
+        </div>
+        <div>
+          <DefaultButton
+            className={styles.button}
+            onClick={this._expand}
+            text="Expand/collapse"
+            aria-expanded={this.state.expanded}
+          />
+        </div>
         <WeeklyDayPicker
-          {...this.props}
+          weeksToShow={6}
           onSelectDate={this._onSelectDate}
-          firstDayOfWeek={this.props.firstDayOfWeek ? this.props.firstDayOfWeek : DayOfWeek.Sunday}
+          firstDayOfWeek={DayOfWeek.Sunday}
           strings={defaultDayPickerStrings}
           initialDate={this.state.selectedDate}
           showFullMonth={this.state.expanded}
         />
-        {this.props.showNavigateButtons && (
-          <div>
-            <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
-            <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
-          </div>
-        )}
+        <div>
+          <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+          <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+        </div>
       </div>
     );
   }
 
-  private _onSelectDate(date: Date): void {
+  private _onSelectDate = (date: Date): void => {
     this.setState((prevState: IWeeklyDayPickerInlineExpandableExampleState) => {
       return {
         selectedDate: date,
       };
     });
-  }
+  };
 
   private _goPrevious = () => {
     if (this.state && this.state.selectedDate) {

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -108,7 +108,7 @@ export const CalendarInlineExample: React.FunctionComponent<ICalendarInlineExamp
     <div style={divStyle}>
       {
         <div>
-          Selected date(s): <span>{!selectedDate ? 'Not set' : selectedDate.toLocaleString()}</span>
+          Selected 2date(s): <span>{!selectedDate ? 'Not set' : selectedDate.toLocaleString()}</span>
         </div>
       }
       <div>

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -108,7 +108,7 @@ export const CalendarInlineExample: React.FunctionComponent<ICalendarInlineExamp
     <div style={divStyle}>
       {
         <div>
-          Selected 2date(s): <span>{!selectedDate ? 'Not set' : selectedDate.toLocaleString()}</span>
+          Selected date(s): <span>{!selectedDate ? 'Not set' : selectedDate.toLocaleString()}</span>
         </div>
       }
       <div>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Refactoring the Calendar and WeeklyDatePicker examples so that they all show up in the local storybook build. Storybook just looks for any *.Example.tsx files, which means no props can be passed in to the component, so this separates all the various configurations into separate files with the props hardcoded. As a bonus, it also makes the code examples linked much more clear about exactly what configuration is being used.

While working on this, found a bug where an externally controlled Calendar component would update the selected date but would not navigate when the prop value changed. Added a fix for it.

#### Focus areas to test

(optional)
