### PR TITLE
Fixing the order of hooks updation for addition and deletion of items in UnifiedPeoplePicker

### DIFF
--- a/change/@uifabric-experiments-2020-07-12-12-54-10-u-nebhatna-fixUppBugs.json
+++ b/change/@uifabric-experiments-2020-07-12-12-54-10-u-nebhatna-fixUppBugs.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixing order of hooks",
+  "comment": "UnifiedPeoplePicker: Fixing order of hooks",
   "packageName": "@uifabric/experiments",
   "email": "nebhatna@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@uifabric-experiments-2020-07-12-12-54-10-u-nebhatna-fixUppBugs.json
+++ b/change/@uifabric-experiments-2020-07-12-12-54-10-u-nebhatna-fixUppBugs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing order of hooks",
+  "packageName": "@uifabric/experiments",
+  "email": "nebhatna@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-12T19:54:10.262Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -189,10 +189,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     showPicker(true);
   };
   const _onSuggestionSelected = (ev: any, item: IFloatingSuggestionItemProps<T>) => {
+    addItems([item.item]);
     if (props.floatingSuggestionProps.onSuggestionSelected) {
       props.floatingSuggestionProps.onSuggestionSelected(ev, item);
     }
-    addItems([item.item]);
     if (input.current) {
       input.current.clear();
     }

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -199,10 +199,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     showPicker(false);
   };
   const _onRemoveSelectedItems = (itemsToRemove: T[]) => {
+    removeItems(itemsToRemove);
     if (props.selectedItemsListProps.onItemsRemoved) {
       props.selectedItemsListProps.onItemsRemoved(itemsToRemove);
     }
-    removeItems(itemsToRemove);
   };
   const _renderFloatingPicker = () =>
     onRenderFloatingSuggestions({


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
While integrating with OWA, realized that the internal state needs to be updated for the UPP component first and then we need to call the props. The reason to do so, is that useSelectedItems custom hooks is maintaining the internal state and gets set based on initial value, we want that value to be updated correctly and in order. The source of truth is the caller, so we want to make sure UPP is maintaining the right state at its end if the callbacks dont work etc.

#### Focus areas to test

(optional)
