### PR TITLE
Update sectionProps' title props to also be a IContextualMenuItem to keep parity with passing down itemProps

### DIFF
--- a/change/office-ui-fabric-react-2020-07-16-13-46-01-updateSectionHeadertype.json
+++ b/change/office-ui-fabric-react-2020-07-16-13-46-01-updateSectionHeadertype.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update section header type to allow for it to be an item, to get itemProps",
+  "packageName": "office-ui-fabric-react",
+  "email": "makopch@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T20:46:00.970Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3084,7 +3084,7 @@ export interface IContextualMenuRenderItem {
 export interface IContextualMenuSection extends React.ClassAttributes<any> {
     bottomDivider?: boolean;
     items: IContextualMenuItem[];
-    title?: string;
+    title?: string | IContextualMenuItem;
     topDivider?: boolean;
 }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -622,19 +622,36 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
     let headerItem;
     let groupProps;
     if (sectionProps.title) {
-      // Since title is a user-facing string, it needs to be stripped of whitespace in order to build a valid element ID
-      const id = this._id + sectionProps.title.replace(/\s/g, '');
-      const headerContextualMenuItem: IContextualMenuItem = {
-        key: `section-${sectionProps.title}-title`,
-        itemType: ContextualMenuItemType.Header,
-        text: sectionProps.title,
-        id: id,
-      };
-      groupProps = {
-        role: 'group',
-        'aria-labelledby': id,
-      };
-      headerItem = this._renderHeaderMenuItem(headerContextualMenuItem, menuClassNames, index, hasCheckmarks, hasIcons);
+      let headerContextualMenuItem: IContextualMenuItem | undefined = undefined;
+      let ariaLabellledby = '';
+      if (typeof sectionProps.title === 'string') {
+        // Since title is a user-facing string, it needs to be stripped of whitespace in order to build a valid element ID
+        const id = this._id + sectionProps.title.replace(/\s/g, '');
+        headerContextualMenuItem = {
+          key: `section-${sectionProps.title}-title`,
+          itemType: ContextualMenuItemType.Header,
+          text: sectionProps.title,
+          id: id,
+        };
+        ariaLabellledby = id;
+      } else {
+        headerContextualMenuItem = sectionProps.title;
+        ariaLabellledby = this._id + sectionProps.title.text?.replace(/\s/g, '');
+      }
+
+      if (headerContextualMenuItem) {
+        groupProps = {
+          role: 'group',
+          'aria-labelledby': ariaLabellledby,
+        };
+        headerItem = this._renderHeaderMenuItem(
+          headerContextualMenuItem,
+          menuClassNames,
+          index,
+          hasCheckmarks,
+          hasIcons,
+        );
+      }
     }
 
     if (sectionProps.items && sectionProps.items.length > 0) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -625,7 +625,8 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
       let headerContextualMenuItem: IContextualMenuItem | undefined = undefined;
       let ariaLabellledby = '';
       if (typeof sectionProps.title === 'string') {
-        // Since title is a user-facing string, it needs to be stripped of whitespace in order to build a valid element ID
+        // Since title is a user-facing string, it needs to be stripped
+        // of whitespace in order to build a valid element ID
         const id = this._id + sectionProps.title.replace(/\s/g, '');
         headerContextualMenuItem = {
           key: `section-${sectionProps.title}-title`,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -634,6 +634,7 @@ describe('ContextualMenu', () => {
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
           key: 'Section1',
+          title: 'TestTitle',
           topDivider: true,
           bottomDivider: true,
           items: [
@@ -654,6 +655,7 @@ describe('ContextualMenu', () => {
         itemType: ContextualMenuItemType.Section,
         sectionProps: {
           key: 'Section1',
+          title: { key: 'title1', text: 'TestTitle' },
           items: [
             {
               text: 'TestText 5',
@@ -671,7 +673,7 @@ describe('ContextualMenu', () => {
     ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
 
     const menuItems = document.querySelectorAll('li');
-    expect(menuItems.length).toEqual(8);
+    expect(menuItems.length).toEqual(10);
   });
 
   describe('with links', () => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -538,7 +538,7 @@ export interface IContextualMenuSection extends React.ClassAttributes<any> {
   /**
    * The optional section title.
    */
-  title?: string;
+  title?: string | IContextualMenuItem;
 
   /**
    * If set to true, the section will display a divider at the top of the section.


### PR DESCRIPTION
sectionProps limits the title prop to a string.  This prevents sending any additional properties to the title.

A while ago, there was a PR to apply html div properties specified on itemProps of a an IContextualMenuItem element to the surrounding div of the section header.

This PR makes parity with that.

#### Focus areas to test

Titles still render on contextual menus
