### PR TITLE
PeoplePicker keyboard focus state: Add styles to PeoplePicker to fix keyboard focus state ratio

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -233,8 +233,6 @@ exports[`a11y test checks accessibility of Button (Button.Default.Example) 1`] =
 
 exports[`a11y test checks accessibility of Button (Button.Icon.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.Primary.Example) 1`] = `Array []`;
-
 exports[`a11y test checks accessibility of Button (Button.ScreenReader.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `
@@ -2197,8 +2195,6 @@ exports[`a11y test checks accessibility of Callout (Callout.Directional.Example)
 
 exports[`a11y test checks accessibility of Callout (Callout.FocusTrap.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Callout (Callout.Nested.Example) 1`] = `Array []`;
-
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Other.Example) 1`] = `Array []`;
@@ -2214,8 +2210,6 @@ exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Image.Exampl
 exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Label.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Coachmark (Coachmark.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Coachmark/PositioningContainer (PositioningContainer.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ColorPicker (ColorPicker.Basic.Example) 1`] = `Array []`;
 
@@ -4706,8 +4700,6 @@ Array [
 
 exports[`a11y test checks accessibility of MessageBar (MessageBar.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of MessageBar (MessageBar.Styled.Example) 1`] = `Array []`;
-
 exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `
 Array [
   Object {
@@ -5133,117 +5125,6 @@ Array [
 ]
 `;
 
-exports[`a11y test checks accessibility of Panel (Panel.Custom.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.CustomLeft.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.ExtraLarge.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
 exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `
 Array [
   Object {
@@ -5320,120 +5201,9 @@ Array [
 
 exports[`a11y test checks accessibility of Panel (Panel.HiddenOnDismiss.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Large.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.LargeFixed.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
 exports[`a11y test checks accessibility of Panel (Panel.LightDismiss.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Panel (Panel.LightDismissCustom.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Panel (Panel.Medium.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
 
 exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `
 Array [
@@ -5474,191 +5244,6 @@ Array [
 
 exports[`a11y test checks accessibility of Panel (Panel.NonModal.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.PreventDefault.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.Scroll.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.SmallFluid.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.SmallLeft.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Panel (Panel.SmallRight.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
 exports[`a11y test checks accessibility of Persona (Persona.Alternate.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Persona (Persona.Basic.Example) 1`] = `Array []`;
@@ -5676,8 +5261,6 @@ exports[`a11y test checks accessibility of Persona (Persona.Presence.Example) 1`
 exports[`a11y test checks accessibility of Persona (Persona.UnknownPersona.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Pivot (Pivot.Fabric.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `
 Array [
@@ -5767,53 +5350,6 @@ Array [
     },
     "ruleId": "aria-roles",
     "ruleIndex": 10,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Pivot (Pivot.SeparateNoSelectedKey.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-Button--icon",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-15\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-16\\"><i data-icon-name=\\"Settings\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-21\\" style=\\"color:blue\\"></i></div></button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
   },
 ]
 `;
@@ -8994,43 +8530,6 @@ exports[`a11y test checks accessibility of TextField (TextField.Styled.Example) 
 
 exports[`a11y test checks accessibility of Toggle (Toggle.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Absolute.Position.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#targetButton1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"targetButton1\\" aria-labelledby=\\"tooltipHost0\\" style=\\"position:absolute;top:50px;left:200px\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `
 Array [
   Object {
@@ -9211,45 +8710,6 @@ Array [
 ]
 `;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.NoScroll.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-labelledby=\\"text-tooltip0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Overflow.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of pickers (TagPicker.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Types.Example) 1`] = `Array []`;

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -10,7 +10,21 @@ exports[`a11y test checks accessibility of Announced (Announced.BulkOperations.E
 
 exports[`a11y test checks accessibility of Announced (Announced.LazyLoading.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Announced (Announced.QuickActions.Example) 1`] = `
+exports[`a11y test checks accessibility of Announced (Announced.QuickActions.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Announced (Announced.SearchResults.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Static.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Action.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Anchor.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.Command.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -19,7 +33,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".ms-DetailsList",
+            "fullyQualifiedName": ".root-16",
             "kind": "element",
           },
         ],
@@ -30,7 +44,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
             },
           },
         },
@@ -38,47 +52,597 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element should have focusable content.
-- Element should be focusable.",
-      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
-    "ruleId": "scrollable-region-focusable",
-    "ruleIndex": 58,
+    "ruleId": "button-name",
+    "ruleIndex": 15,
   },
 ]
 `;
-
-exports[`a11y test checks accessibility of Announced (Announced.SearchResults.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Collapsing.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Static.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Button (Button.Action.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Button (Button.Anchor.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Button (Button.Command.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Compound.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.ContextualMenu.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Button (Button.Default.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Icon.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.IconWithTooltip.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Primary.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.ScreenReader.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div:nth-child(1) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-34",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-34\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-36",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button is-disabled root-36\\" aria-disabled=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Button (Button.Split.Example) 2`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
+    },
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-10",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Button (Button.Toggle.Example) 1`] = `Array []`;
 
@@ -104,7 +668,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -112,11 +676,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -136,7 +700,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -144,11 +708,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -168,7 +732,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -176,11 +740,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -200,7 +764,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -208,11 +772,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -232,7 +796,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -240,11 +804,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -264,7 +828,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button ms-DatePicker-day--today undefined\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button ms-DatePicker-day--today undefined\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -272,11 +836,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"true\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"true\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -296,7 +860,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -304,11 +868,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -328,7 +892,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -336,11 +900,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -360,7 +924,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -368,11 +932,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -392,7 +956,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -400,11 +964,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -424,7 +988,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -432,11 +996,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -456,7 +1020,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -464,11 +1028,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -488,7 +1052,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -496,11 +1060,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -520,7 +1084,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -528,11 +1092,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -552,7 +1116,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -560,11 +1124,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -584,7 +1148,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -592,11 +1156,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -616,7 +1180,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -624,11 +1188,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -648,7 +1212,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -656,11 +1220,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -680,7 +1244,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -688,11 +1252,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -712,7 +1276,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -720,11 +1284,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -744,7 +1308,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -752,11 +1316,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -776,7 +1340,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -784,11 +1348,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -808,7 +1372,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -816,11 +1380,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -840,7 +1404,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -848,11 +1412,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -872,7 +1436,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -880,11 +1444,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -904,7 +1468,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -912,11 +1476,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -936,7 +1500,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -944,11 +1508,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -968,7 +1532,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -976,11 +1540,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1000,7 +1564,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1008,11 +1572,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1032,7 +1596,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1040,11 +1604,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1064,7 +1628,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1072,11 +1636,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1096,7 +1660,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1104,11 +1668,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1128,7 +1692,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1136,11 +1700,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1160,7 +1724,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1168,11 +1732,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1192,7 +1756,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1200,11 +1764,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
-      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+- ARIA role gridcell  is not allowed for given element.",
+      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
     },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
+    "ruleId": "aria-allowed-role",
+    "ruleIndex": 3,
   },
   Object {
     "kind": "fail",
@@ -1608,7 +2172,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1620,7 +2184,7 @@ Array [
       "text": "Fix any of the following: Document has multiple elements referenced with ARIA with the same id attribute: DatePickerDay-active0.",
     },
     "ruleId": "duplicate-id-aria",
-    "ruleIndex": 25,
+    "ruleIndex": 22,
   },
 ]
 `;
@@ -1633,17 +2197,13 @@ exports[`a11y test checks accessibility of Callout (Callout.Directional.Example)
 
 exports[`a11y test checks accessibility of Callout (Callout.FocusTrap.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Callout (Callout.Status.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Callout (Callout.Nested.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Checkbox (Checkbox.Indeterminate.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Other.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Controlled.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Custom.Example) 1`] = `Array []`;
 
@@ -1655,87 +2215,50 @@ exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Label.Exampl
 
 exports[`a11y test checks accessibility of Coachmark (Coachmark.Basic.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of Coachmark/PositioningContainer (PositioningContainer.Basic.Example) 1`] = `Array []`;
+
 exports[`a11y test checks accessibility of ColorPicker (ColorPicker.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#ComboBox23-label",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<label id=\\"ComboBox23-label\\" for=\\"ComboBox23-input\\" class=\\"ms-Label root-30\\">Disabled ComboBox</label>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+    },
+    "ruleId": "color-contrast",
+    "ruleIndex": 17,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of ComboBox (ComboBox.Controlled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ComboBox (ComboBox.ControlledMulti.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of ComboBox (ComboBox.CustomStyled.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#ComboBox0-error",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"region\\" aria-live=\\"polite\\" aria-atomic=\\"true\\" id=\\"ComboBox0-error\\" class=\\"\\"></div>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-    },
-    "ruleId": "landmark-unique",
-    "ruleIndex": 46,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of ComboBox (ComboBox.ErrorHandling.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#ComboBox0-error",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"region\\" aria-live=\\"polite\\" aria-atomic=\\"true\\" id=\\"ComboBox0-error\\" class=\\"css-2\\">Oh no! This ComboBox has an error!</div>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-    },
-    "ruleId": "landmark-unique",
-    "ruleIndex": 46,
-  },
-]
-`;
+exports[`a11y test checks accessibility of ComboBox (ComboBox.CustomStyled.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ComboBox (ComboBox.Toggles.Example) 1`] = `Array []`;
 
@@ -1747,7 +2270,7 @@ exports[`a11y test checks accessibility of CommandBar (CommandBar.ButtonAs.Examp
 
 exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of CommandBar (CommandBar.Lazy.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 2`] = `Array []`;
 
 exports[`a11y test checks accessibility of CommandBar (CommandBar.SplitDisabled.Example) 1`] = `Array []`;
 
@@ -1762,8 +2285,6 @@ exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Custom
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Customization.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.CustomizationWithNoWrap.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Default.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Directional.Example) 1`] = `Array []`;
 
@@ -1823,7 +2344,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-29\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-describedby=\\"header0-thumbnail-tooltip\\" aria-haspopup=\\"false\\">",
+              "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-38\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"false\\"><span id=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellName cellName-39\\"></span></span>",
             },
           },
         },
@@ -1831,16 +2352,18 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 19,
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -1849,45 +2372,7 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomFooter
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomGroupHeaders.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomRows.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#header0-check",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-3 ms-DetailsRow-check--isHeader ms-Check-checkHost check-18\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element does not have text that is visible to screen readers.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
-    },
-    "ruleId": "aria-toggle-field-name",
-    "ruleIndex": 13,
-  },
-]
-`;
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomRows.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.Documents.Example) 1`] = `Array []`;
 
@@ -1899,11 +2384,116 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.Grouped.Larg
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.NavigatingFocus.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Dialog (Dialog.Modeless.Example) 1`] = `
 Array [
@@ -1914,7 +2504,71 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "input",
+            "fullyQualifiedName": "button[aria-labelledby=\\"id__1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__1\\" aria-describedby=\\"id__2\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"id__4\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__4\\" aria-describedby=\\"id__5\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "input[type=\\"text\\"]",
             "kind": "element",
           },
         ],
@@ -1941,12 +2595,47 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleIndex": 34,
   },
 ]
 `;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Divider (VerticalDivider.Basic.Example) 1`] = `Array []`;
 
@@ -1982,7 +2671,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label class=\\"ms-Label ms-Dropdown-label root-24\\" id=\\"Dropdown1-label\\">Disabled example with defaultSelectedKey</label>",
+              "text": "<label class=\\"ms-Label ms-Dropdown-label label-26\\" id=\\"Dropdown1-label\\" for=\\"Dropdown1\\">Disabled example with defaultSelectedKey</label>",
             },
           },
         },
@@ -1990,11 +2679,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -2029,7 +2718,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
             },
           },
         },
@@ -2041,7 +2730,7 @@ Array [
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
     "ruleId": "aria-required-children",
-    "ruleIndex": 9,
+    "ruleIndex": 8,
   },
 ]
 `;
@@ -2066,7 +2755,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
             },
           },
         },
@@ -2078,18 +2767,14 @@ Array [
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
     "ruleId": "aria-required-children",
-    "ruleIndex": 9,
+    "ruleIndex": 8,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of Facepile (Facepile.AddFace.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Facepile (Facepile.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Facepile (Facepile.Overflow.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FloatingPicker/PeoplePicker (FloatingPeoplePicker.Basic.Example) 1`] = `
+exports[`a11y test checks accessibility of Facepile (Facepile.Basic.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -2098,7 +2783,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#SearchBox0",
+            "fullyQualifiedName": "button",
             "kind": "element",
           },
         ],
@@ -2109,26 +2794,61 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search for person\\" value=\\"\\" role=\\"searchbox\\">",
+              "text": "<button type=\\"button\\" data-is-focusable=\\"true\\" aria-hidden=\\"true\\" title=\\"Alex Lundberg\\" class=\\"ms-Button ms-Facepile-itemButton ms-Facepile-person ms-Button--facepile itemButton-19\\">",
             },
           },
         },
       },
     ],
     "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+      "markdown": "Fix all of the following:
+- Focusable content should be disabled or be removed from the DOM.",
+      "text": "Fix all of the following: Focusable content should be disabled or be removed from the DOM.",
     },
-    "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleId": "aria-hidden-focus",
+    "ruleIndex": 6,
   },
 ]
 `;
+
+exports[`a11y test checks accessibility of Facepile (Facepile.Overflow.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" data-is-focusable=\\"true\\" aria-hidden=\\"true\\" title=\\"Alex Lundberg\\" class=\\"ms-Button ms-Facepile-itemButton ms-Facepile-person ms-Button--facepile itemButton-19\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Focusable content should be disabled or be removed from the DOM.",
+      "text": "Fix all of the following: Focusable content should be disabled or be removed from the DOM.",
+    },
+    "ruleId": "aria-hidden-focus",
+    "ruleIndex": 6,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FloatingPicker/PeoplePicker (FloatingPeoplePicker.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Click.Example) 1`] = `Array []`;
 
@@ -2136,17 +2856,7 @@ exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Exam
 
 exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.FocusOnCustomElement.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.FocusZone.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.HorizontalMenu.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -2155,7 +2865,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#TextField2",
+            "fullyQualifiedName": "button",
             "kind": "element",
           },
         ],
@@ -2166,24 +2876,29 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" readonly=\\"\\" value=\\"ReadOnly Item-0\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
             },
           },
         },
       },
     ],
     "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
     },
-    "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
   },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.FocusZone.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `
+Array [
   Object {
     "kind": "fail",
     "level": "error",
@@ -2191,7 +2906,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#TextField5",
+            "fullyQualifiedName": "#TextField7",
             "kind": "element",
           },
         ],
@@ -2202,7 +2917,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField5\\" value=\\"Item-0\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -2218,151 +2933,7 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField9",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField9\\" readonly=\\"\\" value=\\"ReadOnly Item-1\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField12",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField12\\" value=\\"Item-1\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField16",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField16\\" readonly=\\"\\" value=\\"ReadOnly Item-2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField19",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField19\\" value=\\"Item-2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleIndex": 34,
   },
   Object {
     "kind": "fail",
@@ -2382,7 +2953,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField23\\" readonly=\\"\\" value=\\"ReadOnly Item-3\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField23\\" value=\\"Tabbable Element 2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -2398,7 +2969,1118 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleIndex": 34,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\30 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"0\\" data-item-index=\\"0\\" aria-rowindex=\\"1\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\31 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"1\\" data-item-index=\\"1\\" aria-rowindex=\\"2\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone5\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\32 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"2\\" data-item-index=\\"2\\" aria-rowindex=\\"3\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone9\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\33 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"3\\" data-item-index=\\"3\\" aria-rowindex=\\"4\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone13\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\34 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"4\\" data-item-index=\\"4\\" aria-rowindex=\\"5\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone17\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\35 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"5\\" data-item-index=\\"5\\" aria-rowindex=\\"6\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone21\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\36 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"6\\" data-item-index=\\"6\\" aria-rowindex=\\"7\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone25\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\37 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"7\\" data-item-index=\\"7\\" aria-rowindex=\\"8\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone29\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\38 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"8\\" data-item-index=\\"8\\" aria-rowindex=\\"9\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone33\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\39 \\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"9\\" data-item-index=\\"9\\" aria-rowindex=\\"10\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone37\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA parents role not present: rowgroup grid treegrid table.",
+      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
+    },
+    "ruleId": "aria-required-parent",
+    "ruleIndex": 9,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have an alt attribute.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".",
+      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
+    },
+    "ruleId": "image-alt",
+    "ruleIndex": 31,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField7",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 34,
   },
   Object {
     "kind": "fail",
@@ -2418,7 +4100,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"Item-3\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -2434,576 +4116,24 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField30",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField30\\" readonly=\\"\\" value=\\"ReadOnly Item-4\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField33",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField33\\" value=\\"Item-4\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField37",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField37\\" readonly=\\"\\" value=\\"ReadOnly Item-5\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField40",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField40\\" value=\\"Item-5\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField44",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField44\\" readonly=\\"\\" value=\\"ReadOnly Item-6\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField47",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField47\\" value=\\"Item-6\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField51",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField51\\" readonly=\\"\\" value=\\"ReadOnly Item-7\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField54",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField54\\" value=\\"Item-7\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField58",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField58\\" readonly=\\"\\" value=\\"ReadOnly Item-8\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField61",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField61\\" value=\\"Item-8\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField65",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField65\\" readonly=\\"\\" value=\\"ReadOnly Item-9\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField68",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField68\\" value=\\"Item-9\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleIndex": 34,
   },
 ]
 `;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of GroupedList (GroupedList.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of GroupedList (GroupedList.Custom.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of GroupedList (GroupedList.CustomCheckbox.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of HoverCard (HoverCard.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#header0-check",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element does not have text that is visible to screen readers.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
-    },
-    "ruleId": "aria-toggle-field-name",
-    "ruleIndex": 13,
-  },
-]
-`;
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of HoverCard (HoverCard.EventListenerTarget.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of HoverCard (HoverCard.InstantDismiss.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of HoverCard (HoverCard.PlainCard.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#header0-check",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element does not have text that is visible to screen readers.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
-    },
-    "ruleId": "aria-toggle-field-name",
-    "ruleIndex": 13,
-  },
-]
-`;
+exports[`a11y test checks accessibility of HoverCard (HoverCard.PlainCard.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of HoverCard (HoverCard.Target.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#header0-check",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element does not have text that is visible to screen readers.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
-    },
-    "ruleId": "aria-toggle-field-name",
-    "ruleIndex": 13,
-  },
-]
-`;
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Target.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Icon (Icon.Basic.Example) 1`] = `Array []`;
 
@@ -3012,8 +4142,6 @@ exports[`a11y test checks accessibility of Icon (Icon.Color.Example) 1`] = `Arra
 exports[`a11y test checks accessibility of Icon (Icon.ImageSheet.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Icon (Icon.Svg.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Icon (Icon.SvgFactory.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Image (Image.Center.Example) 1`] = `Array []`;
 
@@ -3040,7 +4168,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".root-21",
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
             "kind": "element",
           },
         ],
@@ -3051,7 +4179,167 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-21\\">",
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-1-a\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-1-a\\" data-ktp-execute-target=\\"ktp-1-a\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-2-a\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-2-a\\" data-ktp-execute-target=\\"ktp-2-a\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".css-18",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div aria-describedby=\\"ktp-layer-id ktp-2-b\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-2-b\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-18\\" tabindex=\\"0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-29",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-29\\" aria-describedby=\\"ktp-layer-id ktp-0-0\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-0\\" data-ktp-execute-target=\\"ktp-0-0\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-0-1\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-1\\" data-ktp-execute-target=\\"ktp-0-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-22",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-22\\">",
             },
           },
         },
@@ -3059,23 +4347,23 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 19,
+    "ruleIndex": 15,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of Keytip (Keytips.CommandBar.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Keytip (Keytips.Dynamic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Keytip (Keytips.Overflow.Example) 1`] = `
 Array [
@@ -3086,7 +4374,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".ms-Button--hasMenu",
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 1\\"]",
             "kind": "element",
           },
         ],
@@ -3097,24 +4385,157 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar ms-Button--hasMenu root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
+              "text": "<button type=\\"button\\" name=\\"Link 1\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-q\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-q\\" data-ktp-execute-target=\\"ktp-q\\">",
             },
           },
         },
       },
     ],
     "message": Object {
-      "markdown": "Fix any of the following:
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 2\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" name=\\"Link 2\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-w\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-w\\" data-ktp-execute-target=\\"ktp-w\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[name=\\"Link\\\\ 3\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" name=\\"Link 3\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-e\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-e\\" data-ktp-execute-target=\\"ktp-e\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-11",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-11",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 19,
+    "ruleIndex": 15,
   },
 ]
 `;
@@ -3147,11 +4568,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -3162,7 +4583,42 @@ exports[`a11y test checks accessibility of Layer (Layer.Customized.Example) 1`] 
 
 exports[`a11y test checks accessibility of Layer (Layer.Hosted.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Link (Link.Basic.Example) 1`] = `Array []`;
 
@@ -3190,7 +4646,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-29\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-32\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -3206,7 +4662,7 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 38,
+    "ruleIndex": 34,
   },
 ]
 `;
@@ -3231,7 +4687,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<ul class=\\"photoList-136\\">",
+              "text": "<ul>",
             },
           },
         },
@@ -3243,18 +4699,125 @@ Array [
       "text": "Fix all of the following: List element has direct children that are not allowed inside <li> elements.",
     },
     "ruleId": "list",
-    "ruleIndex": 49,
+    "ruleIndex": 44,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of MessageBar (MessageBar.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of MessageBar (MessageBar.Styled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-Nav-linkText linkText-1\\">Documents</div>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+    },
+    "ruleId": "color-contrast",
+    "ruleIndex": 17,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Nav (Nav.CustomGroupHeaders.Example) 1`] = `Array []`;
 
@@ -3262,39 +4825,839 @@ exports[`a11y test checks accessibility of Nav (Nav.FabricDemoApp.Example) 1`] =
 
 exports[`a11y test checks accessibility of Nav (Nav.Nested.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-Button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.BasicReversed.Example) 1`] = `Array []`;
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-20",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-20\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `Array []`;
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Add\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Upload\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Share\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-haspopup=\\"true\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Overlay (Overlay.Dark.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Overlay (Overlay.Light.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Panel (Panel.ConfirmDismiss.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.Custom.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.CustomLeft.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.ExtraLarge.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Panel (Panel.HiddenOnDismiss.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Large.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.LargeFixed.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Panel (Panel.LightDismiss.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Panel (Panel.LightDismissCustom.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.Medium.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Panel (Panel.NonModal.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Sizes.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Panel (Panel.PreventDefault.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Scroll.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallFluid.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallLeft.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Panel (Panel.SmallRight.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Persona (Persona.Alternate.Example) 1`] = `Array []`;
 
@@ -3310,15 +5673,58 @@ exports[`a11y test checks accessibility of Persona (Persona.Initials.Example) 1`
 
 exports[`a11y test checks accessibility of Persona (Persona.Presence.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Persona (Persona.PresenceColor.Example) 1`] = `Array []`;
-
 exports[`a11y test checks accessibility of Persona (Persona.UnknownPersona.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Pivot (Pivot.AlwaysRender.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Pivot (Pivot.Fabric.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#Pivot0-Tab2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"Pivot0-Tab2\\" class=\\"ms-Button ms-Button--action ms-Button--command ms-Pivot-link link-17\\" role=\\"tab\\" aria-selected=\\"false\\" data-content=\\" xx\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Large.Example) 1`] = `Array []`;
 
@@ -3328,7 +5734,89 @@ exports[`a11y test checks accessibility of Pivot (Pivot.Override.Example) 1`] = 
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Remove.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div aria-labelledby=\\"ShapeColorPivot_rectangleRed\\" role=\\"tabitem\\" style=\\"float:left;width:100px;height:200px;background:red\\"></div>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Role must be one of the valid ARIA roles.",
+      "text": "Fix all of the following: Role must be one of the valid ARIA roles.",
+    },
+    "ruleId": "aria-roles",
+    "ruleIndex": 10,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.SeparateNoSelectedKey.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-Button--icon",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-15\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-16\\"><i data-icon-name=\\"Settings\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-21\\" style=\\"color:blue\\"></i></div></button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Element is in tab order and does not have accessible text.
+
+Fix any of the following:
+- Element has a value attribute and the value attribute is empty.
+- Element has no value attribute or the value attribute is empty.
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 15,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Tabs.Example) 1`] = `Array []`;
 
@@ -4620,6 +7108,70 @@ Array [
     "ruleId": "aria-allowed-role",
     "ruleIndex": 3,
   },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#Rating12-star-0 > span",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<span id=\\"RatingLabel13-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Document has multiple static elements with the same id attribute.",
+      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
+    },
+    "ruleId": "duplicate-id",
+    "ruleIndex": 20,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#Rating15-star-0 > span",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<span id=\\"RatingLabel16-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Document has multiple static elements with the same id attribute.",
+      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
+    },
+    "ruleId": "duplicate-id",
+    "ruleIndex": 20,
+  },
 ]
 `;
 
@@ -4771,7 +7323,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -4794,386 +7346,19 @@ exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.OverflowSet.
 
 exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.VerticalOverflowSet.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.Default.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-ScrollablePane--contentContainer",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div class=\\"ms-ScrollablePane--contentContainer contentContainer-1\\" data-is-scrollable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element should have focusable content.
-- Element should be focusable.",
-      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
-    },
-    "ruleId": "scrollable-region-focusable",
-    "ruleIndex": 58,
-  },
-]
-`;
+exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.Default.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.DetailsList.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.CustomIcon.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox0",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Filter\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.CustomIcon.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Disabled.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox0",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input disabled=\\"\\" id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input disabled=\\"\\" id=\\"SearchBox1\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"search\\" class=\\"ms-SearchBox is-disabled root-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-    },
-    "ruleId": "landmark-unique",
-    "ruleIndex": 46,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Disabled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.FullSize.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox0",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input id=\\"SearchBox1\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search with no animation\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-SearchBox.root-1[role=\\"search\\"]:nth-child(1)",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"search\\" class=\\"ms-SearchBox root-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
-    },
-    "ruleId": "landmark-unique",
-    "ruleIndex": 46,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.FullSize.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Small.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox0",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Small.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#SearchBox0",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Basic.Example) 1`] = `
 Array [
@@ -5207,7 +7392,7 @@ Array [
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
     "ruleId": "aria-required-parent",
-    "ruleIndex": 10,
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -5244,7 +7429,7 @@ Array [
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
     "ruleId": "aria-required-parent",
-    "ruleIndex": 10,
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -5274,7 +7459,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#Slider0",
+            "fullyQualifiedName": ".titleLabel-19",
             "kind": "element",
           },
         ],
@@ -5285,7 +7470,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div id=\\"Slider0\\" aria-valuenow=\\"0\\" aria-valuemin=\\"0\\" aria-valuemax=\\"10\\" aria-valuetext=\\"0\\" aria-disabled=\\"false\\" class=\\"ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-4\\" role=\\"slider\\" tabindex=\\"0\\" data-is-focusable=\\"true\\">",
+              "text": "<label class=\\"ms-Label titleLabel-19\\" for=\\"Slider2\\">Disabled example</label>",
             },
           },
         },
@@ -5293,13 +7478,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
-    "ruleId": "aria-input-field-name",
-    "ruleIndex": 7,
+    "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
   Object {
     "kind": "fail",
@@ -5327,11 +7510,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -5345,6 +7528,38 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
+            "fullyQualifiedName": ".titleLabel-19",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<label class=\\"ms-Label titleLabel-19\\" for=\\"Slider1\\">Disabled</label>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+    },
+    "ruleId": "color-contrast",
+    "ruleIndex": 17,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
             "fullyQualifiedName": ".valueLabel-20",
             "kind": "element",
           },
@@ -5364,11 +7579,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -5385,7 +7600,42 @@ exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicWithIconD
 
 exports[`a11y test checks accessibility of SpinButton (SpinButton.CustomStyled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#input1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" value=\\"7 cm\\" id=\\"input1\\" class=\\"ms-spinButton-input css-5\\" autocomplete=\\"off\\" role=\\"spinbutton\\" aria-labelledby=\\"Label0\\" aria-valuetext=\\"7 cm\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-disabled=\\"false\\" data-lpignore=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Required ARIA attribute not present: aria-valuenow.",
+      "text": "Fix any of the following: Required ARIA attribute not present: aria-valuenow.",
+    },
+    "ruleId": "aria-required-attr",
+    "ruleIndex": 7,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Spinner (Spinner.Basic.Example) 1`] = `Array []`;
 
@@ -5424,7 +7674,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".valueLabel-33",
+            "fullyQualifiedName": ".titleLabel-33",
             "kind": "element",
           },
         ],
@@ -5435,7 +7685,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label class=\\"ms-Label ms-Slider-value valueLabel-33\\">200</label>",
+              "text": "<label class=\\"ms-Label titleLabel-33\\" for=\\"Slider5\\">Container height:</label>",
             },
           },
         },
@@ -5443,11 +7693,43 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".valueLabel-34",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<label class=\\"ms-Label ms-Slider-value valueLabel-34\\">200</label>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+    },
+    "ruleId": "color-contrast",
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -5639,7 +7921,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker17-a-0",
+            "fullyQualifiedName": "#swatchColorPicker18-a-0",
             "kind": "element",
           },
         ],
@@ -5650,7 +7932,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -5671,7 +7953,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker17-b-1",
+            "fullyQualifiedName": "#swatchColorPicker18-b-1",
             "kind": "element",
           },
         ],
@@ -5682,7 +7964,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -5703,7 +7985,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker17-c-2",
+            "fullyQualifiedName": "#swatchColorPicker18-c-2",
             "kind": "element",
           },
         ],
@@ -5714,7 +7996,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
         },
@@ -5735,7 +8017,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker17-d-3",
+            "fullyQualifiedName": "#swatchColorPicker18-d-3",
             "kind": "element",
           },
         ],
@@ -5746,7 +8028,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -5767,7 +8049,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker17-e-4",
+            "fullyQualifiedName": "#swatchColorPicker18-e-4",
             "kind": "element",
           },
         ],
@@ -5778,7 +8060,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
         },
@@ -5799,7 +8081,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker34-a-0",
+            "fullyQualifiedName": "#swatchColorPicker36-a-0",
             "kind": "element",
           },
         ],
@@ -5810,7 +8092,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -5831,7 +8113,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker34-b-1",
+            "fullyQualifiedName": "#swatchColorPicker36-b-1",
             "kind": "element",
           },
         ],
@@ -5842,7 +8124,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -5863,7 +8145,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker34-c-2",
+            "fullyQualifiedName": "#swatchColorPicker36-c-2",
             "kind": "element",
           },
         ],
@@ -5874,7 +8156,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
         },
@@ -5895,7 +8177,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker34-d-3",
+            "fullyQualifiedName": "#swatchColorPicker36-d-3",
             "kind": "element",
           },
         ],
@@ -5906,7 +8188,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -5927,7 +8209,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker34-e-4",
+            "fullyQualifiedName": "#swatchColorPicker36-e-4",
             "kind": "element",
           },
         ],
@@ -5938,7 +8220,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
         },
@@ -5959,7 +8241,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-a-0",
+            "fullyQualifiedName": "#swatchColorPicker54-a-0",
             "kind": "element",
           },
         ],
@@ -5970,7 +8252,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
             },
           },
         },
@@ -5991,7 +8273,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-b-1",
+            "fullyQualifiedName": "#swatchColorPicker54-b-1",
             "kind": "element",
           },
         ],
@@ -6002,7 +8284,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -6023,7 +8305,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-c-2",
+            "fullyQualifiedName": "#swatchColorPicker54-c-2",
             "kind": "element",
           },
         ],
@@ -6034,7 +8316,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
             },
           },
         },
@@ -6055,7 +8337,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-d-3",
+            "fullyQualifiedName": "#swatchColorPicker54-d-3",
             "kind": "element",
           },
         ],
@@ -6066,7 +8348,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
             },
           },
         },
@@ -6087,7 +8369,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-e-4",
+            "fullyQualifiedName": "#swatchColorPicker54-e-4",
             "kind": "element",
           },
         ],
@@ -6098,7 +8380,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
             },
           },
         },
@@ -6119,7 +8401,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-f-5",
+            "fullyQualifiedName": "#swatchColorPicker54-f-5",
             "kind": "element",
           },
         ],
@@ -6130,7 +8412,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -6151,7 +8433,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-g-6",
+            "fullyQualifiedName": "#swatchColorPicker54-g-6",
             "kind": "element",
           },
         ],
@@ -6162,7 +8444,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
             },
           },
         },
@@ -6183,7 +8465,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-h-7",
+            "fullyQualifiedName": "#swatchColorPicker54-h-7",
             "kind": "element",
           },
         ],
@@ -6194,7 +8476,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -6215,7 +8497,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-i-8",
+            "fullyQualifiedName": "#swatchColorPicker54-i-8",
             "kind": "element",
           },
         ],
@@ -6226,7 +8508,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
             },
           },
         },
@@ -6247,7 +8529,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-j-9",
+            "fullyQualifiedName": "#swatchColorPicker54-j-9",
             "kind": "element",
           },
         ],
@@ -6258,7 +8540,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
             },
           },
         },
@@ -6279,7 +8561,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-k-10",
+            "fullyQualifiedName": "#swatchColorPicker54-k-10",
             "kind": "element",
           },
         ],
@@ -6290,7 +8572,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
             },
           },
         },
@@ -6311,7 +8593,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker51-l-11",
+            "fullyQualifiedName": "#swatchColorPicker54-l-11",
             "kind": "element",
           },
         ],
@@ -6322,7 +8604,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
             },
           },
         },
@@ -6343,7 +8625,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker89-a-0",
+            "fullyQualifiedName": "#swatchColorPicker93-a-0",
             "kind": "element",
           },
         ],
@@ -6354,7 +8636,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -6375,7 +8657,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker89-b-1",
+            "fullyQualifiedName": "#swatchColorPicker93-b-1",
             "kind": "element",
           },
         ],
@@ -6386,7 +8668,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -6407,7 +8689,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker89-c-2",
+            "fullyQualifiedName": "#swatchColorPicker93-c-2",
             "kind": "element",
           },
         ],
@@ -6418,7 +8700,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -6439,7 +8721,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker89-d-3",
+            "fullyQualifiedName": "#swatchColorPicker93-d-3",
             "kind": "element",
           },
         ],
@@ -6450,7 +8732,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -6471,7 +8753,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker89-e-4",
+            "fullyQualifiedName": "#swatchColorPicker93-e-4",
             "kind": "element",
           },
         ],
@@ -6482,7 +8764,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -6505,107 +8787,62 @@ exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Conden
 
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Illustration.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.MultiStep.Example) 1`] = `Array []`;
-
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.SmallHeadline.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Wide.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.WideIllustration.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Text (Text.Block.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Text (Text.Ramp.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-DetailsList",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element should have focusable content.
-- Element should be focusable.",
-      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
-    },
-    "ruleId": "scrollable-region-focusable",
-    "ruleIndex": 58,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Text (Text.Weights.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-DetailsList",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element should have focusable content.
-- Element should be focusable.",
-      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
-    },
-    "ruleId": "scrollable-region-focusable",
-    "ruleIndex": 58,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Text (Text.Ramp.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Text (Text.Wrap.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField12",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField12\\" required=\\"\\" value=\\"\\" class=\\"ms-TextField-field field-5\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 34,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of TextField (TextField.Borderless.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TextField (TextField.Controlled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.Multiline.Example) 1`] = `
+exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -6614,7 +8851,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#TextField3",
+            "fullyQualifiedName": "#TextField2",
             "kind": "element",
           },
         ],
@@ -6625,7 +8862,71 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<textarea id=\\"TextField3\\" rows=\\"3\\" disabled=\\"\\" class=\\"ms-TextField-field field-12\\" aria-labelledby=\\"TextFieldLabel5\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Only title used to generate label for form element.",
+      "text": "Fix all of the following: Only title used to generate label for form element.",
+    },
+    "ruleId": "label-title-only",
+    "ruleIndex": 35,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -6633,15 +8934,24 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element should have focusable content.
-- Element should be focusable.",
-      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
-    "ruleId": "scrollable-region-focusable",
-    "ruleIndex": 58,
+    "ruleId": "label",
+    "ruleIndex": 34,
   },
 ]
 `;
+
+exports[`a11y test checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Multiline.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TextField (TextField.PrefixAndSuffix.Example) 1`] = `
 Array [
@@ -6652,7 +8962,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".prefix-14 > span",
+            "fullyQualifiedName": ".prefix-15 > span",
             "kind": "element",
           },
         ],
