### PR TITLE
Start enabling "rules of hooks" lint rules

### DIFF
--- a/apps/perf-test/src/app/useTimer.ts
+++ b/apps/perf-test/src/app/useTimer.ts
@@ -29,6 +29,7 @@ export const useTimer = () => {
         setVisible(false);
       }, 5000);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRunning]);
 
   return {

--- a/change/@fluentui-eslint-plugin-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@fluentui-eslint-plugin-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Enable react-hooks lint rules",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T04:52:18.203Z"
+}

--- a/change/@fluentui-react-next-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@fluentui-react-next-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable react-hooks lint rules for now",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-18T04:53:18.328Z"
+}

--- a/change/@fluentui-react-stylesheets-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@fluentui-react-stylesheets-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix \"rules of hooks\" lint rule violations",
+  "packageName": "@fluentui/react-stylesheets",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T04:53:28.129Z"
+}

--- a/change/@uifabric-date-time-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@uifabric-date-time-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable react-hooks lint rules for now",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-18T04:52:08.572Z"
+}

--- a/change/@uifabric-experiments-2020-07-20-10-53-10-eslint-hooks.json
+++ b/change/@uifabric-experiments-2020-07-20-10-53-10-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable react-hooks lint rules for now.",
+  "packageName": "@uifabric/experiments",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-20T17:53:10.538Z"
+}

--- a/change/@uifabric-foundation-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@uifabric-foundation-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix \"rules of hooks\" lint rule violations",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T04:52:49.183Z"
+}

--- a/change/@uifabric-react-hooks-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@uifabric-react-hooks-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable react-hooks lint rules for now",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-18T04:53:13.903Z"
+}

--- a/change/@uifabric-tsx-editor-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@uifabric-tsx-editor-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix \"rules of hooks\" lint rule violations",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T04:53:43.812Z"
+}

--- a/change/@uifabric-utilities-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/@uifabric-utilities-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Disable react-hooks lint rules for now",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-18T04:53:53.969Z"
+}

--- a/change/office-ui-fabric-react-2020-07-17-21-53-53-eslint-hooks.json
+++ b/change/office-ui-fabric-react-2020-07-17-21-53-53-eslint-hooks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix \"rules of hooks\" lint rule violations",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T04:53:02.288Z"
+}

--- a/packages/date-time/.eslintrc.json
+++ b/packages/date-time/.eslintrc.json
@@ -1,4 +1,9 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
-  "root": true
+  "root": true,
+  "rules": {
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
+  }
 }

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-jest": "^23.13.2",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
-    "eslint-plugin-react-hooks": "^4.0.4",
+    "eslint-plugin-react-hooks": "^4.0.8",
     "jju": "^1.4.0"
   },
   "devDependencies": {

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -108,6 +108,8 @@ const config = {
     ],
     'react/no-string-refs': 'error',
     'react/self-closing-comp': 'error',
+    'react-hooks/exhaustive-deps': 'error',
+    'react-hooks/rules-of-hooks': 'error',
 
     // airbnb or other config overrides (some temporary)
     // TODO: determine which rules we want to enable, and make needed changes (separate PR)
@@ -193,9 +195,6 @@ const config = {
     'react/static-property-placement': 'off',
     'spaced-comment': 'off',
 
-    // Enable ASAP (not done in this PR to make resulting changes reviewable)
-    'react-hooks/exhaustive-deps': 'off',
-    'react-hooks/rules-of-hooks': 'off',
     // airbnb options ban for-of which is unnecessary for TS and modern node (https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/style.js#L334)
     // but this is a very powerful rule we may want to use in other ways
     'no-restricted-syntax': 'off',

--- a/packages/experiments/.eslintrc.json
+++ b/packages/experiments/.eslintrc.json
@@ -2,6 +2,9 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
   }
 }

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -47,7 +47,7 @@ export function createComponent<
   const { factoryOptions = {} } = options;
   const { defaultProp } = factoryOptions;
 
