### PR TITLE
feat(Datepicker): Add Calendar navigation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `Datepicker` and `DatepickerCalendar` @rymeskar ([#13855](https://github.com/microsoft/fluentui/pull/13855))
 - Add `label` and `labelPosition` to `Input` to allow `inside` label variation @assuncaocharles ([#13949](https://github.com/microsoft/fluentui/pull/13949))
 - Add `HeadsetIcon` @PressX2Jason ([#12956](https://github.com/microsoft/fluentui/pull/12956))
+- Add navigation and shorthands for `Datepicker` @pompompon ([#14061](https://github.com/microsoft/fluentui/pull/14061))
 
 ### Documentation
 - Fix required version of CSB package, improve dependency generation for exported CodeSandboxes @layershifter ([#13637](https://github.com/microsoft/fluentui/pull/13637))

--- a/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarHeaderBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarHeaderBehavior.ts
@@ -1,0 +1,16 @@
+import { Accessibility } from '../../types';
+/**
+ * @description
+ * Behavior for a datepicked calendar component
+ * @specification
+ * Adds role='group'.
+ */
+export const datepickerCalendarHeaderBehavior: Accessibility<DatepickerCalendarHeaderBehaviorProps> = props => ({
+  attributes: {
+    root: {
+      role: 'group',
+    },
+  },
+});
+
+export type DatepickerCalendarHeaderBehaviorProps = never;

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -122,3 +122,4 @@ export { hiddenComponentBehavior } from './Common/hiddenComponentBehavior';
 export * from './Datepicker/datepickerBehavior';
 
 export * from './Datepicker/datepickerCalendarBehavior';
+export * from './Datepicker/datepickerCalendarHeaderBehavior';

--- a/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/behavior-test.tsx
@@ -92,6 +92,7 @@ import {
   dropdownSelectedItemBehavior,
   datepickerBehavior,
   datepickerCalendarBehavior,
+  datepickerCalendarHeaderBehavior,
 } from '@fluentui/accessibility';
 import { TestHelper } from './testHelper';
 import { definitions } from './testDefinitions';
@@ -188,5 +189,6 @@ testHelper.addBehavior('cardSelectableBehavior', cardSelectableBehavior);
 testHelper.addBehavior('dropdownSelectedItemBehavior', dropdownSelectedItemBehavior);
 testHelper.addBehavior('datepickerBehavior', datepickerBehavior);
 testHelper.addBehavior('datepickerCalendarBehavior', datepickerCalendarBehavior);
+testHelper.addBehavior('datepickerCalendarHeaderBehavior', datepickerCalendarHeaderBehavior);
 
 testHelper.run(behaviorMenuItems);

--- a/packages/fluentui/docs/src/components/ComponentPlayground/componentGenerators.tsx
+++ b/packages/fluentui/docs/src/components/ComponentPlayground/componentGenerators.tsx
@@ -14,6 +14,7 @@ import {
   CardHeader as _CardHeader,
   Flex as _Flex,
   Text as _Text,
+  DatepickerProps,
 } from '@fluentui/react-northstar';
 import * as _ from 'lodash';
 import * as faker from 'faker';
@@ -33,6 +34,10 @@ export const Avatar: KnobComponentGenerators<AvatarProps> = {
 export const Box: KnobComponentGenerators<BoxProps> = {
   // TODO: fix support for boxes
   children: () => null,
+};
+
+export const Datepicker: KnobComponentGenerators<DatepickerProps> = {
+  calendar: () => null,
 };
 
 export const Card: KnobComponentGenerators<CardProps> = {

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -211,7 +211,6 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     defaultProps: () =>
       getA11yProps('calendar', {
         className: datepickerCalendarClassName,
-        localizedStrings: DEFAULT_LOCALIZED_STRINGS,
       }),
     overrideProps: () => ({
       ...calendarOptions,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -222,11 +222,10 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
   const calendarElement = createShorthand(DatepickerCalendar, calendar, {
     defaultProps: () =>
       getA11yProps('calendar', {
-        className: datepickerCalendarClassName,
       }),
-    overrideProps: () => ({
+    overrideProps: (predefinedProps) => ({
       ...calendarOptions,
-      onDateChange: handleChange,
+      onDateChange: handleChange(predefinedProps),
     }),
   });
 

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -28,7 +28,7 @@ import { ComponentEventHandler, FluentComponentStaticProps, ShorthandValue } fro
 import { commonPropTypes, createShorthand, createShorthandFactory, UIComponentProps } from '../../utils';
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
-import { Popup } from '../Popup/Popup';
+import { Popup, PopupProps } from '../Popup/Popup';
 import { DatepickerCalendar, datepickerCalendarClassName, DatepickerCalendarProps } from './DatepickerCalendar';
 import { DatepickerCalendarCell } from './DatepickerCalendarCell';
 import { DatepickerCalendarHeader } from './DatepickerCalendarHeader';
@@ -119,6 +119,9 @@ export interface DatepickerProps extends IDatepickerOptions, IDateFormatting, UI
   /** Shorthand for the datepicker calendar. */
   calendar?: ShorthandValue<DatepickerCalendarProps>;
 
+  /** Shorthand for the datepicker popup. */
+  popup?: ShorthandValue<PopupProps>;
+
   /** Datepicker shows it is currently unable to be interacted with. */
   disabled?: boolean;
 
@@ -166,7 +169,17 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
   const [open, setOpen] = React.useState<boolean>(false);
   const [selectedDate, setSelectedDate] = React.useState<Date | undefined>();
   const valueFormatter = date => (date ? formatMonthDayYear(date, DEFAULT_LOCALIZED_STRINGS) : '');
-  const { firstDayOfWeek, firstWeekOfYear, dateRangeType } = props;
+  const {
+    firstDayOfWeek,
+    firstWeekOfYear,
+    dateRangeType,
+    calendar,
+    popup,
+    className,
+    design,
+    styles,
+    variables,
+  } = props;
   const calendarOptions: IDayGridOptions = {
     selectedDate: selectedDate ?? props.today ?? new Date(),
     navigatedDate: selectedDate ?? props.today ?? new Date(),
@@ -179,7 +192,6 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     setOpen(true);
   };
 
-  const { className, design, styles, variables, calendar } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(Datepicker.handledProps, props);
   const getA11yProps = useAccessibility(props.accessibility, {
@@ -228,9 +240,17 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
           })}
         >
           <Input readOnly onClick={showCalendarGrid} value={valueFormatter(selectedDate)} />
-          <Popup open={open} onOpenChange={(e, { open }) => setOpen(open)} content={calendarElement} trapFocus>
-            <Button icon={<CalendarIcon />} title="Open calendar" iconOnly />
-          </Popup>
+          {createShorthand(Popup, popup, {
+            defaultProps: () => ({
+              open,
+              content: calendarElement,
+              trapFocus: true,
+              trigger: <Button icon={<CalendarIcon />} title="Open calendar" iconOnly />,
+            }),
+            overrideProps: () => ({
+              onOpenChange: (e, { open }) => setOpen(open),
+            }),
+          })}
         </ElementType>,
       )}
     </Ref>
@@ -244,6 +264,7 @@ Datepicker.displayName = 'Datepicker';
 Datepicker.propTypes = {
   ...commonPropTypes.createCommon(),
   calendar: customPropTypes.itemShorthand,
+  popup: customPropTypes.itemShorthand,
 
   minDate: PropTypes.instanceOf(Date),
   maxDate: PropTypes.instanceOf(Date),
@@ -272,6 +293,7 @@ Datepicker.propTypes = {
 Datepicker.defaultProps = {
   accessibility: datepickerBehavior,
   calendar: {},
+  popup: {},
   firstDayOfWeek: DayOfWeek.Monday,
   firstWeekOfYear: FirstWeekOfYear.FirstDay,
   dateRangeType: DateRangeType.Day,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -29,7 +29,7 @@ import { commonPropTypes, createShorthand, createShorthandFactory, UIComponentPr
 import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { Popup, PopupProps } from '../Popup/Popup';
-import { DatepickerCalendar, datepickerCalendarClassName, DatepickerCalendarProps } from './DatepickerCalendar';
+import { DatepickerCalendar, DatepickerCalendarProps } from './DatepickerCalendar';
 import { DatepickerCalendarCell } from './DatepickerCalendarCell';
 import { DatepickerCalendarHeader } from './DatepickerCalendarHeader';
 import { DatepickerCalendarHeaderAction } from './DatepickerCalendarHeaderAction';
@@ -211,22 +211,18 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
     rtl: context.rtl,
   });
 
-  const handleChange: DatepickerCalendarProps['onDateChange'] = (e, data) => {
-    const targetDay = data.value;
-    setSelectedDate(targetDay.originalDate);
-    setOpen(false);
-
-    _.invoke(props, 'onDateChange', e, { ...props, value: targetDay });
-  };
+  const overrideDatepickerCalendarProps = (predefinedProps: DatepickerCalendarProps): DatepickerCalendarProps => ({
+    ...calendarOptions,
+    onDateChange: (e, itemProps) => {
+      setSelectedDate(itemProps.value.originalDate);
+      setOpen(false);
+      _.invoke(predefinedProps, 'onDateChange', e, itemProps);
+    },
+  });
 
   const calendarElement = createShorthand(DatepickerCalendar, calendar, {
-    defaultProps: () =>
-      getA11yProps('calendar', {
-      }),
-    overrideProps: (predefinedProps) => ({
-      ...calendarOptions,
-      onDateChange: handleChange(predefinedProps),
-    }),
+    defaultProps: () => getA11yProps('calendar', {}),
+    overrideProps: overrideDatepickerCalendarProps,
   });
 
   const element = (
@@ -246,8 +242,11 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
               trapFocus: true,
               trigger: <Button icon={<CalendarIcon />} title="Open calendar" iconOnly />,
             }),
-            overrideProps: () => ({
-              onOpenChange: (e, { open }) => setOpen(open),
+            overrideProps: (predefinedProps: PopupProps): PopupProps => ({
+              onOpenChange: (e, { open }) => {
+                setOpen(open);
+                _.invoke(predefinedProps, 'onOpenChange', e, { open });
+              },
             }),
           })}
         </ElementType>,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -29,6 +29,10 @@ import { Button } from '../Button/Button';
 import { Input } from '../Input/Input';
 import { Popup } from '../Popup/Popup';
 import { DatepickerCalendar, DatepickerCalendarProps } from './DatepickerCalendar';
+import { DatepickerCalendarHeader } from './DatepickerCalendarHeader';
+import { DatepickerCalendarHeaderAction } from './DatepickerCalendarHeaderAction';
+import { DatepickerCalendarHeaderCell } from './DatepickerCalendarHeaderCell';
+import { DatepickerCalendarCell } from './DatepickerCalendarCell';
 
 // TODO: extract to date-time-utilities
 export const DEFAULT_LOCALIZED_STRINGS: IDateGridStrings = {
@@ -146,6 +150,10 @@ export const datepickerClassName = 'ui-datepicker';
 export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
   FluentComponentStaticProps<DatepickerProps> & {
     Calendar: typeof DatepickerCalendar;
+    CalendarHeader: typeof DatepickerCalendarHeader;
+    CalendarHeaderAction: typeof DatepickerCalendarHeaderAction;
+    CalendarHeaderCell: typeof DatepickerCalendarHeaderCell;
+    CalendarCell: typeof DatepickerCalendarCell;
   } = props => {
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(Datepicker.displayName, context.telemetry);
@@ -268,3 +276,7 @@ Datepicker.handledProps = Object.keys(Datepicker.propTypes) as any;
 Datepicker.create = createShorthandFactory({ Component: Datepicker });
 
 Datepicker.Calendar = DatepickerCalendar;
+Datepicker.CalendarHeader = DatepickerCalendarHeader;
+Datepicker.CalendarHeaderAction = DatepickerCalendarHeaderAction;
+Datepicker.CalendarHeaderCell = DatepickerCalendarHeaderCell;
+Datepicker.CalendarCell = DatepickerCalendarCell;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -1,34 +1,33 @@
 import { Accessibility, datepickerBehavior, DatepickerBehaviorProps } from '@fluentui/accessibility';
 import {
-  getElementType,
-  useAccessibility,
-  useStyles,
-  useTelemetry,
-  useFluentContext,
-  useUnhandledProps,
-  ComponentWithAs,
-} from '@fluentui/react-bindings';
-import { Ref } from '@fluentui/react-component-ref';
-import * as React from 'react';
-import * as PropTypes from 'prop-types';
-import * as _ from 'lodash';
-
-import { FluentComponentStaticProps, ShorthandRenderFunction, ComponentEventHandler } from '../../types';
-import { commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
-import { Input } from '../Input/Input';
-import { Button } from '../Button/Button';
-import { CalendarIcon } from '@fluentui/react-icons-northstar';
-import { Popup } from '../Popup/Popup';
-import {
-  IRestrictedDatesOptions,
-  IDay,
+  DateRangeType,
   DayOfWeek,
   FirstWeekOfYear,
-  DateRangeType,
-  IDateGridStrings,
   formatMonthDayYear,
+  IDateGridStrings,
+  IDay,
   IDayGridOptions,
+  IRestrictedDatesOptions,
 } from '@fluentui/date-time-utilities';
+import {
+  ComponentWithAs,
+  getElementType,
+  useAccessibility,
+  useFluentContext,
+  useStyles,
+  useTelemetry,
+  useUnhandledProps,
+} from '@fluentui/react-bindings';
+import { Ref } from '@fluentui/react-component-ref';
+import { CalendarIcon } from '@fluentui/react-icons-northstar';
+import * as _ from 'lodash';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { ComponentEventHandler, FluentComponentStaticProps } from '../../types';
+import { commonPropTypes, createShorthandFactory, UIComponentProps } from '../../utils';
+import { Button } from '../Button/Button';
+import { Input } from '../Input/Input';
+import { Popup } from '../Popup/Popup';
 import { DatepickerCalendar, DatepickerCalendarProps } from './DatepickerCalendar';
 
 // TODO: extract to date-time-utilities
@@ -131,12 +130,6 @@ export interface DatepickerProps extends IDatepickerOptions, IDateFormatting, UI
 
   /** Text placeholder for the input field. */
   placeholder?: string;
-
-  /** A render function to customize how cells are rendered in the Calendar. */
-  renderCell?: ShorthandRenderFunction<any>;
-
-  /** A render function to customize how cells are rendered in the Calendar.. */
-  renderHeaderCell?: ShorthandRenderFunction<any>;
 
   /** Localized labels */
   localizedStrings?: IDateGridStrings;
@@ -261,8 +254,6 @@ Datepicker.propTypes = {
   onDateChange: PropTypes.func,
   goToToday: PropTypes.string,
   placeholder: PropTypes.string,
-  renderCell: PropTypes.func,
-  renderHeaderCell: PropTypes.func,
 };
 
 Datepicker.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -174,6 +174,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
     weeksToShow,
     localizedStrings,
     today,
+    onDateChange,
   } = props;
 
   const ElementType = getElementType(props);
@@ -217,13 +218,6 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
 
   const grid = getSlicedGrid();
 
-  const onPreviousClick = () => {
-    changeMonth(false);
-  };
-  const onNextClick = () => {
-    changeMonth(true);
-  };
-
   const changeMonth = (nextMonth: boolean) => {
     const updatedGridNavigatedDate = addMonths(gridNavigatedDate, nextMonth ? 1 : -1);
     setGridNavigatedDate(updatedGridNavigatedDate);
@@ -242,9 +236,15 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
             defaultProps: () => ({
               label: formatMonthYear(gridNavigatedDate, localizedStrings),
             }),
-            overrideProps: () => ({
-              onPreviousClick,
-              onNextClick,
+            overrideProps: (predefinedProps: DatepickerCalendarHeaderProps): DatepickerCalendarHeaderProps => ({
+              onPreviousClick: (e, data) => {
+                changeMonth(false);
+                _.invoke(predefinedProps, 'onPreviousClick', e, data);
+              },
+              onNextClick: (e, data) => {
+                changeMonth(true);
+                _.invoke(predefinedProps, 'onNextClick', e, data);
+              },
             }),
           })}
           <Grid rows={grid.length + 1} columns={DAYS_IN_WEEK}>
@@ -268,9 +268,10 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
                       primary: day.isSelected,
                       disabled: !day.isInMonth,
                     }),
-                  overrideProps: () => ({
+                  overrideProps: (predefinedProps: DatepickerCalendarCellProps): DatepickerCalendarCellProps => ({
                     onClick: e => {
-                      _.invoke(props, 'onDateChange', e, { ...props, value: day });
+                      onDateChange(e, { ...predefinedProps, value: day });
+                      _.invoke(predefinedProps, 'onClick', e, { ...predefinedProps, value: day });
                     },
                   }),
                 }),

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -286,21 +286,6 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
                         disabled: !day.isInMonth,
                       }),
                   }),
-                // {
-                //   return (
-                //     <Button
-                //       key={day.key}
-                //       content={day.date}
-                //       aria-label={`${formatMonthDayYear(day.originalDate, localizedStrings)}`}
-                //       onClick={e => {
-                //         _.invoke(props, 'onDateChange', e, { ...props, value: day });
-                //       }}
-                //       primary={day.isSelected}
-                //       disabled={!day.isInMonth}
-                //       text
-                //     />
-                //   );
-                // }
               ),
             )}
           </Grid>

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -23,7 +23,6 @@ import {
   useUnhandledProps,
 } from '@fluentui/react-bindings';
 import { Ref } from '@fluentui/react-component-ref';
-import { ArrowRightIcon } from '@fluentui/react-icons-northstar';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
 import * as PropTypes from 'prop-types';
@@ -207,10 +206,12 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
     return createShorthand(DatepickerCalendarHeader, header, {
       defaultProps: () => ({
         styles: resolvedStyles.header,
-        previousButton: { iconOnly: true, icon: <ArrowRightIcon />, onClick: onPreviousClick, title: 'Previous Month' },
-        nextButton: { iconOnly: true, icon: <ArrowRightIcon />, onClick: onNextClick, title: 'Next Month' },
         content: formatMonthYear(gridOptions.navigatedDate, localizedStrings),
       }),
+      overrideProps: {
+        onPreviousClick,
+        onNextClick,
+      },
     });
   };
 

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -132,11 +132,11 @@ export interface DatepickerCalendarProps extends IDatepickerCalendarOptions, IDa
   /**
    * The currently selected date
    */
-  selectedDate: Date;
+  selectedDate?: Date;
   /**
    * The currently navigated date
    */
-  navigatedDate: Date;
+  navigatedDate?: Date;
 
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<DatepickerCalendarBehaviorProps>;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -183,7 +183,6 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
     showWeekNumbers,
   } = props;
 
-  const localizedStrings = props.localizedStrings || DEFAULT_CALENDAR_LOCALIZED_STRINGS;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DatepickerCalendar.handledProps, props);
   const getA11yProps = useAccessibility(props.accessibility, {
@@ -223,7 +222,6 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
   const renderHeader = () => {
     return createShorthand(DatepickerCalendarHeader, header, {
       defaultProps: () => ({
-        styles: resolvedStyles.header,
         content: formatMonthYear(gridOptions.navigatedDate, localizedStrings),
       }),
       overrideProps: {
@@ -260,9 +258,8 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
               createShorthand(DatepickerCalendarHeaderCell, calendarHeaderCell, {
                 defaultProps: () =>
                   getA11yProps('calendarHeaderCell', {
-                    className: datepickerCalendarHeaderCellClassName,
                     content: localizedStrings.shortDays[(dayNumber + firstDayOfWeek) % DAYS_IN_WEEK],
-                    key: `header_${dayNumber}`,
+                    key: dayNumber,
                   }),
               }),
             )}
@@ -273,7 +270,6 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
                   createShorthand(DatepickerCalendarCell, calendarCell, {
                     defaultProps: () =>
                       getA11yProps('calendarCell', {
-                        className: datepickerCalendarCellClassName,
                         content: day.date,
                         key: day.key,
                         'aria-label': formatMonthDayYear(day.originalDate, localizedStrings),

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -242,9 +242,7 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
 
   const changeMonth = (nextMonth: boolean) => {
     const updatedGridNavigatedDate = addMonths(gridOptions.navigatedDate, nextMonth ? 1 : -1);
-    const newGridOptions = { ...gridOptions };
-    newGridOptions.navigatedDate = updatedGridNavigatedDate;
-    setGridOptions(newGridOptions);
+    setGridOptions({ ...gridOptions, navigatedDate:  updatedGridNavigatedDate });
   };
 
   const element = (

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
@@ -1,0 +1,22 @@
+import { compose } from '@fluentui/react-bindings';
+import { Button, ButtonProps, ButtonStylesProps } from '../Button/Button';
+
+export type DatepickerCalendarCellProps = {};
+
+export type DatepickerCalendarCellStylesProps = ButtonStylesProps;
+
+export const datepickerCalendarCellClassName = 'ui-datepicker__calendar-cell';
+export const DatepickerCalendarCell = compose<
+  'button',
+  DatepickerCalendarCellProps,
+  DatepickerCalendarCellStylesProps,
+  ButtonProps,
+  {}
+>(Button, {
+  className: datepickerCalendarCellClassName,
+  displayName: 'DatepickerCalendarCell',
+  mapPropsToStylesProps: () => ({
+    text: true,
+    size: 'small',
+  }),
+});

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarCell.tsx
@@ -5,7 +5,11 @@ export type DatepickerCalendarCellProps = {};
 
 export type DatepickerCalendarCellStylesProps = ButtonStylesProps;
 
-export const datepickerCalendarCellClassName = 'ui-datepicker__calendar-cell';
+export const datepickerCalendarCellClassName = 'ui-datepicker__calendarcell';
+/**
+ * A Datepicker cell is used to display calendar grid cells.
+ * This component is currently UNSTABLE!
+ */
 export const DatepickerCalendarCell = compose<
   'button',
   DatepickerCalendarCellProps,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -1,0 +1,140 @@
+import {
+  Accessibility,
+  datepickerCalendarHeaderBehavior,
+  DatepickerCalendarHeaderBehaviorProps,
+} from '@fluentui/accessibility';
+import { IDateGridStrings } from '@fluentui/date-time-utilities';
+import {
+  ComponentWithAs,
+  getElementType,
+  useAccessibility,
+  useFluentContext,
+  useStyles,
+  useTelemetry,
+  useUnhandledProps,
+} from '@fluentui/react-bindings';
+import * as customPropTypes from '@fluentui/react-proptypes';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { FluentComponentStaticProps, ShorthandValue } from '../../types';
+import { commonPropTypes, ContentComponentProps, createShorthandFactory, UIComponentProps } from '../../utils';
+import { Button, ButtonProps } from '../Button/Button';
+import { carouselSlotClassNames } from '../Carousel/Carousel';
+import { Flex } from '../Flex/Flex';
+import { Text } from '../Text/Text';
+
+// TODO: extract to date-time-utilities
+export const DEFAULT_LOCALIZED_STRINGS: IDateGridStrings = {
+  months: [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ],
+  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+};
+
+export interface DatepickerCalendarHeaderProps extends UIComponentProps, ContentComponentProps {
+  /** Accessibility behavior if overridden by the user. */
+  accessibility?: Accessibility<DatepickerCalendarHeaderBehaviorProps>;
+
+  /** Localized labels */
+  localizedStrings?: IDateGridStrings;
+
+  /** Shorthand for the button that navigates to the previous calendar screen. */
+  previousButton?: ShorthandValue<ButtonProps>;
+
+  /** Shorthand for the button that navigates to the next calendar screen. */
+  nextButton?: ShorthandValue<ButtonProps>;
+}
+
+export type DatepickerCalendarHeaderStylesProps = never;
+
+export const datepickerCalendarHeaderClassName = 'ui-datepicker__calendar-controls';
+
+/**
+ * A Datepicker is used to display dates.
+ * This component is currently UNSTABLE!
+ */
+export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendarHeaderProps> &
+  FluentComponentStaticProps<DatepickerCalendarHeaderProps> = props => {
+  const context = useFluentContext();
+  const { setStart, setEnd } = useTelemetry(DatepickerCalendarHeader.displayName, context.telemetry);
+  setStart();
+
+  const { className, design, styles, variables, content, nextButton, previousButton } = props;
+  const ElementType = getElementType(props);
+  const unhandledProps = useUnhandledProps(DatepickerCalendarHeader.handledProps, props);
+  const getA11yProps = useAccessibility(props.accessibility, {
+    debugName: DatepickerCalendarHeader.displayName,
+    actionHandlers: {},
+    rtl: context.rtl,
+  });
+
+  const { classes } = useStyles<DatepickerCalendarHeaderStylesProps>(DatepickerCalendarHeader.displayName, {
+    className: datepickerCalendarHeaderClassName,
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables,
+    }),
+    rtl: context.rtl,
+  });
+
+  const element = (
+    <ElementType
+      {...getA11yProps('root', {
+        className: classes.root,
+        ...unhandledProps,
+      })}
+    >
+      <Flex fill space="between" vAlign="center">
+        <Text content={content} />
+        {Button.create(previousButton, {
+          defaultProps: () =>
+            getA11yProps('paddleNext', {
+              className: carouselSlotClassNames.paddleNext,
+            }),
+        })}
+        {Button.create(nextButton, {
+          defaultProps: () =>
+            getA11yProps('paddleNext', {
+              className: carouselSlotClassNames.paddleNext,
+            }),
+        })}
+      </Flex>
+    </ElementType>
+  );
+  setEnd();
+  return element;
+};
+
+DatepickerCalendarHeader.displayName = 'DatepickerCalendarHeader';
+
+DatepickerCalendarHeader.propTypes = {
+  ...commonPropTypes.createCommon(),
+  localizedStrings: PropTypes.object as PropTypes.Validator<IDateGridStrings>,
+  nextButton: customPropTypes.itemShorthand,
+  previousButton: customPropTypes.itemShorthand,
+};
+
+DatepickerCalendarHeader.defaultProps = {
+  accessibility: datepickerCalendarHeaderBehavior,
+  nextButton: {},
+  previousButton: {},
+};
+
+DatepickerCalendarHeader.handledProps = Object.keys(DatepickerCalendarHeader.propTypes) as any;
+
+DatepickerCalendarHeader.create = createShorthandFactory({ Component: DatepickerCalendarHeader });

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -13,36 +13,22 @@ import {
   useTelemetry,
   useUnhandledProps,
 } from '@fluentui/react-bindings';
+import { ArrowLeftIcon, ArrowRightIcon } from '@fluentui/react-icons-northstar';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { FluentComponentStaticProps, ShorthandValue } from '../../types';
-import { commonPropTypes, ContentComponentProps, createShorthandFactory, UIComponentProps } from '../../utils';
-import { Button, ButtonProps } from '../Button/Button';
-import { carouselSlotClassNames } from '../Carousel/Carousel';
+import {
+  commonPropTypes,
+  ContentComponentProps,
+  createShorthand,
+  createShorthandFactory,
+  UIComponentProps,
+} from '../../utils';
+import { ButtonProps } from '../Button/Button';
 import { Flex } from '../Flex/Flex';
 import { Text } from '../Text/Text';
-
-// TODO: extract to date-time-utilities
-export const DEFAULT_LOCALIZED_STRINGS: IDateGridStrings = {
-  months: [
-    'January',
-    'February',
-    'March',
-    'April',
-    'May',
-    'June',
-    'July',
-    'August',
-    'September',
-    'October',
-    'November',
-    'December',
-  ],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-};
+import { DatepickerCalendarHeaderAction } from './DatepickerCalendarHeaderAction';
 
 export interface DatepickerCalendarHeaderProps extends UIComponentProps, ContentComponentProps {
   /** Accessibility behavior if overridden by the user. */
@@ -50,6 +36,9 @@ export interface DatepickerCalendarHeaderProps extends UIComponentProps, Content
 
   /** Localized labels */
   localizedStrings?: IDateGridStrings;
+
+  onPreviousClick?: Function;
+  onNextClick?: Function;
 
   /** Shorthand for the button that navigates to the previous calendar screen. */
   previousButton?: ShorthandValue<ButtonProps>;
@@ -72,7 +61,17 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
   const { setStart, setEnd } = useTelemetry(DatepickerCalendarHeader.displayName, context.telemetry);
   setStart();
 
-  const { className, design, styles, variables, content, nextButton, previousButton } = props;
+  const {
+    className,
+    design,
+    styles,
+    variables,
+    content,
+    nextButton,
+    previousButton,
+    onPreviousClick,
+    onNextClick,
+  } = props;
   const ElementType = getElementType(props);
   const unhandledProps = useUnhandledProps(DatepickerCalendarHeader.handledProps, props);
   const getA11yProps = useAccessibility(props.accessibility, {
@@ -101,16 +100,24 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
     >
       <Flex fill space="between" vAlign="center">
         <Text content={content} />
-        {Button.create(previousButton, {
+        {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
           defaultProps: () =>
-            getA11yProps('paddleNext', {
-              className: carouselSlotClassNames.paddleNext,
+            getA11yProps('previousButton', {
+              className: datepickerCalendarHeaderClassName,
+              icon: <ArrowLeftIcon />,
+              title: 'Previous Month',
+              onClick: onPreviousClick,
+              type: 'previous',
             }),
         })}
-        {Button.create(nextButton, {
+        {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
           defaultProps: () =>
-            getA11yProps('paddleNext', {
-              className: carouselSlotClassNames.paddleNext,
+            getA11yProps('nextButton', {
+              className: datepickerCalendarHeaderClassName,
+              icon: <ArrowRightIcon />,
+              title: 'Previous Month',
+              onClick: onNextClick,
+              type: 'next',
             }),
         })}
       </Flex>

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -1,3 +1,6 @@
+import * as _ from 'lodash';
+import * as React from 'react';
+
 import {
   Accessibility,
   datepickerCalendarHeaderBehavior,
@@ -15,7 +18,6 @@ import {
 } from '@fluentui/react-bindings';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
-import * as React from 'react';
 import { FluentComponentStaticProps, ShorthandValue, ComponentEventHandler } from '../../types';
 import {
   commonPropTypes,
@@ -111,8 +113,11 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
             title: 'Previous Month',
             direction: 'previous',
           }),
-        overrideProps: () => ({
-          onClick: onPreviousClick,
+        overrideProps: (predefinedProps: DatepickerCalendarHeaderActionProps): DatepickerCalendarHeaderActionProps => ({
+          onClick: (e, data) => {
+            onPreviousClick(e, data);
+            _.invoke(predefinedProps, 'onClick', e, data);
+          },
         }),
       })}
       {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
@@ -123,8 +128,11 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
             title: 'Next Month',
             direction: 'next',
           }),
-        overrideProps: () => ({
-          onClick: onNextClick,
+        overrideProps: (predefinedProps: DatepickerCalendarHeaderActionProps): DatepickerCalendarHeaderActionProps => ({
+          onClick: (e, data) => {
+            onNextClick(e, data);
+            _.invoke(predefinedProps, 'onClick', e, data);
+          },
         }),
       })}
     </ElementType>

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -49,10 +49,10 @@ export interface DatepickerCalendarHeaderProps extends UIComponentProps, Content
 
 export type DatepickerCalendarHeaderStylesProps = never;
 
-export const datepickerCalendarHeaderClassName = 'ui-datepicker__calendar-controls';
+export const datepickerCalendarHeaderClassName = 'ui-datepicker__calendarheader';
 
 /**
- * A Datepicker is used to display dates.
+ * A DatepickerCalendarHeader is used to display header block above calendar grid.
  * This component is currently UNSTABLE!
  */
 export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendarHeaderProps> &

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -24,12 +24,15 @@ import {
   createShorthandFactory,
   UIComponentProps,
 } from '../../utils';
-import { Text } from '../Text/Text';
 import { DatepickerCalendarHeaderAction, DatepickerCalendarHeaderActionProps } from './DatepickerCalendarHeaderAction';
+import { Text, TextProps } from '../Text/Text';
 
 export interface DatepickerCalendarHeaderProps extends UIComponentProps, ContentComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<DatepickerCalendarHeaderBehaviorProps>;
+
+  /** Shorthand for text label. */
+  label?: ShorthandValue<TextProps>;
 
   /** Localized labels */
   localizedStrings?: IDateGridStrings;
@@ -66,7 +69,7 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
     design,
     styles,
     variables,
-    content,
+    label,
     nextButton,
     previousButton,
     onPreviousClick,
@@ -98,24 +101,31 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
         ...unhandledProps,
       })}
     >
-      <Text content={content} />
+      {createShorthand(Text, label)}
+
       {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
         defaultProps: () =>
           getA11yProps('previousButton', {
             icon: {},
+            // TODO: use value from `localizationStrings` after #14058 implements needed values
             title: 'Previous Month',
-            onClick: onPreviousClick,
             direction: 'previous',
           }),
+        overrideProps: () => ({
+          onClick: onPreviousClick,
+        }),
       })}
       {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
         defaultProps: () =>
           getA11yProps('nextButton', {
             icon: {},
-            title: 'Previous Month',
-            onClick: onNextClick,
+            // TODO: use value from `localizationStrings` after #14058 implements needed values
+            title: 'Next Month',
             direction: 'next',
           }),
+        overrideProps: () => ({
+          onClick: onNextClick,
+        }),
       })}
     </ElementType>
   );
@@ -127,6 +137,7 @@ DatepickerCalendarHeader.displayName = 'DatepickerCalendarHeader';
 
 DatepickerCalendarHeader.propTypes = {
   ...commonPropTypes.createCommon(),
+  label: customPropTypes.itemShorthand,
   localizedStrings: PropTypes.object as PropTypes.Validator<IDateGridStrings>,
   nextButton: customPropTypes.itemShorthand,
   previousButton: customPropTypes.itemShorthand,
@@ -138,6 +149,7 @@ DatepickerCalendarHeader.defaultProps = {
   accessibility: datepickerCalendarHeaderBehavior,
   nextButton: {},
   previousButton: {},
+  label: {},
 };
 
 DatepickerCalendarHeader.handledProps = Object.keys(DatepickerCalendarHeader.propTypes) as any;

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -13,11 +13,10 @@ import {
   useTelemetry,
   useUnhandledProps,
 } from '@fluentui/react-bindings';
-import { ArrowLeftIcon, ArrowRightIcon } from '@fluentui/react-icons-northstar';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { FluentComponentStaticProps, ShorthandValue } from '../../types';
+import { FluentComponentStaticProps, ShorthandValue, ComponentEventHandler } from '../../types';
 import {
   commonPropTypes,
   ContentComponentProps,
@@ -25,10 +24,8 @@ import {
   createShorthandFactory,
   UIComponentProps,
 } from '../../utils';
-import { ButtonProps } from '../Button/Button';
-import { Flex } from '../Flex/Flex';
 import { Text } from '../Text/Text';
-import { DatepickerCalendarHeaderAction } from './DatepickerCalendarHeaderAction';
+import { DatepickerCalendarHeaderAction, DatepickerCalendarHeaderActionProps } from './DatepickerCalendarHeaderAction';
 
 export interface DatepickerCalendarHeaderProps extends UIComponentProps, ContentComponentProps {
   /** Accessibility behavior if overridden by the user. */
@@ -37,14 +34,17 @@ export interface DatepickerCalendarHeaderProps extends UIComponentProps, Content
   /** Localized labels */
   localizedStrings?: IDateGridStrings;
 
-  onPreviousClick?: Function;
-  onNextClick?: Function;
+  /** Action to happen on click on the previous button */
+  onPreviousClick?: ComponentEventHandler<DatepickerCalendarHeaderActionProps>;
+
+  /** Action to happen on click on the next button */
+  onNextClick?: ComponentEventHandler<DatepickerCalendarHeaderActionProps>;
 
   /** Shorthand for the button that navigates to the previous calendar screen. */
-  previousButton?: ShorthandValue<ButtonProps>;
+  previousButton?: ShorthandValue<DatepickerCalendarHeaderActionProps>;
 
   /** Shorthand for the button that navigates to the next calendar screen. */
-  nextButton?: ShorthandValue<ButtonProps>;
+  nextButton?: ShorthandValue<DatepickerCalendarHeaderActionProps>;
 }
 
 export type DatepickerCalendarHeaderStylesProps = never;
@@ -98,29 +98,27 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
         ...unhandledProps,
       })}
     >
-      <Flex fill space="between" vAlign="center">
-        <Text content={content} />
-        {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
-          defaultProps: () =>
-            getA11yProps('previousButton', {
-              className: datepickerCalendarHeaderClassName,
-              icon: <ArrowLeftIcon />,
-              title: 'Previous Month',
-              onClick: onPreviousClick,
-              type: 'previous',
-            }),
-        })}
-        {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
-          defaultProps: () =>
-            getA11yProps('nextButton', {
-              className: datepickerCalendarHeaderClassName,
-              icon: <ArrowRightIcon />,
-              title: 'Previous Month',
-              onClick: onNextClick,
-              type: 'next',
-            }),
-        })}
-      </Flex>
+      <Text content={content} />
+      {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
+        defaultProps: () =>
+          getA11yProps('previousButton', {
+            className: datepickerCalendarHeaderClassName,
+            icon: {},
+            title: 'Previous Month',
+            onClick: onPreviousClick,
+            direction: 'previous',
+          }),
+      })}
+      {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
+        defaultProps: () =>
+          getA11yProps('nextButton', {
+            className: datepickerCalendarHeaderClassName,
+            icon: {},
+            title: 'Previous Month',
+            onClick: onNextClick,
+            direction: 'next',
+          }),
+      })}
     </ElementType>
   );
   setEnd();
