### PR TITLE
Dropdown: fix high contrast styles in disabled state 

### DIFF
--- a/change/@fluentui-react-next-2020-07-23-02-46-39-a11y-dropdown.json
+++ b/change/@fluentui-react-next-2020-07-23-02-46-39-a11y-dropdown.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add high contrast adjust selector to dropdown styles",
+  "packageName": "@fluentui/react-next",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-23T09:46:38.994Z"
+}

--- a/change/office-ui-fabric-react-2020-07-23-02-05-49-a11y-dropdown.json
+++ b/change/office-ui-fabric-react-2020-07-23-02-05-49-a11y-dropdown.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add high contrast adjust selector to dropdown styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-23T09:05:49.407Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -11,6 +11,7 @@ import {
   HighContrastSelectorWhite,
   getScreenSelector,
   ScreenWidthMinMedium,
+  getEdgeChromiumNoHighContrastAdjustSelector,
 } from '../../Styling';
 
 const GlobalClassNames = {
@@ -307,7 +308,14 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         border: 'none',
         color: semanticColors.disabledText,
         cursor: 'default',
-        selectors: { [HighContrastSelector]: { border: '1px solid GrayText', color: 'GrayText' } },
+        selectors: {
+          [HighContrastSelector]: {
+            border: '1px solid GrayText',
+            color: 'GrayText',
+            backgroundColor: 'Window',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
     ],
     caretDownWrapper: [
@@ -326,7 +334,10 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     caretDown: [
       globalClassnames.caretDown,
       { color: palette.neutralSecondary, fontSize: fonts.small.fontSize, pointerEvents: 'none' },
-      disabled && { color: semanticColors.disabledText, selectors: { [HighContrastSelector]: { color: 'GrayText' } } },
+      disabled && {
+        color: semanticColors.disabledText,
+        selectors: { [HighContrastSelector]: { color: 'GrayText' }, ...getEdgeChromiumNoHighContrastAdjustSelector() },
+      },
     ],
     errorMessage: { color: semanticColors.errorText, ...theme.fonts.small, paddingTop: 5 },
     callout: [

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -316,8 +316,12 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                         white-space: nowrap;
                       }
                       @media screen and (-ms-high-contrast: active){& {
+                        background-color: Window;
                         border: 1px solid GrayText;
                         color: GrayText;
+                      }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
                       }
                   id="Dropdown2-option"
                   role="option"
@@ -353,6 +357,9 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                         }
                         @media screen and (-ms-high-contrast: active){& {
                           color: GrayText;
+                        }
+                        @media screen and (forced-colors: active){& {
+                          forced-color-adjust: none;
                         }
                     data-icon-name="ChevronDown"
                   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -388,8 +388,12 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               white-space: nowrap;
             }
             @media screen and (-ms-high-contrast: active){& {
+              background-color: Window;
               border: 1px solid GrayText;
               color: GrayText;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         id="Dropdown1-option"
         role="option"
@@ -425,6 +429,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 color: GrayText;
+              }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           data-icon-name="ChevronDown"
         >

--- a/packages/react-next/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react-next/src/components/Dropdown/Dropdown.styles.ts
@@ -11,6 +11,7 @@ import {
   HighContrastSelectorWhite,
   getScreenSelector,
   ScreenWidthMinMedium,
+  getEdgeChromiumNoHighContrastAdjustSelector,
 } from '../../Styling';
 
 const GlobalClassNames = {
@@ -307,7 +308,14 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         border: 'none',
         color: semanticColors.disabledText,
         cursor: 'default',
-        selectors: { [HighContrastSelector]: { border: '1px solid GrayText', color: 'GrayText' } },
+        selectors: {
+          [HighContrastSelector]: {
+            border: '1px solid GrayText',
+            color: 'GrayText',
+            backgroundColor: 'Window',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
     ],
     caretDownWrapper: [
@@ -326,7 +334,10 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     caretDown: [
       globalClassnames.caretDown,
       { color: palette.neutralSecondary, fontSize: fonts.small.fontSize, pointerEvents: 'none' },
-      disabled && { color: semanticColors.disabledText, selectors: { [HighContrastSelector]: { color: 'GrayText' } } },
+      disabled && {
+        color: semanticColors.disabledText,
+        selectors: { [HighContrastSelector]: { color: 'GrayText' }, ...getEdgeChromiumNoHighContrastAdjustSelector() },
+      },
     ],
     errorMessage: { color: semanticColors.errorText, ...theme.fonts.small, paddingTop: 5 },
     callout: [


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://dev.azure.com/microsoftdesign/fluent-ui/_workitems/edit/7814
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Disabled dropdown component was not adapting high contrast styling. This fix adds styling so dropdown will use high contrast styling.

**Before**
![image](https://user-images.githubusercontent.com/66456876/88270707-e5bad000-cc8a-11ea-813c-c05137f0f4ec.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/88271525-1c451a80-cc8c-11ea-85a1-1d747a310340.png)

Also updated dropdown component in the react-next package as well

#### Focus areas to test

(optional)
