### PR TITLE
Moving Autofill to react-next, in preparation for converting to a function component

### DIFF
--- a/change/@fluentui-react-next-2020-07-22-16-37-11-feat-moving-autofill.json
+++ b/change/@fluentui-react-next-2020-07-22-16-37-11-feat-moving-autofill.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Moving Autofill to react-next in preparation for converting to a function component.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-22T23:37:11.303Z"
+}

--- a/packages/react-next/src/components/Autofill/Autofill.test.tsx
+++ b/packages/react-next/src/components/Autofill/Autofill.test.tsx
@@ -1,0 +1,299 @@
+jest.useFakeTimers();
+
+import * as React from 'react';
+
+import * as ReactTestUtils from 'react-dom/test-utils';
+
+import { IRefObject, KeyCodes } from '../../Utilities';
+import { Autofill, IAutofillState, IAutofill, IAutofillProps } from './index';
+import { ReactWrapper, mount } from 'enzyme';
+import { mockEvent } from '../../common/testUtilities';
+
+describe('Autofill', () => {
+  let autofill: Autofill;
+  const autofillRef: IRefObject<IAutofill> = (ref: IAutofill | null) => {
+    autofill = ref as Autofill;
+  };
+  let component: ReactWrapper<IAutofillProps, IAutofillState, Autofill>;
+
+  afterEach(() => {
+    component.unmount();
+  });
+
+  it('correctly autofills', () => {
+    let updatedText: string | undefined;
+    const onInputValueChange = (text: string | undefined): void => {
+      updatedText = text;
+    };
+
+    component = mount(
+      <Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />,
+    );
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(updatedText).toBe('hel');
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+  });
+
+  it('correctly autofills with composable languages', () => {
+    let updatedText: string | undefined;
+    const onInputValueChange = (text: string | undefined): void => {
+      updatedText = text;
+    };
+
+    component = mount(
+      <Autofill
+        componentRef={autofillRef}
+        onInputValueChange={onInputValueChange}
+        suggestedDisplayValue="こんにちは"
+      />,
+    );
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('こん'));
+    expect(updatedText).toBe('こん');
+    expect(autofill.value).toBe('こん');
+    expect(autofill.inputElement!.value).toBe('こんにちは');
+  });
+
+  it('does not autofill if suggestedDisplayValue does not match input', () => {
+    let updatedText: string | undefined;
+    const onInputValueChange = (text: string | undefined): void => {
+      updatedText = text;
+    };
+
+    component = mount(
+      <Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />,
+    );
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hep'));
+
+    expect(updatedText).toBe('hep');
+    expect(autofill.value).toBe('hep');
+    expect(autofill.inputElement!.value).toBe('hep');
+  });
+
+  it('autofills if left arrow is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.left, which: KeyCodes.left });
+    expect(autofill.value).toBe('hello');
+    expect(autofill.inputElement!.value).toBe('hello');
+  });
+
+  it('autofills if right arrow is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.right, which: KeyCodes.right });
+    expect(autofill.value).toBe('hello');
+    expect(autofill.inputElement!.value).toBe('hello');
+  });
+
+  it('does not autofill if up or down is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.up, which: KeyCodes.up });
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.down, which: KeyCodes.down });
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
+  });
+
+  it('value changes when updateValueInWillReceiveProps is passed in', () => {
+    const propsString = 'Updated';
+    const receivePropsUpdater = () => {
+      return propsString;
+    };
+    component = mount(
+      <Autofill
+        componentRef={autofillRef}
+        suggestedDisplayValue=""
+        updateValueInWillReceiveProps={receivePropsUpdater}
+      />,
+    );
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    component.setProps({ suggestedDisplayValue: 'hello' });
+
+    expect(autofill.value).toBe('Updated');
+    expect(autofill.inputElement!.value).toBe('Updated');
+  });
+
+  it('handles composition events', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="he" />);
+
+    autofill.inputElement!.value = 'he';
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+    expect(autofill.value).toBe('he');
+
+    ReactTestUtils.Simulate.compositionStart(autofill.inputElement!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.l, which: KeyCodes.l });
+    autofill.inputElement!.value = 'hel';
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.p, which: KeyCodes.p });
+    autofill.inputElement!.value = 'help';
+
+    ReactTestUtils.Simulate.compositionEnd(autofill.inputElement!, {});
+    autofill.inputElement!.value = '🆘';
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+
+    expect(autofill.value).toBe('🆘');
+  });
+
+  it('handles composition events when multiple compositionEnd events are dispatched without a compositionStart', () => {
+    const onInputChange = jest.fn((a: string, b: boolean) => a);
+    component = mount(<Autofill componentRef={autofillRef} onInputChange={onInputChange} suggestedDisplayValue="he" />);
+
+    autofill.inputElement!.value = 'hel';
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+    expect(autofill.value).toBe('hel');
+
+    ReactTestUtils.Simulate.compositionStart(autofill.inputElement!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, {
+      keyCode: KeyCodes.p,
+      which: KeyCodes.p,
+    });
+    autofill.inputElement!.value = 'help';
+    ReactTestUtils.Simulate.input(autofill.inputElement!, {
+      target: autofill.inputElement!,
+      nativeEvent: {
+        isComposing: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    });
+
+    ReactTestUtils.Simulate.compositionEnd(autofill.inputElement!, {});
+    autofill.inputElement!.value = '🆘';
+    ReactTestUtils.Simulate.input(autofill.inputElement!, {
+      target: autofill.inputElement!,
+      nativeEvent: {
+        isComposing: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    });
+    jest.runOnlyPendingTimers();
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, {
+      keyCode: KeyCodes.m,
+      which: KeyCodes.m,
+      nativeEvent: {
+        isComposing: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    });
+    autofill.inputElement!.value = '🆘m';
+    ReactTestUtils.Simulate.input(autofill.inputElement!, {
+      target: autofill.inputElement!,
+      nativeEvent: {
+        isComposing: true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    });
+
+    ReactTestUtils.Simulate.compositionEnd(autofill.inputElement!, {});
+    autofill.inputElement!.value = '🆘Ⓜ';
+    ReactTestUtils.Simulate.input(autofill.inputElement!, {
+      target: autofill.inputElement!,
+      nativeEvent: {
+        isComposing: false,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any,
+    });
+    jest.runOnlyPendingTimers();
+
+    expect(onInputChange.mock.calls).toEqual([
+      ['hel', false],
+      ['help', true],
+      ['🆘', true], // from input event
+      ['🆘', false], // from timeout on compositionEnd event
+      ['🆘m', true],
+      ['🆘Ⓜ', false], // from input event
+      ['🆘Ⓜ', false], // from  timeout on compositionEnd event
+    ]);
+    expect(autofill.value).toBe('🆘Ⓜ');
+  });
+
+  it('will call onInputChange w/ composition events', () => {
+    const onInputChange = jest.fn((a: string, b: boolean) => a);
+
+    component = mount(<Autofill componentRef={autofillRef} onInputChange={onInputChange} suggestedDisplayValue="he" />);
+
+    autofill.inputElement!.value = 'he';
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+    expect(autofill.value).toBe('he');
+
+    ReactTestUtils.Simulate.compositionStart(autofill.inputElement!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.l, which: KeyCodes.l });
+    autofill.inputElement!.value = 'hel';
+    ReactTestUtils.Simulate.input(autofill.inputElement!!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.p, which: KeyCodes.p });
+    autofill.inputElement!.value = 'help';
+    ReactTestUtils.Simulate.input(autofill.inputElement!!, {});
+
+    ReactTestUtils.Simulate.compositionEnd(autofill.inputElement!, {});
+    autofill.inputElement!.value = '🆘';
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+
+    expect(onInputChange.mock.calls).toEqual([
+      ['he', false],
+      ['hel', true],
+      ['help', true],
+      ['🆘', false],
+    ]);
+  });
+
+  it('will call onInputValueChanged w/ composition events', () => {
+    const onInputValueChange = jest.fn((a: string, b: boolean) => {
+      return undefined;
+    });
+
+    component = mount(
+      <Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="he" />,
+    );
+
+    autofill.inputElement!.value = 'he';
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+    expect(autofill.value).toBe('he');
+
+    ReactTestUtils.Simulate.compositionStart(autofill.inputElement!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.l, which: KeyCodes.l });
+    autofill.inputElement!.value = 'hel';
+    ReactTestUtils.Simulate.input(autofill.inputElement!!, {});
+
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.p, which: KeyCodes.p });
+    autofill.inputElement!.value = 'help';
+    ReactTestUtils.Simulate.input(autofill.inputElement!!, {});
+
+    ReactTestUtils.Simulate.compositionEnd(autofill.inputElement!, {});
+    autofill.inputElement!.value = '🆘';
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!);
+
+    expect(onInputValueChange.mock.calls).toEqual([
+      ['he', false],
+      ['hel', true],
+      ['help', true],
+      ['🆘', false],
+    ]);
+  });
+});

