### PR TITLE
useMergedRefs: mergedRefs should mutate the function if any of the merged refs mutate

### DIFF
--- a/change/@uifabric-react-hooks-2020-07-15-20-45-10-fix-refs.json
+++ b/change/@uifabric-react-hooks-2020-07-15-20-45-10-fix-refs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "useMergedRefs: now mutates the resulting ref if the merged refs mutate.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T03:45:10.716Z"
+}

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -6,29 +6,11 @@ describe('useMergedRefs', () => {
   let wrapper: ReactWrapper | undefined;
 
   afterEach(() => {
-    if (wrapper && wrapper.exists()) {
-      wrapper.unmount();
-      wrapper = undefined;
-    }
+    wrapper?.unmount();
+    wrapper = undefined;
   });
 
   it('always returns the same ref (refs should be immutable)', () => {
-    let lastMergedRef;
-    const refFunc = () => null;
-    const TestComponent: React.FunctionComponent = () => {
-      lastMergedRef = useMergedRefs<boolean>(refFunc);
-      return null;
-    };
-
-    wrapper = mount(<TestComponent />);
-    const ref1 = lastMergedRef;
-    wrapper.setProps({});
-    const ref2 = lastMergedRef;
-
-    expect(ref1).toBe(ref2);
-  });
-
-  it('always mutates the ref when 1 or more merged refs mutate', () => {
     let lastMergedRef;
 
     const TestComponent: React.FunctionComponent = () => {
@@ -41,7 +23,7 @@ describe('useMergedRefs', () => {
     wrapper.setProps({});
     const ref2 = lastMergedRef;
 
-    expect(ref1).not.toBe(ref2);
+    expect(ref1).toBe(ref2);
   });
 
   it('updates all provided refs', () => {

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -6,11 +6,29 @@ describe('useMergedRefs', () => {
   let wrapper: ReactWrapper | undefined;
 
   afterEach(() => {
-    wrapper?.unmount();
-    wrapper = undefined;
+    if (wrapper && wrapper.exists()) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
   });
 
   it('always returns the same ref (refs should be immutable)', () => {
+    let lastMergedRef;
+    const refFunc = () => null;
+    const TestComponent: React.FunctionComponent = () => {
+      lastMergedRef = useMergedRefs<boolean>(refFunc);
+      return null;
+    };
+
+    wrapper = mount(<TestComponent />);
+    const ref1 = lastMergedRef;
+    wrapper.setProps({});
+    const ref2 = lastMergedRef;
+
+    expect(ref1).toBe(ref2);
+  });
+
+  it('always mutates the ref when 1 or more merged refs mutate', () => {
     let lastMergedRef;
 
     const TestComponent: React.FunctionComponent = () => {
@@ -23,7 +41,7 @@ describe('useMergedRefs', () => {
     wrapper.setProps({});
     const ref2 = lastMergedRef;
 
-    expect(ref1).toBe(ref2);
+    expect(ref1).not.toBe(ref2);
   });
 
   it('updates all provided refs', () => {

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback, Ref, MutableRefObject } from 'react';
+import { useCallback, Ref, MutableRefObject } from 'react';
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,21 +1,24 @@
 import { useRef, useCallback, Ref, MutableRefObject } from 'react';
+
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
 export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
-  return useCallback(
-    (value: T) => {
-      for (const ref of refs) {
-        if (typeof ref === 'function') {
-          ref(value);
-        } else if (ref) {
-          // work around the immutability of the React.Ref type
-          ((ref as unknown) as MutableRefObject<T>).current = value;
-        }
+  const state = useRef<(Ref<T> | undefined)[]>();
+
+  // Update refs list.
+  state.current = refs;
+
+  return useCallback((value: T) => {
+    for (const ref of state.current!) {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref) {
+        // work around the immutability of the React.Ref type
+        ((ref as unknown) as MutableRefObject<T>).current = value;
       }
-    },
-    [...refs],
-  );
+    }
+  }, []);
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,24 +1,21 @@
 import { useRef, useCallback, Ref, MutableRefObject } from 'react';
-
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
 export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
-  const state = useRef<(Ref<T> | undefined)[]>();
-
-  // Update refs list.
-  state.current = refs;
-
-  return useCallback((value: T) => {
-    for (const ref of state.current!) {
-      if (typeof ref === 'function') {
-        ref(value);
-      } else if (ref) {
-        // work around the immutability of the React.Ref type
-        ((ref as unknown) as MutableRefObject<T>).current = value;
+  return useCallback(
+    (value: T) => {
+      for (const ref of refs) {
+        if (typeof ref === 'function') {
+          ref(value);
+        } else if (ref) {
+          // work around the immutability of the React.Ref type
+          ((ref as unknown) as MutableRefObject<T>).current = value;
+        }
       }
-    }
-  }, []);
+    },
+    [...refs],
+  );
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #14041
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This change makes `useMergedRefs` mutate only when merging refs that mutate.

By default `useRef` returns immutable refs, so in normal usage using `useRef` or `createRef`, your refs will not mutate. When using functions as refs, they can easily mutate, causing inconsistencies in behaviors.

#### Focus areas to test

Validated in a @layershifter 's codesandbox forked here:
https://codesandbox.io/s/exciting-golick-8o0gj?file=/src/App.tsx