-  const result: React.FunctionComponent<TComponentProps> = (
+  const ResultComponent: React.FunctionComponent<TComponentProps> = (
     componentProps: TComponentProps & IStyleableComponentProps<TViewProps, TTokens, TStyleSet>,
   ) => {
     const settings: ICustomizationProps<TViewProps, TTokens, TStyleSet> = _getCustomizations(
@@ -62,6 +62,7 @@ export function createComponent<
       // Don't assume state will return all props, so spread useState result over component props.
       componentProps = {
         ...componentProps,
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         ...useState(componentProps),
       };
     }
@@ -89,19 +90,19 @@ export function createComponent<
     return view(viewProps);
   };
 
-  result.displayName = options.displayName || view.name;
+  ResultComponent.displayName = options.displayName || view.name;
 
   // If a shorthand prop is defined, create a factory for the component.
   // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.
   //       Need to weigh creating default factories on component creation vs. memoizing them on use in slots.tsx.
   if (defaultProp) {
-    (result as ISlotCreator<TComponentProps, any>).create = createFactory(result, { defaultProp });
+    (ResultComponent as ISlotCreator<TComponentProps, any>).create = createFactory(ResultComponent, { defaultProp });
   }
 
-  assign(result, options.statics);
+  assign(ResultComponent, options.statics);
 
   // Later versions of TypeSript should allow us to merge objects in a type safe way and avoid this cast.
-  return result as React.FunctionComponent<TComponentProps> & TStatics;
+  return ResultComponent as React.FunctionComponent<TComponentProps> & TStatics;
 }
 
 /**

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -56,14 +56,13 @@ export function createComponent<
       options.fields,
     );
 
-    const useState = options.state;
+    const stateReducer = options.state;
 
-    if (useState) {
+    if (stateReducer) {
       // Don't assume state will return all props, so spread useState result over component props.
       componentProps = {
         ...componentProps,
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        ...useState(componentProps),
+        ...stateReducer(componentProps),
       };
     }
 

--- a/packages/foundation/src/next/composed.tsx
+++ b/packages/foundation/src/next/composed.tsx
@@ -169,14 +169,13 @@ export function composed<
       options.fields,
     );
 
-    const useState = options.state;
+    const stateReducer = options.state;
 
-    if (useState) {
+    if (stateReducer) {
       // Don't assume state will return all props, so spread useState result over component props.
       componentProps = {
         ...componentProps,
-        // eslint-disable-next-line react-hooks/rules-of-hooks
-        ...useState(componentProps),
+        ...stateReducer(componentProps),
       };
     }
 

--- a/packages/foundation/src/next/composed.tsx
+++ b/packages/foundation/src/next/composed.tsx
@@ -152,7 +152,14 @@ export function composed<
   const { factoryOptions = {}, view } = options;
   const { defaultProp } = factoryOptions;
 
-  const result: IFoundationComponent<TComponentProps, TTokens, TStyleSet, TViewProps, TComponentSlots, TStatics> = (
+  const ResultComponent: IFoundationComponent<
+    TComponentProps,
+    TTokens,
+    TStyleSet,
+    TViewProps,
+    TComponentSlots,
+    TStatics
+  > = (
     componentProps: TViewProps &
       IStyleableComponentProps<TViewProps, TTokens, TStyleSet> & { children?: React.ReactNode },
   ) => {
@@ -168,6 +175,7 @@ export function composed<
       // Don't assume state will return all props, so spread useState result over component props.
       componentProps = {
         ...componentProps,
+        // eslint-disable-next-line react-hooks/rules-of-hooks
         ...useState(componentProps),
       };
     }
@@ -263,21 +271,28 @@ export function composed<
     return view ? view(viewProps, Slots) : null;
   };
 
-  result.displayName = options.displayName || (view && view.name);
+  ResultComponent.displayName = options.displayName || (view && view.name);
 
   // If a shorthand prop is defined, create a factory for the component.
   // TODO: This shouldn't be a concern of createComponent.. factoryOptions should just be forwarded.
   //       Need to weigh creating default factories on component creation vs. memoizing them on use in slots.tsx.
   if (defaultProp) {
-    (result as ISlotCreator<TComponentProps, any>).create = createFactory(result, { defaultProp });
+    (ResultComponent as ISlotCreator<TComponentProps, any>).create = createFactory(ResultComponent, { defaultProp });
   }
 
-  result.__options = options;
+  ResultComponent.__options = options;
 
-  assign(result, options.statics);
+  assign(ResultComponent, options.statics);
 
   // Later versions of TypeSript should allow us to merge objects in a type safe way and avoid this cast.
-  return result as IFoundationComponent<TComponentProps, TTokens, TStyleSet, TViewProps, TComponentSlots, TStatics> &
+  return ResultComponent as IFoundationComponent<
+    TComponentProps,
+    TTokens,
+    TStyleSet,
+    TViewProps,
+    TComponentSlots,
+    TStatics
+  > &
     TStatics;
 }
 

--- a/packages/lists/.eslintrc.json
+++ b/packages/lists/.eslintrc.json
@@ -1,4 +1,9 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
-  "root": true
+  "root": true,
+  "rules": {
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -87,7 +87,7 @@ const IndividualCommandBarButtonAsExample: React.FunctionComponent<IIndividualCo
         onClick: () => console.log('Download'),
       },
     ];
-  }, [props.onDismissCoachmark, props.isCoachmarkVisible]);
+  }, [onDismissCoachmark, isCoachmarkVisible]);
 
   return (
     <CommandBar

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
@@ -62,7 +62,7 @@ export const CommandBarLazyExample: React.FunctionComponent = () => {
         },
       },
     ];
-  }, [menuItems]);
+  }, [menuItems, loadItems, onMenuDismissed]);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuItem.Example.tsx
@@ -6,16 +6,14 @@ import {
   IContextualMenuItemProps,
 } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { useConst } from '@uifabric/react-hooks';
 
 export const ContextualMenuWithCustomMenuItemExample: React.FunctionComponent = () => {
-  const menuProps: IContextualMenuProps = React.useMemo(
-    () => ({
-      items: menuItems,
-      shouldFocusOnMount: true,
-      contextualMenuItemAs: (props: IContextualMenuItemProps) => <div>Custom rendered {props.item.text}</div>,
-    }),
-    [menuItems],
-  );
+  const menuProps: IContextualMenuProps = useConst(() => ({
+    items: menuItems,
+    shouldFocusOnMount: true,
+    contextualMenuItemAs: (props: IContextualMenuItemProps) => <div>Custom rendered {props.item.text}</div>,
+  }));
 
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
 };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useConstCallback, useConst } from '@uifabric/react-hooks';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -52,15 +52,12 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
     },
   );
 
-  const menuProps = React.useMemo(
-    () => ({
-      onRenderMenuList: renderMenuList,
-      title: 'Actions',
-      shouldFocusOnMount: true,
-      items,
-    }),
-    [items],
-  );
+  const menuProps = useConst(() => ({
+    onRenderMenuList: renderMenuList,
+    title: 'Actions',
+    shouldFocusOnMount: true,
+    items,
+  }));
 
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
 };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -69,7 +69,7 @@ export const ContextualMenuDirectionalExample: React.FunctionComponent = () => {
       directionalHintFixed: false,
       items: menuItems,
     }),
-    [isBeakVisible, directionalHint, directionalHintForRTL],
+    [isBeakVisible, directionalHint, directionalHintForRTL, useDirectionalHintForRTL],
   );
 
   return (

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
@@ -34,7 +34,7 @@ export const DialogBasicExample: React.FunctionComponent = () => {
       styles: dialogStyles,
       dragOptions: isDraggable ? dragOptions : undefined,
     }),
-    [isDraggable],
+    [isDraggable, labelId, subTextId],
   );
 
   return (

--- a/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/HoverCard.doc.tsx
@@ -20,27 +20,27 @@ export const HoverCardPageProps: IDocPageProps = {
     'https://github.com/microsoft/fluentui/tree/master/packages/office-ui-fabric-react/src/components/HoverCard',
   examples: [
     {
-      title: 'Example 1: Expanding HoverCard wrapping an element',
+      title: 'Expanding HoverCard wrapping an element',
       code: HoverCardBasicExampleCode,
       view: <HoverCardBasicExample />,
     },
     {
-      title: 'Example 2: Expanding HoverCard using Target, DirectionalHint and custom HotKey',
+      title: 'Expanding HoverCard using target, DirectionalHint and custom hotkey',
       code: HoverCardTargetExampleCode,
       view: <HoverCardTargetExample />,
     },
     {
-      title: 'Example 3: Plain HoverCard wrapping an element',
+      title: 'Plain HoverCard wrapping an element',
       code: HoverCardPlainCardExampleCode,
       view: <HoverCardPlainCardExample />,
     },
     {
-      title: 'Example 4: Plain HoverCard with instant dismiss from within the card button click',
+      title: 'Plain HoverCard with instant dismiss from within the card button click',
       code: HoverCardInstantDismissExampleCode,
       view: <HoverCardInstantDismissExample />,
     },
     {
-      title: 'Example 5: HoverCard using eventListenerTarget to trigger card open',
+      title: 'HoverCard using eventListenerTarget to trigger card open',
       code: HoverCardEventListenerTargetExampleCode,
       view: <HoverCardEventListenerTargetExample />,
     },

--- a/packages/office-ui-fabric-react/src/components/HoverCard/docs/HoverCardOverview.md
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/docs/HoverCardOverview.md
@@ -2,5 +2,5 @@ HoverCards supplement content associated with a specific data element.
 
 Two scenarios to consider for your own use case from an accessibility point of view when deciding how the card should open and its behavior after it opened:
 
-- Tabbing with a keyboard to the element triggering the HoverCard to open on focus. In this case no further navigation within the card is available and navigating to the next element will close the card. See Example 1.
-- Tabbing with a keyboard to the element triggering the HoverCard and opening when the hotKey is depressed. When the card is opened it will automatically focus the first focusable element of the card content. See Example 2.
+- Tabbing with a keyboard to the element triggering the HoverCard to open on focus (see first example). In this case no further navigation within the card is available and navigating to the next element will close the card.
+- Tabbing with a keyboard to the element triggering the HoverCard and opening when the hotKey is pressed (see second example). When the card is opened it will automatically focus the first focusable element of the card content.

--- a/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
@@ -15,12 +15,15 @@ export interface IKeytipData {
  */
 export function useKeytipData(options: KeytipDataOptions): IKeytipData {
   const uniqueId = React.useRef<string>();
-  const keytipProps: IKeytipProps | undefined = options.keytipProps
-    ? {
-        disabled: options.disabled,
-        ...options.keytipProps,
-      }
-    : undefined;
+  // TODO: verify with @xugao whether this should ever change
+  const keytipProps: IKeytipProps | undefined = useConst(
+    options.keytipProps
+      ? {
+          disabled: options.disabled,
+          ...options.keytipProps,
+        }
+      : undefined,
+  );
 
   const keytipManager = useConst<KeytipManager>(KeytipManager.getInstance());
 
@@ -34,7 +37,7 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
       // Unregister Keytip in KeytipManager
       keytipProps && keytipManager.unregister(keytipProps, uniqueId.current!);
     };
