### PR TITLE
Legends: Remove tab stop on legends for data viz

### DIFF
--- a/change/@uifabric-charting-2020-07-14-11-32-27-user-v-gorraj-Bug_12428.json
+++ b/change/@uifabric-charting-2020-07-14-11-32-27-user-v-gorraj-Bug_12428.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Legends:Skip all legends in data viz as it is confusing to non sighted users as they have just gone through the data viz.",
+  "packageName": "@uifabric/charting",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-14T06:02:27.164Z"
+}

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -84,8 +84,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
   private _generateData(): ILegendOverflowData {
     const dataItems: ILegendItem[] = this.props.legends.map((legend: ILegend, index: number) => {
       return {
-        'aria-setsize': this.props.legends.length,
-        'aria-posinset': index + 1,
         title: legend.title,
         action: legend.action!,
         hoverAction: legend.hoverAction!,
@@ -106,7 +104,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const { overflowProps } = this.props;
     return (
       <OverflowSet
-        role={'listbox'}
         {...overflowProps}
         items={data.primary}
         overflowItems={data.overflow}
@@ -177,7 +174,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     const hoverCardData = (
       <FocusZone
         direction={FocusZoneDirection.vertical}
-        role={'listbox'}
         {...this.props.focusZonePropsInHoverCard}
         className="hoverCardRoot"
       >
@@ -249,12 +245,9 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       >
         <div
           className={classNames.overflowIndicationTextStyle}
-          role={'combobox'}
           // eslint-disable-next-line react/jsx-no-bind
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
-          aria-expanded={this.state.isHoverCardVisible}
-          aria-label={`${items.length} ${overflowString}`}
-          data-is-focusable={true}
+          data-is-focusable={false}
         >
           {items.length} {overflowString}
         </div>
@@ -314,11 +307,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     };
     return (
       <button
-        aria-selected={this.state.selectedLegend === legend.title}
-        role={'option'}
-        aria-label={legend.title}
-        aria-setsize={data['aria-setsize']}
-        aria-posinset={data['aria-posinset']}
         key={index}
         className={classNames.legend}
         /* eslint-disable react/jsx-no-bind */
@@ -327,6 +315,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         onMouseOut={onMouseOut}
         onFocus={onHoverHandler}
         onBlur={onMouseOut}
+        data-is-focusable={false}
         /* eslint-enable react/jsx-no-bind */
       >
         <div className={this._getShapeClass(classNames, legend)} />

--- a/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
+++ b/packages/charting/src/components/VerticalBarChart/__snapshots__/VerticalBarChart.test.tsx.snap
@@ -183,7 +183,7 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
               onFocus={[Function]}
               onKeyDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="listbox"
+              role="group"
             >
               <div
                 className=
@@ -195,9 +195,6 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-posinset={1}
-                  aria-selected={false}
-                  aria-setsize={2}
                   className=
 
                       {
@@ -234,12 +231,12 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
+                  data-is-focusable={false}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=
@@ -284,9 +281,6 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
                     }
               >
                 <button
-                  aria-posinset={2}
-                  aria-selected={false}
-                  aria-setsize={2}
                   className=
 
                       {
@@ -323,12 +317,12 @@ exports[`VerticalBarChart renders VerticalBarChart correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                         outline-color: #605e5c;
                       }
+                  data-is-focusable={false}
                   onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
                   onMouseOut={[Function]}
                   onMouseOver={[Function]}
-                  role="option"
                 >
                   <div
                     className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Legends: Remove tab stop on legends for data viz

User tabs to first entry point of data vis, the hover states appears over the focus indicator as they arrow through all of the entry points, then tab to the next thing, be it buttons or ellipses, skipping the legend.

Follow the figma: https://www.figma.com/file/HEQiS2rKRQWT7Ph81keQcvv9/Accessibility-Guidance?node-id=982%3A519

Fix the below issues:
https://github.com/microsoft/fluentui/issues/12428
https://office.visualstudio.com/OC/_workitems/edit/4288857
https://office.visualstudio.com/OC/_workitems/edit/4287678

(give an overview)

#### Focus areas to test

(optional)
