### PR TITLE
Add aria label to website search box

### DIFF
--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -263,6 +263,7 @@ export class Nav extends React.Component<INavProps, INavState> {
           onClick={this._onSearchBoxClick}
           underlined={true}
           styles={searchBoxStyles}
+          ariaLabel={`Search ${pageTitle}`}
         />
         <IconButton
           className={styles.filterButton}

--- a/change/@uifabric-fabric-website-2020-07-20-08-29-43-website-search-aria.json
+++ b/change/@uifabric-fabric-website-2020-07-20-08-29-43-website-search-aria.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add aria label to searchbox",
+  "packageName": "@uifabric/fabric-website",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-20T15:29:43.951Z"
+}


### PR DESCRIPTION
website search was missing a label

![image](https://user-images.githubusercontent.com/1434956/87955908-3819a800-ca63-11ea-882c-2f7efb1d556b.png)
