### PR TITLE
Removed control border of disabled DatePicker

### DIFF
--- a/change/@uifabric-azure-themes-2020-07-13-17-39-46-xiaoqiao-disabled-date-picker.json
+++ b/change/@uifabric-azure-themes-2020-07-13-17-39-46-xiaoqiao-disabled-date-picker.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removed control border of disabled DatePicker",
+  "packageName": "@uifabric/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-13T09:39:46.076Z"
+}

--- a/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DatePicker.styles.ts
@@ -153,7 +153,6 @@ export const DatePickerStyles = (props: IDatePickerStyleProps): Partial<IDatePic
         fontSize: FontSizes.size13,
       },
       disabled && {
-        border: `${StyleConstants.borderWidth} solid ${semanticColors.disabledBodyText}`,
         color: semanticColors.disabledBodyText,
       },
     ],

--- a/packages/azure-themes/src/stories/Themes/Themes.tsx
+++ b/packages/azure-themes/src/stories/Themes/Themes.tsx
@@ -68,6 +68,8 @@ const Example = () => (
     <ContextualMenuDefaultExample />
 
     <DatePicker />
+    <DatePicker disabled={true} />
+    <DatePicker label="Disabled (with label)" disabled={true} />
 
     <p>Checked components are not supported in the portal, listed below</p>
     <CompoundButton checked={true} primary text="CompoundButton" />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Disabled DatePicker has a border at top level. This looks wired. Check the 3rd DatePicker below.
![image](https://user-images.githubusercontent.com/67673432/87290203-4716cc80-c530-11ea-88dd-d88785710cb3.png)

After fix
![image](https://user-images.githubusercontent.com/67673432/87290289-61e94100-c530-11ea-8d5b-38216bfc0c63.png)


#### Focus areas to test


@Jacqueline-ms please help to review.