### PR TITLE
fix: make getShorthandInfo compatible with `compose()`

### DIFF
--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -79,7 +79,7 @@ task('build:docs:component-info', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
     .pipe(
       cacheNonCi(gulpReactDocgen(paths.docs('tsconfig.json'), ['DOMAttributes', 'HTMLAttributes']), {
-        name: 'componentInfo-2.1',
+        name: 'componentInfo-2.2',
       }),
     )
     .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() })),


### PR DESCRIPTION
#### Description of changes

This PR updates `getShorthandInfo()` to support the extraction for `shorthandConfig` from composed components, too. I.e.

```tsx
const Button = compose(
  any,
  {
    shorthandConfig: { mappedProp: "content" }
  }
);
```

#### Focus areas to test

(optional)
