### PR TITLE
Linked folder tile

### DIFF
--- a/change/@uifabric-experiments-2020-07-08-21-54-08-linked-folder-tile.json
+++ b/change/@uifabric-experiments-2020-07-08-21-54-08-linked-folder-tile.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Support for linked folder in FolderCover component",
+  "packageName": "@uifabric/experiments",
+  "email": "hemanp@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-09T04:53:53.598Z"
+}

--- a/change/@uifabric-file-type-icons-2020-07-08-21-54-08-linked-folder-tile.json
+++ b/change/@uifabric-file-type-icons-2020-07-08-21-54-08-linked-folder-tile.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Introduce FolderCover for linked folders",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "hemanp@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-09T04:54:08.271Z"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -13,11 +13,25 @@ $folder-accent: #bf5712;
   &.isSmall {
     width: 72px;
     height: 52px;
+
+    &.isLinked {
+      .front {
+        top: 6px;
+        left: -5px;
+      }
+    }
   }
 
   &.isLarge {
     width: 112px;
     height: 80px;
+
+    &.isLinked {
+      .front {
+        top: 10px;
+        left: -4px;
+      }
+    }
   }
 }
 

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -46,6 +46,10 @@ const ASSETS: {
       back: `folderCoverSmallDefaultBack`,
       front: `folderCoverSmallDefaultFront`,
     },
+    linked: {
+      back: `folderCoverSmallLinkedBack`,
+      front: `folderCoverSmallLinkedFront`,
+    },
     media: {
       back: `folderCoverSmallMediaBack`,
       front: `folderCoverSmallMediaFront`,
@@ -55,6 +59,10 @@ const ASSETS: {
     default: {
       back: `folderCoverLargeDefaultBack`,
       front: `folderCoverLargeDefaultFront`,
+    },
+    linked: {
+      back: `folderCoverLargeLinkedBack`,
+      front: `folderCoverLargeLinkedFront`,
     },
     media: {
       back: `folderCoverLargeMediaBack`,
@@ -90,6 +98,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           [`ms-FolderCover--isLarge ${FolderCoverStyles.isLarge}`]: size === 'large',
           [`ms-FolderCover--isDefault ${FolderCoverStyles.isDefault}`]: type === 'default',
           [`ms-FolderCover--isMedia ${FolderCoverStyles.isMedia}`]: type === 'media',
+          [`ms-FolderCover--isLinked ${FolderCoverStyles.isLinked}`]: type === 'linked',
           [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent,
           [`ms-FolderCover--isFluent ${FolderCoverStyles.isFluent}`]: true,
         })}

--- a/packages/experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.types.ts
@@ -3,7 +3,7 @@ import { IBaseProps, ISize } from '../../Utilities';
 
 export type FolderCoverSize = 'small' | 'large';
 
-export type FolderCoverType = 'default' | 'media';
+export type FolderCoverType = 'default' | 'media' | 'linked';
 
 export interface IFolderCoverChildrenProps {
   contentSize: ISize;

--- a/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
+++ b/packages/experiments/src/components/FolderCover/examples/FolderCover.Basic.Example.tsx
@@ -5,9 +5,11 @@ import {
   renderFolderCoverWithLayout,
   IFolderCoverProps,
   SharedSignal,
+  initializeFolderCovers,
 } from '@uifabric/experiments';
 import { ISize, fitContentToBounds } from '@uifabric/experiments/lib/Utilities';
 
+initializeFolderCovers();
 interface IFolderCoverWithImageProps extends IFolderCoverProps {
   originalImageSize: ISize;
 }
@@ -142,6 +144,40 @@ export class FolderCoverBasicExample extends React.Component<{}, {}> {
           folderCoverSize="small"
           folderCoverType="media"
           metadata={15}
+          signal={<SharedSignal />}
+        />
+        <h3>Large Linked Cover</h3>
+        <FolderCoverWithImage
+          isFluent={false}
+          originalImageSize={{
+            width: 200,
+            height: 150,
+          }}
+          folderCoverSize="large"
+          folderCoverType="linked"
+          metadata={20}
+          signal={<SharedSignal />}
+        />
+        <h3>Small Linked Cover</h3>
+        <FolderCoverWithImage
+          isFluent={false}
+          originalImageSize={{
+            width: 200,
+            height: 150,
+          }}
+          folderCoverSize="small"
+          folderCoverType="linked"
+          metadata={15}
+        />
+        <h3>Small Linked Cover -- signal icon only</h3>
+        <FolderCoverWithImage
+          isFluent={true}
+          originalImageSize={{
+            width: 200,
+            height: 150,
+          }}
+          folderCoverSize="small"
+          folderCoverType="linked"
           signal={<SharedSignal />}
         />
       </div>

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { registerIcons, IIconOptions } from '@uifabric/styling';
 
 const ASSET_CDN_BASE_URL =
-  'https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/foldericons';
+  'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/office-ui-fabric-react-assets/foldericons';
 
 export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, options?: Partial<IIconOptions>): void {
   registerIcons(

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -16,6 +16,8 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
       icons: {
         folderCoverLargeDefaultFront: <img src={`${baseUrl}/lg-fg.svg`} />,
         folderCoverLargeDefaultBack: <img src={`${baseUrl}/lg-bg.svg`} />,
+        folderCoverLargeLinkedFront: <img src={`${baseUrl}/lg-fg-linked.svg`} />,
+        folderCoverLargeLinkedBack: <img src={`${baseUrl}/lg-bg.svg`} />,
         folderCoverLargeMediaFront: <img src={`${baseUrl}/lg-fg-media.svg`} />,
         folderCoverLargeMediaBack: <img src={`${baseUrl}/lg-bg.svg`} />,
       },
@@ -34,6 +36,8 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
       icons: {
         folderCoverSmallDefaultFront: <img src={`${baseUrl}/sm-fg.svg`} />,
         folderCoverSmallDefaultBack: <img src={`${baseUrl}/sm-bg.svg`} />,
+        folderCoverSmallLinkedFront: <img src={`${baseUrl}/sm-fg-linked.svg`} />,
+        folderCoverSmallLinkedBack: <img src={`${baseUrl}/sm-bg.svg`} />,
         folderCoverSmallMediaFront: <img src={`${baseUrl}/sm-fg-media.svg`} />,
         folderCoverSmallMediaBack: <img src={`${baseUrl}/sm-bg.svg`} />,
       },

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200622.001/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

* Update the base url for pulling new assets like LinkedFolder, OfficeScript icon and Samsung item type icons
* Update the base url for the FolderCover component
* Add the ability to display LinkedFolder by FolderCover component
* Fixed the FolderCover example page and add samples for LinkedFolder

![image](https://user-images.githubusercontent.com/7531363/86998971-609dca00-c166-11ea-9a1a-fd0342465f93.png)

#### Focus areas to test

(optional)
