### PR TITLE
fix aria labels in WeeklyDayPicker

### DIFF
--- a/change/@uifabric-date-time-2020-07-16-16-00-27-lorejoh12-fixAriaLabelsWeeklyDayPicker.json
+++ b/change/@uifabric-date-time-2020-07-16-16-00-27-lorejoh12-fixAriaLabelsWeeklyDayPicker.json
@@ -1,6 +1,6 @@
 {
-  "type": "patch",
-  "comment": "fix next and previous month/week aria labels in weekly day picker",
+  "type": "minor",
+  "comment": "fix next and previous month/week aria labels in weekly day picker, export new default strings",
   "packageName": "@uifabric/date-time",
   "email": "lorejoh12@gmail.com",
   "dependentChangeType": "patch",

--- a/change/@uifabric-date-time-2020-07-16-16-00-27-lorejoh12-fixAriaLabelsWeeklyDayPicker.json
+++ b/change/@uifabric-date-time-2020-07-16-16-00-27-lorejoh12-fixAriaLabelsWeeklyDayPicker.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix next and previous month/week aria labels in weekly day picker",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-16T23:00:27.922Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -19,6 +19,7 @@ import { IStyle } from '@uifabric/styling';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 import { ITheme } from '@uifabric/styling';
+import { IWeeklyDayPickerStrings as IWeeklyDayPickerStrings_2 } from '@uifabric/date-time';
 import * as React from 'react';
 
 // @public (undocumented)
@@ -60,6 +61,9 @@ export { DayOfWeek }
 
 // @public (undocumented)
 export const defaultDayPickerStrings: ICalendarStrings_2;
+
+// @public (undocumented)
+export const defaultWeeklyDayPickerStrings: IWeeklyDayPickerStrings_2;
 
 export { FirstWeekOfYear }
 

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -243,7 +243,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   private _renderPreviousWeekNavigationButton = (
     classNames: IProcessedStyleSet<IWeeklyDayPickerStyles>,
   ): JSX.Element => {
-    const { minDate, firstDayOfWeek, strings, navigationIcons } = this.props;
+    const { minDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
     const leftNavigationIcon = navigationIcons!.leftNavigation;
 
@@ -261,11 +261,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
         aria-disabled={!prevWeekInBounds}
         onClick={prevWeekInBounds ? this._onSelectPrevDateRange : undefined}
         onKeyDown={prevWeekInBounds ? this._onButtonKeyDown(this._onSelectPrevDateRange) : undefined}
-        title={
-          strings.prevWeekAriaLabel
-            ? strings.prevWeekAriaLabel + ' ' + strings.months[addDays(navigatedDate!, -7).getMonth()]
-            : undefined
-        }
+        title={this.createPreviousWeekAriaLabel()}
         type="button"
       >
         <Icon iconName={leftNavigationIcon} />
@@ -274,7 +270,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
   };
 
   private _renderNextWeekNavigationButton = (classNames: IProcessedStyleSet<IWeeklyDayPickerStyles>): JSX.Element => {
-    const { maxDate, firstDayOfWeek, strings, navigationIcons } = this.props;
+    const { maxDate, firstDayOfWeek, navigationIcons } = this.props;
     const { navigatedDate } = this.state;
     const rightNavigationIcon = navigationIcons!.rightNavigation;
 
@@ -292,11 +288,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
         aria-disabled={!nextWeekInBounds}
         onClick={nextWeekInBounds ? this._onSelectNextDateRange : undefined}
         onKeyDown={nextWeekInBounds ? this._onButtonKeyDown(this._onSelectNextDateRange) : undefined}
-        title={
-          strings.nextWeekAriaLabel
-            ? strings.nextWeekAriaLabel + ' ' + strings.months[addDays(navigatedDate!, -7).getMonth()]
-            : undefined
-        }
+        title={this.createNextWeekAriaLabel()}
         type="button"
       >
         <Icon iconName={rightNavigationIcon} />
@@ -374,5 +366,44 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
       }
       this._initialTouchX = undefined;
     }
+  };
+
+  private createPreviousWeekAriaLabel = () => {
+    const { strings, showFullMonth, firstDayOfWeek } = this.props;
+    const { navigatedDate } = this.state;
+
+    let ariaLabel = undefined;
+    if (showFullMonth && strings.prevMonthAriaLabel) {
+      ariaLabel = strings.prevMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate!, -1).getMonth()];
+    } else if (!showFullMonth && strings.prevWeekAriaLabel) {
+      const firstDayOfPreviousWeek = getStartDateOfWeek(addDays(navigatedDate!, -7), firstDayOfWeek!);
+      const lastDayOfPreviousWeek = addDays(firstDayOfPreviousWeek, 6);
+      ariaLabel =
+        strings.prevWeekAriaLabel + ' ' + this._formatDateRange(firstDayOfPreviousWeek, lastDayOfPreviousWeek);
+    }
+    return ariaLabel;
+  };
+
+  private createNextWeekAriaLabel = () => {
+    const { strings, showFullMonth, firstDayOfWeek } = this.props;
+    const { navigatedDate } = this.state;
+
+    let ariaLabel = undefined;
+    if (showFullMonth && strings.nextMonthAriaLabel) {
+      ariaLabel = strings.nextMonthAriaLabel + ' ' + strings.months[addMonths(navigatedDate!, 1).getMonth()];
+    } else if (!showFullMonth && strings.nextWeekAriaLabel) {
+      const firstDayOfNextWeek = getStartDateOfWeek(addDays(navigatedDate!, 7), firstDayOfWeek!);
+      const lastDayOfNextWeek = addDays(firstDayOfNextWeek, 6);
+      ariaLabel = strings.nextWeekAriaLabel + ' ' + this._formatDateRange(firstDayOfNextWeek, lastDayOfNextWeek);
+    }
+    return ariaLabel;
+  };
+
+  private _formatDateRange = (startDate: Date, endDate: Date) => {
+    const { dateTimeFormatter, strings } = this.props;
+    return `${dateTimeFormatter?.formatMonthDayYear(startDate, strings)} - ${dateTimeFormatter?.formatMonthDayYear(
+      endDate,
+      strings,
+    )}`;
   };
 }

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -261,7 +261,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
         aria-disabled={!prevWeekInBounds}
         onClick={prevWeekInBounds ? this._onSelectPrevDateRange : undefined}
         onKeyDown={prevWeekInBounds ? this._onButtonKeyDown(this._onSelectPrevDateRange) : undefined}
