### PR TITLE
Use new service connection in release pipelines

### DIFF
--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -38,7 +38,7 @@ steps:
     displayName: Upload docs site
     inputs:
       SourcePath: 'packages/fluentui/docs/dist'
-      azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+      azureSubscription: 'Azure: UI Fabric'
       storage: fluentsite
       ContainerName: '$web'
       BlobPrefix: ''

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -128,7 +128,7 @@ steps:
     displayName: Upload Package Manifest
     inputs:
       SourcePath: 'package-manifest.json'
-      azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+      azureSubscription: 'Azure: UI Fabric'
       storage: fabricweb
       ContainerName: 'fabric'
       BlobPrefix: 'package-manifest/latest'


### PR DESCRIPTION
The token for the release build's Azure storage service connection had expired. Switch to a new connection.