### PR TITLE
Calendar accessibility fixes

### DIFF
--- a/change/@uifabric-date-time-2020-07-14-17-24-29-lorejoh12-calendarAccessibilityFixes.json
+++ b/change/@uifabric-date-time-2020-07-14-17-24-29-lorejoh12-calendarAccessibilityFixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding accessibility fixes for alt+tab to datepicker, turn button -> div if not clickable, and high contrast color selectors",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T00:24:29.858Z"
+}

--- a/change/office-ui-fabric-react-2020-07-15-12-29-29-lorejoh12-calendarAccessibilityFixes.json
+++ b/change/office-ui-fabric-react-2020-07-15-12-29-29-lorejoh12-calendarAccessibilityFixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "removing unnecessary !important, fixing two linting errors, fixing high contrast bug in oufr calendar",
+  "packageName": "office-ui-fabric-react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T19:29:29.887Z"
+}

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -57,7 +57,7 @@ export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwa
   });
 
   const monthAndYear = dateTimeFormatter.formatMonthYear(navigatedDate, strings);
-  const HeaderButtonComponentType = !!onHeaderSelect ? 'button' : 'div';
+  const HeaderButtonComponentType = onHeaderSelect ? 'button' : 'div';
 
   return (
     <div className={classNames.root} id={dayPickerId} ref={forwardedRef}>

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -57,11 +57,12 @@ export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwa
   });
 
   const monthAndYear = dateTimeFormatter.formatMonthYear(navigatedDate, strings);
+  const HeaderButtonComponentType = !!onHeaderSelect ? 'button' : 'div';
 
   return (
     <div className={classNames.root} id={dayPickerId} ref={forwardedRef}>
       <div className={classNames.header}>
-        <button
+        <HeaderButtonComponentType
           // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
           aria-live="polite"
           aria-atomic="true"
@@ -75,7 +76,7 @@ export const CalendarDayBase = React.forwardRef((props: ICalendarDayProps, forwa
           type="button"
         >
           {monthAndYear}
-        </button>
+        </HeaderButtonComponentType>
         <CalendarDayNavigationButtons {...props} classNames={classNames} dayPickerId={dayPickerId} />
       </div>
       <CalendarDayGrid
@@ -187,7 +188,9 @@ const CalendarDayNavigationButtons = (props: ICalendarDayNavigationButtonsProps)
 };
 CalendarDayNavigationButtons.displayName = 'CalendarDayNavigationButtons';
 
-const onButtonKeyDown = (callback?: () => void): ((ev: React.KeyboardEvent<HTMLButtonElement>) => void) => (
+const onButtonKeyDown = (
+  callback?: () => void,
+): ((ev: React.KeyboardEvent<HTMLButtonElement | HTMLDivElement>) => void) => (
   ev: React.KeyboardEvent<HTMLButtonElement>,
 ) => {
   switch (ev.which) {

--- a/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -1,5 +1,13 @@
 import { ICalendarPickerStyleProps, ICalendarPickerStyles } from './CalendarPicker.types';
-import { normalize, FontSizes, FontWeights, getFocusStyle, IRawStyle, AnimationStyles } from '@uifabric/styling';
+import {
+  normalize,
+  FontSizes,
+  FontWeights,
+  getFocusStyle,
+  IRawStyle,
+  AnimationStyles,
+  HighContrastSelector,
+} from '@uifabric/styling';
 import { AnimationDirection } from '../Calendar.types';
 
 export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyles => {
@@ -138,9 +146,24 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
             backgroundColor: palette.neutralLight,
             cursor: 'pointer',
             outline: '1px solid transparent',
+            selectors: {
+              [HighContrastSelector]: {
+                background: 'Window',
+                color: 'WindowText',
+                outline: '1px solid Highlight',
+                MsHighContrastAdjust: 'none',
+              },
+            },
           },
           '&:active': {
             backgroundColor: palette.themeLight,
+            selectors: {
+              [HighContrastSelector]: {
+                background: 'Window',
+                color: 'Highlight',
+                MsHighContrastAdjust: 'none',
+              },
+            },
           },
         },
       },
@@ -155,6 +178,18 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
             },
             '&:hover': {
               backgroundColor: palette.themePrimary,
+              selectors: {
+                [HighContrastSelector]: {
+                  backgroundColor: 'WindowText',
+                  color: 'Window',
+                  MsHighContrastAdjust: 'none',
+                },
+              },
+            },
+            [HighContrastSelector]: {
+              backgroundColor: 'WindowText',
+              color: 'Window',
+              MsHighContrastAdjust: 'none',
             },
           },
         }
