### PR TITLE
@fluentui/react: add missing dist/sass and dist/css content

### DIFF
--- a/change/@fluentui-react-2020-07-24-12-26-30-xgao-react-package.json
+++ b/change/@fluentui-react-2020-07-24-12-26-30-xgao-react-package.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing dist/sass and dist/css content.",
+  "packageName": "@fluentui/react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-24T19:26:30.458Z"
+}

--- a/packages/react/config/pre-copy.json
+++ b/packages/react/config/pre-copy.json
@@ -1,0 +1,6 @@
+{
+  "copyTo": {
+    "dist/sass": ["office-ui-fabric-react/dist/sass/**/*"],
+    "dist/css": ["office-ui-fabric-react/dist/css/**/*"]
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14186
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`office-ui-fabric-react` has content in `dist/css` and `dist/sass`, which are missing from `@fluentui/react` package

#### Focus areas to test

(optional)
