### PR TITLE
Adding filetype mapping for .osts extension

### DIFF
--- a/change/@uifabric-experiments-2020-07-09-13-25-59-caperez-filetype_osts_update.json
+++ b/change/@uifabric-experiments-2020-07-09-13-25-59-caperez-filetype_osts_update.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing sample storyboard for icons to initialize properly and show different icons.",
+  "packageName": "@uifabric/experiments",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-09T20:25:59.111Z"
+}

--- a/change/@uifabric-file-type-icons-2020-07-09-13-25-59-caperez-filetype_osts_update.json
+++ b/change/@uifabric-file-type-icons-2020-07-09-13-25-59-caperez-filetype_osts_update.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding file icon mapping support for `osts` extension.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-09T20:25:28.147Z"
+}

--- a/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
+++ b/packages/experiments/src/components/FileTypeIcon/examples/FileTypeIcon.Basic.Example.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { getFileTypeIconProps, FileIconType } from '@uifabric/file-type-icons';
+import { getFileTypeIconProps, FileIconType, initializeFileTypeIcons } from '@uifabric/file-type-icons';
+
+initializeFileTypeIcons(undefined);
 
 export class FileTypeIconBasicExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
@@ -23,11 +25,11 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <h3>Size 16 dotx icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ extension: 'dot', size: 16, imageFileType: 'svg' })} />
         <h3>Size 20 email icon as .svg</h3>
-        <Icon {...getFileTypeIconProps({ extension: '.msg', size: 20, imageFileType: 'svg' })} />
+        <Icon {...getFileTypeIconProps({ extension: 'msg', size: 20, imageFileType: 'svg' })} />
         <h3>Size 32 exe icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ extension: 'msi', size: 32 })} />
-        <h3>Size 40 font icon as .svg</h3>
-        <Icon {...getFileTypeIconProps({ extension: '.woff', size: 40 })} />
+        <h3>Size 40 script icon as .svg</h3>
+        <Icon {...getFileTypeIconProps({ extension: 'osts', size: 40 })} />
         <h3>Size 48 html icon as .svg</h3>
         <Icon {...getFileTypeIconProps({ extension: 'html', size: 48 })} />
         <h3>Size 64 mpp icon as .svg</h3>
@@ -44,6 +46,8 @@ export class FileTypeIconBasicExample extends React.Component<{}, {}> {
         <Icon {...getFileTypeIconProps({ type: FileIconType.listItem, size: 48, imageFileType: 'svg' })} />
         <h3>Size 64 sharedfolder icon as .png</h3>
         <Icon {...getFileTypeIconProps({ type: FileIconType.sharedFolder, size: 64, imageFileType: 'png' })} />
+        <h3>Size 64 linkedfolder icon as .png</h3>
+        <Icon {...getFileTypeIconProps({ type: FileIconType.linkedFolder, size: 64, imageFileType: 'png' })} />
       </div>
     );
   }

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -289,6 +289,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['lnk', 'link', 'url', 'website', 'webloc'],
   },
   linkedfolder: {},
+  officescript: {
+    extensions: ['osts'],
+  },
   splist: {
     extensions: ['listitem'],
   },


### PR DESCRIPTION
#### Pull request checklist

- [x] Added .osts mapping to filetype icons
- [x] Fixed the filetype storyboard sample to properly initialize and render icons.
- [x] Include a change request file using `$ yarn change`
#### Focus areas to test

- http://`experiments pkg storyboard`/?path=/story/filetypeicon--file-type-icon-basic-example