@@ -6671,11 +8981,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 20,
+    "ruleIndex": 17,
   },
 ]
 `;
@@ -6684,185 +8994,262 @@ exports[`a11y test checks accessibility of TextField (TextField.Styled.Example) 
 
 exports[`a11y test checks accessibility of Toggle (Toggle.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Toggle (Toggle.CustomLabel.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Absolute.Position.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#targetButton1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" id=\\"targetButton1\\" aria-labelledby=\\"tooltipHost0\\" style=\\"position:absolute;top:50px;left:200px\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.AbsolutePosition.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost10\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost10\\">Hover Over Me</button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost21\\"]",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost21\\">Hover Over Me</button>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.NoScroll.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" aria-labelledby=\\"text-tooltip0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix all of the following:
+- Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
+      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"text-tooltip0\\".",
+    },
+    "ruleId": "aria-valid-attr-value",
+    "ruleIndex": 12,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Overflow.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of pickers (TagPicker.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Compact.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Controlled.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-BasePicker-input",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input autocapitalize=\\"off\\" autocomplete=\\"off\\" aria-autocomplete=\\"both\\" spellcheck=\\"false\\" class=\\"ms-BasePicker-input input-2\\" aria-controls=\\" \\" role=\\"textbox\\" value=\\"\\" data-lpignore=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 38,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.LimitedSearch.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.List.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Normal.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.PreselectedItems.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\30 \\"] > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 19,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\31 \\"] > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 19,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\32 \\"] > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 19,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.ProcessSelection.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Types.Example) 1`] = `Array []`;

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Basic.Exam
 
 exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Example) 2`] = `Array []`;
-
 exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 2`] = `Array []`;
 
 exports[`a11y test checks accessibility of Announced (Announced.BulkOperations.Example) 1`] = `Array []`;
 

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -4,17 +4,57 @@ exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Basic.Exam
 
 exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Example) 2`] = `Array []`;
+
 exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Announced (Announced.BulkOperations.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Announced (Announced.LazyLoading.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Announced (Announced.QuickActions.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of Announced (Announced.QuickActions.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-DetailsList",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element should have focusable content.
+- Element should be focusable.",
+      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
+    },
+    "ruleId": "scrollable-region-focusable",
+    "ruleIndex": 58,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Announced (Announced.SearchResults.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Collapsing.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Breadcrumb (Breadcrumb.Static.Example) 1`] = `Array []`;
 
