### PR TITLE
chore: use minification for stats task and proper env

### DIFF
--- a/scripts/webpack/webpack.config.stats.ts
+++ b/scripts/webpack/webpack.config.stats.ts
@@ -5,6 +5,7 @@ import webpack from 'webpack';
 import config from '../config';
 import glob from 'glob';
 import * as _ from 'lodash';
+import { argv } from 'yargs';
 import TerserWebpackPlugin from 'terser-webpack-plugin';
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -59,31 +60,32 @@ const makeConfig = (srcPath: string, name: string): webpack.Configuration => ({
     react: 'react',
     'react-dom': 'reactDOM',
   },
-  optimization: {
-    minimizer: [
-      new TerserWebpackPlugin({
-        cache: true,
-        parallel: true,
-        sourceMap: false,
+  ...(argv.debug && {
+    optimization: {
+      minimizer: [
+        new TerserWebpackPlugin({
+          cache: true,
+          parallel: true,
+          sourceMap: false,
 
-        terserOptions: {
-          mangle: false,
-          output: {
-            beautify: true,
-            comments: true,
-            preserve_annotations: true,
+          terserOptions: {
+            mangle: false,
+            output: {
+              beautify: true,
+              comments: true,
+              preserve_annotations: true,
+            },
           },
-        },
-      }),
-    ],
-  },
+        }),
+      ],
+    },
+  }),
   plugins: [
     new CleanWebpackPlugin([paths.base('stats')], {
       root: paths.base(),
       verbose: false, // do not log
     }),
     new IgnoreNotFoundExportPlugin(),
-    new webpack.DefinePlugin(config.compiler_globals),
     // new BundleAnalyzerPlugin({
     //   reportFilename: `${name}.html`,
     //   analyzerMode: 'static',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This partially reverts changes from #13862 to run our tests with default minification config as there is no sense to run them without minification...

Also disables `DefinePlugin` as it defined wrong `NODE_ENV` settings.

#### Focus areas to test

(optional)