-        title={this.createPreviousWeekAriaLabel()}
+        title={this._createPreviousWeekAriaLabel()}
         type="button"
       >
         <Icon iconName={leftNavigationIcon} />
@@ -288,7 +288,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
         aria-disabled={!nextWeekInBounds}
         onClick={nextWeekInBounds ? this._onSelectNextDateRange : undefined}
         onKeyDown={nextWeekInBounds ? this._onButtonKeyDown(this._onSelectNextDateRange) : undefined}
-        title={this.createNextWeekAriaLabel()}
+        title={this._createNextWeekAriaLabel()}
         type="button"
       >
         <Icon iconName={rightNavigationIcon} />
@@ -368,7 +368,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
     }
   };
 
-  private createPreviousWeekAriaLabel = () => {
+  private _createPreviousWeekAriaLabel = () => {
     const { strings, showFullMonth, firstDayOfWeek } = this.props;
     const { navigatedDate } = this.state;
 
@@ -384,7 +384,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
     return ariaLabel;
   };
 
-  private createNextWeekAriaLabel = () => {
+  private _createNextWeekAriaLabel = () => {
     const { strings, showFullMonth, firstDayOfWeek } = this.props;
     const { navigatedDate } = this.state;
 

--- a/packages/date-time/src/components/WeeklyDayPicker/defaults.ts
+++ b/packages/date-time/src/components/WeeklyDayPicker/defaults.ts
@@ -1,0 +1,7 @@
+import { IWeeklyDayPickerStrings, defaultDayPickerStrings } from '@uifabric/date-time';
+
+export const WeeklyDayPickerStrings: IWeeklyDayPickerStrings = {
+  ...defaultDayPickerStrings,
+  prevWeekAriaLabel: 'Previous week',
+  nextWeekAriaLabel: 'Next week',
+};

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { WeeklyDayPicker, DayOfWeek, addDays, defaultDayPickerStrings } from '@uifabric/date-time';
+import { WeeklyDayPicker, DayOfWeek, addDays, defaultWeeklyDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
@@ -27,7 +27,7 @@ export class WeeklyDayPickerInlineExample extends React.Component<{}, IWeeklyDay
         <WeeklyDayPicker
           onSelectDate={this._onSelectDate}
           firstDayOfWeek={DayOfWeek.Sunday}
-          strings={defaultDayPickerStrings}
+          strings={defaultWeeklyDayPickerStrings}
           initialDate={this.state.selectedDate}
         />
         <div>

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { WeeklyDayPicker, DayOfWeek, addDays, defaultDayPickerStrings } from '@uifabric/date-time';
+import { WeeklyDayPicker, DayOfWeek, addDays, defaultWeeklyDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
@@ -41,7 +41,7 @@ export class WeeklyDayPickerInlineExpandableExample extends React.Component<
           weeksToShow={6}
           onSelectDate={this._onSelectDate}
           firstDayOfWeek={DayOfWeek.Sunday}
-          strings={defaultDayPickerStrings}
+          strings={defaultWeeklyDayPickerStrings}
           initialDate={this.state.selectedDate}
           showFullMonth={this.state.expanded}
         />

--- a/packages/date-time/src/components/WeeklyDayPicker/index.ts
+++ b/packages/date-time/src/components/WeeklyDayPicker/index.ts
@@ -1,2 +1,3 @@
 export * from './WeeklyDayPicker';
 export * from './WeeklyDayPicker.types';
+export { WeeklyDayPickerStrings as defaultWeeklyDayPickerStrings } from './defaults';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix the aria labels in the WeeklyDayPicker component in date-time. The next/previous buttons were using the week aria label, but were populating the month, so you'd end up with weird tooltips like "next week August".

Fixing it to use the week strings if not expanded and the month strings if expanded. Also correctly calculating the range info for next/previous week and populating like "next week July 19 2020 - July 25 2020", and "next month August".

Also exporting the default weekly day picker strings from the index and updating the test case.

#### Focus areas to test

(optional)