@@ -24,623 +64,23 @@ exports[`a11y test checks accessibility of Button (Button.Anchor.Example) 1`] = 
 
 exports[`a11y test checks accessibility of Button (Button.Command.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-16",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Button (Button.CommandBar.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Compound.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.ContextualMenu.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-10",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-10",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-Button--icon",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-16",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Button (Button.CustomSplit.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Default.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Icon.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of Button (Button.IconWithTooltip.Example) 1`] = `Array []`;
+
 exports[`a11y test checks accessibility of Button (Button.ScreenReader.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div:nth-child(1) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-34",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-34\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div:nth-child(2) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div:nth-child(3) > .css-10[data-is-focusable=\\"true\\"][role=\\"button\\"] > span > .root-25",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-25\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-36",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button is-disabled root-36\\" aria-disabled=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Button (Button.Split.Example) 2`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-10",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-      "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
-    },
-    "ruleId": "aria-allowed-attr",
-    "ruleIndex": 2,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-10",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-10\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-Button--icon",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" class=\\"ms-Button ms-Button--icon root-1\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-16",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button root-16\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Button (Button.Split.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Button (Button.Toggle.Example) 1`] = `Array []`;
 
@@ -666,7 +106,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -674,11 +114,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -698,7 +138,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -706,11 +146,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -730,7 +170,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -738,11 +178,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -762,7 +202,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -770,11 +210,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -794,7 +234,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -802,11 +242,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -826,7 +266,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button ms-DatePicker-day--today undefined\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button ms-DatePicker-day--today undefined\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"true\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -834,11 +274,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"true\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"true\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -858,7 +298,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -866,11 +306,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -890,7 +330,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -898,11 +338,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -922,7 +362,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -930,11 +370,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -954,7 +394,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -962,11 +402,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -986,7 +426,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -994,11 +434,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1018,7 +458,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1026,11 +466,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1050,7 +490,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1058,11 +498,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1082,7 +522,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1090,11 +530,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1114,7 +554,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1122,11 +562,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1146,7 +586,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1154,11 +594,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1178,7 +618,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1186,11 +626,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1210,7 +650,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1218,11 +658,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1242,7 +682,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1250,11 +690,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1274,7 +714,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1282,11 +722,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1306,7 +746,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1314,11 +754,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1338,7 +778,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1346,11 +786,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1370,7 +810,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1378,11 +818,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1402,7 +842,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1410,11 +850,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1434,7 +874,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1442,11 +882,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1466,7 +906,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1474,11 +914,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1498,7 +938,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1506,11 +946,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1530,7 +970,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1538,11 +978,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1562,7 +1002,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1570,11 +1010,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1594,7 +1034,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1602,11 +1042,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1626,7 +1066,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1634,11 +1074,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1658,7 +1098,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1666,11 +1106,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1690,7 +1130,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1698,11 +1138,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1722,7 +1162,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1730,11 +1170,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -1754,7 +1194,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -1762,11 +1202,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- ARIA role gridcell  is not allowed for given element.",
-      "text": "Fix any of the following: ARIA role gridcell  is not allowed for given element.",
+- ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
+      "text": "Fix any of the following: ARIA attributes are not allowed: aria-readonly=\\"true\\" aria-selected=\\"false\\".",
     },
