### PR TITLE
Dialog: VoiceOver / aria-modal fix

### DIFF
--- a/change/office-ui-fabric-react-2020-07-17-16-06-51-dialog-voiceover-bug.json
+++ b/change/office-ui-fabric-react-2020-07-17-16-06-51-dialog-voiceover-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add document role to child of modal to fix VoiceOver issue",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-17T23:06:51.087Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -91,6 +91,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
               transition: opacity 0.267s;
               width: 100%;
             }
+        role="document"
       >
         <div
           className=
@@ -400,6 +401,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
               transition: opacity 0.267s;
               width: 100%;
             }
+        role="document"
       >
         <div
           className=
@@ -709,6 +711,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
               transition: opacity 0.267s;
               width: 100%;
             }
+        role="document"
       >
         <div
           className=
@@ -1151,6 +1154,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
               transition: opacity 0.267s;
               width: 100%;
             }
+        role="document"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -270,7 +270,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
             onDismiss={onDismiss}
             shouldRestoreFocus={!ignoreExternalFocusing}
           >
-            <div className={classNames.root}>
+            <div className={classNames.root} role={!isModeless ? 'document' : undefined}>
               {!isModeless && (
                 <Overlay
                   isDarkThemed={isDarkOverlay}

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -258,6 +258,7 @@ exports[`Modal renders Modal correctly 1`] = `
               transition: opacity 0.267s;
               width: 100%;
             }
+        role="document"
       >
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds `role="document"` to the child of the modal if `aria-modal` is set to true. This fixes a known VoiceOver behavior with modals: https://bugs.webkit.org/show_bug.cgi?id=174667

Related to #13945 