--- a/packages/react-next/src/components/Autofill/Autofill.tsx
+++ b/packages/react-next/src/components/Autofill/Autofill.tsx
@@ -1,0 +1,354 @@
+import * as React from 'react';
+import { IAutofillProps, IAutofill } from './Autofill.types';
+import { KeyCodes, getNativeProps, inputProperties, isIE11, Async, initializeComponentRef } from '../../Utilities';
+
+export interface IAutofillState {
+  displayValue?: string;
+}
+
+const SELECTION_FORWARD = 'forward';
+const SELECTION_BACKWARD = 'backward';
+
+/**
+ * {@docCategory Autofill}
+ */
+export class Autofill extends React.Component<IAutofillProps, IAutofillState> implements IAutofill {
+  public static defaultProps = {
+    enableAutofillOnKeyPress: [KeyCodes.down, KeyCodes.up] as KeyCodes[],
+  };
+
+  private _inputElement = React.createRef<HTMLInputElement>();
+  private _autoFillEnabled = true;
+  private _value: string;
+  private _isComposing: boolean = false;
+  private _async: Async;
+
+  constructor(props: IAutofillProps) {
+    super(props);
+
+    initializeComponentRef(this);
+    this._async = new Async(this);
+
+    this._value = props.defaultVisibleValue || '';
+    this.state = {
+      displayValue: props.defaultVisibleValue || '',
+    };
+  }
+
+  public get cursorLocation(): number | null {
+    if (this._inputElement.current) {
+      const inputElement = this._inputElement.current;
+      if (inputElement.selectionDirection !== SELECTION_FORWARD) {
+        return inputElement.selectionEnd;
+      } else {
+        return inputElement.selectionStart;
+      }
+    } else {
+      return -1;
+    }
+  }
+
+  public get isValueSelected(): boolean {
+    return Boolean(this.inputElement && this.inputElement.selectionStart !== this.inputElement.selectionEnd);
+  }
+
+  public get value(): string {
+    return this._value;
+  }
+
+  public get selectionStart(): number | null {
+    return this._inputElement.current ? this._inputElement.current.selectionStart : -1;
+  }
+
+  public get selectionEnd(): number | null {
+    return this._inputElement.current ? this._inputElement.current.selectionEnd : -1;
+  }
+
+  public get inputElement(): HTMLInputElement | null {
+    return this._inputElement.current;
+  }
+
+  public UNSAFE_componentWillReceiveProps(nextProps: IAutofillProps): void {
+    if (this.props.updateValueInWillReceiveProps) {
+      const updatedInputValue = this.props.updateValueInWillReceiveProps();
+      // Don't update if we have a null value or the value isn't changing
+      // the value should still update if an empty string is passed in
+      if (updatedInputValue !== null && updatedInputValue !== this._value) {
+        this._value = updatedInputValue;
+      }
+    }
+
+    const newDisplayValue = this._getDisplayValue(this._value, nextProps.suggestedDisplayValue);
+
+    if (typeof newDisplayValue === 'string') {
+      this.setState({ displayValue: newDisplayValue });
+    }
+  }
+
+  public componentDidUpdate() {
+    const value = this._value;
+    const { suggestedDisplayValue, shouldSelectFullInputValueInComponentDidUpdate, preventValueSelection } = this.props;
+    let differenceIndex = 0;
+
+    if (preventValueSelection) {
+      return;
+    }
+
+    if (
+      this._autoFillEnabled &&
+      value &&
+      suggestedDisplayValue &&
+      this._doesTextStartWith(suggestedDisplayValue, value)
+    ) {
+      let shouldSelectFullRange = false;
+
+      if (shouldSelectFullInputValueInComponentDidUpdate) {
+        shouldSelectFullRange = shouldSelectFullInputValueInComponentDidUpdate();
+      }
+
+      if (shouldSelectFullRange && this._inputElement.current) {
+        this._inputElement.current.setSelectionRange(0, suggestedDisplayValue.length, SELECTION_BACKWARD);
+      } else {
+        while (
+          differenceIndex < value.length &&
+          value[differenceIndex].toLocaleLowerCase() === suggestedDisplayValue[differenceIndex].toLocaleLowerCase()
+        ) {
+          differenceIndex++;
+        }
+        if (differenceIndex > 0 && this._inputElement.current) {
+          this._inputElement.current.setSelectionRange(
+            differenceIndex,
+            suggestedDisplayValue.length,
+            SELECTION_BACKWARD,
+          );
+        }
+      }
+    }
+  }
+
+  public componentWillUnmount(): void {
+    this._async.dispose();
+  }
+
+  public render(): JSX.Element {
+    const { displayValue } = this.state;
+
+    const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
+    return (
+      <input
+        autoCapitalize="off"
+        autoComplete="off"
+        aria-autocomplete={'both'}
+        {...nativeProps}
+        ref={this._inputElement}
+        value={displayValue}
+        onCompositionStart={this._onCompositionStart}
+        onCompositionUpdate={this._onCompositionUpdate}
+        onCompositionEnd={this._onCompositionEnd}
+        // TODO (Fabric 8?) - switch to calling only onChange. See notes in TextField._onInputChange.
+        onChange={this._onChanged}
+        onInput={this._onInputChanged}
+        onKeyDown={this._onKeyDown}
+        onClick={this.props.onClick ? this.props.onClick : this._onClick}
+        data-lpignore={true}
+      />
+    );
+  }
+
+  public focus() {
+    this._inputElement.current && this._inputElement.current.focus();
+  }
+
+  public clear() {
+    this._autoFillEnabled = true;
+    this._updateValue('', false);
+    this._inputElement.current && this._inputElement.current.setSelectionRange(0, 0);
+  }
+
+  // Composition events are used when the character/text requires several keystrokes to be completed.
+  // Some examples of this are mobile text input and langauges like Japanese or Arabic.
+  // Find out more at https://developer.mozilla.org/en-US/docs/Web/Events/compositionstart
+  private _onCompositionStart = (ev: React.CompositionEvent<HTMLInputElement>) => {
+    this._isComposing = true;
+    this._autoFillEnabled = false;
+  };
+
+  // Composition events are used when the character/text requires several keystrokes to be completed.
+  // Some examples of this are mobile text input and languages like Japanese or Arabic.
+  // Find out more at https://developer.mozilla.org/en-US/docs/Web/Events/compositionstart
+  private _onCompositionUpdate = () => {
+    if (isIE11()) {
+      this._updateValue(this._getCurrentInputValue(), true);
+    }
+  };
+
+  // Composition events are used when the character/text requires several keystrokes to be completed.
+  // Some examples of this are mobile text input and langauges like Japanese or Arabic.
+  // Find out more at https://developer.mozilla.org/en-US/docs/Web/Events/compositionstart
+  private _onCompositionEnd = (ev: React.CompositionEvent<HTMLInputElement>) => {
+    const inputValue = this._getCurrentInputValue();
+    this._tryEnableAutofill(inputValue, this.value, false, true);
+    this._isComposing = false;
+    // Due to timing, this needs to be async, otherwise no text will be selected.
+    this._async.setTimeout(() => {
+      // it's technically possible that the value of _isComposing is reset during this timeout,
+      // so explicitly trigger this with composing=true here, since it is supposed to be the
+      // update for composition end
+      this._updateValue(this._getCurrentInputValue(), false);
+    }, 0);
+  };
+
+  private _onClick = () => {
+    if (this._value && this._value !== '' && this._autoFillEnabled) {
+      this._autoFillEnabled = false;
+    }
+  };
+
+  private _onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (this.props.onKeyDown) {
+      this.props.onKeyDown(ev);
+    }
+
+    // If the event is actively being composed, then don't alert autofill.
+    // Right now typing does not have isComposing, once that has been fixed any should be removed.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (!(ev.nativeEvent as any).isComposing) {
+      switch (ev.which) {
+        case KeyCodes.backspace:
+          this._autoFillEnabled = false;
+          break;
+        case KeyCodes.left:
+        case KeyCodes.right:
+          if (this._autoFillEnabled) {
+            this._value = this.state.displayValue!;
+            this._autoFillEnabled = false;
+          }
+          break;
+        default:
+          if (!this._autoFillEnabled) {
+            if (this.props.enableAutofillOnKeyPress!.indexOf(ev.which) !== -1) {
+              this._autoFillEnabled = true;
+            }
+          }
+          break;
+      }
+    }
+  };
+
+  private _onInputChanged = (ev: React.FormEvent<HTMLElement>) => {
+    const value: string = this._getCurrentInputValue(ev);
+
+    if (!this._isComposing) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this._tryEnableAutofill(value, this._value, (ev.nativeEvent as any).isComposing);
+    }
+
+    // If it is not IE11 and currently composing, update the value
+    if (!(isIE11() && this._isComposing)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const nativeEventComposing = (ev.nativeEvent as any).isComposing;
+      const isComposing = nativeEventComposing === undefined ? this._isComposing : nativeEventComposing;
+      this._updateValue(value, isComposing);
+    }
+  };
+
+  private _onChanged = (): void => {
+    // Swallow this event, we don't care about it
+    // We must provide it because React PropTypes marks it as required, but onInput serves the correct purpose
+    return;
+  };
+
+  private _getCurrentInputValue(ev?: React.FormEvent<HTMLElement>): string {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if (ev && ev.target && (ev.target as any).value) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (ev.target as any).value;
+    } else if (this.inputElement && this.inputElement.value) {
+      return this.inputElement.value;
+    } else {
+      return '';
+    }
+  }
+
+  /**
+   * Attempts to enable autofill. Whether or not autofill is enabled depends on the input value,
+   * whether or not any text is selected, and only if the new input value is longer than the old input value.
+   * Autofill should never be set to true if the value is composing. Once compositionEnd is called, then
+   * it should be completed.
+   * See https://developer.mozilla.org/en-US/docs/Web/API/CompositionEvent for more information on composition.
+   * @param newValue - new input value
+   * @param oldValue - old input value
+   * @param isComposing - if true then the text is actively being composed and it has not completed.
+   * @param isComposed - if the text is a composed text value.
+   */
+  private _tryEnableAutofill(newValue: string, oldValue: string, isComposing?: boolean, isComposed?: boolean): void {
+    if (
+      !isComposing &&
+      newValue &&
+      this._inputElement.current &&
+      this._inputElement.current.selectionStart === newValue.length &&
+      !this._autoFillEnabled &&
+      (newValue.length > oldValue.length || isComposed)
+    ) {
+      this._autoFillEnabled = true;
+    }
+  }
+
+  private _notifyInputChange(newValue: string, composing: boolean): void {
+    if (this.props.onInputValueChange) {
+      this.props.onInputValueChange(newValue, composing);
+    }
+  }
+
+  /**
+   * Updates the current input value as well as getting a new display value.
+   * @param newValue - The new value from the input
+   */
+  private _updateValue = (newValue: string, composing: boolean) => {
+    // Only proceed if the value is nonempty and is different from the old value
+    // This is to work around the fact that, in IE 11, inputs with a placeholder fire an onInput event on focus
+    if (!newValue && newValue === this._value) {
+      return;
+    }
+    this._value = this.props.onInputChange ? this.props.onInputChange(newValue, composing) : newValue;
+    this.setState(
+      {
+        displayValue: this._getDisplayValue(this._value, this.props.suggestedDisplayValue),
+      },
+      () => this._notifyInputChange(this._value, composing),
+    );
+  };
+
+  /**
+   * Returns a string that should be used as the display value.
+   * It evaluates this based on whether or not the suggested value starts with the input value
+   * and whether or not autofill is enabled.
+   * @param inputValue - the value that the input currently has.
+   * @param suggestedDisplayValue - the possible full value
+   */
+  private _getDisplayValue(inputValue: string, suggestedDisplayValue?: string): string {
+    let displayValue = inputValue;
+    if (
+      suggestedDisplayValue &&
+      inputValue &&
+      this._doesTextStartWith(suggestedDisplayValue, displayValue) &&
+      this._autoFillEnabled
+    ) {
+      displayValue = suggestedDisplayValue;
+    }
+    return displayValue;
+  }
+
+  private _doesTextStartWith(text: string, startWith: string): boolean {
+    if (!text || !startWith) {
+      return false;
+    }
+    return text.toLocaleLowerCase().indexOf(startWith.toLocaleLowerCase()) === 0;
+  }
+}
+
+/**
+ *  @deprecated do not use.
+ * {@docCategory Autofill}
+ */
+export class BaseAutoFill extends Autofill {}