-    "ruleId": "aria-allowed-role",
-    "ruleIndex": 3,
+    "ruleId": "aria-allowed-attr",
+    "ruleIndex": 2,
   },
   Object {
     "kind": "fail",
@@ -2170,7 +1610,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-DatePicker-day-button\\" role=\\"gridcell\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
+              "text": "<button class=\\"ms-DatePicker-day-button\\" aria-label=\\"January 6, 2017\\" id=\\"DatePickerDay-active0\\" aria-readonly=\\"true\\" aria-selected=\\"false\\" data-is-focusable=\\"true\\" aria-disabled=\\"false\\" type=\\"button\\"><span aria-hidden=\\"true\\">6</span></button>",
             },
           },
         },
@@ -2182,7 +1622,7 @@ Array [
       "text": "Fix any of the following: Document has multiple elements referenced with ARIA with the same id attribute: DatePickerDay-active0.",
     },
     "ruleId": "duplicate-id-aria",
-    "ruleIndex": 22,
+    "ruleIndex": 25,
   },
 ]
 `;
@@ -2195,11 +1635,17 @@ exports[`a11y test checks accessibility of Callout (Callout.Directional.Example)
 
 exports[`a11y test checks accessibility of Callout (Callout.FocusTrap.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of Callout (Callout.Status.Example) 1`] = `Array []`;
