### PR TITLE
Fix codesandbox template production build

### DIFF
--- a/apps/codesandbox-react-template/just.config.ts
+++ b/apps/codesandbox-react-template/just.config.ts
@@ -1,3 +1,6 @@
-const { preset } = require('@uifabric/build');
+const { preset, just } = require('@uifabric/build');
+const { task } = just;
 
 preset();
+
+task('build', 'ts:commonjs-only');

--- a/apps/codesandbox-react-template/package.json
+++ b/apps/codesandbox-react-template/package.json
@@ -4,7 +4,7 @@
   "version": "7.0.0",
   "private": true,
   "scripts": {
-    "build": "tsc --noEmit",
+    "build": "just-scripts build",
     "lint": "just-scripts lint",
     "just": "just-scripts",
     "clean": "just-scripts clean",

--- a/apps/codesandbox-react-template/tsconfig.json
+++ b/apps/codesandbox-react-template/tsconfig.json
@@ -2,11 +2,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es5",
-    "outDir": "lib",
+    "noEmit": true, // build output of this project doesn't matter
     "module": "commonjs",
     "jsx": "react",
-    "declaration": true,
-    "sourceMap": true,
     "experimentalDecorators": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",


### PR DESCRIPTION
The release build was failing because it passes the option `--production` to all projects' `build` task, and the codesandbox template's build task just did `tsc --noEmit` which doesn't understand that option.

The simplest fix is to switch the codesandbox project to do a basic `just`-based build for now. @tomi-msft you'll need to make this change in the other templates too.