### PR TITLE
FocusZone: Fix onKeyDownCapture event listener leak

### DIFF
--- a/change/office-ui-fabric-react-2020-07-15-17-38-30-focusZoneLeak.json
+++ b/change/office-ui-fabric-react-2020-07-15-17-38-30-focusZoneLeak.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Fix onKeyDownCapture event listener leak.",
+  "packageName": "office-ui-fabric-react",
+  "email": "makotom@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-15T17:38:30.269Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.EventHandler.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.EventHandler.test.tsx
@@ -1,0 +1,90 @@
+import * as ReactDOM from 'react-dom';
+import * as React from 'react';
+import { FocusZone } from './FocusZone';
+
+type EventHandler = {
+  listener: EventListenerOrEventListenerObject;
+  options?: boolean | AddEventListenerOptions;
+};
+
+function optionsEqual(a: boolean | AddEventListenerOptions | undefined, b: boolean | AddEventListenerOptions | undefined) {
+  if (typeof a !== 'object' || typeof b !== 'object') {
+    return a === b;
+  }
+
+  return a.once === b.once && a.passive === b.passive && a.capture === b.capture;
+}
+
+function handlersEqual(a: EventHandler, b: EventHandler) {
+  return a.listener === b.listener && optionsEqual(a.options, b.options);
+}
+
+// HEADS UP: this test is intentionally in a separate file aside from the rest of FocusZone tests
+// As it is testing ref counting on a global `window` object it would interfere with other FocusZone tests
+// which use ReactTestUtils.renderIntoDocument() which renders FocusZone into a detached DOM node and never unmounts.
+describe('FocusZone keydown event handler', () => {
+  let host: HTMLElement;
+  let keydownEventHandlers: EventHandler[];
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    keydownEventHandlers = [];
+
+    window.addEventListener = jest.fn((type, listener, options) => {
+      if (type === 'keydown') {
+        const eventListener = { listener, options };
+        if (!keydownEventHandlers.some((item) => handlersEqual(item, eventListener))) {
+          keydownEventHandlers.push(eventListener);
+        }
+      }
+    });
+
+    window.removeEventListener = jest.fn((type, listener, options) => {
+      if (type === 'keydown') {
+        const eventListener = { listener, options };
+        for (let index = 0; index < keydownEventHandlers.length; index++) {
+          if (handlersEqual(keydownEventHandlers[index], eventListener)) {
+            keydownEventHandlers.splice(index, 1);
+          }
+        }
+      }
+    });
+  });
+
+  it('is added on mount/removed on unmount', () => {
+    ReactDOM.render(<FocusZone />, host);
+    expect(keydownEventHandlers.length).toBe(1);
+
+    ReactDOM.unmountComponentAtNode(host);
+    expect(keydownEventHandlers.length).toBe(0);
+  });
+
+  it('is added only once for nested focus zones', () => {
+    ReactDOM.render(
+      <div>
+        <FocusZone>
+          <FocusZone />
+        </FocusZone>
+      </div>,
+      host
+    );
+    expect(keydownEventHandlers.length).toBe(1);
+
+    ReactDOM.unmountComponentAtNode(host);
+    expect(keydownEventHandlers.length).toBe(0);
+  });
+
+  it('is added only once for sibling focus zones', () => {
+    ReactDOM.render(
+      <div>
+        <FocusZone />
+        <FocusZone />
+      </div>,
+      host
+    );
+    expect(keydownEventHandlers.length).toBe(1);
+
+    ReactDOM.unmountComponentAtNode(host);
+    expect(keydownEventHandlers.length).toBe(0);
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -24,7 +24,7 @@ import {
   warnDeprecations,
   portalContainsElement,
   IPoint,
-  findScrollableParent
+  findScrollableParent,
 } from '../../Utilities';
 import { mergeStyles } from '@uifabric/merge-styles';
 
@@ -48,9 +48,9 @@ function getRootClass(): string {
       {
         selectors: {
           ':focus': {
-            outline: 'none'
-          }
-        }
+            outline: 'none',
+          },
+        },
       },
       focusZoneClass
     );
@@ -70,7 +70,7 @@ const ALLOW_VIRTUAL_ELEMENTS = false;
 export class FocusZone extends React.Component<IFocusZoneProps> implements IFocusZone {
   public static defaultProps: IFocusZoneProps = {
     isCircularNavigation: false,
-    direction: FocusZoneDirection.bidirectional
+    direction: FocusZoneDirection.bidirectional,
   };
 
   private _disposables: Function[] = [];
@@ -105,6 +105,17 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     return _outerZones.size;
   }
 
+  /**
+   * Handle global tab presses so that we can patch tabindexes on the fly.
+   * HEADS UP: This must not be an arrow function in order to be referentially equal among instances
+   * for ref counting to work correctly!
+   */
+  private static _onKeyDownCapture(ev: KeyboardEvent): void {
+    if (ev.which === KeyCodes.tab) {
+      _outerZones.forEach((zone) => zone._updateTabIndexes());
+    }
+  }
+
   constructor(props: IFocusZoneProps) {
     super(props);
     // Manage componentRef resolution.
@@ -116,7 +127,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         allowTabKey: 'handleTabKey',
         elementType: 'as',
         ariaDescribedBy: 'aria-describedby',
-        ariaLabelledBy: 'aria-labelledby'
+        ariaLabelledBy: 'aria-labelledby',
       });
     }
 
@@ -124,7 +135,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     this._focusAlignment = {
       x: 0,
-      y: 0
+      y: 0,
     };
 
     this._processingTabKey = false;
@@ -152,7 +163,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
         _outerZones.add(this);
 
         if (windowElement && _outerZones.size === 1) {
-          this._disposables.push(on(windowElement, 'keydown', this._onKeyDownCapture, true));
+          this._disposables.push(on(windowElement, 'keydown', FocusZone._onKeyDownCapture, true));
         }
       }
 
@@ -415,15 +426,6 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
   private _onBlur = (): void => {
     this._setParkedFocus(false);
-  };
-
-  /**
-   * Handle global tab presses so that we can patch tabindexes on the fly.
-   */
-  private _onKeyDownCapture = (ev: KeyboardEvent): void => {
-    if (ev.which === KeyCodes.tab) {
-      _outerZones.forEach((zone) => zone._updateTabIndexes());
-    }
   };
 
   private _onMouseDown = (ev: React.MouseEvent<HTMLElement>): void => {
@@ -1040,7 +1042,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       if (!this._focusAlignment) {
         this._focusAlignment = {
           x: left,
-          y: top
+          y: top,
         };
       }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #14025
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR converts the `keydown` event handler in `FocusZone` from a member arrow function to a regular member function to make it equal among class instances in order to avoid memory leak.

Backport of #14031.

#### Focus areas to test

(optional)