--- a/packages/react-next/src/components/Autofill/Autofill.types.ts
+++ b/packages/react-next/src/components/Autofill/Autofill.types.ts
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { Autofill } from './Autofill';
+import { IRefObject, KeyCodes } from '../../Utilities';
+
+/**
+ * {@docCategory Autofill}
+ */
+export interface IAutofill {
+  /**
+   * The current index of the cursor in the input area. Returns -1 if the input element
+   * is not ready.
+   */
+  cursorLocation: number | null;
+  /**
+   * A boolean for whether or not there is a value selected in the input area.
+   */
+  isValueSelected: boolean;
+  /**
+   * The current text value that the user has entered.
+   */
+  value: string;
+  /**
+   * The current index of where the selection starts. Returns -1 if the input element
+   * is not ready.
+   */
+  selectionStart: number | null;
+  /**
+   * the current index of where the selection ends. Returns -1 if the input element
+   * is not ready.
+   */
+  selectionEnd: number | null;
+  /**
+   * The current input element.
+   */
+  inputElement: HTMLInputElement | null;
+  /**
+   * Focus the input element.
+   */
+  focus(): void;
+  /**
+   * Clear all text in the input. Sets value to '';
+   */
+  clear(): void;
+}
+
+/**
+ * {@docCategory Autofill}
+ */
+export interface IAutofillProps extends React.InputHTMLAttributes<HTMLInputElement | Autofill> {
+  /**
+   * Gets the compoonent ref.
+   */
+  componentRef?: IRefObject<IAutofill>;
+
+  /**
+   * The suggested autofill value that will display.
+   */
+  suggestedDisplayValue?: string;
+
+  /**
+   * A callback for when the current input value changes.
+   *
+   * @param composing - true if the change event was triggered while the
+   * inner input was in the middle of a multi-character composition.
+   * (for example, jp-hiragana IME input)
+   */
+  onInputValueChange?: (newValue?: string, composing?: boolean) => void;
+
+  /**
+   * When the user uses left arrow, right arrow, clicks, or deletes text autofill is disabled
+   * Since the user has taken control. It is automatically reenabled when the user enters text and the
+   * cursor is at the end of the text in the input box. This specifies other key presses that will reenabled
+   * autofill.
+   * @defaultvalue [KeyCodes.down, KeyCodes.up]
+   */
+  enableAutofillOnKeyPress?: KeyCodes[];
+
+  /**
+   * The default value to be visible. This is different from placeholder
+   * because it actually sets the current value of the picker
+   * Note: This will only be set upon component creation
+   * and will not update with subsequent prop updates.
+   */
+  defaultVisibleValue?: string;
+
+  /**
+   * Handler for checking and updating the value if needed
+   * in componentWillReceiveProps
+   *
+   * @returns - the updated value to set, if needed
+   */
+  updateValueInWillReceiveProps?: () => string | null;
+
+  /**
+   * Handler for checking if the full value of the input should
+   * be seleced in componentDidUpdate
+   *
+   * @returns - should the full value of the input be selected?
+   */
+  shouldSelectFullInputValueInComponentDidUpdate?: () => boolean;
+
+  /**
+   * A callback used to modify the input string.
+   *
+   * @param composing - true if the change event was triggered while the
+   * inner input was in the middle of a multi-character composition.
+   * (for example, jp-hiragana IME input)
+   */
+  onInputChange?: (value: string, composing: boolean) => string;
+
+  /**
+   * Should the value of the input be selected? True if we're focused on our input, false otherwise.
+   * We need to explicitly not select the text in the autofill if we are no longer focused.
+   * In IE11, selecting a input will also focus the input, causing other element's focus to be stolen.
+   */
+  preventValueSelection?: boolean;
+}
+
+/**
+ * Deprecated, do not use.
+ * @deprecated do not use, will be removed in 6.0
+ * {@docCategory Autofill}
+ */
+export interface IBaseAutoFill extends IAutofill {}
+
+/**
+ * Deprecated, do not use.
+ * @deprecated do not use, will be removed in 6.0
+ * {@docCategory Autofill}
+ */
+export interface IBaseAutoFillProps extends IAutofillProps {}

--- a/packages/react-next/src/components/Autofill/index.ts
+++ b/packages/react-next/src/components/Autofill/index.ts
@@ -1,0 +1,2 @@
+export * from './Autofill';
+export * from './Autofill.types';


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
This change does not modify Autofill; it simply moves it to react-next for better diffing in the actual conversion PR.