+
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Checkbox (Checkbox.Indeterminate.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Checkbox (Checkbox.Other.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Controlled.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ChoiceGroup (ChoiceGroup.Custom.Example) 1`] = `Array []`;
 
@@ -2213,7 +1659,13 @@ exports[`a11y test checks accessibility of Coachmark (Coachmark.Basic.Example) 1
 
 exports[`a11y test checks accessibility of ColorPicker (ColorPicker.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.Controlled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.ControlledMulti.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ComboBox (ComboBox.CustomStyled.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -2222,7 +1674,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#ComboBox23-label",
+            "fullyQualifiedName": "#ComboBox0-error",
             "kind": "element",
           },
         ],
@@ -2233,7 +1685,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label id=\\"ComboBox23-label\\" for=\\"ComboBox23-input\\" class=\\"ms-Label root-30\\">Disabled ComboBox</label>",
+              "text": "<div role=\\"region\\" aria-live=\\"polite\\" aria-atomic=\\"true\\" id=\\"ComboBox0-error\\" class=\\"\\"></div>",
             },
           },
         },
@@ -2241,18 +1693,51 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
     },
-    "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleId": "landmark-unique",
+    "ruleIndex": 46,
   },
 ]
 `;
 
-exports[`a11y test checks accessibility of ComboBox (ComboBox.Controlled.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of ComboBox (ComboBox.CustomStyled.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ComboBox (ComboBox.ErrorHandling.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#ComboBox0-error",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"region\\" aria-live=\\"polite\\" aria-atomic=\\"true\\" id=\\"ComboBox0-error\\" class=\\"css-2\\">Oh no! This ComboBox has an error!</div>",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+    },
+    "ruleId": "landmark-unique",
+    "ruleIndex": 46,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of ComboBox (ComboBox.Toggles.Example) 1`] = `Array []`;
 
@@ -2264,7 +1749,7 @@ exports[`a11y test checks accessibility of CommandBar (CommandBar.ButtonAs.Examp
 
 exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of CommandBar (CommandBar.CommandBarButtonAs.Example) 2`] = `Array []`;
+exports[`a11y test checks accessibility of CommandBar (CommandBar.Lazy.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of CommandBar (CommandBar.SplitDisabled.Example) 1`] = `Array []`;
 
@@ -2279,6 +1764,8 @@ exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Custom
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Customization.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.CustomizationWithNoWrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Default.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of ContextualMenu (ContextualMenu.Directional.Example) 1`] = `Array []`;
 
@@ -2338,7 +1825,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-38\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"false\\"><span id=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellName cellName-39\\"></span></span>",
+              "text": "<span id=\\"header0-thumbnail\\" aria-labelledby=\\"header0-thumbnail-name\\" class=\\"ms-DetailsHeader-cellTitle cellTitle-29\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-describedby=\\"header0-thumbnail-tooltip\\" aria-haspopup=\\"false\\">",
             },
           },
         },
@@ -2346,18 +1833,16 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 15,
+    "ruleIndex": 19,
   },
 ]
 `;
@@ -2366,7 +1851,45 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomFooter
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomGroupHeaders.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomRows.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of DetailsList (DetailsList.CustomRows.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#header0-check",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-3 ms-DetailsRow-check--isHeader ms-Check-checkHost check-18\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element does not have text that is visible to screen readers.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
+    },
+    "ruleId": "aria-toggle-field-name",
+    "ruleIndex": 13,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.Documents.Example) 1`] = `Array []`;
 
@@ -2378,116 +1901,11 @@ exports[`a11y test checks accessibility of DetailsList (DetailsList.Grouped.Larg
 
 exports[`a11y test checks accessibility of DetailsList (DetailsList.NavigatingFocus.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Dialog (Dialog.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Dialog (Dialog.Blocking.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Dialog (Dialog.LargeHeader.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Dialog (Dialog.Modeless.Example) 1`] = `
 Array [
@@ -2498,71 +1916,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "button[aria-labelledby=\\"id__1\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__1\\" aria-describedby=\\"id__2\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__2\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-labelledby=\\"id__4\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__4\\" aria-describedby=\\"id__5\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__5\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "input[type=\\"text\\"]",
+            "fullyQualifiedName": "input",
             "kind": "element",
           },
         ],
@@ -2589,47 +1943,12 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleIndex": 38,
   },
 ]
 `;
 
-exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Dialog (Dialog.TopOffsetFixed.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Divider (VerticalDivider.Basic.Example) 1`] = `Array []`;
 
@@ -2665,7 +1984,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label class=\\"ms-Label ms-Dropdown-label label-26\\" id=\\"Dropdown1-label\\" for=\\"Dropdown1\\">Disabled example with defaultSelectedKey</label>",
+              "text": "<label class=\\"ms-Label ms-Dropdown-label root-24\\" id=\\"Dropdown1-label\\">Disabled example with defaultSelectedKey</label>",
             },
           },
         },
@@ -2673,11 +1992,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -2712,7 +2031,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
             },
           },
         },
@@ -2724,7 +2043,7 @@ Array [
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
     "ruleId": "aria-required-children",
-    "ruleIndex": 8,
+    "ruleIndex": 9,
   },
 ]
 `;
@@ -2749,7 +2068,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
             },
           },
         },
@@ -2761,14 +2080,18 @@ Array [
       "text": "Fix any of the following: Required ARIA child role not present: listitem.",
     },
     "ruleId": "aria-required-children",
-    "ruleIndex": 8,
+    "ruleIndex": 9,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of Facepile (Facepile.AddFace.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Facepile (Facepile.Basic.Example) 1`] = `
+exports[`a11y test checks accessibility of Facepile (Facepile.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Facepile (Facepile.Overflow.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FloatingPicker/PeoplePicker (FloatingPeoplePicker.Basic.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -2777,7 +2100,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "button",
+            "fullyQualifiedName": "#SearchBox0",
             "kind": "element",
           },
         ],
@@ -2788,130 +2111,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" data-is-focusable=\\"true\\" aria-hidden=\\"true\\" title=\\"Alex Lundberg\\" class=\\"ms-Button ms-Facepile-itemButton ms-Facepile-person ms-Button--facepile itemButton-19\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Focusable content should be disabled or be removed from the DOM.",
-      "text": "Fix all of the following: Focusable content should be disabled or be removed from the DOM.",
-    },
-    "ruleId": "aria-hidden-focus",
-    "ruleIndex": 6,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of Facepile (Facepile.Overflow.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" data-is-focusable=\\"true\\" aria-hidden=\\"true\\" title=\\"Alex Lundberg\\" class=\\"ms-Button ms-Facepile-itemButton ms-Facepile-person ms-Button--facepile itemButton-19\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Focusable content should be disabled or be removed from the DOM.",
-      "text": "Fix all of the following: Focusable content should be disabled or be removed from the DOM.",
-    },
-    "ruleId": "aria-hidden-focus",
-    "ruleIndex": 6,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of FloatingPicker/PeoplePicker (FloatingPeoplePicker.Basic.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Click.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.FocusOnCustomElement.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.FocusZone.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField7",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search for person\\" value=\\"\\" role=\\"searchbox\\">",
             },
           },
         },
@@ -2927,7 +2127,244 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleIndex": 38,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Click.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Box.FocusOnCustomElement.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.DialogInPanel.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.FocusZone.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusTrapZone (FocusTrapZone.Nested.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Disabled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.HorizontalMenu.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField2",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField2\\" readonly=\\"\\" value=\\"ReadOnly Item-0\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField5",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField5\\" value=\\"Item-0\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField9",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField9\\" readonly=\\"\\" value=\\"ReadOnly Item-1\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField12",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField12\\" value=\\"Item-1\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField16",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField16\\" readonly=\\"\\" value=\\"ReadOnly Item-2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField19",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField19\\" value=\\"Item-2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
   },
   Object {
     "kind": "fail",
@@ -2947,7 +2384,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField23\\" value=\\"Tabbable Element 2\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField23\\" readonly=\\"\\" value=\\"ReadOnly Item-3\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -2963,1118 +2400,7 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 34,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.List.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\30 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"0\\" data-item-index=\\"0\\" aria-rowindex=\\"1\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\31 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"1\\" data-item-index=\\"1\\" aria-rowindex=\\"2\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone5\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\32 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"2\\" data-item-index=\\"2\\" aria-rowindex=\\"3\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone9\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\33 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"3\\" data-item-index=\\"3\\" aria-rowindex=\\"4\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone13\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\34 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"4\\" data-item-index=\\"4\\" aria-rowindex=\\"5\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone17\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\35 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"5\\" data-item-index=\\"5\\" aria-rowindex=\\"6\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone21\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\36 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"6\\" data-item-index=\\"6\\" aria-rowindex=\\"7\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone25\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\37 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"7\\" data-item-index=\\"7\\" aria-rowindex=\\"8\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone29\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\38 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"8\\" data-item-index=\\"8\\" aria-rowindex=\\"9\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone33\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[data-selection-index=\\"\\\\39 \\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div role=\\"row\\" class=\\"ms-FocusZone css-29 ms-DetailsRow css-45 root-0\\" data-is-focusable=\\"true\\" data-selection-index=\\"9\\" data-item-index=\\"9\\" aria-rowindex=\\"10\\" data-automationid=\\"DetailsRow\\" style=\\"min-width:0\\" data-focuszone-id=\\"FocusZone37\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA parents role not present: rowgroup grid treegrid table.",
-      "text": "Fix any of the following: Required ARIA parents role not present: rowgroup grid treegrid table.",
-    },
-    "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\33 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\34 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\35 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\36 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\37 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\38 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\39 \\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 0\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 1\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 2\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 3\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 4\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 5\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 6\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 7\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 8\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\31 9\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "li[aria-posinset=\\"\\\\32 0\\"] > div > img",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<img src=\\"http://placehold.it/50x100\\" class=\\"ms-Image-image ms-Image-image--portrait is-notLoaded is-fadeIn image-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element does not have an alt attribute.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element has no title attribute or the title attribute is empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".",
-      "text": "Fix any of the following: Element does not have an alt attribute. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\".",
-    },
-    "ruleId": "image-alt",
-    "ruleIndex": 31,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField7",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField7\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleIndex": 38,
   },
   Object {
     "kind": "fail",
@@ -4094,7 +2420,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"FocusZone TextField\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField26\\" value=\\"Item-3\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -4110,24 +2436,576 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField30",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField30\\" readonly=\\"\\" value=\\"ReadOnly Item-4\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField33",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField33\\" value=\\"Item-4\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField37",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField37\\" readonly=\\"\\" value=\\"ReadOnly Item-5\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField40",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField40\\" value=\\"Item-5\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField44",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField44\\" readonly=\\"\\" value=\\"ReadOnly Item-6\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField47",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField47\\" value=\\"Item-6\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField51",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField51\\" readonly=\\"\\" value=\\"ReadOnly Item-7\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField54",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField54\\" value=\\"Item-7\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField58",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField58\\" readonly=\\"\\" value=\\"ReadOnly Item-8\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField61",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField61\\" value=\\"Item-8\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField65",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField65\\" readonly=\\"\\" value=\\"ReadOnly Item-9\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#TextField68",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input type=\\"text\\" id=\\"TextField68\\" value=\\"Item-9\\" class=\\"ms-TextField-field field-13\\" aria-invalid=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
   },
 ]
 `;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Photos.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of FocusZone (FocusZone.Tabbable.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of GroupedList (GroupedList.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of GroupedList (GroupedList.Custom.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of HoverCard (HoverCard.Basic.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of GroupedList (GroupedList.CustomCheckbox.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Basic.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#header0-check",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element does not have text that is visible to screen readers.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
+    },
+    "ruleId": "aria-toggle-field-name",
+    "ruleIndex": 13,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of HoverCard (HoverCard.EventListenerTarget.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of HoverCard (HoverCard.InstantDismiss.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of HoverCard (HoverCard.PlainCard.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of HoverCard (HoverCard.PlainCard.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#header0-check",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element does not have text that is visible to screen readers.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
+    },
+    "ruleId": "aria-toggle-field-name",
+    "ruleIndex": 13,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of HoverCard (HoverCard.Target.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of HoverCard (HoverCard.Target.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#header0-check",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div id=\\"header0-check\\" data-is-focusable=\\"true\\" role=\\"checkbox\\" class=\\"ms-DetailsRow-check ms-DetailsHeader-check check-5 ms-DetailsRow-check--isHeader ms-Check-checkHost check-20\\" aria-checked=\\"false\\" data-selection-toggle=\\"true\\" data-automationid=\\"DetailsRowCheck\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.
+- Element does not have text that is visible to screen readers.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty. Element does not have text that is visible to screen readers.",
+    },
+    "ruleId": "aria-toggle-field-name",
+    "ruleIndex": 13,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of Icon (Icon.Basic.Example) 1`] = `Array []`;
 
@@ -4136,6 +3014,8 @@ exports[`a11y test checks accessibility of Icon (Icon.Color.Example) 1`] = `Arra
 exports[`a11y test checks accessibility of Icon (Icon.ImageSheet.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Icon (Icon.Svg.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Icon (Icon.SvgFactory.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Image (Image.Center.Example) 1`] = `Array []`;
 
@@ -4162,7 +3042,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-1-a\\"]",
+            "fullyQualifiedName": ".root-21",
             "kind": "element",
           },
         ],
@@ -4173,167 +3053,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-1-a\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-1-a\\" data-ktp-execute-target=\\"ktp-1-a\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-1-a\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-2-a\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-2-a\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-2-a\\" data-ktp-execute-target=\\"ktp-2-a\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-a\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".css-18",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div aria-describedby=\\"ktp-layer-id ktp-2-b\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-2-b\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-18\\" tabindex=\\"0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-2-b\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-29",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-29\\" aria-describedby=\\"ktp-layer-id ktp-0-0\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-0\\" data-ktp-execute-target=\\"ktp-0-0\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-describedby=\\"ktp-layer-id\\\\ ktp-0-1\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-1\\" aria-describedby=\\"ktp-layer-id ktp-0-1\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-0-1\\" data-ktp-execute-target=\\"ktp-0-1\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-0-1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-22",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-22\\">",
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" data-ktp-execute-target=\\"ktp-2-b\\" tabindex=\\"-1\\" class=\\"ms-Button root-21\\">",
             },
           },
         },
@@ -4341,23 +3061,23 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 15,
+    "ruleIndex": 19,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of Keytip (Keytips.CommandBar.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Keytip (Keytips.Dynamic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Keytip (Keytips.Overflow.Example) 1`] = `
 Array [
@@ -4368,7 +3088,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "button[name=\\"Link\\\\ 1\\"]",
+            "fullyQualifiedName": ".ms-Button--hasMenu",
             "kind": "element",
           },
         ],
@@ -4379,157 +3099,24 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" name=\\"Link 1\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-q\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-q\\" data-ktp-execute-target=\\"ktp-q\\">",
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar ms-Button--hasMenu root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
             },
           },
         },
       },
     ],
     "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-q\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[name=\\"Link\\\\ 2\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" name=\\"Link 2\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-w\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-w\\" data-ktp-execute-target=\\"ktp-w\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-w\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[name=\\"Link\\\\ 3\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" name=\\"Link 3\\" class=\\"ms-Button ms-Button--commandBar root-3\\" aria-describedby=\\"ktp-layer-id ktp-e\\" data-is-focusable=\\"true\\" data-ktp-target=\\"ktp-e\\" data-ktp-execute-target=\\"ktp-e\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-e\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-11",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"ktp-layer-id ktp-r\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-11",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-11\\" aria-describedby=\\"ktp-layer-id ktp-r\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" data-ktp-target=\\"ktp-r\\" data-ktp-execute-target=\\"ktp-r\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
+      "markdown": "Fix any of the following:
 - Element does not have inner text that is visible to screen readers.
 - aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".
 - Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "button-name",
-    "ruleIndex": 15,
+    "ruleIndex": 19,
   },
 ]
 `;
@@ -4562,11 +3149,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -4577,42 +3164,7 @@ exports[`a11y test checks accessibility of Layer (Layer.Customized.Example) 1`] 
 
 exports[`a11y test checks accessibility of Layer (Layer.Hosted.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Layer (Layer.NestedLayers.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Link (Link.Basic.Example) 1`] = `Array []`;
 
@@ -4640,7 +3192,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-32\\" aria-invalid=\\"false\\">",
+              "text": "<input type=\\"text\\" id=\\"TextField14\\" value=\\"0\\" class=\\"ms-TextField-field field-29\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -4656,7 +3208,7 @@ Array [
       "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
     },
     "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleIndex": 38,
   },
 ]
 `;
@@ -4681,7 +3233,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<ul>",
+              "text": "<ul class=\\"photoList-136\\">",
             },
           },
         },