@@ -170,6 +205,18 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
             },
             '&:hover, &:active': {
               backgroundColor: palette.themeLight,
+              selectors: {
+                [HighContrastSelector]: {
+                  color: 'Window',
+                  background: 'Highlight',
+                  MsHighContrastAdjust: 'none',
+                },
+              },
+            },
+            [HighContrastSelector]: {
+              background: 'Highlight',
+              color: 'Window',
+              MsHighContrastAdjust: 'none',
             },
           },
         }

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -7,6 +7,7 @@ import {
   AnimationStyles,
   IRawStyle,
   keyframes,
+  HighContrastSelector,
 } from '@uifabric/styling';
 import { DateRangeType } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { AnimationDirection } from '../Calendar/Calendar.types';
@@ -104,12 +105,33 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       fontWeight: FontWeights.regular,
       color: palette.neutralPrimary,
       cursor: 'pointer',
+      position: 'relative',
       selectors: {
+        [HighContrastSelector]: {
+          color: 'WindowText!important',
+          backgroundColor: 'Window!important',
+          zIndex: 0,
+        },
         ['&.' + classNames.hoverStyle]: {
           backgroundColor: palette.neutralLighter,
+          selectors: {
+            [HighContrastSelector]: {
+              zIndex: 3,
+              overflow: 'visible',
+              outline: '1px solid Highlight!important',
+              MsHighContrastAdjust: 'none',
+            },
+          },
         },
         ['&.' + classNames.pressedStyle]: {
           backgroundColor: palette.neutralLight,
+          selectors: {
+            [HighContrastSelector]: {
+              borderColor: 'Highlight!important',
+              color: 'Highlight!important',
+              MsHighContrastAdjust: 'none',
+            },
+          },
         },
       },
     },
@@ -119,6 +141,18 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
         selectors: {
           ['&:hover, &.' + classNames.hoverStyle + ', &.' + classNames.pressedStyle]: {
             backgroundColor: palette.neutralLight + '!important',
+            selectors: {
+              [HighContrastSelector]: {
+                color: 'HighlightText!important',
+                background: 'Highlight!important',
+              },
+            },
+          },
+          [HighContrastSelector]: {
+            background: 'Highlight!important',
+            color: 'HighlightText!important',
+            borderColor: 'Highlight!important',
+            MsHighContrastAdjust: 'none',
           },
         },
       },
@@ -171,6 +205,14 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       borderRadius: '100%',
       color: palette.white + '!important',
       fontWeight: (FontWeights.semibold + '!important') as 'initial',
+      selectors: {
+        [HighContrastSelector]: {
+          background: 'WindowText!important',
+          color: 'Window!important',
+          borderColor: 'WindowText!important',
+          MsHighContrastAdjust: 'none',
+        },
+      },
     },
     firstTransitionWeek: {
       position: 'absolute',

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -108,8 +108,8 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       position: 'relative',
       selectors: {
         [HighContrastSelector]: {
-          color: 'WindowText!important',
-          backgroundColor: 'Window!important',
+          color: 'WindowText',
+          backgroundColor: 'Window',
           zIndex: 0,
         },
         ['&.' + classNames.hoverStyle]: {
@@ -118,7 +118,9 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
             [HighContrastSelector]: {
               zIndex: 3,
               overflow: 'visible',
-              outline: '1px solid Highlight!important',
+              color: 'WindowText',
+              backgroundColor: 'Window',
+              outline: '1px solid Highlight',
               MsHighContrastAdjust: 'none',
             },
           },
@@ -127,8 +129,19 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
           backgroundColor: palette.neutralLight,
           selectors: {
             [HighContrastSelector]: {
-              borderColor: 'Highlight!important',
-              color: 'Highlight!important',
+              borderColor: 'Highlight',
+              color: 'Highlight',
+              backgroundColor: 'Window',
+              MsHighContrastAdjust: 'none',
+            },
+          },
+        },
+        ['&.' + classNames.pressedStyle + '.' + classNames.hoverStyle]: {
+          selectors: {
+            [HighContrastSelector]: {
+              color: 'Highlight',
+              backgroundColor: 'Window',
+              outline: '1px solid Highlight',
               MsHighContrastAdjust: 'none',
             },
           },

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -111,17 +111,15 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
           color: 'WindowText',
           backgroundColor: 'Window',
           zIndex: 0,
+          MsHighContrastAdjust: 'none',
         },
         ['&.' + classNames.hoverStyle]: {
           backgroundColor: palette.neutralLighter,
           selectors: {
             [HighContrastSelector]: {
               zIndex: 3,
-              overflow: 'visible',
-              color: 'WindowText',
               backgroundColor: 'Window',
               outline: '1px solid Highlight',
-              MsHighContrastAdjust: 'none',
             },
           },
         },
@@ -132,17 +130,14 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
               borderColor: 'Highlight',
               color: 'Highlight',
               backgroundColor: 'Window',
-              MsHighContrastAdjust: 'none',
             },
           },
         },
         ['&.' + classNames.pressedStyle + '.' + classNames.hoverStyle]: {
           selectors: {
             [HighContrastSelector]: {
-              color: 'Highlight',
               backgroundColor: 'Window',
               outline: '1px solid Highlight',
-              MsHighContrastAdjust: 'none',
             },
           },
         },

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -414,6 +414,10 @@ export class DatePickerBase extends React.Component<IDatePickerProps, IDatePicke
         this._handleEscKey(ev);
         break;
 
