### PR TITLE
Fix useMergedRefs behaves differently from useRef due to returning a static ref

### DIFF
--- a/change/@uifabric-react-hooks-2020-07-15-14-39-51-xgao-useMergedRef.json
+++ b/change/@uifabric-react-hooks-2020-07-15-14-39-51-xgao-useMergedRef.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix useMergedRefs behaves differently from useRef due to returning a static ref.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T21:39:51.885Z"
+}

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback, Ref, MutableRefObject } from 'react';
+import { Ref, MutableRefObject } from 'react';
 
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
@@ -6,13 +6,8 @@ import { useRef, useCallback, Ref, MutableRefObject } from 'react';
  * @param refs- Refs to collectively update with one ref value.
  */
 export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
-  const state = useRef<(Ref<T> | undefined)[]>();
-
-  // Update refs list.
-  state.current = refs;
-
-  return useCallback((value: T) => {
-    for (const ref of state.current!) {
+  return (value: T) => {
+    for (const ref of refs) {
       if (typeof ref === 'function') {
         ref(value);
       } else if (ref) {
@@ -20,5 +15,5 @@ export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
         ((ref as unknown) as MutableRefObject<T>).current = value;
       }
     }
-  }, []);
+  };
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14041
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`useMergedRef` should return ref that behaves the same as `useRef` (native ref). 
The hook needs to return new ref instance on every hook call / render. Otherwise `ref` that passed down to element won't be called, see repro [here](https://codesandbox.io/s/ref-changes-on-every-render-o7szs?file=/src/App.tsx).

This change basically reverts changes in #13712, as well as removing `useCallback` logic all together.

#### Focus areas to test

(optional)
