### PR TITLE
Enable "rules of hooks" lint rules in react-hooks and utilities; hook fixes

### DIFF
--- a/change/@uifabric-react-hooks-2020-07-17-23-16-18-eslint-hooks-utilities.json
+++ b/change/@uifabric-react-hooks-2020-07-17-23-16-18-eslint-hooks-utilities.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix rules of hooks issues, make useForceUpdate always return the same value, and update docs",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T06:16:07.914Z"
+}

--- a/change/@uifabric-utilities-2020-07-17-23-16-18-eslint-hooks-utilities.json
+++ b/change/@uifabric-utilities-2020-07-17-23-16-18-eslint-hooks-utilities.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix \"rules of hooks\" lint rule violations",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-18T06:16:18.220Z"
+}

--- a/packages/react-hooks/.eslintrc.json
+++ b/packages/react-hooks/.eslintrc.json
@@ -1,9 +1,4 @@
 {
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
-  "root": true,
-  "rules": {
-    // Disable until issues are dealt with
-    "react-hooks/exhaustive-deps": "off",
-    "react-hooks/rules-of-hooks": "off"
-  }
+  "root": true
 }

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -4,15 +4,59 @@
 
 Helpful hooks not provided by React itself. These hooks were built for use in Fluent UI React ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/)) but can be used in React apps built with any UI library.
 