-  }, []);
+  }, [keytipManager, keytipProps]);
 
   const prevOptions = usePrevious(options);
 

--- a/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipData.ts
@@ -15,15 +15,12 @@ export interface IKeytipData {
  */
 export function useKeytipData(options: KeytipDataOptions): IKeytipData {
   const uniqueId = React.useRef<string>();
-  // TODO: verify with @xugao whether this should ever change
-  const keytipProps: IKeytipProps | undefined = useConst(
-    options.keytipProps
-      ? {
-          disabled: options.disabled,
-          ...options.keytipProps,
-        }
-      : undefined,
-  );
+  const keytipProps: IKeytipProps | undefined = options.keytipProps
+    ? {
+        disabled: options.disabled,
+        ...options.keytipProps,
+      }
+    : undefined;
 
   const keytipManager = useConst<KeytipManager>(KeytipManager.getInstance());
 
@@ -37,7 +34,9 @@ export function useKeytipData(options: KeytipDataOptions): IKeytipData {
       // Unregister Keytip in KeytipManager
       keytipProps && keytipManager.unregister(keytipProps, uniqueId.current!);
     };
-  }, [keytipManager, keytipProps]);
+    // this is meant to run only at mount, and updates are handled separately
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const prevOptions = usePrevious(options);
 

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
@@ -4,7 +4,7 @@ import { List } from 'office-ui-fabric-react/lib/List';
 import { IRectangle } from 'office-ui-fabric-react/lib/Utilities';
 import { ITheme, getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
-import { useConst } from '@uifabric/react-hooks';
+import { useConst, useConstCallback } from '@uifabric/react-hooks';
 
 const theme: ITheme = getTheme();
 const { palette, fonts } = theme;
@@ -68,39 +68,36 @@ export const ListGridExample: React.FunctionComponent = () => {
   const columnCount = React.useRef(0);
   const rowHeight = React.useRef(0);
 
-  const getItemCountForPage = React.useCallback((itemIndex: number, surfaceRect: IRectangle) => {
+  const getItemCountForPage = useConstCallback((itemIndex: number, surfaceRect: IRectangle) => {
     if (itemIndex === 0) {
       columnCount.current = Math.ceil(surfaceRect.width / MAX_ROW_HEIGHT);
       rowHeight.current = Math.floor(surfaceRect.width / columnCount.current);
     }
     return columnCount.current * ROWS_PER_PAGE;
-  }, []);
+  });
 
-  const onRenderCell = React.useCallback(
-    (item: IExampleItem, index: number | undefined) => {
-      return (
-        <div
-          className={classNames.listGridExampleTile}
-          data-is-focusable
-          style={{
-            width: 100 / columnCount.current + '%',
-          }}
-        >
-          <div className={classNames.listGridExampleSizer}>
-            <div className={classNames.listGridExamplePadder}>
-              <img src={item.thumbnail} className={classNames.listGridExampleImage} />
-              <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>
-            </div>
+  const onRenderCell = useConstCallback((item: IExampleItem, index: number | undefined) => {
+    return (
+      <div
+        className={classNames.listGridExampleTile}
+        data-is-focusable
+        style={{
+          width: 100 / columnCount.current + '%',
+        }}
+      >
+        <div className={classNames.listGridExampleSizer}>
+          <div className={classNames.listGridExamplePadder}>
+            <img src={item.thumbnail} className={classNames.listGridExampleImage} />
+            <span className={classNames.listGridExampleLabel}>{`item ${index}`}</span>
           </div>
         </div>
-      );
-    },
-    [columnCount.current],
-  );
+      </div>
+    );
+  });
 
-  const getPageHeight = (): number => {
+  const getPageHeight = useConstCallback((): number => {
     return rowHeight.current * ROWS_PER_PAGE;
-  };
+  });
 
   const items = useConst(() => createListItems(5000));
   return (
@@ -109,7 +106,6 @@ export const ListGridExample: React.FunctionComponent = () => {
         className={classNames.listGridExample}
         items={items}
         getItemCountForPage={getItemCountForPage}
-        // eslint-disable-next-line react/jsx-no-bind
         getPageHeight={getPageHeight}
         renderedWindowsAhead={4}
         onRenderCell={onRenderCell}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -24,13 +24,18 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
 >
   <p>
     Hover over the 
-    <i>
+    <strong>
       key
-    </i>
+    </strong>
      cell of a row item to see the card or use the keyboard to navigate to it by tabbing to a row and hitting the right arrow key.
   </p>
   <p>
-    When using the keyboard to navigate, open the card with the hotKey and it will automatically focus the first focusable element in the card allowing further navigation inside the card. The hotKey is defined by the hotKey prop and is defined as 'enter' in the following example.
+    When using the keyboard to navigate, open the card with the hotkey and it will automatically focus the first focusable element in the card allowing further navigation inside the card. The hotkey is defined by the
+     
+    <code>
+      openHotKey
+    </code>
+     prop and is defined as 'enter' in the following example.
   </p>
   <div
     className="ms-Viewport"

--- a/packages/react-hooks/.eslintrc.json
+++ b/packages/react-hooks/.eslintrc.json
@@ -1,4 +1,9 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
-  "root": true
+  "root": true,
+  "rules": {
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
+  }
 }

--- a/packages/react-next/.eslintrc.json
+++ b/packages/react-next/.eslintrc.json
@@ -3,6 +3,9 @@
   "extends": ["../office-ui-fabric-react/.eslintrc"],
   "root": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "error"
+    "@typescript-eslint/no-explicit-any": "error",
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
   }
 }

--- a/packages/react-stylesheets/src/StylesheetProvider.tsx
+++ b/packages/react-stylesheets/src/StylesheetProvider.tsx
@@ -17,6 +17,7 @@ export const StylesheetProvider = (props: React.PropsWithChildren<StylesheetProv
     }),
     // Only recompute the context to pass down if the parent passes a new one. Props should not
     // be mutating dynamically for a provider, or may be doing so accidentally. Avoid recomputations.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [context],
   );
 

