### PR TITLE
useCustomizationSettings: get settings from CustomizerContext if exists.

### DIFF
--- a/change/@uifabric-utilities-2020-07-21-11-56-13-xgao-useCustomization.json
+++ b/change/@uifabric-utilities-2020-07-21-11-56-13-xgao-useCustomization.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "useCustomizationSettings: get settings from CustomizerContext if exists.",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-21T18:56:13.311Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1198,7 +1198,7 @@ export const trProperties: Record<string, number>;
 export function unhoistMethods(source: any, methodNames: string[]): void;
 
 // @public
-export function useCustomizationSettings(properties: string[], scopeName?: string, localSettings?: ICustomizations): ISettings;
+export function useCustomizationSettings(properties: string[], scopeName?: string): ISettings;
 
 // @public
 export function useFocusRects(rootRef?: React.RefObject<HTMLElement>): void;

--- a/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
+++ b/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 import { Customizations, ISettings } from './Customizations';
+import { CustomizerContext } from './CustomizerContext';
 import { useCustomizationSettings } from './useCustomizationSettings';
 
 describe('useCustomizatioSettings', () => {
@@ -64,5 +65,25 @@ describe('useCustomizatioSettings', () => {
     wrapper = mount(<TestComponent />);
     expect(settingsStates.length).toBe(1);
     expect(settingsStates[0]).toEqual({ a: undefined });
+  });
+
+  it('get settings from CustomizerContext', () => {
+    const settingsStates: ISettings[] = [];
+
+    const TestComponent: React.FunctionComponent = () => {
+      const settings = useCustomizationSettings(['theme']);
+
+      settingsStates.push(settings);
+      return null;
+    };
+
+    const newContext = { customizations: { settings: { theme: { color: 'red' } }, scopedSettings: {} } };
+    wrapper = mount(
+      <CustomizerContext.Provider value={newContext}>
+        <TestComponent />
+      </CustomizerContext.Provider>,
+    );
+    expect(settingsStates.length).toBe(1);
+    expect(settingsStates[0]).toEqual({ theme: { color: 'red' } });
   });
 });

--- a/packages/utilities/src/customizations/useCustomizationSettings.ts
+++ b/packages/utilities/src/customizations/useCustomizationSettings.ts
@@ -1,14 +1,13 @@
 import * as React from 'react';
-import { ISettings, Customizations, ICustomizations } from './Customizations';
+import { ISettings, Customizations } from './Customizations';
+import { CustomizerContext } from './CustomizerContext';
 
 /**
  * Hook to get Customizations settings. It will trigger component state update on settings change observed.
  */
-export function useCustomizationSettings(
-  properties: string[],
-  scopeName?: string,
-  localSettings?: ICustomizations,
-): ISettings {
+export function useCustomizationSettings(properties: string[], scopeName?: string): ISettings {
+  const customizerContext = React.useContext(CustomizerContext);
+  const localSettings = customizerContext.customizations;
   const [settings, setSettings] = React.useState(Customizations.getSettings(properties, scopeName, localSettings));
 
   const onCustomizationChange = React.useCallback(() => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
get local settings from context by default within the hook, instead of being passed as a param.

#### Focus areas to test

(optional)