+      case KeyCodes.down:
+        if (ev.altKey && !this.state.isDatePickerShown) {
+          this.showDatePickerPopup();
+        }
       default:
         break;
     }

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -418,6 +418,7 @@ export class DatePickerBase extends React.Component<IDatePickerProps, IDatePicke
         if (ev.altKey && !this.state.isDatePickerShown) {
           this.showDatePickerPopup();
         }
+        break;
       default:
         break;
     }

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -148,12 +148,14 @@ $Calendar-dayPicker-margin: 10px;
   &:hover,
   &:active {
     @include high-contrast {
-      outline: 1px solid highlight;
+      outline: 1px solid Highlight;
+      -ms-high-contrast-adjust: none;
     }
   }
   &:active {
     @include high-contrast {
-      color: highlight;
+      color: Highlight;
+      -ms-high-contrast-adjust: none;
     }
   }
 }
@@ -167,7 +169,8 @@ $Calendar-dayPicker-margin: 10px;
   position: relative;
   background-color: $ms-color-neutralLighter;
   @include high-contrast {
-    background-color: highlight;
+    background-color: Highlight;
+    -ms-high-contrast-adjust: none;
   }
   &:hover {
     border-radius: 100%;
@@ -200,9 +203,10 @@ $Calendar-dayPicker-margin: 10px;
   background-color: $ms-color-neutralLight;
   border-radius: 2px;
   @include high-contrast {
-    border: 2px solid Highlight;
+    outline: 2px solid Highlight;
     :not(.dayIsToday) span {
       color: Highlight;
+      -ms-high-contrast-adjust: none;
     }
   }
 }
@@ -215,6 +219,7 @@ $Calendar-dayPicker-margin: 10px;
     span {
       @include high-contrast {
         color: Window;
+        -ms-high-contrast-adjust: none;
       }
     }
   }
@@ -285,6 +290,11 @@ $Calendar-dayPicker-margin: 10px;
   font-weight: $ms-font-weight-semibold;
   background: $ms-color-themePrimary;
   border-radius: 100%;
+  @include high-contrast {
+    background-color: Highlight;
+    color: HighlightText;
+    -ms-high-contrast-adjust: none;
+  }
 }
 
 .showWeekNumbers {
@@ -743,7 +753,7 @@ $Calendar-dayPicker-margin: 10px;
     background-color: $ms-color-neutralLighter;
     color: $ms-color-neutralDark;
     @include high-contrast {
-      outline: 1px solid highlight;
+      outline: 1px solid Highlight;
     }
   }
   &:active {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11508, Fixes #12444, Fixes #13848 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

3 accessibility fixes for Calendar and DatePicker.
- for DatePicker, alt+down arrow should open if the span has focus. Added keydown listener case for it
- for button in header of day picker in Calendar, the button does nothing if the month and day pickers are side by side. We mark the tabIndex = -1 already, but if the user navigates to the header using Narrator's functions, it reports the button as clickable. Changing button to a div so that doesn't happen.
- Added all the various high contrast selectors to match Ben's design for Calendar.

#### Focus areas to test

Can test high contrast only in Win10 + Edge, turn on High Contrast settings from windows settings.
