### PR TITLE
fix(UI Builder): load babel before loading the UI Builder

### DIFF
--- a/packages/fluentui/docs/src/components/ComponentDoc/LazyWithBabel.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/LazyWithBabel.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import useScript from '@charlietango/use-script';
+import { Loader } from 'src/components/Loader/Loader';
+
+export const LazyWithBabel: React.FunctionComponent = ({ children }) => {
+  const url = `https://cdn.jsdelivr.net/npm/@babel/standalone@${window['versions'].babelStandalone}/babel.min.js`;
+  const [ready] = useScript(url);
+
+  return ready ? <React.Suspense fallback={<Loader />}>{children}</React.Suspense> : <Loader />;
+};

--- a/packages/fluentui/docs/src/components/ComponentDoc/SourceRender.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/SourceRender.tsx
@@ -1,6 +1,5 @@
-import useScript from '@charlietango/use-script';
-import { Loader } from '@fluentui/react-northstar';
 import * as React from 'react';
+import { LazyWithBabel } from './LazyWithBabel';
 
 const _SourceRender = React.lazy(() => import('react-source-render'));
 
@@ -13,15 +12,8 @@ type SourceRenderProps = {
   onRender?: (error: Error | null) => void;
 };
 
-export const SourceRender: React.FC<SourceRenderProps> = props => {
-  const url = `https://cdn.jsdelivr.net/npm/@babel/standalone@${window['versions'].babelStandalone}/babel.min.js`;
-  const [ready] = useScript(url);
-
-  return ready ? (
-    <React.Suspense fallback={<Loader />}>
-      <_SourceRender {...props} />
-    </React.Suspense>
-  ) : (
-    <Loader />
-  );
-};
+export const SourceRender: React.FC<SourceRenderProps> = props => (
+  <LazyWithBabel>
+    <_SourceRender {...props} />
+  </LazyWithBabel>
+);

--- a/packages/fluentui/docs/src/routes.tsx
+++ b/packages/fluentui/docs/src/routes.tsx
@@ -34,10 +34,18 @@ import AccessibilityBehaviors from './views/AccessibilityBehaviors';
 import FocusZone from './views/FocusZoneDoc';
 import FocusTrapZone from './views/FocusTrapZoneDoc';
 import AutoFocusZone from './views/AutoFocusZoneDoc';
+import { LazyWithBabel } from './components/ComponentDoc/LazyWithBabel';
 
-const Builder = React.lazy(async () => ({
+const _Builder = React.lazy(async () => ({
   default: (await import(/* webpackChunkName: "builder" */ '@fluentui/react-builder')).Builder,
 }));
+
+const Builder: React.FunctionComponent = () => (
+  <LazyWithBabel>
+    <_Builder />
+  </LazyWithBabel>
+);
+
 const FullScreenPreview = React.lazy(async () => ({
   default: (await import(/* webpackChunkName: "builder" */ '@fluentui/react-builder')).FullScreenPreview,
 }));


### PR DESCRIPTION
#### Description of changes

UI Builder depends on babel being loaded on `window`.
Fetch and load babel before loading the builder.

#### Focus areas to test

- UI Builder loads, babel is fetched before loading the builder.