@@ -134,6 +132,8 @@ DatepickerCalendarHeader.propTypes = {
   localizedStrings: PropTypes.object as PropTypes.Validator<IDateGridStrings>,
   nextButton: customPropTypes.itemShorthand,
   previousButton: customPropTypes.itemShorthand,
+  onPreviousClick: PropTypes.func,
+  onNextClick: PropTypes.func,
 };
 
 DatepickerCalendarHeader.defaultProps = {

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -102,7 +102,6 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
       {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
         defaultProps: () =>
           getA11yProps('previousButton', {
-            className: datepickerCalendarHeaderClassName,
             icon: {},
             title: 'Previous Month',
             onClick: onPreviousClick,
@@ -112,7 +111,6 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
       {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
         defaultProps: () =>
           getA11yProps('nextButton', {
-            className: datepickerCalendarHeaderClassName,
             icon: {},
             title: 'Previous Month',
             onClick: onNextClick,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -1,0 +1,27 @@
+import { compose } from '@fluentui/react-bindings';
+import { Button, ButtonProps, ButtonStylesProps } from '../Button/Button';
+
+export type DatepickerCalendarHeaderActionProps = {
+  type?: 'previous' | 'next';
+};
+
+export type DatepickerCalendarHeaderActionStylesProps = ButtonStylesProps;
+
+export const datepickerCalendarHeaderClassName = 'ui-datepicker__calendar-header-action';
+export const DatepickerCalendarHeaderAction = compose<
+  'button',
+  DatepickerCalendarHeaderActionProps,
+  DatepickerCalendarHeaderActionStylesProps,
+  ButtonProps,
+  ButtonStylesProps
+>(Button, {
+  className: datepickerCalendarHeaderClassName,
+  displayName: 'DatepickerCalendarHeaderAction',
+  handledProps: ['type'],
+  mapPropsToStylesProps: () => ({
+    iconOnly: true,
+  }),
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -1,8 +1,12 @@
+import * as React from 'react';
+
 import { compose } from '@fluentui/react-bindings';
+import { ChevronEndIcon, ChevronStartIcon } from '@fluentui/react-icons-northstar';
 import { Button, ButtonProps, ButtonStylesProps } from '../Button/Button';
 
 export type DatepickerCalendarHeaderActionProps = {
-  type?: 'previous' | 'next';
+  /** What direction the action button should be pointing */
+  direction?: 'previous' | 'next';
 };
 
 export type DatepickerCalendarHeaderActionStylesProps = ButtonStylesProps;
@@ -13,15 +17,18 @@ export const DatepickerCalendarHeaderAction = compose<
   DatepickerCalendarHeaderActionProps,
   DatepickerCalendarHeaderActionStylesProps,
   ButtonProps,
-  ButtonStylesProps
+  {}
 >(Button, {
   className: datepickerCalendarHeaderClassName,
   displayName: 'DatepickerCalendarHeaderAction',
-  handledProps: ['type'],
+  handledProps: ['direction'],
   mapPropsToStylesProps: () => ({
     iconOnly: true,
+    text: true,
   }),
-  shorthandConfig: {
-    mappedProp: 'content',
-  },
+  slotProps: props => ({
+    icon: {
+      content: props.direction === 'next' ? <ChevronEndIcon /> : <ChevronStartIcon />,
+    },
+  }),
 });

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -11,7 +11,12 @@ export type DatepickerCalendarHeaderActionProps = {
 
 export type DatepickerCalendarHeaderActionStylesProps = ButtonStylesProps;
 
-export const datepickerCalendarHeaderClassName = 'ui-datepicker__calendar-header-action';
+export const datepickerCalendarHeaderActionClassName = 'ui-datepicker__calendarheaderaction';
+
+/**
+ * A DatepickerCalendarHeaderAction is used to display action button for DatepickerCalendarHeader.
+ * This component is currently UNSTABLE!
+ */
 export const DatepickerCalendarHeaderAction = compose<
   'button',
   DatepickerCalendarHeaderActionProps,
@@ -19,7 +24,7 @@ export const DatepickerCalendarHeaderAction = compose<
   ButtonProps,
   {}
 >(Button, {
-  className: datepickerCalendarHeaderClassName,
+  className: datepickerCalendarHeaderActionClassName,
   displayName: 'DatepickerCalendarHeaderAction',
   handledProps: ['direction'],
   mapPropsToStylesProps: () => ({

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -4,7 +4,7 @@ import { compose } from '@fluentui/react-bindings';
 import { ChevronEndIcon, ChevronStartIcon } from '@fluentui/react-icons-northstar';
 import { Button, ButtonProps, ButtonStylesProps } from '../Button/Button';
 
-export type DatepickerCalendarHeaderActionProps = {
+export type DatepickerCalendarHeaderActionProps = ButtonProps & {
   /** What direction the action button should be pointing */
   direction?: 'previous' | 'next';
 };

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
@@ -6,7 +6,11 @@ export type DatepickerCalendarHeaderCellProps = {};
 
 export type DatepickerCalendarHeaderCellStylesProps = {};
 
-export const datepickerCalendarHeaderCellClassName = 'ui-datepicker__calendar-headercell';
+export const datepickerCalendarHeaderCellClassName = 'ui-datepicker__calendarheadercell';
+/**
+ * A DatepickerCalendarHeaderCell is used to display header cells in DatepickerCalendar grid.
+ * This component is currently UNSTABLE!
+ */
 export const DatepickerCalendarHeaderCell = compose<
   'span',
   DatepickerCalendarHeaderCellProps,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderCell.tsx
@@ -1,0 +1,29 @@
+import { compose } from '@fluentui/react-bindings';
+import { commonPropTypes } from '../../utils';
+import { BoxProps, Box } from '../Box/Box';
+
+export type DatepickerCalendarHeaderCellProps = {};
+
+export type DatepickerCalendarHeaderCellStylesProps = {};
+
+export const datepickerCalendarHeaderCellClassName = 'ui-datepicker__calendar-headercell';
+export const DatepickerCalendarHeaderCell = compose<
+  'span',
+  DatepickerCalendarHeaderCellProps,
+  DatepickerCalendarHeaderCellStylesProps,
+  BoxProps,
+  {}
+>(Box, {
+  className: datepickerCalendarHeaderCellClassName,
+  displayName: 'DatepickerCalendarHeaderCell',
+  overrideStyles: true,
+  shorthandConfig: {
+    mappedProp: 'content',
+  },
+});
+
+DatepickerCalendarHeaderCell.defaultProps = {
+  as: 'span',
+};
+
+DatepickerCalendarHeaderCell.propTypes = commonPropTypes.createCommon();

--- a/packages/fluentui/react-northstar/src/index.ts
+++ b/packages/fluentui/react-northstar/src/index.ts
@@ -205,6 +205,10 @@ export * from './components/Card/CardExpandableBox';
 
 export * from './components/Datepicker/Datepicker';
 export * from './components/Datepicker/DatepickerCalendar';
+export * from './components/Datepicker/DatepickerCalendarHeader';
+export * from './components/Datepicker/DatepickerCalendarHeaderAction';
+export * from './components/Datepicker/DatepickerCalendarHeaderCell';
+export * from './components/Datepicker/DatepickerCalendarCell';
 
 //
 // Utilities

--- a/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentStyles.ts
@@ -147,3 +147,6 @@ export { cardTopControlsStyles as CardTopControls } from './components/Card/card
 export { cardExpandableBoxStyles as CardExpandableBox } from './components/Card/cardExpandableBoxStyles';
 
 export { datepickerStyles as Datepicker } from './components/Datepicker/datepickerStyles';
+export { datepickerCalendarStyles as DatepickerCalendar } from './components/Datepicker/datepickerCalendarStyles';
+export { datepickerCalendarHeaderStyles as DatepickerCalendarHeader } from './components/Datepicker/datepickerCalendarHeaderStyles';
+export { datepickerCalendarHeaderCellStyles as DatepickerCalendarHeaderCell } from './components/Datepicker/datepickerCalendarHeaderCellStyles';

--- a/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/componentVariables.ts
@@ -136,3 +136,6 @@ export { cardTopControlsVariables as CardTopControls } from './components/Card/c
 export { cardExpandableBoxVariables as CardExpandableBox } from './components/Card/cardExpandableBoxVariables';
 
 export { datepickerVariables as Datepicker } from './components/Datepicker/datepickerVariables';
+export { datepickerCalendarVariables as DatepickerCalendar } from './components/Datepicker/datepickerCalendarVariables';
+export { datepickerCalendarHeaderVariables as DatepickerCalendarHeader } from './components/Datepicker/datepickerCalendarHeaderVariables';
+export { datepickerCalendarHeaderCellVariables as DatepickerCalendarHeaderCell } from './components/Datepicker/datepickerCalendarHeaderCellVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellStyles.ts
@@ -1,0 +1,14 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { DatepickerVariables } from './datepickerVariables';
+import { DatepickerCalendarHeaderCellStylesProps } from 'src/components/Datepicker/DatepickerCalendarHeaderCell';
+
+export const datepickerCalendarHeaderCellStyles: ComponentSlotStylesPrepared<
+  DatepickerCalendarHeaderCellStylesProps,
+  DatepickerVariables
+> = {
+  root: (): ICSSInJSStyle => {
+    return {
+      textAlign: 'center',
+    };
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellStyles.ts
@@ -1,6 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { DatepickerVariables } from './datepickerVariables';
-import { DatepickerCalendarHeaderCellStylesProps } from 'src/components/Datepicker/DatepickerCalendarHeaderCell';
+import { DatepickerCalendarHeaderCellStylesProps } from '../../../../components/Datepicker/DatepickerCalendarHeaderCell';
 
 export const datepickerCalendarHeaderCellStyles: ComponentSlotStylesPrepared<
   DatepickerCalendarHeaderCellStylesProps,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderCellVariables.ts
@@ -1,0 +1,1 @@
+export { datepickerVariables as datepickerCalendarHeaderCellVariables } from './datepickerVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
@@ -1,0 +1,16 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { DatepickerVariables } from './datepickerVariables';
+import { DatepickerCalendarHeaderStylesProps } from 'src/components/Datepicker/DatepickerCalendarHeader';
+
+export const datepickerCalendarHeaderStyles: ComponentSlotStylesPrepared<
+  DatepickerCalendarHeaderStylesProps,
+  DatepickerVariables
+> = {
+  root: (): ICSSInJSStyle => {
+    return {
+      display: 'grid',
+      gridTemplateColumns: '1fr auto auto',
+      msGridColumns: '1fr auto auto',
+    };
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
@@ -8,6 +8,7 @@ export const datepickerCalendarHeaderStyles: ComponentSlotStylesPrepared<
 > = {
   root: (): ICSSInJSStyle => {
     return {
+      // TODO: check if grid is needed here and if so, make sure that it works in IE11
       display: 'grid',
       gridTemplateColumns: '1fr auto auto',
       msGridColumns: '1fr auto auto',

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
@@ -11,7 +11,6 @@ export const datepickerCalendarHeaderStyles: ComponentSlotStylesPrepared<
       display: 'grid',
       gridTemplateColumns: '1fr auto auto',
       msGridColumns: '1fr auto auto',
-      verticalAlign: 'middle',
     };
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
@@ -1,6 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { DatepickerVariables } from './datepickerVariables';
-import { DatepickerCalendarHeaderStylesProps } from 'src/components/Datepicker/DatepickerCalendarHeader';
+import { DatepickerCalendarHeaderStylesProps } from '../../../../components/Datepicker/DatepickerCalendarHeader';
 
 export const datepickerCalendarHeaderStyles: ComponentSlotStylesPrepared<
   DatepickerCalendarHeaderStylesProps,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderStyles.ts
@@ -11,6 +11,7 @@ export const datepickerCalendarHeaderStyles: ComponentSlotStylesPrepared<
       display: 'grid',
       gridTemplateColumns: '1fr auto auto',
       msGridColumns: '1fr auto auto',
+      verticalAlign: 'middle',
     };
   },
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarHeaderVariables.ts
@@ -1,0 +1,1 @@
+export { datepickerVariables as datepickerCalendarHeaderVariables } from './datepickerVariables';

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
@@ -1,0 +1,12 @@
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
+import { DatepickerVariables } from './datepickerVariables';
+import { DatepickerCalendarStylesProps } from 'src/components/Datepicker/DatepickerCalendar';
+
+export const datepickerCalendarStyles: ComponentSlotStylesPrepared<
+  DatepickerCalendarStylesProps,
+  DatepickerVariables
+> = {
+  root: (): ICSSInJSStyle => {
+    return {};
+  },
+};

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
@@ -1,6 +1,6 @@
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { DatepickerVariables } from './datepickerVariables';
-import { DatepickerCalendarStylesProps } from 'src/components/Datepicker/DatepickerCalendar';
+import { DatepickerCalendarStylesProps } from '../../../../components/Datepicker/DatepickerCalendar';
 
 export const datepickerCalendarStyles: ComponentSlotStylesPrepared<
   DatepickerCalendarStylesProps,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarVariables.ts
@@ -1,0 +1,1 @@
+export { datepickerVariables as datepickerCalendarVariables } from './datepickerVariables';

--- a/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarCell-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarCell-test.tsx
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import { DatepickerCalendarCell } from 'src/components/Datepicker/DatepickerCalendarCell';
+
+describe('DatepickerCalendarCell', () => {
+  isConformant(DatepickerCalendarCell, { constructorName: 'DatepickerCalendarCell' });
+});

--- a/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeader-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeader-test.tsx
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import { DatepickerCalendarHeader } from 'src/components/Datepicker/DatepickerCalendarHeader';
+
+describe('DatepickerCalendarHeader', () => {
+  isConformant(DatepickerCalendarHeader, { constructorName: 'DatepickerCalendarHeader' });
+});

--- a/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeaderAction-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeaderAction-test.tsx
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import { DatepickerCalendarHeaderAction } from 'src/components/Datepicker/DatepickerCalendarHeaderAction';
+
+describe('DatepickerCalendarHeaderAction', () => {
+  isConformant(DatepickerCalendarHeaderAction, { constructorName: 'DatepickerCalendarHeaderAction' });
+});

--- a/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeaderCell-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Datepicker/DatepickerCalendarHeaderCell-test.tsx
@@ -1,0 +1,6 @@
+import { isConformant } from 'test/specs/commonTests';
+import { DatepickerCalendarHeaderCell } from 'src/components/Datepicker/DatepickerCalendarHeaderCell';
+
+describe('DatepickerCalendarHeaderCell', () => {
+  isConformant(DatepickerCalendarHeaderCell, { constructorName: 'DatepickerCalendarHeaderCell' });
+});

--- a/specs/Datepicker.md
+++ b/specs/Datepicker.md
@@ -46,7 +46,7 @@
 
 Consider having a single property to be a dictionary containing all needed localized strings.
 
-`renderCell` and `renderHeaderCell` are replaced with `calendarCell` and `calendarHeaderCell` shorthand components respectively.
+`renderCell` and `renderHeaderCell` are replaced with `calendarCell` and `calendarHeaderCell` shorthand components respectively in Fluent UI v0 implementation.
 
 ## Structure
 

--- a/specs/Datepicker.md
+++ b/specs/Datepicker.md
@@ -46,6 +46,8 @@
 
 Consider having a single property to be a dictionary containing all needed localized strings.
 
+`renderCell` and `renderHeaderCell` are replaced with `calendarCell` and `calendarHeaderCell` shorthand components respectively.
+
 ## Structure
 
 ### Proposed React structure


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adding arrow buttons for navigation in `DatepickerCalendar`. Adding child components and exposing them in Datepicker props for consumer overrides
**UI before**
![image](https://user-images.githubusercontent.com/2802155/87939360-42a26480-ca98-11ea-93b2-4b536277de75.png)

**UI after**
![image](https://user-images.githubusercontent.com/2802155/87939289-243c6900-ca98-11ea-9439-99b4441a5bbd.png)


