### PR TITLE
Add multi select delimiter to combobox

### DIFF
--- a/change/office-ui-fabric-react-2020-07-09-20-17-46-add-multi-select-delimiter-to-combobox.json
+++ b/change/office-ui-fabric-react-2020-07-09-20-17-46-add-multi-select-delimiter-to-combobox.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add mutliSelectDelimiter property to ComboBox",
+  "packageName": "office-ui-fabric-react",
+  "email": "cocahill@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-10T00:17:46.712Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2754,6 +2754,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
     iconButtonProps?: IButtonProps;
     isButtonAriaHidden?: boolean;
     keytipProps?: IKeytipProps;
+    multiSelectDelimiter?: string;
     onChange?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number, value?: string) => void;
     onItemClick?: (event: React.FormEvent<IComboBox>, option?: IComboBoxOption, index?: number) => void;
     onMenuDismiss?: () => void;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -743,6 +743,29 @@ describe('ComboBox', () => {
     expect((inputElement.instance() as any).value).toEqual(compare);
   });
 
+  it('in multiSelect mode, input has correct value when multiSelectDelimiter specified', () => {
+    const comboBoxRef = React.createRef<any>();
+    wrapper = mount(
+      <ComboBox multiSelect multiSelectDelimiter="; " options={DEFAULT_OPTIONS} componentRef={comboBoxRef} />,
+    );
+
+    const comboBoxRoot = wrapper.find('.ms-ComboBox');
+    const inputElement = comboBoxRoot.find('input');
+    inputElement.simulate('keydown', { which: KeyCodes.enter });
+    const buttons = document.querySelectorAll('.ms-ComboBox-option > input');
+
+    ReactTestUtils.Simulate.change(buttons[0]);
+    ReactTestUtils.Simulate.change(buttons[2]);
+    const compare = [DEFAULT_OPTIONS[0], DEFAULT_OPTIONS[2]].reduce((previous: string, current: IComboBoxOption) => {
+      if (previous !== '') {
+        return previous + '; ' + current.text;
+      }
+      return current.text;
+    }, '');
+
+    expect((inputElement.instance() as any).value).toEqual(compare);
+  });
+
   it('in multiSelect mode, optional onItemClick callback invoked per option select', () => {
     const onItemClickMock = jest.fn();
     wrapper = mount(<ComboBox multiSelect options={DEFAULT_OPTIONS} onItemClick={onItemClickMock} />);

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -706,14 +706,8 @@ export class ComboBox extends React.Component<IComboBoxProps, IComboBoxState> {
           : this._normalizeToString(suggestedDisplayValue),
       );
     }
-    let displayString = '';
-    for (let idx = 0; idx < displayValues.length; idx++) {
-      if (idx > 0) {
-        displayString += ', ';
-      }
-      displayString += displayValues[idx];
-    }
-    return displayString;
+    const { multiSelectDelimiter = ', ' } = this.props;
+    return displayValues.join(multiSelectDelimiter);
   }
 
   /**

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -134,6 +134,13 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
   text?: string;
 
   /**
+   * When multiple items are selected, this will be used to separate values in the combobox input.
+   *
+   * @defaultvalue ", "
+   */
+  multiSelectDelimiter?: string;
+
+  /**
    * The IconProps to use for the button aspect of the combobox
    */
   buttonIconProps?: IIconProps;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #13978
- [X] Include a change request file using `$ yarn change`

#### Description of changes

This change adds a `multiSelectDelimiter` property to ComboBox that is analogous to Dropdown's `multiSelectDelimiter` property.

#### Focus areas to test

ComboBox.
