### PR TITLE
Removed disabled TextField border

### DIFF
--- a/change/@uifabric-azure-themes-2020-07-13-16-55-03-xiaoqiao-disabled-text-field.json
+++ b/change/@uifabric-azure-themes-2020-07-13-16-55-03-xiaoqiao-disabled-text-field.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removed disabled TextField border",
+  "packageName": "@uifabric/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-13T08:55:03.028Z"
+}

--- a/packages/azure-themes/src/azure/styles/TextField.styles.ts
+++ b/packages/azure-themes/src/azure/styles/TextField.styles.ts
@@ -20,7 +20,7 @@ export const TextFieldStyles = (props: ITextFieldStyleProps): Partial<ITextField
         borderColor: semanticColors.focusBorder,
       },
       disabled && {
-        borderColor: semanticColors.disabledBodyText,
+        borderWidth: 0,
       },
       hasErrorMessage && [
         {

--- a/packages/azure-themes/src/stories/Themes/Themes.tsx
+++ b/packages/azure-themes/src/stories/Themes/Themes.tsx
@@ -60,6 +60,7 @@ const Example = () => (
     <DropdownBasicExample />
     <SearchBox />
     <TextField placeholder="Hello" />
+    <TextField placeholder="Hello" disabled />
     <ActivityItemBasicExample />
     <ChoiceGroupBasicExample />
     <ToggleBasicExample />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Disabled TextField should not have a border, which is aligned to other disabled controls.

Current appearance
![image](https://user-images.githubusercontent.com/67673432/87285242-dd93bf80-c529-11ea-966c-94dda3d86fc5.png)

Compared to disabled Dropdown and Button
![image](https://user-images.githubusercontent.com/67673432/87285380-0916aa00-c52a-11ea-949b-46d01f6c663c.png)
![image](https://user-images.githubusercontent.com/67673432/87285443-1a5fb680-c52a-11ea-80d7-fbe287bba5e5.png)

After fix
![image](https://user-images.githubusercontent.com/67673432/87285498-29deff80-c52a-11ea-9186-f1eb45f17f0f.png)


#### Focus areas to test

@Jacqueline-ms please help review this change.
