### PR TITLE
fix(dropdown): event propagation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix an issue with throwing errors when a component is rendered outside of `Provider` @layershifter ([#14010](https://github.com/microsoft/fluentui/pull/14010))
 - Fix for `TeamsIcon`. Renamed current `TeamsIcon` to `ContactGroupIcon`. `TeamsIcon` is now the colored app icon as per current naming standards for other icons in project. @TanelVari ([#13966](https://github.com/microsoft/fluentui/pull/13966))
 - Fix memory leak in `FocusZone` @miroslavstastny ([#14031](https://github.com/microsoft/fluentui/pull/14031))
+- Fix `Dropdown` to only stop `ESC` keydown propagation if `Dropdown` is open @assuncaocharles ([#14184](https://github.com/microsoft/fluentui/pull/14184))
 
 ### Features
 - Add Emotion as an optional CSS-in-JS renderer @layershifter ([#13547](https://github.com/microsoft/fluentui/pull/13547))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Restricted prop sets in the `Grid` component which are passed to styles functions @layershifter ([#13863](https://github.com/microsoft/fluentui/pull/13863))
 - Restricted prop sets in the `Dropdown` component which are passed to styles functions @layershifter ([#13962](https://github.com/microsoft/fluentui/pull/13962))
 - `UIComponent` and `AutoControlledComponent` are removed @layershifter ([#13962](https://github.com/microsoft/fluentui/pull/13962))
+- Set `Dropdown` to only stop `ESC` keydown propagation if `Dropdown` is open @assuncaocharles ([#14184](https://github.com/microsoft/fluentui/pull/14184))
 
 ### Fixes
 - Fix `Tooltip` layouting when it is closed @fealkhou ([#13237](https://github.com/microsoft/fluentui/pull/13237))
@@ -41,7 +42,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix an issue with throwing errors when a component is rendered outside of `Provider` @layershifter ([#14010](https://github.com/microsoft/fluentui/pull/14010))
 - Fix for `TeamsIcon`. Renamed current `TeamsIcon` to `ContactGroupIcon`. `TeamsIcon` is now the colored app icon as per current naming standards for other icons in project. @TanelVari ([#13966](https://github.com/microsoft/fluentui/pull/13966))
 - Fix memory leak in `FocusZone` @miroslavstastny ([#14031](https://github.com/microsoft/fluentui/pull/14031))
-- Fix `Dropdown` to only stop `ESC` keydown propagation if `Dropdown` is open @assuncaocharles ([#14184](https://github.com/microsoft/fluentui/pull/14184))
 
 ### Features
 - Add Emotion as an optional CSS-in-JS renderer @layershifter ([#13547](https://github.com/microsoft/fluentui/pull/13547))

--- a/packages/fluentui/e2e/tests/dialogWithDropdown-test.ts
+++ b/packages/fluentui/e2e/tests/dialogWithDropdown-test.ts
@@ -5,6 +5,7 @@ const outerTrigger = `#${selectors.outerTrigger}`;
 const dropdownSelector = `#${selectors.dropdown}`;
 const dialogHeader = `#${selectors.dialogHeader}`;
 const dropdownIndicator = `.${dropdownSlotClassNames.toggleIndicator}`;
+const dropdownList = `.${dropdownSlotClassNames.itemsList}`;
 
 describe('Dialog scroll', () => {
   beforeEach(async () => {
@@ -29,6 +30,16 @@ describe('Dialog scroll', () => {
     await e2e.pressKey('Escape');
     expect(await e2e.exists(dropdownSelector)).toBe(true);
     await e2e.clickOn(dialogHeader);
+    await e2e.pressKey('Escape');
+    expect(await e2e.exists(dropdownSelector)).toBe(false);
+  });
+
+  it('should close when ESC pressed in the closed dropdown', async () => {
+    await e2e.clickOn(outerTrigger); // open dialog
+    await e2e.focusOn(dropdownSelector);
+    await e2e.pressKey('ArrowDown'); // open list
+    expect(await e2e.exists(dropdownList)).toBe(true);
+    await e2e.pressKey('Escape'); // closes list
     await e2e.pressKey('Escape');
     expect(await e2e.exists(dropdownSelector)).toBe(false);
   });

--- a/packages/fluentui/e2e/tests/dialogWithDropdown-test.ts
+++ b/packages/fluentui/e2e/tests/dialogWithDropdown-test.ts
@@ -40,7 +40,7 @@ describe('Dialog scroll', () => {
     await e2e.pressKey('ArrowDown'); // open list
     expect(await e2e.exists(dropdownList)).toBe(true);
     await e2e.pressKey('Escape'); // closes list
-    await e2e.pressKey('Escape');
+    await e2e.pressKey('Escape'); // closes dialog
     expect(await e2e.exists(dropdownSelector)).toBe(false);
   });
 });

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -1037,7 +1037,9 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
           case keyboardKey.Escape:
             // If dropdown list is open ESC should close it and not propagate to the parent
             // otherwise event should propagate
-            open && e.stopPropagation();
+            if (open) {
+              e.stopPropagation();
+            }
           default:
             break;
         }

--- a/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react-northstar/src/components/Dropdown/Dropdown.tsx
@@ -1035,7 +1035,9 @@ export const Dropdown: ComponentWithAs<'div', DropdownProps> &
             tryRemoveItemFromValue();
             break;
           case keyboardKey.Escape:
-            e.stopPropagation();
+            // If dropdown list is open ESC should close it and not propagate to the parent
+            // otherwise event should propagate
+            open && e.stopPropagation();
           default:
             break;
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`Dropdown` should only prevents propagation of `ESC` keydown if the list is open, otherwise propagation should still happen. 

#### Focus areas to test

(optional)
