### PR TITLE
Re-enable editor with better error handling

### DIFF
--- a/change/@uifabric-example-app-base-2020-07-16-19-30-18-enable-editor.json
+++ b/change/@uifabric-example-app-base-2020-07-16-19-30-18-enable-editor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Re-enable editor with improved error handling",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T02:30:15.544Z"
+}

--- a/change/@uifabric-tsx-editor-2020-07-16-19-30-18-enable-editor.json
+++ b/change/@uifabric-tsx-editor-2020-07-16-19-30-18-enable-editor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Prevent infinite render loops on error",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T02:30:18.104Z"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -168,7 +168,6 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
               </div>
               {isCodeVisible ? (
                 <EditorWrapper
-                  useEditor={false}
                   code={latestCode}
                   supportedPackages={editorSupportedPackages}
                   editorClassName={classNames.code}

--- a/packages/tsx-editor/src/components/EditorErrorHandler.tsx
+++ b/packages/tsx-editor/src/components/EditorErrorHandler.tsx
@@ -60,17 +60,11 @@ export class EditorErrorBoundary extends React.Component<IEditorErrorBoundaryPro
       /* eslint-enable no-console */
     }
 
-    // If there was another error within the past second, or if we're rendering a list example,
-    // get rid of the "last good children" because re-rendering them may cause an infinite loop
-    // (this definitely happens with list examples, probably for reasons related to measurement,
-    // and the cooldown time is meant to prevent similar errors from other cases)
+    // If there was another error within the past second, get rid of the "last good children"
+    // because re-rendering them may cause an infinite loop (has sometimes happened with list
+    // examples in the past)
     const errorTime = Date.now();
-    const transformedCode = this.props.transformResult.output || '';
-    if (
-      (this._lastErrorTime && errorTime - this._lastErrorTime < 1000) ||
-      /^var (List|DetailsList|GroupedList)\w+Example =/m.test(transformedCode) ||
-      /\bcreateElement\((List|DetailsList|GroupedList)/.test(transformedCode)
-    ) {
+    if (this._lastErrorTime && errorTime - this._lastErrorTime < 1000) {
       this._lastGoodChildren = null;
     }
 

--- a/packages/tsx-editor/src/components/EditorErrorHandler.tsx
+++ b/packages/tsx-editor/src/components/EditorErrorHandler.tsx
@@ -25,6 +25,7 @@ interface IEditorErrorBoundaryState {
 export class EditorErrorBoundary extends React.Component<IEditorErrorBoundaryProps, IEditorErrorBoundaryState> {
   public state: IEditorErrorBoundaryState = {};
   private _lastGoodChildren: React.ReactNode;
+  private _lastErrorTime: number | undefined;
 
   public static getDerivedStateFromError(error: Error) {
     return { caughtError: `Error while rendering component: ${error.message || error}` };
@@ -35,7 +36,11 @@ export class EditorErrorBoundary extends React.Component<IEditorErrorBoundaryPro
     // remove the caught error state if:
     // - the error state is not new (present in both curr/prev state)
     // - we have an updated result to render
-    if (state.caughtError && prevState.caughtError && props.transformResult !== prevProps.transformResult) {
+    if (
+      state.caughtError &&
+      prevState.caughtError &&
+      props.transformResult.output !== prevProps.transformResult.output
+    ) {
       this.setState({ caughtError: undefined });
     }
 
@@ -54,6 +59,22 @@ export class EditorErrorBoundary extends React.Component<IEditorErrorBoundaryPro
       console.error('In component: ' + errorInfo.componentStack);
       /* eslint-enable no-console */
     }
+
+    // If there was another error within the past second, or if we're rendering a list example,
+    // get rid of the "last good children" because re-rendering them may cause an infinite loop
+    // (this definitely happens with list examples, probably for reasons related to measurement,
+    // and the cooldown time is meant to prevent similar errors from other cases)
+    const errorTime = Date.now();
+    const transformedCode = this.props.transformResult.output || '';
+    if (
+      (this._lastErrorTime && errorTime - this._lastErrorTime < 1000) ||
+      /^var (List|DetailsList|GroupedList)\w+Example =/m.test(transformedCode) ||
+      /\bcreateElement\((List|DetailsList|GroupedList)/.test(transformedCode)
+    ) {
+      this._lastGoodChildren = null;
+    }
+
+    this._lastErrorTime = errorTime;
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12754
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#12776 disabled the editor for all examples since the editor was causing out of memory crashes for the list examples (see #12754) and we couldn't quickly figure out why. We think the issue in the list examples has to do with measurement, but it doesn't repro in local builds and therefore is very hard to debug, and no one has had time to look into it more deeply. (I also can't repro it now on the live site when I enable the editor with `?useEditor=1`.)

Instead of leaving the editor disabled indefinitely, we should re-enable it with additional logic to hopefully prevent infinite rendering loops in error cases. Generally the editor tries to re-render the last known good children when there's an error, but this was probably contributing to the infinite loop issue. So disable that behavior ~~entirely for list-related examples, and also disable it~~ for any example if more than one error is caught in < 1 second. (EDIT: removed list special case)