### PR TITLE
fix: useMergedRefs() to accept only two params

### DIFF
--- a/change/@uifabric-react-hooks-2020-07-20-11-43-15-fix-merged-refs.json
+++ b/change/@uifabric-react-hooks-2020-07-20-11-43-15-fix-merged-refs.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "fix: useMergedRefs() to accept only two params",
+  "packageName": "@uifabric/react-hooks",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-20T09:43:15.410Z"
+}

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -46,7 +46,7 @@ export function useForceUpdate(): () => void;
 export function useId(prefix?: string, providedId?: string): string;
 
 // @public
-export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void;
+export function useMergedRefs<T>(refA: Ref<T>, refB: Ref<T>): (instance: T) => void;
 
 // @public
 export function useOnEvent<TElement extends Element, TEvent extends Event>(element: React.RefObject<TElement | undefined | null> | TElement | Window | undefined | null, eventName: string, callback: (ev: TEvent) => void, useCapture?: boolean): void;

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -15,8 +15,10 @@ describe('useMergedRefs', () => {
   it('always returns the same ref (refs should be immutable)', () => {
     let lastMergedRef;
     const refFunc = () => null;
+    const refObject = React.createRef<boolean>();
+
     const TestComponent: React.FunctionComponent = () => {
-      lastMergedRef = useMergedRefs<boolean>(refFunc);
+      lastMergedRef = useMergedRefs<boolean>(refFunc, refObject);
       return null;
     };
 
@@ -32,7 +34,7 @@ describe('useMergedRefs', () => {
     let lastMergedRef;
 
     const TestComponent: React.FunctionComponent = () => {
-      lastMergedRef = useMergedRefs<boolean>(() => ({}));
+      lastMergedRef = useMergedRefs<boolean>(() => ({}), React.createRef());
       return null;
     };
 

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,13 +1,15 @@
 import { useCallback, Ref, MutableRefObject } from 'react';
+
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
- * @param refs- Refs to collectively update with one ref value.
+ * @param refA- A first ref to collectively update with one ref value.
+ * @param refB- A second ref to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
+export function useMergedRefs<T>(refA: Ref<T>, refB: Ref<T>): (instance: T) => void {
   return useCallback(
     (value: T) => {
-      for (const ref of refs) {
+      for (const ref of [refA, refB]) {
         if (typeof ref === 'function') {
           ref(value);
         } else if (ref) {
@@ -16,6 +18,6 @@ export function useMergedRefs<T>(...refs: Ref<T>[]): (instance: T) => void {
         }
       }
     },
-    [...refs],
+    [refA, refB],
   );
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14104
- [x] Include a change request file using `$ yarn change`

#### Description of changes

See the original issue for more details. This PR restricts params for `useMergedRefs()` hook to accept only two params as otherwise there is no obvious way to handle dependencies for `useCallback()`.

Technically as it's a public API changes there are **breaking**.

#### Focus areas to test

(optional)
