### PR TITLE
Linechart : Fix issue The tool tip seems to display all the data in same day, instead of the point where my mouse hovers.

### DIFF
--- a/change/@uifabric-charting-2020-07-24-15-51-19-user-v-gorraj-Bug_4323737.json
+++ b/change/@uifabric-charting-2020-07-24-15-51-19-user-v-gorraj-Bug_4323737.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Linechart : Fix issue The tool tip seems to display all the data in same day, instead of the point where my mouse hovers.",
+  "packageName": "@uifabric/charting",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-24T10:21:19.135Z"
+}

--- a/packages/charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/charting/src/components/AreaChart/AreaChart.base.tsx
@@ -425,7 +425,8 @@ export class AreaChartBase extends React.Component<ILineChartProps, IAreaChartSt
 
   private _onMouseHover = (target: SVGCircleElement, x: number | Date, xAxisCalloutData: string) => {
     const formattedDate = x instanceof Date ? x.toLocaleDateString() : x;
-    const found = this._calloutPoints.find((element: { x: string | number }) => element.x === formattedDate);
+    const xVal = x instanceof Date ? x.getTime() : x;
+    const found = this._calloutPoints.find((element: { x: string | number }) => element.x === xVal);
     const presentData = found.values[0];
     if (
       this.state.isLegendSelected === false ||
@@ -476,7 +477,8 @@ export class AreaChartBase extends React.Component<ILineChartProps, IAreaChartSt
     xAxisCalloutData: string,
   ) => {
     const formattedDate = x instanceof Date ? x.toLocaleDateString() : x;
-    const found = this._calloutPoints.find((element: { x: string | number }) => element.x === formattedDate);
+    const xVal = x instanceof Date ? x.getTime() : x;
+    const found = this._calloutPoints.find((element: { x: string | number }) => element.x === xVal);
     const presentData = found.values[0];
     if (
       this.state.isLegendSelected === false ||

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -496,7 +496,8 @@ export class LineChartBase extends React.Component<
   ) => {
     this._uniqueCallOutID = circleId;
     const formattedData = x instanceof Date ? x.toLocaleDateString() : x;
-    const found = find(this._calloutPoints, (element: { x: string | number }) => element.x === formattedData);
+    const xVal = x instanceof Date ? x.getTime() : x;
+    const found = find(this._calloutPoints, (element: { x: string | number }) => element.x === xVal);
     d3Select('#' + circleId)
       .attr('fill', '#fff')
       .attr('r', 8)
@@ -530,6 +531,7 @@ export class LineChartBase extends React.Component<
     mouseEvent.persist();
     this._uniqueCallOutID = circleId;
     const formattedData = x instanceof Date ? x.toLocaleDateString() : x;
+    const xVal = x instanceof Date ? x.getTime() : x;
     const _this = this;
     d3Select(`#${circleId}`)
       .attr('fill', '#fff')
@@ -537,7 +539,7 @@ export class LineChartBase extends React.Component<
     d3Select(`#${this._verticalLine}`)
       .attr('transform', () => `translate(${_this._xAxisScale(x)}, 0)`)
       .attr('visibility', 'visibility');
-    const found = find(this._calloutPoints, (element: { x: string | number }) => element.x === formattedData);
+    const found = find(this._calloutPoints, (element: { x: string | number }) => element.x === xVal);
     this.setState({
       isCalloutVisible: true,
       refSelected: mouseEvent,

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -36,8 +36,18 @@ export class LineChartBasicExample extends React.Component<{}, ILineChartBasicSt
           data: [
             {
               x: new Date('2020-03-03T00:00:00.000Z'),
-              y: 217000,
+              y: 216000,
               onDataPointClick: () => alert('click on 217000'),
+            },
+            {
+              x: new Date('2020-03-03T10:00:00.000Z'),
+              y: 218123,
+              onDataPointClick: () => alert('click on 217123'),
+            },
+            {
+              x: new Date('2020-03-03T11:00:00.000Z'),
+              y: 217124,
+              onDataPointClick: () => alert('click on 217124'),
             },
             {
               x: new Date('2020-03-04T00:00:00.000Z'),

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -225,13 +225,13 @@ export function calloutData(values: ILineChartPoints[]) {
       e1: { legend: string; y: number; x: number | Date | string; color: string; yAxisCalloutData: string },
       index: number,
     ) => {
-      e1.x = e1.x instanceof Date ? e1.x.toLocaleDateString() : e1.x;
+      e1.x = e1.x instanceof Date ? e1.x.getTime() : e1.x;
       const filteredValues = [{ legend: e1.legend, y: e1.y, color: e1.color, yAxisCalloutData: e1.yAxisCalloutData }];
       combinedResult
         .slice(index + 1)
         .forEach(
           (e2: { legend: string; y: number; x: number | Date | string; color: string; yAxisCalloutData: string }) => {
-            e2.x = e2.x instanceof Date ? e2.x.toLocaleDateString() : e2.x;
+            e2.x = e2.x instanceof Date ? e2.x.getTime() : e2.x;
             if (e1.x === e2.x) {
               filteredValues.push({
                 legend: e2.legend,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Linechart : Fix issue The tool tip seems to display all the data in same day, instead of the point where my mouse hovers.

#### Focus areas to test

Line chart and area chart on hover and onfocus

#### Screenshots
Before fix 
![image](https://user-images.githubusercontent.com/13463251/88382481-2f5c0580-cdc6-11ea-8bc8-d7bacefd1302.png)

After fix
![image](https://user-images.githubusercontent.com/13463251/88382495-384cd700-cdc6-11ea-8aa7-0b40431c4050.png)

