### PR TITLE
Syntax highlighting a11y

### DIFF
--- a/change/@uifabric-example-app-base-2020-07-21-09-34-50-syntax-highlighting-a11y.json
+++ b/change/@uifabric-example-app-base-2020-07-21-09-34-50-syntax-highlighting-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "updated syntax highlighting to remove a11y violations",
+  "packageName": "@uifabric/example-app-base",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-21T16:34:50.192Z"
+}

--- a/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.styles.ts
+++ b/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.styles.ts
@@ -7,7 +7,7 @@ export const codeFontFamily = 'Monaco, Menlo, Consolas, "Droid Sans Mono", "Inco
 export const baseCodeStyle: IRawStyle = {
   fontFamily: codeFontFamily,
   fontSize: FontSizes.size14,
-  background: NeutralColors.gray20,
+  background: NeutralColors.gray10,
   color: NeutralColors.gray160,
 };
 

--- a/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
@@ -45,10 +45,6 @@ style['hljs-link'] = style['hljs-regexp'] = {
   color: SharedColors.green20,
 };
 
-console.log(SharedColors.green20);
-
-console.log(style);
-
 export interface ICodeSnippetProps {
   className?: string;
   language?: string;

--- a/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
+++ b/packages/example-app-base/src/components/CodeSnippet/CodeSnippet.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyleFunctionOrObject, ITheme, IStyle, styled, classNamesFunction, IRawStyle } from 'office-ui-fabric-react';
-import { NeutralColors } from '@uifabric/fluent-theme';
+import { NeutralColors, FluentTheme, SharedColors } from '@uifabric/fluent-theme';
 import { baseCodeStyle, getStyles } from './CodeSnippet.styles';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -33,9 +33,21 @@ style.hljs = {
 };
 // Darken comment color for accessibility
 style['hljs-comment'] = style['hljs-quote'] = {
-  color: NeutralColors.gray120,
+  color: NeutralColors.gray130,
   fontStyle: 'italic',
 };
+
+style['hljs-built_in'] = style['builtin-name'] = {
+  color: FluentTheme.palette.themeDarker,
+};
+
+style['hljs-link'] = style['hljs-regexp'] = {
+  color: SharedColors.green20,
+};
+
+console.log(SharedColors.green20);
+
+console.log(style);
 
 export interface ICodeSnippetProps {
   className?: string;

--- a/packages/example-app-base/src/demo/demo.md
+++ b/packages/example-app-base/src/demo/demo.md
@@ -1,1 +1,78 @@
 # Example markdown file
+
+```tsx
+import * as React from 'react';
+import { Link, ILinkProps } from 'office-ui-fabric-react/lib/Link';
+import { removeAnchorLink } from '../../utilities/index2';
+
+export const MarkdownLink: React.FunctionComponent<ILinkProps> = props => {
+  let href = props.href;
+  if (href && href[0] === '#' && href.indexOf('/') === -1) {
+    // This is an anchor link within this page. We need to prepend the current route.
+    href = removeAnchorLink(location.hash) + href;
+  }
+
+  return <Link {...props} href={href} />;
+};
+```
+
+```shell
+git clone https://github.com/microsoft/create-react-app-uifabric.git my-app
+cd my-app
+
+# with npm (default)
+npm install
+npm start
+
+# with yarn (optional)
+yarn
+yarn start
+```
+
+```scss
+html,
+body {
+  -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
+  background: $ms-color-gray10; // Match header/footer color for browsers with momentum scroll
+  background: linear-gradient(
+    to right,
+    $ms-color-white 0%,
+    $ms-color-white 50%,
+    $ms-color-gray10 50%,
+    $ms-color-gray10 100%
+  );
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+
+  @include high-contrast {
+    // The gradient doesn't behave well in high contrast, so get rid of it.
+    background: transparent;
+  }
+}
+
+// Border box everywhere
+html {
+  box-sizing: border-box;
+}
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+// Buttons
+button {
+  background: transparent;
+  border: none;
+}
+
+// Example card headers
+.ExampleCard-title {
+  @include ms-fontSize-20;
+  @include ms-fontWeight-semibold;
+  @include ms-fontColor-gray130;
+}
+```


### PR DESCRIPTION
Updating syntax highlighting to resolve some a11y contrast issues. Bit of a stopgap until we can do a full pass. 

![image](https://user-images.githubusercontent.com/1434956/88081730-a9299000-cb35-11ea-8cc8-9ee1533685e5.png)