--- a/packages/tsx-editor/src/components/TsxEditor.tsx
+++ b/packages/tsx-editor/src/components/TsxEditor.tsx
@@ -53,7 +53,7 @@ export const TsxEditor: React.FunctionComponent<ITsxEditorProps> = (props: ITsxE
     if (hasLoadedTypes && modelRef.current) {
       onChangeRef.current!(modelRef.current.getValue());
     }
-  }, [onChangeRef, hasLoadedTypes, modelRef.current]);
+  }, [onChangeRef, hasLoadedTypes, modelRef]);
 
   return (
     <Editor

--- a/packages/utilities/.eslintrc.json
+++ b/packages/utilities/.eslintrc.json
@@ -2,6 +2,9 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "prefer-const": "off"
+    "prefer-const": "off",
+    // Disable until issues are dealt with
+    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/rules-of-hooks": "off"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8938,10 +8938,10 @@ eslint-plugin-jsx-a11y@^6.2.3:
     has "^1.0.3"
     jsx-ast-utils "^2.2.1"
 
-eslint-plugin-react-hooks@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz#aed33b4254a41b045818cacb047b81e6df27fa58"
-  integrity sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==
+eslint-plugin-react-hooks@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.8.tgz#a9b1e3d57475ccd18276882eff3d6cba00da7a56"
+  integrity sha512-6SSb5AiMCPd8FDJrzah+Z4F44P2CdOaK026cXFV+o/xSRzfOiV1FNFeLl2z6xm3yqWOQEZ5OfVgiec90qV2xrQ==
 
 eslint-plugin-react@^7.20.0:
   version "7.20.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Start enabling the `react-hooks` "rules of hooks" lint rules.

This PR enables the rules by default and contains fixes (mostly simple/safe ones) for these packages:
- office-ui-fabric-react
- perf-test
- foundation
- react-stylesheets
- tsx-editor

It also disables the rules for the following packages which had more problematic violations that will be fixed ASAP separately:
- react-next (WIP)
- date-time (see #14098)
- lists (see #14098)
- experiments (see #14100)
- react-hooks (see #14099)
- utilities (see #14099)

One common fix in this PR is adding a "missing" dependency on a value which will never actually change, such as those returned by `useConst`, `useConstCallback`, `useId`, or certain other custom hooks. This is because the hooks rules only handle React's built-in hooks, not our custom hooks. I chose to add the unnecessary-but-harmless dependencies rather than disabling the rule because that way the rule will still catch any newly-added missing deps.