### PR TITLE
DetailsList header should be sentense case

### DIFF
--- a/change/@uifabric-azure-themes-2020-07-22-11-18-40-detailslist-header-uppercase.json
+++ b/change/@uifabric-azure-themes-2020-07-22-11-18-40-detailslist-header-uppercase.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList header should be sentense case",
+  "packageName": "@uifabric/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-22T03:18:40.018Z"
+}

--- a/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DetailsList.styles.ts
@@ -53,7 +53,6 @@ export const DetailsListStyles = (props: IDetailsListStyleProps): Partial<IDetai
       selectors: {
         '.ms-DetailsHeader': {
           borderColor: semanticColors.variantBorder,
-          textTransform: 'uppercase',
           borderTop: StyleConstants.borderNone,
           selectors: {
             '.ms-DetailsHeader-cellTitle': {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
DetailsList header should be sentence case and not all caps. 
This change was in #13807 but got abandoned.

#### Focus areas to test

Before change
![image](https://user-images.githubusercontent.com/67673432/88130644-a8642d00-cc0d-11ea-89fd-1db6a55155a1.png)

After change
![image](https://user-images.githubusercontent.com/67673432/88130649-ae5a0e00-cc0d-11ea-88e3-f01a2e260e0a.png)

