### PR TITLE
fix: useFocusRects should resolve window inside useEffect

### DIFF
--- a/change/@fluentui-react-button-2020-07-16-15-14-48-fix-focus-rects.json
+++ b/change/@fluentui-react-button-2020-07-16-15-14-48-fix-focus-rects.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: use a proper ref in useButton hook",
+  "packageName": "@fluentui/react-button",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T13:14:45.336Z"
+}

--- a/change/@uifabric-utilities-2020-07-16-15-14-48-fix-focus-rects.json
+++ b/change/@uifabric-utilities-2020-07-16-15-14-48-fix-focus-rects.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: useFocusRects should resolve window inside useEffect",
+  "packageName": "@uifabric/utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T13:14:48.164Z"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -166,7 +166,7 @@ export interface ToggleState extends ToggleProps {
 }
 
 // @public
-export const useButton: (props: ButtonProps, ref: import("react").Ref<HTMLElement>, options: ComposePreparedOptions<{}, any, {}>) => ButtonState;
+export const useButton: (props: ButtonProps, ref: React.Ref<HTMLElement>, options: ComposePreparedOptions<{}, any, {}>) => ButtonState;
 
 // @public
 export const useMenuButton: (props: MenuButtonProps, ref: React.Ref<HTMLElement>, options: ComposePreparedOptions<{}, any, {}>) => MenuButtonState;

--- a/packages/react-button/src/components/Button/useButton.ts
+++ b/packages/react-button/src/components/Button/useButton.ts
@@ -1,4 +1,4 @@
-import { useImperativeHandle, useRef } from 'react';
+import * as React from 'react';
 import { getStyleFromPropsAndOptions } from '@fluentui/react-theme-provider';
 import { useFocusRects } from '@uifabric/utilities';
 import { ComposePreparedOptions } from '@fluentui/react-compose';
@@ -13,12 +13,12 @@ export const useButton = (
   ref: React.Ref<HTMLElement>,
   options: ComposePreparedOptions,
 ): ButtonState => {
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const buttonRef = React.useRef<HTMLButtonElement | null>(null);
 
-  useImperativeHandle(props.componentRef, () => ({
+  React.useImperativeHandle(props.componentRef, () => ({
     focus: () => buttonRef.current?.focus(),
   }));
-  useFocusRects(ref as React.RefObject<HTMLElement>);
+  useFocusRects(buttonRef);
 
   return {
     ...props,

--- a/packages/utilities/src/useFocusRects.ts
+++ b/packages/utilities/src/useFocusRects.ts
@@ -40,9 +40,9 @@ type AppWindow = (Window & { FabricConfig?: { disableFocusRects?: boolean } }) |
  * @param rootRef - A Ref object. Focus rectangle can be applied on itself and all its children.
  */
 export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
-  const win = getWindow(rootRef?.current) as AppWindow;
-
   React.useEffect(() => {
+    const win = getWindow(rootRef?.current) as AppWindow;
+
     if (!win || win.FabricConfig?.disableFocusRects === true) {
       return undefined;
     }
@@ -66,7 +66,7 @@ export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void {
         win.removeEventListener('keydown', _onKeyDown, true);
       }
     };
-  }, [win]);
+  }, [rootRef]);
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14062
- [x] Include a change request file using `$ yarn change`

#### Description of changes

1. `useFocusRects` uses a wrong `ref` in `useButton`:

https://github.com/microsoft/fluentui/blob/8247d915e42b98aceeeaaf0061c1ce3773bd17fb/packages/react-button/src/components/Button/useButton.ts#L21

Previously it passed a `ref` from the second param of `React.forwardRef()` which will be `null` a user will provide an input.

2. `useFocusRects` resolved `win` during a render

https://github.com/microsoft/fluentui/blob/8247d915e42b98aceeeaaf0061c1ce3773bd17fb/packages/utilities/src/useFocusRects.ts#L42-L46

The resolution occured during render when `rootRef.current` will be `null` 🧷 

#### Focus areas to test

(optional)