@@ -4693,123 +3245,18 @@ Array [
       "text": "Fix all of the following: List element has direct children that are not allowed inside <li> elements.",
     },
     "ruleId": "list",
-    "ruleIndex": 44,
+    "ruleIndex": 49,
   },
 ]
 `;
 
 exports[`a11y test checks accessibility of MessageBar (MessageBar.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Modal (Modal.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-8\\" aria-labelledby=\\"id__3\\" aria-describedby=\\"id__4\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__4\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Modal (Modal.Modeless.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".link-42 > .ms-Button-flexContainer.flexContainer-31 > .ms-Nav-linkText.linkText-1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div class=\\"ms-Nav-linkText linkText-1\\">Documents</div>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 4.05 (foreground color: #0078d4, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-    },
-    "ruleId": "color-contrast",
-    "ruleIndex": 17,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Nav (Nav.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Nav (Nav.CustomGroupHeaders.Example) 1`] = `Array []`;
 
@@ -4817,387 +3264,27 @@ exports[`a11y test checks accessibility of Nav (Nav.FabricDemoApp.Example) 1`] =
 
 exports[`a11y test checks accessibility of Nav (Nav.Nested.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-Button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Basic.Example) 1`] = `Array []`;
 
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.BasicReversed.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".root-20",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-20\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Custom.Example) 1`] = `Array []`;
 
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
-
-exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(1) > .ms-TooltipHost.root-3 > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Add\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(2) > .ms-TooltipHost.root-3 > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Upload\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".ms-OverflowSet-item.item-1:nth-child(3) > .ms-TooltipHost.root-3 > button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\"><div class=\\"ms-Button-flexContainer flexContainer-5\\"><i data-icon-name=\\"Share\\" role=\\"presentation\\" aria-hidden=\\"true\\" class=\\"ms-Button-icon icon-13\\"></i></div></button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-haspopup=\\"true\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--commandBar root-4\\" data-is-focusable=\\"true\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of OverflowSet (OverflowSet.Vertical.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Overlay (Overlay.Dark.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Overlay (Overlay.Light.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Panel (Panel.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Panel (Panel.ConfirmDismiss.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Panel (Panel.Controlled.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Footer.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.HandleDismissTarget.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Panel (Panel.HiddenOnDismiss.Example) 1`] = `Array []`;
 
@@ -5205,44 +3292,11 @@ exports[`a11y test checks accessibility of Panel (Panel.LightDismiss.Example) 1`
 
 exports[`a11y test checks accessibility of Panel (Panel.LightDismissCustom.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--default root-0\\" aria-labelledby=\\"id__0\\" aria-describedby=\\"id__1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-describedby=\\"id__1\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Panel (Panel.Navigation.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Panel (Panel.NonModal.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Panel (Panel.Sizes.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Persona (Persona.Alternate.Example) 1`] = `Array []`;
 
@@ -5258,56 +3312,15 @@ exports[`a11y test checks accessibility of Persona (Persona.Initials.Example) 1`
 
 exports[`a11y test checks accessibility of Persona (Persona.Presence.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of Persona (Persona.PresenceColor.Example) 1`] = `Array []`;
+
 exports[`a11y test checks accessibility of Persona (Persona.UnknownPersona.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Pivot (Pivot.AlwaysRender.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#Pivot0-Tab2",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"Pivot0-Tab2\\" class=\\"ms-Button ms-Button--action ms-Button--command ms-Pivot-link link-17\\" role=\\"tab\\" aria-selected=\\"false\\" data-content=\\" xx\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Element is in tab order and does not have accessible text.
-
-Fix any of the following:
-- Element has a value attribute and the value attribute is empty.
-- Element has no value attribute or the value attribute is empty.
-- Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Element's default semantics were not overridden with role=\\"presentation\\".
-- Element's default semantics were not overridden with role=\\"none\\".
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix all of the following: Element is in tab order and does not have accessible text. Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
-    },
-    "ruleId": "button-name",
-    "ruleIndex": 15,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Pivot (Pivot.IconCount.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Large.Example) 1`] = `Array []`;
 
@@ -5317,42 +3330,7 @@ exports[`a11y test checks accessibility of Pivot (Pivot.Override.Example) 1`] = 
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Remove.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "div[aria-labelledby=\\"ShapeColorPivot_rectangleRed\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<div aria-labelledby=\\"ShapeColorPivot_rectangleRed\\" role=\\"tabitem\\" style=\\"float:left;width:100px;height:200px;background:red\\"></div>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Role must be one of the valid ARIA roles.",
-      "text": "Fix all of the following: Role must be one of the valid ARIA roles.",
-    },
-    "ruleId": "aria-roles",
-    "ruleIndex": 10,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Pivot (Pivot.Separate.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Pivot (Pivot.Tabs.Example) 1`] = `Array []`;
 
@@ -6644,70 +4622,6 @@ Array [
     "ruleId": "aria-allowed-role",
     "ruleIndex": 3,
   },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#Rating12-star-0 > span",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<span id=\\"RatingLabel13-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Document has multiple static elements with the same id attribute.",
-      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
-    },
-    "ruleId": "duplicate-id",
-    "ruleIndex": 20,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#Rating15-star-0 > span",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<span id=\\"RatingLabel16-2.5\\" class=\\"ms-Rating-labelText labelText-9\\">2.5 of 5 stars selected</span>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Document has multiple static elements with the same id attribute.",
-      "text": "Fix any of the following: Document has multiple static elements with the same id attribute.",
-    },
-    "ruleId": "duplicate-id",
-    "ruleIndex": 20,
-  },
 ]
 `;
 
@@ -6859,7 +4773,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
+              "text": "<button class=\\"ms-Rating-button ratingButton-6 ms-Rating--small ratingStarIsSmall-7\\" id=\\"Rating0-star-4\\" data-is-current=\\"true\\" disabled=\\"\\" role=\\"presentation\\" type=\\"button\\">",
             },
           },
         },
@@ -6882,19 +4796,386 @@ exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.OverflowSet.
 
 exports[`a11y test checks accessibility of ResizeGroup (ResizeGroup.VerticalOverflowSet.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.Default.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.Default.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-ScrollablePane--contentContainer",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-ScrollablePane--contentContainer contentContainer-1\\" data-is-scrollable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element should have focusable content.
+- Element should be focusable.",
+      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
+    },
+    "ruleId": "scrollable-region-focusable",
+    "ruleIndex": 58,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of ScrollablePane (ScrollablePane.DetailsList.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.CustomIcon.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.CustomIcon.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Filter\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Disabled.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Disabled.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input disabled=\\"\\" id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input disabled=\\"\\" id=\\"SearchBox1\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".root-1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"search\\" class=\\"ms-SearchBox is-disabled root-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+    },
+    "ruleId": "landmark-unique",
+    "ruleIndex": 46,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.FullSize.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.FullSize.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox1",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input id=\\"SearchBox1\\" class=\\"ms-SearchBox-field field-5\\" placeholder=\\"Search with no animation\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-SearchBox.root-1[role=\\"search\\"]:nth-child(1)",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div role=\\"search\\" class=\\"ms-SearchBox root-1\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+      "text": "Fix any of the following: The landmark must have a unique aria-label, aria-labelledby, or title to make landmarks distinguishable.",
+    },
+    "ruleId": "landmark-unique",
+    "ruleIndex": 46,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Small.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Small.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+]
+`;
 
-exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Example) 1`] = `Array []`;
+exports[`a11y test checks accessibility of SearchBox (SearchBox.Underlined.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "#SearchBox0",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input id=\\"SearchBox0\\" class=\\"ms-SearchBox-field field-4\\" placeholder=\\"Search\\" value=\\"\\" role=\\"searchbox\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+]
+`;
 
 exports[`a11y test checks accessibility of SelectedItemsList (SelectedPeopleList.Basic.Example) 1`] = `
 Array [
@@ -6928,7 +5209,7 @@ Array [
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
     "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
+    "ruleIndex": 10,
   },
 ]
 `;
@@ -6965,7 +5246,7 @@ Array [
       "text": "Fix any of the following: Required ARIA parent role not present: list.",
     },
     "ruleId": "aria-required-parent",
-    "ruleIndex": 9,
+    "ruleIndex": 10,
   },
 ]
 `;
@@ -6995,7 +5276,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".titleLabel-19",
+            "fullyQualifiedName": "#Slider0",
             "kind": "element",
           },
         ],
@@ -7006,7 +5287,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label class=\\"ms-Label titleLabel-19\\" for=\\"Slider2\\">Disabled example</label>",
+              "text": "<div id=\\"Slider0\\" aria-valuenow=\\"0\\" aria-valuemin=\\"0\\" aria-valuemax=\\"10\\" aria-valuetext=\\"0\\" aria-disabled=\\"false\\" class=\\"ms-Slider-slideBox ms-Slider-showValue ms-Slider-showTransitions slideBox-4\\" role=\\"slider\\" tabindex=\\"0\\" data-is-focusable=\\"true\\">",
             },
           },
         },
@@ -7014,11 +5295,13 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element has no title attribute or the title attribute is empty.",
     },
-    "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleId": "aria-input-field-name",
+    "ruleIndex": 7,
   },
   Object {
     "kind": "fail",
@@ -7046,11 +5329,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -7064,38 +5347,6 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".titleLabel-19",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<label class=\\"ms-Label titleLabel-19\\" for=\\"Slider1\\">Disabled</label>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-    },
-    "ruleId": "color-contrast",
-    "ruleIndex": 17,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
             "fullyQualifiedName": ".valueLabel-20",
             "kind": "element",
           },
@@ -7115,11 +5366,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -7136,42 +5387,7 @@ exports[`a11y test checks accessibility of SpinButton (SpinButton.BasicWithIconD
 
 exports[`a11y test checks accessibility of SpinButton (SpinButton.CustomStyled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#input1",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" value=\\"7 cm\\" id=\\"input1\\" class=\\"ms-spinButton-input css-5\\" autocomplete=\\"off\\" role=\\"spinbutton\\" aria-labelledby=\\"Label0\\" aria-valuetext=\\"7 cm\\" aria-valuemin=\\"0\\" aria-valuemax=\\"100\\" aria-disabled=\\"false\\" data-lpignore=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Required ARIA attribute not present: aria-valuenow.",
-      "text": "Fix any of the following: Required ARIA attribute not present: aria-valuenow.",
-    },
-    "ruleId": "aria-required-attr",
-    "ruleIndex": 7,
-  },
-]
-`;
+exports[`a11y test checks accessibility of SpinButton (SpinButton.Stateful.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Spinner (Spinner.Basic.Example) 1`] = `Array []`;
 
@@ -7210,7 +5426,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".titleLabel-33",
+            "fullyQualifiedName": ".valueLabel-33",
             "kind": "element",
           },
         ],
@@ -7221,7 +5437,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<label class=\\"ms-Label titleLabel-33\\" for=\\"Slider5\\">Container height:</label>",
+              "text": "<label class=\\"ms-Label ms-Slider-value valueLabel-33\\">200</label>",
             },
           },
         },
@@ -7229,43 +5445,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt (14px), font weight: bold). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": ".valueLabel-34",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<label class=\\"ms-Label ms-Slider-value valueLabel-34\\">200</label>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.63 (foreground color: #a19f9d, background color: #ffffff, font size: 10.5pt, font weight: bold). Expected contrast ratio of 4.5:1.",
-    },
-    "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -7457,7 +5641,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker18-a-0",
+            "fullyQualifiedName": "#swatchColorPicker17-a-0",
             "kind": "element",
           },
         ],
@@ -7468,7 +5652,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -7489,7 +5673,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker18-b-1",
+            "fullyQualifiedName": "#swatchColorPicker17-b-1",
             "kind": "element",
           },
         ],
@@ -7500,7 +5684,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -7521,7 +5705,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker18-c-2",
+            "fullyQualifiedName": "#swatchColorPicker17-c-2",
             "kind": "element",
           },
         ],
@@ -7532,7 +5716,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
         },
@@ -7553,7 +5737,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker18-d-3",
+            "fullyQualifiedName": "#swatchColorPicker17-d-3",
             "kind": "element",
           },
         ],
@@ -7564,7 +5748,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-12\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -7585,7 +5769,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker18-e-4",
+            "fullyQualifiedName": "#swatchColorPicker17-e-4",
             "kind": "element",
           },
         ],
@@ -7596,7 +5780,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker18-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker17-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-14\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
         },
@@ -7617,7 +5801,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker36-a-0",
+            "fullyQualifiedName": "#swatchColorPicker34-a-0",
             "kind": "element",
           },
         ],
@@ -7628,7 +5812,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -7649,7 +5833,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker36-b-1",
+            "fullyQualifiedName": "#swatchColorPicker34-b-1",
             "kind": "element",
           },
         ],
@@ -7660,7 +5844,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -7681,7 +5865,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker36-c-2",
+            "fullyQualifiedName": "#swatchColorPicker34-c-2",
             "kind": "element",
           },
         ],
@@ -7692,7 +5876,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" aria-label=\\"blueMagenta\\">",
             },
           },
         },
@@ -7713,7 +5897,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker36-d-3",
+            "fullyQualifiedName": "#swatchColorPicker34-d-3",
             "kind": "element",
           },
         ],
@@ -7724,7 +5908,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-16\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -7745,7 +5929,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker36-e-4",
+            "fullyQualifiedName": "#swatchColorPicker34-e-4",
             "kind": "element",
           },
         ],
@@ -7756,7 +5940,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker36-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker34-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-18\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" aria-label=\\"white\\">",
             },
           },
         },
@@ -7777,7 +5961,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-a-0",
+            "fullyQualifiedName": "#swatchColorPicker51-a-0",
             "kind": "element",
           },
         ],
@@ -7788,7 +5972,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-a-0\\" data-index=\\"0\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"red\\" aria-label=\\"red\\">",
             },
           },
         },
@@ -7809,7 +5993,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-b-1",
+            "fullyQualifiedName": "#swatchColorPicker51-b-1",
             "kind": "element",
           },
         ],
@@ -7820,7 +6004,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-b-1\\" data-index=\\"1\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" aria-label=\\"orange\\">",
             },
           },
         },
@@ -7841,7 +6025,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-c-2",
+            "fullyQualifiedName": "#swatchColorPicker51-c-2",
             "kind": "element",
           },
         ],
@@ -7852,7 +6036,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-c-2\\" data-index=\\"2\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orangeYellow\\" aria-label=\\"orangeYellow\\">",
             },
           },
         },
@@ -7873,7 +6057,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-d-3",
+            "fullyQualifiedName": "#swatchColorPicker51-d-3",
             "kind": "element",
           },
         ],
@@ -7884,7 +6068,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-d-3\\" data-index=\\"3\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"yellowGreen\\" aria-label=\\"yellowGreen\\">",
             },
           },
         },
@@ -7905,7 +6089,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-e-4",
+            "fullyQualifiedName": "#swatchColorPicker51-e-4",
             "kind": "element",
           },
         ],
@@ -7916,7 +6100,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-e-4\\" data-index=\\"4\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"green\\" aria-label=\\"green\\">",
             },
           },
         },
@@ -7937,7 +6121,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-f-5",
+            "fullyQualifiedName": "#swatchColorPicker51-f-5",
             "kind": "element",
           },
         ],
@@ -7948,7 +6132,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-f-5\\" data-index=\\"5\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" aria-label=\\"cyan\\">",
             },
           },
         },
@@ -7969,7 +6153,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-g-6",
+            "fullyQualifiedName": "#swatchColorPicker51-g-6",
             "kind": "element",
           },
         ],
@@ -7980,7 +6164,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-g-6\\" data-index=\\"6\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyanBlue\\" aria-label=\\"cyanBlue\\">",
             },
           },
         },
@@ -8001,7 +6185,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-h-7",
+            "fullyQualifiedName": "#swatchColorPicker51-h-7",
             "kind": "element",
           },
         ],
@@ -8012,7 +6196,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-h-7\\" data-index=\\"7\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" aria-label=\\"magenta\\">",
             },
           },
         },
@@ -8033,7 +6217,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-i-8",
+            "fullyQualifiedName": "#swatchColorPicker51-i-8",
             "kind": "element",
           },
         ],
@@ -8044,7 +6228,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-i-8\\" data-index=\\"8\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magentaPink\\" aria-label=\\"magentaPink\\">",
             },
           },
         },
@@ -8065,7 +6249,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-j-9",
+            "fullyQualifiedName": "#swatchColorPicker51-j-9",
             "kind": "element",
           },
         ],
@@ -8076,7 +6260,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-j-9\\" data-index=\\"9\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"black\\" aria-label=\\"black\\">",
             },
           },
         },
@@ -8097,7 +6281,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-k-10",
+            "fullyQualifiedName": "#swatchColorPicker51-k-10",
             "kind": "element",
           },
         ],
@@ -8108,7 +6292,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-k-10\\" data-index=\\"10\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray\\" aria-label=\\"gray\\">",
             },
           },
         },
@@ -8129,7 +6313,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker54-l-11",
+            "fullyQualifiedName": "#swatchColorPicker51-l-11",
             "kind": "element",
           },
         ],
@@ -8140,7 +6324,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker54-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker51-l-11\\" data-index=\\"11\\" data-is-focusable=\\"true\\" class=\\"ms-Button ms-Button--action ms-Button--command colorCell-20\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"gray20\\" aria-label=\\"gray20\\">",
             },
           },
         },
@@ -8161,7 +6345,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker93-a-0",
+            "fullyQualifiedName": "#swatchColorPicker89-a-0",
             "kind": "element",
           },
         ],
@@ -8172,7 +6356,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-a-0\\" data-index=\\"0\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"orange\\" disabled=\\"\\" aria-label=\\"orange\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -8193,7 +6377,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker93-b-1",
+            "fullyQualifiedName": "#swatchColorPicker89-b-1",
             "kind": "element",
           },
         ],
@@ -8204,7 +6388,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-b-1\\" data-index=\\"1\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"cyan\\" disabled=\\"\\" aria-label=\\"cyan\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -8225,7 +6409,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker93-c-2",
+            "fullyQualifiedName": "#swatchColorPicker89-c-2",
             "kind": "element",
           },
         ],
@@ -8236,7 +6420,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-c-2\\" data-index=\\"2\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"blueMagenta\\" disabled=\\"\\" aria-label=\\"blueMagenta\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -8257,7 +6441,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker93-d-3",
+            "fullyQualifiedName": "#swatchColorPicker89-d-3",
             "kind": "element",
           },
         ],
@@ -8268,7 +6452,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-d-3\\" data-index=\\"3\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-22\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"magenta\\" disabled=\\"\\" aria-label=\\"magenta\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -8289,7 +6473,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#swatchColorPicker93-e-4",
+            "fullyQualifiedName": "#swatchColorPicker89-e-4",
             "kind": "element",
           },
         ],
@@ -8300,7 +6484,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" id=\\"swatchColorPicker93-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" id=\\"swatchColorPicker89-e-4\\" data-index=\\"4\\" data-is-focusable=\\"false\\" class=\\"ms-Button ms-Button--action ms-Button--command undefined is-disabled colorCell-24\\" role=\\"gridcell\\" aria-selected=\\"false\\" title=\\"white\\" disabled=\\"\\" aria-label=\\"white\\" aria-disabled=\\"true\\">",
             },
           },
         },
@@ -8323,17 +6507,17 @@ exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Conden
 
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Illustration.Example) 1`] = `Array []`;
 
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.MultiStep.Example) 1`] = `Array []`;
+
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.SmallHeadline.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.Wide.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TeachingBubble (TeachingBubble.WideIllustration.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Text (Text.Block.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Text (Text.Ramp.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of Text (Text.Wrap.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `
+exports[`a11y test checks accessibility of Text (Text.Ramp.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -8342,7 +6526,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#TextField12",
+            "fullyQualifiedName": ".ms-DetailsList",
             "kind": "element",
           },
         ],
@@ -8353,7 +6537,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField12\\" required=\\"\\" value=\\"\\" class=\\"ms-TextField-field field-5\\" aria-invalid=\\"false\\">",
+              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
             },
           },
         },
@@ -8361,24 +6545,69 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+- Element should have focusable content.
+- Element should be focusable.",
+      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
     },
-    "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleId": "scrollable-region-focusable",
+    "ruleIndex": 58,
   },
 ]
 `;
+
+exports[`a11y test checks accessibility of Text (Text.Weights.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-DetailsList",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<div class=\\"ms-DetailsList is-fixed is-horizontalConstrained root-0\\" data-automationid=\\"DetailsList\\" data-is-scrollable=\\"false\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element should have focusable content.
+- Element should be focusable.",
+      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
+    },
+    "ruleId": "scrollable-region-focusable",
+    "ruleIndex": 58,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of Text (Text.Wrap.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Basic.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TextField (TextField.Borderless.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TextField (TextField.Controlled.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `
+exports[`a11y test checks accessibility of TextField (TextField.CustomRender.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of TextField (TextField.Multiline.Example) 1`] = `
 Array [
   Object {
     "kind": "fail",
@@ -8387,7 +6616,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": "#TextField2",
+            "fullyQualifiedName": "#TextField3",
             "kind": "element",
           },
         ],
@@ -8398,71 +6627,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"TextFieldLabel4\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField2",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Only title used to generate label for form element.",
-      "text": "Fix all of the following: Only title used to generate label for form element.",
-    },
-    "ruleId": "label-title-only",
-    "ruleIndex": 35,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "#TextField2",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input type=\\"text\\" id=\\"TextField2\\" aria-labelledby=\\"TextFieldLabel4\\" value=\\"\\" class=\\"ms-TextField-field field-4\\" aria-describedby=\\"TextFieldDescription3\\" aria-invalid=\\"false\\">",
+              "text": "<textarea id=\\"TextField3\\" rows=\\"3\\" disabled=\\"\\" class=\\"ms-TextField-field field-12\\" aria-labelledby=\\"TextFieldLabel5\\" aria-invalid=\\"false\\">",
             },
           },
         },
@@ -8470,24 +6635,15 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- aria-label attribute does not exist or is empty.
-- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
-- Form element does not have an implicit (wrapped) &lt;label>.
-- Form element does not have an explicit &lt;label>.
-- Element has no title attribute or the title attribute is empty.",
-      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+- Element should have focusable content.
+- Element should be focusable.",
+      "text": "Fix any of the following: Element should have focusable content. Element should be focusable.",
     },
-    "ruleId": "label",
-    "ruleIndex": 34,
+    "ruleId": "scrollable-region-focusable",
+    "ruleIndex": 58,
   },
 ]
 `;
-
-exports[`a11y test checks accessibility of TextField (TextField.ErrorMessage.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.Masked.Example) 1`] = `Array []`;
-
-exports[`a11y test checks accessibility of TextField (TextField.Multiline.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of TextField (TextField.PrefixAndSuffix.Example) 1`] = `
 Array [
@@ -8498,7 +6654,7 @@ Array [
       Object {
         "logicalLocations": Array [
           Object {
-            "fullyQualifiedName": ".prefix-15 > span",
+            "fullyQualifiedName": ".prefix-14 > span",
             "kind": "element",
           },
         ],
@@ -8517,11 +6673,11 @@ Array [
     ],
     "message": Object {
       "markdown": "Fix any of the following:
-- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
-      "text": "Fix any of the following: Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+- Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1.",
+      "text": "Fix any of the following: Element has insufficient color contrast of 2.35 (foreground color: #a19f9d, background color: #f3f2f1, font size: 10.5pt (14px), font weight: normal). Expected contrast ratio of 4.5:1.",
     },
     "ruleId": "color-contrast",
-    "ruleIndex": 17,
+    "ruleIndex": 20,
   },
 ]
 `;
@@ -8530,186 +6686,185 @@ exports[`a11y test checks accessibility of TextField (TextField.Styled.Example) 
 
 exports[`a11y test checks accessibility of Toggle (Toggle.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Toggle (Toggle.CustomLabel.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.AbsolutePosition.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost10\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost10\\">Hover Over Me</button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost10\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button[aria-labelledby=\\"tooltipHost21\\"]",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button style=\\"font-size:2em\\" aria-labelledby=\\"tooltipHost21\\">Hover Over Me</button>",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost21\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Basic.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `
-Array [
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "button",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<button type=\\"button\\" aria-labelledby=\\"tooltipHost0\\" class=\\"ms-Button ms-Button--default root-1\\" data-is-focusable=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-labelledby=\\"tooltipHost0\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
-  },
-]
-`;
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Custom.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Display.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of Tooltip (Tooltip.Interactive.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Tooltip (Tooltip.Overflow.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of pickers (TagPicker.Basic.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Compact.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Controlled.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": ".ms-BasePicker-input",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<input autocapitalize=\\"off\\" autocomplete=\\"off\\" aria-autocomplete=\\"both\\" spellcheck=\\"false\\" class=\\"ms-BasePicker-input input-2\\" aria-controls=\\" \\" role=\\"textbox\\" value=\\"\\" data-lpignore=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Form element does not have an implicit (wrapped) &lt;label>.
+- Form element does not have an explicit &lt;label>.
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "label",
+    "ruleIndex": 38,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.LimitedSearch.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.List.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.Normal.Example) 1`] = `Array []`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.PreselectedItems.Example) 1`] = `
+Array [
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\30 \\"] > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 19,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\31 \\"] > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 19,
+  },
+  Object {
+    "kind": "fail",
+    "level": "error",
+    "locations": Array [
+      Object {
+        "logicalLocations": Array [
+          Object {
+            "fullyQualifiedName": "div[data-selection-index=\\"\\\\32 \\"] > button",
+            "kind": "element",
+          },
+        ],
+        "physicalLocation": Object {
+          "artifactLocation": Object {
+            "index": 0,
+            "uri": "about:blank",
+          },
+          "region": Object {
+            "snippet": Object {
+              "text": "<button type=\\"button\\" class=\\"ms-Button ms-Button--icon ms-PickerItem-removeButton removeButton-24\\" data-is-focusable=\\"true\\">",
+            },
+          },
+        },
+      },
+    ],
+    "message": Object {
+      "markdown": "Fix any of the following:
+- Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
+- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
+- Element's default semantics were not overridden with role=\\"presentation\\".
+- Element's default semantics were not overridden with role=\\"none\\".
+- Element has no title attribute or the title attribute is empty.",
+      "text": "Fix any of the following: Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
+    },
+    "ruleId": "button-name",
+    "ruleIndex": 19,
+  },
+]
+`;
+
+exports[`a11y test checks accessibility of pickers/PeoplePicker (PeoplePicker.ProcessSelection.Example) 1`] = `Array []`;

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -6,8 +6,6 @@ exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Compact.Ex
 
 exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 1`] = `Array []`;
 
