### PR TITLE
ESLint: add faster max-len rule

### DIFF
--- a/apps/fabric-website/src/pages/Controls/ButtonPage/ButtonPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ButtonPage/ButtonPage.tsx
@@ -7,7 +7,7 @@ import { IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { ImplementationSection } from '@uifabric/example-app-base/lib/index2';
 import { ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 const toggleStyles: Partial<IToggleStyles> = {
   root: { margin: '10px 0' },

--- a/apps/fabric-website/src/pages/Controls/LinkPage/LinkPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/LinkPage/LinkPage.tsx
@@ -6,7 +6,7 @@ import { Platforms } from '../../../interfaces/Platforms';
 import { ImplementationSection } from '@uifabric/example-app-base/lib/index2';
 import { ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 const baseUrl = 'https://github.com/microsoft/fluentui/tree/master/apps/fabric-website/src/pages/Controls/LinkPage';
 

--- a/apps/fabric-website/src/pages/Controls/PersonaPage/PersonaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/PersonaPage/PersonaPage.tsx
@@ -6,7 +6,7 @@ import { Platforms } from '../../../interfaces/Platforms';
 import { ImplementationSection } from '@uifabric/example-app-base/lib/index2';
 import { ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 const baseUrl = 'https://github.com/microsoft/fluentui/tree/master/apps/fabric-website/src/pages/Controls/PersonaPage/';
 

--- a/apps/fabric-website/src/pages/Controls/SeparatorPage/SeparatorPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/SeparatorPage/SeparatorPage.tsx
@@ -6,7 +6,7 @@ import { IPageSectionProps } from '@uifabric/example-app-base/lib/index2';
 import { ImplementationSection } from '@uifabric/example-app-base/lib/index2';
 import { ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 const baseUrl =
   'https://github.com/microsoft/fluentui/tree/master/apps/fabric-website/src/pages/Controls/SeparatorPage/';

--- a/apps/fabric-website/src/pages/Controls/TextPage/TextPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/TextPage/TextPage.tsx
@@ -5,7 +5,7 @@ import { Platforms } from '../../../interfaces/Platforms';
 import { IPageSectionProps, ImplementationSection } from '@uifabric/example-app-base/lib/index2';
 import { ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 const baseUrl = 'https://github.com/microsoft/fluentui/tree/master/apps/fabric-website/src/pages/Controls/TextPage/';
 

--- a/apps/vr-tests/src/stories/Checkbox.stories.tsx
+++ b/apps/vr-tests/src/stories/Checkbox.stories.tsx
@@ -38,7 +38,7 @@ storiesOf('Checkbox', module)
   .addStory('End', () => <Checkbox label="Checkbox end" boxSide="end" />, { rtl: true })
   .addStory('Multi-line Checkbox', () => (
     <Checkbox
-      // eslint-disable-next-line max-len
+      // eslint-disable-next-line @fluentui/max-len
       label="Dignissim vehicula pretium. Mauris sapien lorem. Ipsum metus tristique. Aliquam mauris ac purus id nunc. Erat aenean ut commodo integer litora amet rutrum mus maecenas quisque lectus eget fames massa. Pede proin metus sollicitudin donec purus. Sem at tempus morbi metus sit. Quam odio porta. Cras nulla sed. Aliquam mauris auctor. Adipiscing magna rutrum est sed porttitor. Duis rhoncus convallis. Nunc qui amet. Quo eros ac. Nec laboris pharetra erat nec hymenaeos phasellus urna neque rerum ut ac. In natoque morbi. Risus wisi maecenas eros magna pellentesque inceptos mi nec mattis lacus tortor volutpat lorem vivamus. Magna amet nam non in non. Semper sagittis purus et tincidunt justo. Magna fusce enim amet nulla neque. A vestibulum risus wisi temporibus consectetuer. Non sociis sed risus sagittis condimentum. Erat vel interdum quas libero erat elementum massa duis elementum malesuada lacinia. Scelerisque vivamus elit. Bibendum libero adipiscing. Curae quis lacus. At metus vestibulum. Diam natoque nullam posuere vestibulum aliquam suscipit quis posuere sed penatibus sit sed sapien eros con sodales hymenaeos. Nulla vestibulum ut. Aenean curabitur diam lorem commodo malesuada dui nascetur pulvinar."
       defaultChecked={true}
     />

--- a/apps/vr-tests/src/stories/CheckboxNext.stories.tsx
+++ b/apps/vr-tests/src/stories/CheckboxNext.stories.tsx
@@ -47,7 +47,7 @@ storiesOf('Checkbox Next', module)
   .addStory('End', () => <Checkbox label="Checkbox end" boxSide="end" />, { rtl: true })
   .addStory('Multi-line Checkbox', () => (
     <Checkbox
-      // eslint-disable-next-line max-len
+      // eslint-disable-next-line @fluentui/max-len
       label="Dignissim vehicula pretium. Mauris sapien lorem. Ipsum metus tristique. Aliquam mauris ac purus id nunc. Erat aenean ut commodo integer litora amet rutrum mus maecenas quisque lectus eget fames massa. Pede proin metus sollicitudin donec purus. Sem at tempus morbi metus sit. Quam odio porta. Cras nulla sed. Aliquam mauris auctor. Adipiscing magna rutrum est sed porttitor. Duis rhoncus convallis. Nunc qui amet. Quo eros ac. Nec laboris pharetra erat nec hymenaeos phasellus urna neque rerum ut ac. In natoque morbi. Risus wisi maecenas eros magna pellentesque inceptos mi nec mattis lacus tortor volutpat lorem vivamus. Magna amet nam non in non. Semper sagittis purus et tincidunt justo. Magna fusce enim amet nulla neque. A vestibulum risus wisi temporibus consectetuer. Non sociis sed risus sagittis condimentum. Erat vel interdum quas libero erat elementum massa duis elementum malesuada lacinia. Scelerisque vivamus elit. Bibendum libero adipiscing. Curae quis lacus. At metus vestibulum. Diam natoque nullam posuere vestibulum aliquam suscipit quis posuere sed penatibus sit sed sapien eros con sodales hymenaeos. Nulla vestibulum ut. Aenean curabitur diam lorem commodo malesuada dui nascetur pulvinar."
       defaultChecked={true}
     />

--- a/apps/vr-tests/src/stories/GroupedList.stories.tsx
+++ b/apps/vr-tests/src/stories/GroupedList.stories.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { GroupedList } from 'office-ui-fabric-react';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 const items = [
   {
     thumbnail: '//placehold.it/175x175',

--- a/apps/vr-tests/src/stories/List.stories.tsx
+++ b/apps/vr-tests/src/stories/List.stories.tsx
@@ -5,7 +5,7 @@ import { storiesOf } from '@storybook/react';
 import { FabricDecorator } from '../utilities';
 import { List } from 'office-ui-fabric-react';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 const items = [
   {
     thumbnail: '//placehold.it/233x233',

--- a/apps/vr-tests/src/stories/MessageBar.stories.tsx
+++ b/apps/vr-tests/src/stories/MessageBar.stories.tsx
@@ -7,7 +7,7 @@ import { MessageBarButton, Link, MessageBar, MessageBarType } from 'office-ui-fa
 
 const noop = (): void => undefined;
 const longText =
-  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @fluentui/max-len
   'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque vestibulum tellus at malesuada vestibulum. Pellentesque eget mi sagittis, sagittis nisi a, tristique nisl. Sed sed consequat neque, et dignissim ipsum. Integer in neque vestibulum, aliquet erat nec, vestibulum ex. Nullam et imperdiet lectus. Cras tempus eu tortor a elementum. Proin non justo lacus. Donec tincidunt laoreet malesuada. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Aenean augue nisl, lobortis ut sodales eu, convallis in metus.';
 const link = <Link href="www.bing.com">Visit our website</Link>;
 

--- a/change/@fluentui-eslint-plugin-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@fluentui-eslint-plugin-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add custom max-len rule",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-13T19:23:36.528Z"
+}

--- a/change/@fluentui-react-next-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@fluentui-react-next-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:47.133Z"
+}

--- a/change/@uifabric-azure-themes-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-azure-themes-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:29.007Z"
+}

--- a/change/@uifabric-example-app-base-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-example-app-base-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:40.216Z"
+}

--- a/change/@uifabric-fabric-website-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-fabric-website-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:26.098Z"
+}

--- a/change/@uifabric-migration-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-migration-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/migration",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:42.254Z"
+}

--- a/change/@uifabric-tsx-editor-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-tsx-editor-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:50.775Z"
+}

--- a/change/@uifabric-utilities-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/@uifabric-utilities-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:52.863Z"
+}

--- a/change/office-ui-fabric-react-2020-07-13-12-23-52-eslint-max-len.json
+++ b/change/office-ui-fabric-react-2020-07-13-12-23-52-eslint-max-len.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: switch from `max-len` rule to `@fluentui/max-len`",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-13T19:23:44.713Z"
+}

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -10,7 +10,7 @@ export const borderWidthError = '2px';
 export const borderSolid = 'solid';
 export const borderNone = 'none';
 export const fontFamily =
-  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @fluentui/max-len
   'Segoe UI, "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue",sans-serif';
 export const fontWeightBold = '700';
 export const inputControlHeight = '24px';

--- a/packages/eslint-plugin/.eslintrc.json
+++ b/packages/eslint-plugin/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  // eslint config for the package itself
+  "extends": ["plugin:@fluentui/eslint-plugin/node"],
+  "root": true,
+  "overrides": [
+    {
+      "files": ["src/rules/*.js"],
+      "rules": {
+        // too many false positives on node types
+        "@typescript-eslint/naming-convention": "off"
+      }
+    }
+  ]
+}

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -43,6 +43,19 @@ Example:
 
 Prevent using deprecated `KeyboardEvent` props `which` and `keyCode`, and recommend using `@fluentui/keyboard-key` instead.
 
+### `max-len`
+
+Enforces max line length, more performantly than [ESLint's `max-len`](https://eslint.org/docs/rules/max-len).
+
+(The default max-len rule is surprisingly slow, which may be because it has options to detect and specially handle comments, and because it checks the ignore regex without even a preliminary length check first.)
+
+#### Options
+
+The rule requires an options object containing:
+
+- `max` (required): the maximum line length
+- `ignorePatterns` (optional): ignore the line if it matches any of these regular expressions
+
 ### `no-tslint-comments`
 
 Ban `tslint:disable` and `tslint:enable` comments.

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -47,7 +47,13 @@ Prevent using deprecated `KeyboardEvent` props `which` and `keyCode`, and recomm
 
 Enforces max line length, more performantly than [ESLint's `max-len`](https://eslint.org/docs/rules/max-len).
 
-(The default max-len rule is surprisingly slow, which may be because it has options to detect and specially handle comments, and because it checks the ignore regex without even a preliminary length check first.)
+This rule is significantly faster than the default `max-len` rule because it **does not** support:
+
+- Expanding tabs (only handles spaces for indentation)
+- Multi-byte unicode characters (they will be counted as multiple characters)
+- Extra options for handling comments, strings, or URLs
+
+(Skipping these extra features lets us do a basic string length check before running any regular expressions or other extra logic, which makes the huge majority of line length checks very fast.)
 
 #### Options
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/microsoft/fluentui"
   },
   "license": "MIT",
+  "scripts": {
+    "lint": "eslint --ext .js src"
+  },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/experimental-utils": "^3.4.0",

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -47,6 +47,21 @@ const config = {
     '**/*.scss.ts',
   ],
   rules: {
+    '@fluentui/max-len': [
+      'error',
+      {
+        ignorePatterns: [
+          'require(<.*?>)?\\(',
+          'https?:\\/\\/',
+          '^(import|export) \\{ \\w+( as \\w+)? \\} from',
+          '^import \\* as',
+          '^\\s+(<path )?d=',
+          '!raw-loader!',
+          '\\bdata:image/',
+        ],
+        max: 120,
+      },
+    ],
     '@fluentui/no-tslint-comments': 'error',
 
     // tslint: function-name, variable-name
@@ -62,21 +77,6 @@ const config = {
     'guard-for-in': 'error',
     'import/no-extraneous-dependencies': ['error', { devDependencies: [...configHelpers.devDependenciesFiles] }],
     'jsx-a11y/tabindex-no-positive': 'error',
-    'max-len': [
-      'error',
-      {
-        ignorePattern: [
-          'require(<.*?>)?\\(',
-          'https?:\\/\\/',
-          '^(import|export) \\{ \\w+( as \\w+)? \\} from',
-          '^import \\* as',
-          '^\\s+(<path )?d=',
-          '!raw-loader!',
-          '\\bdata:image/',
-        ].join('|'),
-        code: 120,
-      },
-    ],
     'no-alert': 'error',
     'no-bitwise': 'error',
     'no-caller': 'error',
@@ -116,7 +116,6 @@ const config = {
     'default-case': 'off',
     'func-names': 'off',
     'global-require': 'off',
-    'import/export': 'off',
     'import/extensions': 'off',
     'import/first': 'off',
     'import/newline-after-import': 'off',
@@ -126,7 +125,6 @@ const config = {
     'import/no-unresolved': 'off',
     'import/no-useless-path-segments': 'off',
     'import/order': 'off',
-    'import/prefer-default-export': 'off',
     'jsx-a11y/alt-text': 'off',
     'jsx-a11y/anchor-is-valid': 'off',
     'jsx-a11y/aria-activedescendant-has-tabindex': 'off',
@@ -203,10 +201,17 @@ const config = {
     'no-restricted-syntax': 'off',
 
     // permanently disable because we disagree with these rules
+    'import/prefer-default-export': 'off',
     'no-await-in-loop': 'off', // contrary to rule docs, awaited things often are NOT parallelizable
     'no-restricted-globals': 'off', // airbnb bans isNaN in favor of Number.isNaN which is unavailable in IE 11
     'react/jsx-props-no-spreading': 'off',
     'react/prop-types': 'off',
+
+    // permanently disable due to redundancy with custom rules
+    'max-len': 'off',
+
+    // permanently disable due to being unnecessary or having limited benefit for TS
+    'import/export': 'off',
 
     // permanently disable due to perf problems and limited benefit
     // see here for perf testing (note that you must run eslint directly)

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -207,7 +207,7 @@ const config = {
     'react/jsx-props-no-spreading': 'off',
     'react/prop-types': 'off',
 
-    // permanently disable due to redundancy with custom rules
+    // permanently disable due to performance issues (using custom rule `@fluentui/max-len` instead)
     'max-len': 'off',
 
     // permanently disable due to being unnecessary or having limited benefit for TS

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -10,6 +10,7 @@ module.exports = {
   rules: {
     'ban-imports': require('./rules/ban-imports'),
     'deprecated-keyboard-event-props': require('./rules/deprecated-keyboard-event-props'),
+    'max-len': require('./rules/max-len'),
     'no-tslint-comments': require('./rules/no-tslint-comments'),
     'no-visibility-modifiers': require('./rules/no-visibility-modifiers'),
   },

--- a/packages/eslint-plugin/src/rules/max-len.js
+++ b/packages/eslint-plugin/src/rules/max-len.js
@@ -1,0 +1,66 @@
+// @ts-check
+const createRule = require('../utils/createRule');
+
+module.exports = createRule({
+  name: 'max-len',
+  meta: {
+    type: 'layout',
+    docs: {
+      // The default max-len rule is surprisingly slow, because:
+      // - it has options to detect and specially handle comments, strings, etc
+      // - it checks the ignore regex without even a preliminary length check first
+      description: 'Enforces a maximum line length, more cheaply than default ESLint version',
+      category: 'Best Practices',
+      recommended: false,
+    },
+    messages: {
+      max: 'This line has a length of {{lineLength}}. Maximum allowed is {{max}}.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignorePatterns: {
+            description: 'regular expressions to ignore',
+            type: 'array',
+            items: { type: 'string' },
+          },
+          max: {
+            type: 'integer',
+            minimum: 0,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  defaultOptions: [],
+  create: context => {
+    const options = /** @type {{ max?: number; ignorePatterns?: string[]; }} */ (context.options[0] || {});
+    const { ignorePatterns = /** @type {string[]} */ ([]), max = 120 } = options;
+
+    const ignoreRegexes = ignorePatterns.map(pat => new RegExp(pat));
+
+    const sourceCode = context.getSourceCode();
+
+    return {
+      Program: program => {
+        sourceCode.getLines().forEach((line, i) => {
+          // Check length FIRST. Important for performance.
+          if (line.length > max && !ignoreRegexes.some(r => r.test(line))) {
+            const lineNumber = i + 1;
+            context.report({
+              node: program,
+              loc: {
+                start: { line: lineNumber, column: 0 },
+                end: { line: lineNumber, column: line.length },
+              },
+              messageId: 'max',
+              data: { lineLength: line.length, max },
+            });
+          }
+        });
+      },
+    };
+  },
+});

--- a/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
+++ b/packages/example-app-base/src/components/ComponentPage/ComponentPage.tsx
@@ -139,7 +139,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
         componentNameJsx = <code>{allowNativePropsForComponentName}</code>;
       }
 
-      /* eslint-disable max-len */
+      /* eslint-disable @fluentui/max-len */
       return (
         <MessageBar>
           <strong>Native props allowed {componentNameJsx && <>for {componentNameJsx}</>}</strong> - all HTML attributes
@@ -147,7 +147,7 @@ export class ComponentPageBase extends React.PureComponent<IComponentPageProps> 
           {componentNameJsx || 'this component'}.
         </MessageBar>
       );
-      /* eslint-enable max-len */
+      /* eslint-enable @fluentui/max-len */
     }
   }
 

--- a/packages/migration/tsconfig.json
+++ b/packages/migration/tsconfig.json
@@ -18,11 +18,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "lib": ["es2017"],
-    "types": ["jest", "node"],
-    "paths": {
-      "@uifabric/migration/lib/*": ["./src/*"],
-      "@uifabric/migration": ["./src"]
-    }
+    "types": ["jest", "node"]
   },
   "include": ["src"]
 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -59,7 +59,7 @@ const overflowButtonProps: IButtonProps = {
 };
 
 /** Command bar which renders the Share button with a coachmark */
-// eslint-disable-next-line max-len
+// eslint-disable-next-line @fluentui/max-len
 const IndividualCommandBarButtonAsExample: React.FunctionComponent<IIndividualCommandBarButtonAsExampleProps> = props => {
   const { onDismissCoachmark, isCoachmarkVisible } = props;
   const items: ICommandBarItemProps[] = React.useMemo(() => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/ShimmeredDetailsList.styles.ts
@@ -15,7 +15,7 @@ export const getStyles = (props: IShimmeredDetailsListStyleProps): IShimmeredDet
           right: 0,
           bottom: 0,
           left: 0,
-          // eslint-disable-next-line max-len
+          // eslint-disable-next-line @fluentui/max-len
           backgroundImage: `linear-gradient(to bottom, transparent 30%, ${palette.whiteTranslucent40} 65%,${palette.white} 100%)`,
         },
       },

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.test.tsx
@@ -65,7 +65,7 @@ describe('Facepile', () => {
     expectOne(wrapper, '.ms-Facepile-itemButton');
   });
 
-  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @fluentui/max-len
   it('renders without descriptive overflow button if overflowButtonProps are not null and maximum personas are not exceeded', () => {
     const wrapper = mount(
       <Facepile personas={[]} overflowButtonProps={{}} overflowButtonType={OverflowButtonType.descriptive} />,
@@ -75,7 +75,7 @@ describe('Facepile', () => {
     expectMissing(wrapper, '.ms-Facepile-itemButton');
   });
 
-  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @fluentui/max-len
   it('renders with descriptive overflow button if overflowButtonProps are not null and maximum personas are exceeded', () => {
     const personas: IFacepilePersona[] = facepilePersonas.concat(...facepilePersonas, ...facepilePersonas);
     const wrapper = mount(

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.test.tsx
@@ -213,7 +213,7 @@ describe('GroupedList', () => {
     wrapper.unmount();
   });
 
-  // eslint-disable-next-line max-len
+  // eslint-disable-next-line @fluentui/max-len
   it('renders the specified count of rows if "Show All" is to be displayed and all rows once "Show All" is clicked', () => {
     const _selection = new Selection();
     const _items: Array<{ key: string }> = [{ key: '1' }, { key: '2' }, { key: '3' }];

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -392,7 +392,7 @@ describe('KeytipLayer', () => {
       expect(getKeytip(visibleKeytips, 'X')).toBeDefined();
     });
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @fluentui/max-len
     it('keytipAdded event does not show a keytip if the current keytip is its parent when delay updating and not in keytip mode', () => {
       ktpMgr.delayUpdatingKeytipChange = true;
       ktpTree.currentKeytip = ktpTree.getNode(keytipIdB);
@@ -408,7 +408,7 @@ describe('KeytipLayer', () => {
       expect(getKeytip(visibleKeytips, 'X')).toBeUndefined();
     });
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @fluentui/max-len
     it('keytipAdded event delay-shows a keytip if the current keytip is its parent when delay updating and in keytip mode', () => {
       ktpMgr.delayUpdatingKeytipChange = true;
       ktpMgr.inKeytipMode = true;

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -326,7 +326,7 @@ describe('ResizeGroup', () => {
       expect(getMeasuredElementWidthStub.callCount).toEqual(1);
     });
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @fluentui/max-len
     it('sets resize direction to shrink when resizeDirection is grow, contents do not fit, and there is no onGrowData', () => {
       const dataToMeasure = { index: 8 };
       const resizeGroupProps = getRequiredResizeGroupProps();

--- a/packages/office-ui-fabric-react/src/components/Stack/StackUtils.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackUtils.test.ts
@@ -85,7 +85,7 @@ describe('StackUtils', () => {
       });
     });
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @fluentui/max-len
     it('can parse a string with horizontal and vertical gap with one of them getting value from the theme when given a spacing key', () => {
       expect(parseGap('50px m', theme)).toEqual({
         rowGap: { value: 50, unit: 'px' },

--- a/packages/office-ui-fabric-react/src/utilities/keytips/KeytipManager.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/keytips/KeytipManager.test.tsx
@@ -168,7 +168,7 @@ describe('KeytipManager', () => {
         expect(eventTriggered).toEqual(true);
       });
 
-      // eslint-disable-next-line max-len
+      // eslint-disable-next-line @fluentui/max-len
       it('adds the keytip and does not raise persistedKeytipAdded event while delaying updates and not in keytip mode', () => {
         let eventTriggered = false;
         events.on(ktpMgr, KeytipEvents.PERSISTED_KEYTIP_ADDED, (eventArgs: any) => {
@@ -206,7 +206,7 @@ describe('KeytipManager', () => {
         expect(eventTriggered).toEqual(true);
       });
 
-      // eslint-disable-next-line max-len
+      // eslint-disable-next-line @fluentui/max-len
       it('removes a keytip and does not raise persistedKeytipRemoved event while delaying updates and not in keytip mode', () => {
         let eventTriggered = false;
         events.on(ktpMgr, KeytipEvents.PERSISTED_KEYTIP_REMOVED, (eventArgs: any) => {

--- a/packages/react-next/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/react-next/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -328,7 +328,7 @@ describe('ResizeGroup', () => {
       expect(getMeasuredElementWidthStub.callCount).toEqual(1);
     });
 
-    // eslint-disable-next-line max-len
+    // eslint-disable-next-line @fluentui/max-len
     it('sets resize direction to shrink when resizeDirection is grow, contents do not fit, and there is no onGrowData', () => {
       const dataToMeasure = { index: 8 };
       const resizeGroupProps = getRequiredResizeGroupProps();

--- a/packages/tsx-editor/src/imports.test.ts
+++ b/packages/tsx-editor/src/imports.test.ts
@@ -5,7 +5,7 @@ describe('monaco imports', () => {
 
   // These tests take advantage of the fact that Monaco's JS files use ES module format, which Jest
   // doesn't support--so it should throw an exception when importing anything besides types from Monaco.
-  /* eslint-disable max-len */
+  /* eslint-disable @fluentui/max-len */
 
   it('test can detect monaco imports', () => {
     try {

--- a/packages/utilities/src/initials.ts
+++ b/packages/utilities/src/initials.ts
@@ -22,7 +22,7 @@ const MULTIPLE_WHITESPACES_REGEX: RegExp = /\s+/g;
  * CJK:      CJK Unified Ideographs Extension A, CJK Unified Ideographs, CJK Compatibility Ideographs,
  *             CJK Unified Ideographs Extension B
  */
-// eslint-disable-next-line max-len
+// eslint-disable-next-line @fluentui/max-len
 const UNSUPPORTED_TEXT_REGEX: RegExp = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF\u3040-\u309F\u30A0-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]|[\uD840-\uD869][\uDC00-\uDED6]/;
 
 function getInitialsLatin(displayName: string, isRtl: boolean): string {

--- a/packages/utilities/src/osDetector.test.ts
+++ b/packages/utilities/src/osDetector.test.ts
@@ -1,6 +1,6 @@
 import { isMac } from './osDetector';
 
-/* eslint-disable max-len */
+/* eslint-disable @fluentui/max-len */
 
 function testIsMac(agent: string, result: boolean): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
When running ESLint with timing data to investigate why it's slower, one outlier I noticed was the `max-len` rule. I looked into it and the reason it's slow is because it supports a lot of different options, and it **unconditionally** does extra calculations related to those options even if they're not being used. It also handles tabs and multi-byte unicode characters when calculating line length (rather than using raw string length), and neither of those is very important to us.

Since this is a pretty simple rule, I made a custom rule `@fluentui/max-len` with the following optimizations:
- The only options are `max` and a list of `ignorePatterns` (ignore lines which match these regexes)
- In the implementation, check the line length FIRST. If it's less than `max`, skip other checks.
- Don't account for tab expansion or multi-byte unicode characters when calculating length (just use string length)