+- [useBoolean](#useboolean) - Return a boolean value and callbacks for setting it to true or false, or toggling
 - [useConst](#useconst) - Initialize and return a value that's always constant
 - [useConstCallback](#useconstcallback) - Like `useConst` but for functions
+- [useControllableValue](#usecontrollablevalue) - Manage the current value for a component that could be either controlled or uncontrolled
+- [useForceUpdate](#useforceupdate) - Force a function component to update
 - [useId](#useid) - Get a globally unique ID
-- [useBoolean](#useboolean) - Return a boolean value and callbacks for setting it to true or false, or toggling
+- [useMergedRefs](#usemergedrefs) - Merge multiple refs into a single ref callback
+- [useOnEvent](#useonevent) - Attach an event handler on mount and handle cleanup
+- [usePrevious](#useprevious) - Get a value from the previous execution of the component
 - [useRefEffect](#userefeffect) - Call a function with cleanup when a ref changes. Like `useEffect` with a dependency on a ref.
+- [useSetInterval](#usesetinterval) - Version of `setInterval` that automatically cleans up when component is unmounted
+- [useSetTimeout](#usesettimeout) - Version of `setTimeout` that automatically cleans up when component is unmounted
+
+## useBoolean
+
+```ts
+function useBoolean(initialState: boolean): [boolean, IUseBooleanCallbacks];
+
+interface IUseBooleanCallbacks {
+  setTrue: () => void;
+  setFalse: () => void;
+  toggle: () => void;
+}
+```
+
+Hook to store a boolean state value and generate callbacks for setting the value to true or false, or toggling the value.
+
+The hook returns a tuple containing the current value and an object with callbacks for updating the value.
+
+Each callback will always have the same identity.
+
+### Example
+
+```jsx
+import { useBoolean } from '@uifabric/react-hooks';
+
+const MyComponent = () => {
+  const [value, { setTrue: showDialog, setFalse: hideDialog, toggle: toggleDialogVisible }] = useBoolean(false);
+  // ^^^ Instead of:
+  // const [isDialogVisible, setIsDialogVisible] = React.useState(false);
+  // const showDialog = useConstCallback(() => setIsDialogVisible(true));
+  // const hideDialog = useConstCallback(() => setIsDialogVisible(false));
+  // const toggleDialogVisible = isDialogVisible ? setFalse : setTrue;
+
+  // ... code that shows a dialog when a button is clicked ...
+};
+```
 
 ## useConst
 
-`function useConst<T>(initialValue: T | (() => T)): T`
+```ts
+function useConst<T>(initialValue: T | (() => T)): T;
+```
 
 Hook to initialize and return a constant value. Unlike `React.useMemo`, this will **always** return the same value (and if the initializer is a function, only call it once). This is similar to setting a private member in a class constructor.
 
@@ -46,7 +90,9 @@ In cases where the value **must** never change, the recommended workaround is to
 
 ## useConstCallback
 
-`function useConstCallback<T extends (...args: any[]) => any>(callback: T): T`
+```ts
+function useConstCallback<T extends (...args: any[]) => any>(callback: T): T;
+```
 
 Hook to ensure a callback function always has the same identity. Unlike `React.useCallback`, this is guaranteed to always return the same value.
 
@@ -56,9 +102,53 @@ If the callback should ever change based on dependencies, use `React.useCallback
 
 `useConstCallback(fn)` has the same behavior as `useConst(() => fn)`.
 
+## useControllableValue
+
+```ts
+function useControllableValue<TValue, TElement extends HTMLElement>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+): Readonly<[TValue | undefined, (newValue: TValue | undefined) => void]>;
+
+function useControllableValue<
+  TValue,
+  TElement extends HTMLElement,
+  TCallback extends ChangeCallback<TElement, TValue> | undefined
+>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+  onChange: TCallback,
+): Readonly<[TValue | undefined, (newValue: TValue | undefined, ev: React.FormEvent<TElement>) => void]>;
+
+type ChangeCallback<TElement extends HTMLElement, TValue> = (
+  ev: React.FormEvent<TElement> | undefined,
+  newValue: TValue | undefined,
+) => void;
+```
+
+Hook to manage the current value for a component that could be either controlled or uncontrolled, such as a checkbox or input field.
+
+Its two required parameters are the `controlledValue` (the current value of the control in the controlled state), and the `defaultUncontrolledValue` (for the uncontrolled state). Optionally, you may pass a third `onChange` callback to be notified of any changes triggered by the control.
+
+The return value will be a setter function that will set the internal state in the uncontrolled state, and invoke the `onChange` callback if present.
+
+See [React docs](https://reactjs.org/docs/uncontrolled-components.html) about the distinction between controlled and uncontrolled components.
+
+## useForceUpdate
+
+```ts
+function useForceUpdate(): () => void;
+```
+
+Returns a function which, when called, will force update a function component by updating a fake state value.
+
+The returned function always has the same identity.
+
 ## useId
 
-`function useId(prefix?: string): string`
+```ts
+function useId(prefix?: string): string;
+```
 
 Hook to generate a unique ID (with optional `prefix`) in the global scope. This will return the same ID on every render.
 
@@ -80,77 +170,61 @@ const TextField = ({ labelText, defaultValue }) => {
 };
 ```
 
-## useBoolean
-
-`function useBoolean(initialState: boolean): [boolean, IUseBooleanCallbacks]`
-
-Hook to store a boolean state value and generate callbacks for setting the value to true or false, or toggling the value.
-
-The hook returns a tuple containing the current value and an object with callbacks for updating the value.
-
-### `IUseBooleanCallbacks` properties
-
-- `setTrue: () => void`: Set the value to true. Always has the same identity.
-- `setFalse: () => void`: Set the value to false. Always has the same identity.
-- `toggle: () => void`: Toggle the value. Always has the same identity.
-
-### Example
-
-```jsx
-import { useBoolean } from '@uifabric/react-hooks';
-
-const MyComponent = () => {
-  const [value, { setTrue: showDialog, setFalse: hideDialog, toggle: toggleDialogVisible }] = useBoolean(false);
-  // ^^^ Instead of:
-  // const [isDialogVisible, setIsDialogVisible] = React.useState(false);
-  // const showDialog = useConstCallback(() => setIsDialogVisible(true));
-  // const hideDialog = useConstCallback(() => setIsDialogVisible(false));
-  // const toggleDialogVisible = isDialogVisible ? setFalse : setTrue;
-
-  // ... code that shows a dialog when a button is clicked ...
-};
-```
-
-## useControllableValue
-
-`function useControllableValue<TValue, TElement extends HTMLElement>( controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, ): Readonly<[TValue | undefined, (newValue: TValue | undefined) => void]>`
-
-`function useControllableValue< TValue, TElement extends HTMLElement, TCallback extends ChangeCallback<TElement, TValue> | undefined \>( controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: TCallback, ): Readonly<[TValue | undefined, (newValue: TValue | undefined, ev: React.FormEvent<TElement>) => void]>`
-
-Hook to manage the current value for a component that could be either controlled or uncontrolled, such as a checkbox or input field.
-
-Its two required parameters are the `controlledValue` (the current value of the control in the controlled state), and the `defaultUncontrolledValue` (for the uncontrolled state). Optionally, you may pass a third `onChange` callback to be notified of any changes triggered by the control.
-
-The return value will be a setter function that will set the internal state in the uncontrolled state, and invoke the `onChange` callback if present.
-
-See [React docs](https://reactjs.org/docs/uncontrolled-components.html) about the distinction between controlled and uncontrolled components.
-
 ## useMergedRefs
 
-`function useMergedRefs<T>(...refs: React.Ref<T>[]): (instance: T) => void`
+```ts
+function useMergedRefs<T>(...refs: React.Ref<T>[]): (instance: T) => void;
+```
 
 Hook to merge multiple refs (such as one passed in as a prop and one used locally) into a single ref callback that can be passed on to a child component.
 
-```typescriptreact
-const Example = React.forwardRef(function Example(props:{}, forwardedRef: React.Ref<HTMLDivElement>) {
+```tsx
+const Example = React.forwardRef(function Example(props: {}, forwardedRef: React.Ref<HTMLDivElement>) {
   const localRef = React.useRef<HTMLDivElement>();
   const mergedRef = useMergedRef(localRef, forwardedRef);
 
-  React.useEffect(() => { localRef.current.focus() }, []);
+  React.useEffect(() => {
+    localRef.current.focus();
+  }, []);
 
   return <div>Example</div>;
-})
+});
 ```
+
+## useOnEvent
+
+```ts
+function useOnEvent<TElement extends Element, TEvent extends Event>(
+  element: React.RefObject<TElement | undefined | null> | TElement | Window | undefined | null,
+  eventName: string,
+  callback: (ev: TEvent) => void,
+  useCapture?: boolean,
+): void;
+```
+
+Attach an event handler on mount and handle cleanup. The event handler is attached using `on()` from `@uifabric/utilities`.
+
+## usePrevious
+
+```ts
+function usePrevious<T>(value: T): T | undefined;
+```
+
+Hook keeping track of a given value from a previous execution of the component the Hook is used in. See [React Hooks FAQ](https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state).
 
 ## useRefEffect
 
-`function useRefEffect<T>(callback: (value: T) => (() => void) | void, initial: T | null = null): RefCallback<T>;`
+```ts
+function useRefEffect<T>(callback: (value: T) => (() => void) | void, initial: T | null = null): RefCallback<T>;
+
+type RefCallback<T> = ((value: T | null) => void) & React.RefObject<T>;
+```
 
 Creates a ref, and calls a callback whenever the ref changes to a non-null value. The callback can optionally return a cleanup function that'll be called before the value changes, and when the ref is unmounted.
 
 The return value is a function that should be called to set the ref's value. The returned object also has a `.current` member that can be used to access the ref's value (like a normal `RefObject`). This can be hooked up to an element's `ref` property.
 
-`useRefEffect` can be used to work around a limitation that `useEffect` cannot depend on `[ref.current]` (see [https://github.com/facebook/react/issues/14387](https://github.com/facebook/react/issues/14387#issuecomment-503616820)).
+`useRefEffect` can be used to work around a limitation that [`useEffect` cannot depend on `ref.current`](https://github.com/facebook/react/issues/14387#issuecomment-503616820).
 
 ### Example
 
@@ -174,9 +248,16 @@ const MyComponent = () => {
 
 ## useSetInterval
 
-`useSetInterval: () => { setInterval, clearInterval }`
+```ts
+function useSetInterval(): {
+  setInterval: (callback: () => void, duration: number) => number;
+  clearInterval: (id: number) => void;
+};
+```
 
 Hook which returns safe `setInterval` and `clearInterval` methods. Intervals set up using this hook will be automatically cleared when the component is unmounted.
+
+The returned callbacks always have the same identity.
 
 ### Example
 
@@ -196,9 +277,16 @@ const MyComponent = () => {
 
 ## useSetTimeout
 
-`const useSetTimeout: () => { setTimeout, clearTimeout }`
+```ts
+function useSetTimeout(): {
+  setTimeout: (callback: () => void, duration: number) => number;
+  clearTimeout: (id: number) => void;
+};
+```
 
 Hook which returns safe `setTimeout` and `clearTimeout` methods. Timeout callbacks set up using this hook will be automatically cleared when the component is unmounted.
+
+The returned callbacks always have the same identity.
 
 ### Example
 

--- a/packages/react-hooks/src/useControllableValue.ts
+++ b/packages/react-hooks/src/useControllableValue.ts
@@ -9,9 +9,9 @@ export type ChangeCallback<TElement extends HTMLElement, TValue> = (
 /**
  * Hook to manage a value that could be either controlled or uncontrolled, such as a checked state or
  * text box string.
- * @param controlledValue- The controlled value passed in the props. This value will always be used if provided, and the
- * internal state will be updated to reflect it.
- * @param defaultUncontrolledValue- Initial value for the internal state in the uncontrolled case.
+ * @param controlledValue - The controlled value passed in the props. This value will always be used if provided,
+ * and the internal state will be updated to reflect it.
+ * @param defaultUncontrolledValue - Initial value for the internal state in the uncontrolled case.
  * @see https://reactjs.org/docs/uncontrolled-components.html
  */
 export function useControllableValue<TValue, TElement extends HTMLElement>(

--- a/packages/react-hooks/src/useForceUpdate.test.tsx
+++ b/packages/react-hooks/src/useForceUpdate.test.tsx
@@ -7,7 +7,7 @@ describe('useForceUpdate', () => {
     let renderCount = 0;
     const TestComponent: React.FunctionComponent = () => {
       const forceUpdate = useForceUpdate();
-      React.useEffect(() => forceUpdate(), []);
+      React.useEffect(() => forceUpdate(), [forceUpdate]);
 
       renderCount++;
       return <>Test Component</>;
@@ -15,5 +15,24 @@ describe('useForceUpdate', () => {
 
     mount(<TestComponent />);
     expect(renderCount).toBe(2);
+  });
+
+  it('returns the same callback each time', () => {
+    let latestForceUpdate: (() => void) | undefined;
+    let renderCount = 0;
+
+    const TestComponent: React.FunctionComponent = props => {
+      latestForceUpdate = useForceUpdate();
+      renderCount++;
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent />);
+    const firstForceUpate = latestForceUpdate;
+    latestForceUpdate = undefined;
+
+    wrapper.setProps({});
+    expect(renderCount).toBe(2);
+    expect(latestForceUpdate).toBe(firstForceUpate);
   });
 });

--- a/packages/react-hooks/src/useForceUpdate.ts
+++ b/packages/react-hooks/src/useForceUpdate.ts
@@ -1,9 +1,11 @@
 import * as React from 'react';
+import { useConstCallback } from './useConstCallback';
 
 /**
  * Hook to force update a function component by updating a dummy state.
  */
 export function useForceUpdate(): () => void {
   const [, setValue] = React.useState(0);
-  return () => setValue(value => ++value);
+  const forceUpdate = useConstCallback(() => setValue(value => ++value));
+  return forceUpdate;
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -16,6 +16,7 @@ export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
         }
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
   );
 }

--- a/packages/react-hooks/src/useOnEvent.ts
+++ b/packages/react-hooks/src/useOnEvent.ts
@@ -3,10 +3,10 @@ import * as React from 'react';
 
 /**
  * Hook to attach an event handler on mount and handle cleanup.
- * @param element- Element (or ref to an element) to attach the event handler to
- * @param eventName- The event to attach a handler for
- * @param callback- The handler for the event
- * @param useCapture- Whether or not to attach the handler for the capture phase
+ * @param element - Element (or ref to an element) to attach the event handler to
+ * @param eventName - The event to attach a handler for
+ * @param callback - The handler for the event
+ * @param useCapture - Whether or not to attach the handler for the capture phase
  */
 export function useOnEvent<TElement extends Element, TEvent extends Event>(
   element: React.RefObject<TElement | undefined | null> | TElement | Window | undefined | null,
@@ -19,14 +19,12 @@ export function useOnEvent<TElement extends Element, TEvent extends Event>(
   callbackRef.current = callback;
 
   React.useEffect(() => {
-    if (element && 'current' in element) {
-      element = element.current;
-    }
-    if (!element) {
+    const actualElement = element && 'current' in element ? element.current : element;
+    if (!actualElement) {
       return;
     }
 
-    const dispose = on(element, eventName, (ev: TEvent) => callbackRef.current(ev), useCapture);
+    const dispose = on(actualElement, eventName, (ev: TEvent) => callbackRef.current(ev), useCapture);
     return dispose;
   }, [element, eventName, useCapture]);
 }

--- a/packages/react-hooks/src/useSetInterval.test.tsx
+++ b/packages/react-hooks/src/useSetInterval.test.tsx
@@ -11,10 +11,13 @@ describe('useSetInterval', () => {
     const { setInterval, clearInterval } = useSetInterval();
     const { current: state } = React.useRef<{ id: number }>({ id: 0 });
 
-    // This should not have a dependency array because `clearInterval` will always be the same
-    React.useImperativeHandle(ref, () => ({
-      clearInterval: () => clearInterval(state.id),
-    }));
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        clearInterval: () => clearInterval(state.id),
+      }),
+      [clearInterval, state],
+    );
 
     state.id = setInterval(() => {
       timesCalled++;

--- a/packages/react-hooks/src/useSetInterval.test.tsx
+++ b/packages/react-hooks/src/useSetInterval.test.tsx
@@ -11,13 +11,10 @@ describe('useSetInterval', () => {
     const { setInterval, clearInterval } = useSetInterval();
     const { current: state } = React.useRef<{ id: number }>({ id: 0 });
 
-    React.useImperativeHandle(
-      ref,
-      () => ({
-        clearInterval: () => clearInterval(state.id),
-      }),
-      [clearInterval],
-    );
+    // This should not have a dependency array because `clearInterval` will always be the same
+    React.useImperativeHandle(ref, () => ({
+      clearInterval: () => clearInterval(state.id),
+    }));
 
     state.id = setInterval(() => {
       timesCalled++;

--- a/packages/react-hooks/src/useSetInterval.ts
+++ b/packages/react-hooks/src/useSetInterval.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useConst } from './useConst';
-import { useEffect } from 'react';
 
 export type UseSetIntervalReturnType = {
   setInterval: (callback: () => void, duration: number) => number;
@@ -13,28 +12,29 @@ export type UseSetIntervalReturnType = {
 export const useSetInterval = (): UseSetIntervalReturnType => {
   const intervalIds = useConst<Record<number, number>>({});
 
-  useEffect(
+  React.useEffect(
     () => () => {
       for (const id of Object.keys(intervalIds)) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         clearInterval(id as any);
       }
     },
-    [],
+    // useConst ensures this will never change, but react-hooks/exhaustive-deps doesn't know that
+    [intervalIds],
   );
 
-  return {
-    setInterval: React.useCallback((func: () => void, duration: number): number => {
+  return useConst({
+    setInterval: (func: () => void, duration: number): number => {
       const id = (setInterval(func, duration) as unknown) as number;
 
       intervalIds[id] = 1;
 
       return id;
-    }, []),
+    },
 
-    clearInterval: React.useCallback((id: number): void => {
+    clearInterval: (id: number): void => {
       delete intervalIds[id];
       clearInterval(id);
-    }, []),
-  };
+    },
+  });
 };

--- a/packages/react-hooks/src/useSetTimeout.test.tsx
+++ b/packages/react-hooks/src/useSetTimeout.test.tsx
@@ -11,10 +11,13 @@ describe('useSetTimeout', () => {
     const { setTimeout, clearTimeout } = useSetTimeout();
     const { current: state } = React.useRef<{ id: number }>({ id: 0 });
 
-    // This should not have a dependency array because `clearInterval` will always be the same
-    React.useImperativeHandle(ref, () => ({
-      clearTimeout: () => clearTimeout(state.id),
-    }));
+    React.useImperativeHandle(
+      ref,
+      () => ({
+        clearTimeout: () => clearTimeout(state.id),
+      }),
+      [clearTimeout, state],
+    );
 
     state.id = setTimeout(() => {
       timesCalled++;

--- a/packages/react-hooks/src/useSetTimeout.test.tsx
+++ b/packages/react-hooks/src/useSetTimeout.test.tsx
@@ -11,13 +11,10 @@ describe('useSetTimeout', () => {
     const { setTimeout, clearTimeout } = useSetTimeout();
     const { current: state } = React.useRef<{ id: number }>({ id: 0 });
 
-    React.useImperativeHandle(
-      ref,
-      () => ({
-        clearTimeout: () => clearTimeout(state.id),
-      }),
-      [clearTimeout],
-    );
+    // This should not have a dependency array because `clearInterval` will always be the same
+    React.useImperativeHandle(ref, () => ({
+      clearTimeout: () => clearTimeout(state.id),
+    }));
 
     state.id = setTimeout(() => {
       timesCalled++;

--- a/packages/utilities/.eslintrc.json
+++ b/packages/utilities/.eslintrc.json
@@ -2,9 +2,6 @@
   "extends": ["plugin:@fluentui/eslint-plugin/react--legacy"],
   "root": true,
   "rules": {
-    "prefer-const": "off",
-    // Disable until issues are dealt with
-    "react-hooks/exhaustive-deps": "off",
-    "react-hooks/rules-of-hooks": "off"
+    "prefer-const": "off"
   }
 }

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -105,9 +105,8 @@ export function styled<
 
         return () => Customizations.unobserve(forceUpdate);
       }
-      // TODO: check with @MLoughry about whether to add dep on
-      // context.customizations.inCustomizerContext
-    }, [forceUpdate]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
+    }, []);
 
     const settings = Customizations.getSettings(fields, scope, context.customizations);
     const { styles: customizedStyles, dir, ...rest } = settings;

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -105,7 +105,9 @@ export function styled<
 
         return () => Customizations.unobserve(forceUpdate);
       }
-    }, []);
+      // TODO: check with @MLoughry about whether to add dep on
+      // context.customizations.inCustomizerContext
+    }, [forceUpdate]);
 
     const settings = Customizations.getSettings(fields, scope, context.customizations);
     const { styles: customizedStyles, dir, ...rest } = settings;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Enable `eslint-plugin-react-hooks` "rules of hooks" lint rules in `@uifabric/react-hooks` and `@uifabric/utilities`.

Make `useForceUpdate` always return the same function instead of mutating every render. This will be important with more exhaustive listings of deps requested by the lint rules.

Make `useSetInterval` and `useSetTimeout` always return the same entire result object (they already returned probably-constant functions with `useCallback`).

Add missing hooks to `@uifabric/react-hooks` readme.