-exports[`a11y test checks accessibility of ActivityItem (ActivityItem.Persona.Example) 2`] = `Array []`;
-
 exports[`a11y test checks accessibility of Announced (Announced.BulkOperations.Example) 1`] = `Array []`;
 
 exports[`a11y test checks accessibility of Announced (Announced.LazyLoading.Example) 1`] = `Array []`;

--- a/change/office-ui-fabric-react-2020-07-20-13-52-07-a11y-messagebar.json
+++ b/change/office-ui-fabric-react-2020-07-20-13-52-07-a11y-messagebar.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add :after styles to fix ratio of suggested items in PeoplePicker on keyboard focus",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-20T20:52:07.719Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -1,6 +1,5 @@
 import { getGlobalClassNames, HighContrastSelector } from '../../../Styling';
 import { ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
-import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const SuggestionsItemGlobalClassNames = {
   root: 'ms-Suggestions-item',

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -33,7 +33,20 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
           },
         },
       },
-
+      suggested && {
+        selectors: {
+          ':after': {
+            pointerEvents: 'none',
+            content: '""',
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            right: 0,
+            border: `1px solid ${theme.semanticColors.focusBorder}`,
+          },
+        },
+      },
       className,
     ],
     itemButton: [
@@ -67,16 +80,8 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
       suggested && [
         classNames.isSuggested,
         {
+          background: semanticColors.menuItemBackgroundPressed,
           selectors: {
-            ':after': {
-              content: '""',
-              position: 'absolute',
-              left: 0,
-              top: 0,
-              bottom: 0,
-              right: 0,
-              border: `1px solid ${theme.semanticColors.focusBorder}`,
-            },
             ':hover': {
               background: semanticColors.menuDivider,
             },

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -1,5 +1,6 @@
 import { getGlobalClassNames, HighContrastSelector } from '../../../Styling';
 import { ISuggestionsItemStyleProps, ISuggestionsItemStyles } from './SuggestionsItem.types';
+import { IsFocusVisibleClassName } from 'office-ui-fabric-react/lib/Utilities';
 
 export const SuggestionsItemGlobalClassNames = {
   root: 'ms-Suggestions-item',
@@ -67,8 +68,17 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
       suggested && [
         classNames.isSuggested,
         {
-          background: semanticColors.menuItemBackgroundPressed,
           selectors: {
+            ':after': {
+              content: '""',
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              bottom: 0,
+              right: 0,
+              border: `1px solid ${theme.palette.neutralSecondary}`,
+              zIndex: 1,
+            },
             ':hover': {
               background: semanticColors.menuDivider,
             },

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsItem.styles.ts
@@ -75,8 +75,7 @@ export function getStyles(props: ISuggestionsItemStyleProps): ISuggestionsItemSt
               top: 0,
               bottom: 0,
               right: 0,
-              border: `1px solid ${theme.palette.neutralSecondary}`,
-              zIndex: 1,
+              border: `1px solid ${theme.semanticColors.focusBorder}`,
             },
             ':hover': {
               background: semanticColors.menuDivider,

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -34,6 +34,16 @@ exports[`Suggestions renders a list properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
       >
         <button
           className=
@@ -46,6 +56,7 @@ exports[`Suggestions renders a list properly 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
+                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -119,15 +130,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
-              }
-              &:after {
-                border: 1px solid #605e5c;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -2069,6 +2071,16 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
       >
         <button
           className=
@@ -2081,6 +2093,7 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
+                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -2154,15 +2167,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
-              }
-              &:after {
-                border: 1px solid #605e5c;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -5158,6 +5162,16 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
             &:hover .ms-Suggestions-closeButton {
               display: block;
             }
+            &:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
       >
         <button
           className=
@@ -5170,6 +5184,7 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
+                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -5243,15 +5258,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
-              }
-              &:after {
-                border: 1px solid #605e5c;
-                bottom: 0px;
-                content: "";
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
               }
           data-is-focusable={true}
           onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -46,7 +46,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
-                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -120,6 +119,16 @@ exports[`Suggestions renders a list properly 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
+              }
+              &:after {
+                border: 1px solid #605e5c;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -2073,7 +2082,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
-                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -2147,6 +2155,16 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
+              }
+              &:after {
+                border: 1px solid #605e5c;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -5154,7 +5172,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
                 background-color: transparent;
-                background: #edebe9;
                 border-radius: 2px;
                 border: none;
                 box-sizing: border-box;
@@ -5228,6 +5245,16 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 -ms-high-contrast-adjust: none;
                 background: Highlight;
                 color: HighlightText;
+              }
+              &:after {
+                border: 1px solid #605e5c;
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -128,7 +128,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 position: absolute;
                 right: 0px;
                 top: 0px;
-                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -2164,7 +2163,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 position: absolute;
                 right: 0px;
                 top: 0px;
-                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}
@@ -5254,7 +5252,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 position: absolute;
                 right: 0px;
                 top: 0px;
-                z-index: 1;
               }
           data-is-focusable={true}
           onClick={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11576 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Fix styles of PeoplePicker to fix keyboard focus state ratio.

The keyboard focus state for the message bar in PeoplePicker is currently below 3:1

**Before**
![image](https://user-images.githubusercontent.com/66456876/87988184-c9554280-ca94-11ea-913a-1e166691a74b.png)

The fix is to add a neutralSecondary 1px border, similar to dropdownItems

**After**
![image](https://user-images.githubusercontent.com/66456876/87988432-281abc00-ca95-11ea-87aa-e08dac7d8830.png)


#### Focus areas to test

(optional)
