### PR TITLE
Updating existing react-next examples to use the newest ones found inside of office-ui-fabric-react

### DIFF
--- a/change/@fluentui-react-next-2020-07-27-12-32-04-updating-react-next-examples.json
+++ b/change/@fluentui-react-next-2020-07-27-12-32-04-updating-react-next-examples.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Updating existing react-next examples to use newest examples inside of OUFR.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-27T19:32:04.609Z"
+}

--- a/change/@fluentui-react-next-2020-07-27-12-32-04-updating-react-next-examples.json
+++ b/change/@fluentui-react-next-2020-07-27-12-32-04-updating-react-next-examples.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Updating existing react-next examples to use newest examples inside of OUFR.",
+  "comment": "Updating existing react-next examples to use the newest ones found inside of office-ui-fabric-react.",
   "packageName": "@fluentui/react-next",
   "email": "czearing@outlook.com",
   "dependentChangeType": "patch",

--- a/packages/react-next/src/components/Checkbox/examples/Checkbox.Other.Example.tsx
+++ b/packages/react-next/src/components/Checkbox/examples/Checkbox.Other.Example.tsx
@@ -26,27 +26,10 @@ export const CheckboxOtherExample: React.FunctionComponent = () => {
 
       <Checkbox label="Checkbox with extra props for the input" inputProps={inputProps} />
 
-      <Checkbox label={<span>Custom label 1</span>} />
-
-      <Checkbox label={{ className: 'label', children: 'Custom label 2' }} />
-
-      <Checkbox label={{ children: _renderCustomLabel }} />
-
-      <Checkbox onRenderLabel={_renderLabelWithLink} />
+      <Checkbox label="Checkbox with link inside the label" onRenderLabel={_renderLabelWithLink} />
     </Stack>
   );
 };
-
-function _renderCustomLabel(Component: React.ElementType, props: React.HTMLAttributes<HTMLSpanElement>): JSX.Element {
-  return (
-    <Component {...props}>
-      Custom-rendered label with a{' '}
-      <Link href="https://www.microsoft.com" target="_blank">
-        link
-      </Link>
-    </Component>
-  );
-}
 
 function _renderLabelWithLink() {
   return (

--- a/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/examples/FocusTrapZone.Nested.Example.tsx
@@ -33,8 +33,11 @@ const FocusTrapComponent: React.FunctionComponent<React.PropsWithChildren<{ zone
           // Set a width on these toggles in the horizontal zone to prevent jumping when enabled
           styles={zoneNumber >= 2 && zoneNumber <= 4 ? fixedWidthToggleStyles : undefined}
         />
-        {/* eslint-disable-next-line react/jsx-no-bind */}
-        <DefaultButton onClick={onStringButtonClicked} text={`Zone ${zoneNumber} button`} />
+        <DefaultButton
+          // eslint-disable-next-line react/jsx-no-bind
+          onClick={onStringButtonClicked}
+          text={`Zone ${zoneNumber} button`}
+        />
         {children}
       </Stack>
     </FocusTrapZone>

--- a/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
+++ b/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
@@ -20,42 +20,36 @@ const sampleOptions = [
   { key: 'C', text: 'Option 3' },
 ];
 
-export const KeytipsBasicExample: React.FunctionComponent = () => {
-  const checkboxRef = useKeytipRef<HTMLDivElement>({ keytipProps: keytipMap.CheckboxKeytip });
-  const linkRef = useKeytipRef<HTMLAnchorElement>({ keytipProps: keytipMap.LinkKeytip });
-  const toggleRef = useKeytipRef<HTMLDivElement>({ keytipProps: keytipMap.ToggleKeytip });
+export const KeytipsBasicExample: React.FunctionComponent = () => (
+  <div>
+    <p>
+      For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content
+      are shown.
+    </p>
+    <Pivot>
+      <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={pivotItemStyle}>
+        <Stack tokens={stackTokens}>
+          <SpinButton label="Spin Button" keytipProps={keytipMap.SpinButtonKeytip} styles={spinButtonStyles} />
+          <Toggle onText="Yes" offText="No" keytipProps={keytipMap.ToggleKeytip} />
+          <span>
+            Go to{' '}
+            <Link keytipProps={keytipMap.LinkKeytip} href="http://www.bing.com" target="_blank">
+              Bing
+            </Link>
+          </span>
+        </Stack>
+      </PivotItem>
 
-  return (
-    <div>
-      <p>
-        For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content
-        are shown.
-      </p>
-      <Pivot>
-        <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={pivotItemStyle}>
-          <Stack tokens={stackTokens}>
-            <SpinButton label="Spin Button" keytipProps={keytipMap.SpinButtonKeytip} styles={spinButtonStyles} />
-            <Toggle ref={toggleRef} onText="Yes" offText="No" />
-            <span>
-              Go to{' '}
-              <Link ref={linkRef} href="http://www.bing.com" target="_blank">
-                Bing
-              </Link>
-            </span>
-          </Stack>
-        </PivotItem>
+      <PivotItem headerText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={pivotItemStyle}>
+        <Stack tokens={stackTokens}>
+          <Checkbox label="Checkbox" keytipProps={keytipMap.CheckboxKeytip} />
+          <Dropdown label="Dropdown" keytipProps={keytipMap.DropdownKeytip} options={sampleOptions} />
+        </Stack>
+      </PivotItem>
 
-        <PivotItem headerText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={pivotItemStyle}>
-          <Stack tokens={stackTokens}>
-            <Checkbox label="Checkbox" ref={checkboxRef} />
-            <Dropdown label="Dropdown" keytipProps={keytipMap.DropdownKeytip} options={sampleOptions} />
-          </Stack>
-        </PivotItem>
-
-        <PivotItem headerText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={pivotItemStyle}>
-          <ComboBox label="Combo Box" keytipProps={keytipMap.ComboBoxKeytip} options={sampleOptions} />
-        </PivotItem>
-      </Pivot>
-    </div>
-  );
-};
+      <PivotItem headerText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={pivotItemStyle}>
+        <ComboBox label="Combo Box" keytipProps={keytipMap.ComboBoxKeytip} options={sampleOptions} />
+      </PivotItem>
+    </Pivot>
+  </div>
+);

--- a/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
+++ b/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
@@ -8,7 +8,6 @@ import { SpinButton, ISpinButtonStyles } from '@fluentui/react-next/lib/SpinButt
 import { Toggle } from '@fluentui/react-next/lib/Toggle';
 import { Pivot, PivotItem } from '@fluentui/react-next/lib/Pivot';
 import { IStackTokens, Stack } from '@fluentui/react-next/lib/Stack';
-import { useKeytipRef } from '@fluentui/react-next/lib/KeytipData';
 
 const pivotItemStyle: React.CSSProperties = { width: 500, paddingTop: 20 };
 const stackTokens: IStackTokens = { childrenGap: 20 };

--- a/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
+++ b/packages/react-next/src/components/Keytip/examples/Keytips.Basic.Example.tsx
@@ -8,6 +8,7 @@ import { SpinButton, ISpinButtonStyles } from '@fluentui/react-next/lib/SpinButt
 import { Toggle } from '@fluentui/react-next/lib/Toggle';
 import { Pivot, PivotItem } from '@fluentui/react-next/lib/Pivot';
 import { IStackTokens, Stack } from '@fluentui/react-next/lib/Stack';
+import { useKeytipRef } from '@fluentui/react-next/lib/KeytipData';
 
 const pivotItemStyle: React.CSSProperties = { width: 500, paddingTop: 20 };
 const stackTokens: IStackTokens = { childrenGap: 20 };
@@ -19,36 +20,42 @@ const sampleOptions = [
   { key: 'C', text: 'Option 3' },
 ];
 
-export const KeytipsBasicExample: React.FunctionComponent = () => (
-  <div>
-    <p>
-      For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content
-      are shown.
-    </p>
-    <Pivot>
-      <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={pivotItemStyle}>
-        <Stack tokens={stackTokens}>
-          <SpinButton label="Spin Button" keytipProps={keytipMap.SpinButtonKeytip} styles={spinButtonStyles} />
-          <Toggle onText="Yes" offText="No" keytipProps={keytipMap.ToggleKeytip} />
-          <span>
-            Go to{' '}
-            <Link keytipProps={keytipMap.LinkKeytip} href="http://www.bing.com" target="_blank">
-              Bing
-            </Link>
-          </span>
-        </Stack>
-      </PivotItem>
+export const KeytipsBasicExample: React.FunctionComponent = () => {
+  const checkboxRef = useKeytipRef<HTMLDivElement>({ keytipProps: keytipMap.CheckboxKeytip });
+  const linkRef = useKeytipRef<HTMLAnchorElement>({ keytipProps: keytipMap.LinkKeytip });
+  const toggleRef = useKeytipRef<HTMLDivElement>({ keytipProps: keytipMap.ToggleKeytip });
 
-      <PivotItem headerText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={pivotItemStyle}>
-        <Stack tokens={stackTokens}>
-          <Checkbox label="Checkbox" keytipProps={keytipMap.CheckboxKeytip} />
-          <Dropdown label="Dropdown" keytipProps={keytipMap.DropdownKeytip} options={sampleOptions} />
-        </Stack>
-      </PivotItem>
+  return (
+    <div>
+      <p>
+        For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content
+        are shown.
+      </p>
+      <Pivot>
+        <PivotItem headerText="Pivot 1" keytipProps={keytipMap.Pivot1Keytip} style={pivotItemStyle}>
+          <Stack tokens={stackTokens}>
+            <SpinButton label="Spin Button" keytipProps={keytipMap.SpinButtonKeytip} styles={spinButtonStyles} />
+            <Toggle ref={toggleRef} onText="Yes" offText="No" />
+            <span>
+              Go to{' '}
+              <Link ref={linkRef} href="http://www.bing.com" target="_blank">
+                Bing
+              </Link>
+            </span>
+          </Stack>
+        </PivotItem>
 
-      <PivotItem headerText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={pivotItemStyle}>
-        <ComboBox label="Combo Box" keytipProps={keytipMap.ComboBoxKeytip} options={sampleOptions} />
-      </PivotItem>
-    </Pivot>
-  </div>
-);
+        <PivotItem headerText="Pivot 2" keytipProps={keytipMap.Pivot2Keytip} style={pivotItemStyle}>
+          <Stack tokens={stackTokens}>
+            <Checkbox label="Checkbox" ref={checkboxRef} />
+            <Dropdown label="Dropdown" keytipProps={keytipMap.DropdownKeytip} options={sampleOptions} />
+          </Stack>
+        </PivotItem>
+
+        <PivotItem headerText="Pivot 3" keytipProps={keytipMap.Pivot3Keytip} style={pivotItemStyle}>
+          <ComboBox label="Combo Box" keytipProps={keytipMap.ComboBoxKeytip} options={sampleOptions} />
+        </PivotItem>
+      </Pivot>
+    </div>
+  );
+};

--- a/packages/react-next/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
+++ b/packages/react-next/src/components/Keytip/examples/Keytips.CommandBar.Example.tsx
@@ -9,26 +9,20 @@ const commandBarFarItemsProps = [
   {
     key: 'farItem1',
     text: 'Options',
-    iconProps: {
-      iconName: 'SortLines',
-    },
+    iconProps: { iconName: 'SortLines' },
     keytipProps: keytipMap.CommandButton3Keytip,
     subMenuProps: {
       items: [
         {
           key: 'emailMessage',
           text: 'Send Email',
-          iconProps: {
-            iconName: 'Mail',
-          },
+          iconProps: { iconName: 'Mail' },
           keytipProps: keytipMap.SubmenuKeytip1,
         },
         {
           key: 'calendarEvent',
           text: 'Make Calendar Event',
-          iconProps: {
-            iconName: 'Calendar',
-          },
+          iconProps: { iconName: 'Calendar' },
           keytipProps: keytipMap.SubmenuKeytip2,
           subMenuProps: {
             items: [
@@ -77,18 +71,14 @@ export const KeytipsCommandBarExample: React.FunctionComponent = () => {
     {
       key: 'commandBarItem1',
       text: 'New',
-      iconProps: {
-        iconName: 'Add',
-      },
+      iconProps: { iconName: 'Add' },
       onClick: toggleShowModal,
       keytipProps: keytipMap.CommandButton1Keytip,
     },
     {
       key: 'commandBarItem2',
       text: 'Upload',
-      iconProps: {
-        iconName: 'Upload',
-      },
+      iconProps: { iconName: 'Upload' },
       onClick: toggleShowMessageBar,
       keytipProps: keytipMap.CommandButton2Keytip,
     },

--- a/packages/react-next/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/react-next/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import { CommandBarButton } from '@fluentui/react-next/lib/compat/Button';
-import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
-import { OverflowSet, IOverflowSetStyles } from 'office-ui-fabric-react/lib/OverflowSet';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { ResizeGroup } from '@fluentui/react-next/lib/ResizeGroup';
+import { OverflowSet, IOverflowSetStyles } from '@fluentui/react-next/lib/OverflowSet';
+import { IContextualMenuItem } from '@fluentui/react-next/lib/ContextualMenu';
+import { Dropdown, IDropdownOption } from '@fluentui/react-next/lib/Dropdown';
 import { mergeStyleSets } from 'office-ui-fabric-react';
+import { useBoolean } from '@uifabric/react-hooks';
+import { Toggle } from '@fluentui/react-next/lib/Toggle';
 
 const styles = mergeStyleSets({
   root: {
     display: 'block',
-  },
-  resizeIsShort: {
-    width: '400px',
   },
   settingsGroup: {
     paddingTop: '20px',
@@ -23,14 +21,22 @@ const styles = mergeStyleSets({
 });
 
 const overflowSetStyles: Partial<IOverflowSetStyles> = { root: { height: 40 } };
-
+const dropdownOptions = [
+  { key: '20', text: '20' },
+  { key: '30', text: '30' },
+  { key: '40', text: '40' },
+  { key: '50', text: '50' },
+  { key: '75', text: '75' },
+  { key: '100', text: '100' },
+  { key: '200', text: '200' },
+];
 export interface IOverflowData {
   primary: IContextualMenuItem[];
   overflow: IContextualMenuItem[];
   cacheKey?: string;
 }
 
-function generateData(count: number, cachingEnabled: boolean, checked: boolean): IOverflowData {
+const generateData = (count: number, cachingEnabled: boolean, checked: boolean): IOverflowData => {
   const icons = ['Add', 'Share', 'Upload'];
   const dataItems = [];
   let cacheKey = '';
@@ -41,156 +47,120 @@ function generateData(count: number, cachingEnabled: boolean, checked: boolean):
       icon: icons[index % icons.length],
       checked: checked,
     };
-
     cacheKey = cacheKey + item.key;
     dataItems.push(item);
   }
-
   let result: IOverflowData = {
     primary: dataItems,
-    overflow: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    overflow: [] as any[],
   };
-
   if (cachingEnabled) {
     result = { ...result, cacheKey };
   }
-
   return result;
-}
+};
 
-export interface IResizeGroupOverflowSetExampleState {
-  short: boolean;
-  numberOfItems: number;
-  buttonsChecked: boolean;
-  cachingEnabled: boolean;
-  onGrowDataEnabled: boolean;
-}
-
-function computeCacheKey(primaryControls: IContextualMenuItem[]): string {
+const computeCacheKey = (primaryControls: IContextualMenuItem[]): string => {
   return primaryControls.reduce((acc, current) => acc + current.key, '');
-}
+};
 
-export class ResizeGroupOverflowSetExample extends React.Component<{}, IResizeGroupOverflowSetExampleState> {
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      short: false,
-      buttonsChecked: false,
-      cachingEnabled: false,
-      onGrowDataEnabled: false,
-      numberOfItems: 20,
-    };
-  }
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onRenderItem = (item: any) => (
+  <CommandBarButton
+    role="menuitem"
+    text={item.name}
+    iconProps={{ iconName: item.icon }}
+    onClick={item.onClick}
+    checked={item.checked}
+  />
+);
 
-  public render(): JSX.Element {
-    const { numberOfItems, cachingEnabled, buttonsChecked, short, onGrowDataEnabled } = this.state;
-    const dataToRender = generateData(numberOfItems, cachingEnabled, buttonsChecked);
-    return (
-      <div className={short ? styles.resizeIsShort : 'notResized'}>
-        <ResizeGroup
-          role="tabpanel"
-          aria-label="Resize Group with an Overflow Set"
-          data={dataToRender}
-          onReduceData={this._onReduceData}
-          onGrowData={onGrowDataEnabled ? this._onGrowData : undefined}
-          // eslint-disable-next-line react/jsx-no-bind
-          onRenderData={data => {
-            return (
-              <OverflowSet
-                role="menubar"
-                items={data.primary}
-                overflowItems={data.overflow.length ? data.overflow : null}
-                // eslint-disable-next-line react/jsx-no-bind
-                onRenderItem={item => {
-                  return (
-                    <CommandBarButton
-                      role="menuitem"
-                      text={item.name}
-                      iconProps={{ iconName: item.icon }}
-                      onClick={item.onClick}
-                      checked={item.checked}
-                    />
-                  );
-                }}
-                // eslint-disable-next-line react/jsx-no-bind
-                onRenderOverflowButton={overflowItems => {
-                  return <CommandBarButton role="menuitem" menuProps={{ items: overflowItems! }} />;
-                }}
-                styles={overflowSetStyles}
-              />
-            );
-          }}
-        />
-        <div className={styles.settingsGroup}>
-          <Checkbox label="Enable caching" onChange={this._onCachingEnabledChanged} checked={cachingEnabled} />
-          <Checkbox label="Set onGrowData" onChange={this._onGrowDataEnabledChanged} checked={onGrowDataEnabled} />
-          <Checkbox label="Buttons checked" onChange={this._onButtonsCheckedChanged} checked={buttonsChecked} />
-          <div className={styles.itemCountDropdown}>
-            <Dropdown
-              label="Number of items to render"
-              selectedKey={numberOfItems.toString()}
-              onChange={this._onNumberOfItemsChanged}
-              options={[
-                { key: '20', text: '20' },
-                { key: '30', text: '30' },
-                { key: '40', text: '40' },
-                { key: '50', text: '50' },
-                { key: '75', text: '75' },
-                { key: '100', text: '100' },
-                { key: '200', text: '200' },
-              ]}
-            />
-          </div>
-        </div>
-      </div>
-    );
-  }
+export const ResizeGroupOverflowSetExample: React.FunctionComponent = () => {
+  const [numberOfItems, setNumberOfItems] = React.useState(20);
+  const [buttonsChecked, { toggle: toggleButtonsChecked }] = useBoolean(false);
+  const [cachingEnabled, { toggle: toggleCachingEnabled }] = useBoolean(false);
+  const [onGrowDataEnabled, { toggle: toggleOnGrowDataEnabled }] = useBoolean(false);
+  const dataToRender = generateData(numberOfItems, cachingEnabled, buttonsChecked);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _onReduceData = (currentData: any): any => {
+  const onReduceData = (currentData: any) => {
     if (currentData.primary.length === 0) {
       return undefined;
     }
-
     const overflow = [...currentData.primary.slice(-1), ...currentData.overflow];
     const primary = currentData.primary.slice(0, -1);
-
     let cacheKey = undefined;
-    if (this.state.cachingEnabled) {
+    if (cachingEnabled) {
       cacheKey = computeCacheKey(primary);
     }
     return { primary, overflow, cacheKey };
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _onGrowData = (currentData: any): any => {
+  const onGrowData = (currentData: any) => {
     if (currentData.overflow.length === 0) {
       return undefined;
     }
-
     const overflow = currentData.overflow.slice(1);
     const primary = [...currentData.primary, ...currentData.overflow.slice(0, 1)];
-
     let cacheKey = undefined;
-    if (this.state.cachingEnabled) {
+    if (cachingEnabled) {
       cacheKey = computeCacheKey(primary);
     }
     return { primary, overflow, cacheKey };
   };
 
-  private _onCachingEnabledChanged = (_: React.FormEvent<HTMLElement | HTMLInputElement>, checked: boolean): void => {
-    this.setState({ cachingEnabled: checked });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onRenderOverflowButton = (overflowItems: any) => (
+    <CommandBarButton role="menuitem" menuProps={{ items: overflowItems! }} />
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const onRenderData = (data: any) => {
+    return (
+      <OverflowSet
+        role="menubar"
+        items={data.primary}
+        overflowItems={data.overflow.length ? data.overflow : null}
+        onRenderItem={onRenderItem}
+        // eslint-disable-next-line react/jsx-no-bind
+        onRenderOverflowButton={onRenderOverflowButton}
+        styles={overflowSetStyles}
+      />
+    );
   };
 
-  private _onGrowDataEnabledChanged = (_: React.FormEvent<HTMLElement | HTMLInputElement>, checked: boolean): void => {
-    this.setState({ onGrowDataEnabled: checked });
+  const onNumberOfItemsChanged = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
+    setNumberOfItems(parseInt(option.text, 10));
   };
 
-  private _onButtonsCheckedChanged = (_: React.FormEvent<HTMLElement | HTMLInputElement>, checked: boolean): void => {
-    this.setState({ buttonsChecked: checked });
-  };
-
-  private _onNumberOfItemsChanged = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
-    this.setState({ numberOfItems: parseInt(option.text, 10) });
-  };
-}
+  return (
+    <div>
+      <ResizeGroup
+        role="tabpanel"
+        aria-label="Resize Group with an Overflow Set"
+        data={dataToRender}
+        // eslint-disable-next-line react/jsx-no-bind
+        onReduceData={onReduceData}
+        onGrowData={onGrowDataEnabled ? onGrowData : undefined}
+        // eslint-disable-next-line react/jsx-no-bind
+        onRenderData={onRenderData}
+      />
+      <div className={styles.settingsGroup}>
+        <Toggle label="Enable caching" onChange={toggleCachingEnabled} checked={cachingEnabled} />
+        <Toggle label="Enable onGrowData" onChange={toggleOnGrowDataEnabled} checked={onGrowDataEnabled} />
+        <Toggle label="Buttons checked" onChange={toggleButtonsChecked} checked={buttonsChecked} />
+        <div className={styles.itemCountDropdown}>
+          <Dropdown
+            label="Number of items to render"
+            selectedKey={numberOfItems.toString()}
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={onNumberOfItemsChanged}
+            options={dropdownOptions}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/react-next/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
+++ b/packages/react-next/src/components/ResizeGroup/examples/ResizeGroup.VerticalOverflowSet.Example.tsx
@@ -8,6 +8,7 @@ import {
   OverflowSet,
   IButtonStyles,
   DirectionalHint,
+  createArray,
 } from 'office-ui-fabric-react';
 
 export interface IOverflowData {
@@ -16,35 +17,29 @@ export interface IOverflowData {
   cacheKey?: string;
 }
 
-function generateData(count: number, cachingEnabled: boolean, checked: boolean): IOverflowData {
+const generateData = (count: number, cachingEnabled: boolean, checked: boolean): IOverflowData => {
   const icons = ['Add', 'Share', 'Upload'];
-  const dataItems = [];
   let cacheKey = '';
-  for (let index = 0; index < count; index++) {
-    const item = {
+  const dataItems = createArray(count, index => {
+    cacheKey = cacheKey + `item${index}`;
+    return {
       key: `item${index}`,
       name: `Item ${index}`,
       icon: icons[index % icons.length],
       checked: checked,
     };
-
-    cacheKey = cacheKey + item.key;
-    dataItems.push(item);
-  }
-
+  });
   let result: IOverflowData = {
     primary: dataItems,
-    overflow: [],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    overflow: [] as any[],
   };
-
   if (cachingEnabled) {
     result = { ...result, cacheKey };
   }
-
   return result;
-}
+};
 
-// Styles for the vertical buttons
 const buttonStyles: IButtonStyles = {
   root: {
     paddingBottom: 10,
@@ -53,70 +48,62 @@ const buttonStyles: IButtonStyles = {
   },
 };
 
-// Styles for the container of the ResizeGroup
-// This is only for the example to be constrained to a certain height to demonstrate the resizing
 const exampleHeight = '40vh';
 const resizeRootClassName = mergeStyles({ height: exampleHeight });
+const dataToRender = generateData(20, false, false);
 
-export class ResizeGroupVerticalOverflowSetExample extends React.Component {
-  public render(): JSX.Element {
-    const dataToRender = generateData(20, false, false);
-    return (
-      <ResizeGroup
-        className={resizeRootClassName}
-        role="tabpanel"
-        aria-label="Vertical Resize Group with an Overflow Set"
-        direction={ResizeGroupDirection.vertical}
-        data={dataToRender}
-        onReduceData={this._onReduceData}
-        // eslint-disable-next-line react/jsx-no-bind
-        onRenderData={data => {
-          return (
-            <OverflowSet
-              role="menubar"
-              vertical={true}
-              items={data.primary}
-              overflowItems={data.overflow.length ? data.overflow : null}
-              // eslint-disable-next-line react/jsx-no-bind
-              onRenderItem={item => {
-                return (
-                  <CommandBarButton
-                    role="menuitem"
-                    text={item.name}
-                    iconProps={{ iconName: item.icon }}
-                    onClick={item.onClick}
-                    checked={item.checked}
-                    styles={buttonStyles}
-                  />
-                );
-              }}
-              // eslint-disable-next-line react/jsx-no-bind
-              onRenderOverflowButton={overflowItems => {
-                return (
-                  <CommandBarButton
-                    role="menuitem"
-                    styles={buttonStyles}
-                    menuIconProps={{ iconName: 'ChevronRight' }}
-                    menuProps={{ items: overflowItems!, directionalHint: DirectionalHint.rightCenter }}
-                  />
-                );
-              }}
-            />
-          );
-        }}
-      />
-    );
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onRenderItem = (item: any) => (
+  <CommandBarButton
+    role="menuitem"
+    text={item.name}
+    iconProps={{ iconName: item.icon }}
+    onClick={item.onClick}
+    checked={item.checked}
+    styles={buttonStyles}
+  />
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onRenderOverflowButton = (overflowItems: any) => (
+  <CommandBarButton
+    role="menuitem"
+    styles={buttonStyles}
+    menuIconProps={{ iconName: 'ChevronRight' }}
+    menuProps={{ items: overflowItems!, directionalHint: DirectionalHint.rightCenter }}
+  />
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onRenderData = (data: any) => (
+  <OverflowSet
+    role="menubar"
+    vertical
+    items={data.primary}
+    overflowItems={data.overflow.length ? data.overflow : null}
+    onRenderItem={onRenderItem}
+    onRenderOverflowButton={onRenderOverflowButton}
+  />
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const onReduceData = (currentData: any): any => {
+  if (currentData.primary.length === 0) {
+    return undefined;
   }
+  const overflow = [...currentData.primary.slice(-1), ...currentData.overflow];
+  const primary = currentData.primary.slice(0, -1);
+  return { primary, overflow };
+};
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _onReduceData = (currentData: any): any => {
-    if (currentData.primary.length === 0) {
-      return undefined;
-    }
-
-    const overflow = [...currentData.primary.slice(-1), ...currentData.overflow];
-    const primary = currentData.primary.slice(0, -1);
-
-    return { primary, overflow };
-  };
-}
+export const ResizeGroupVerticalOverflowSetExample: React.FunctionComponent = () => (
+  <ResizeGroup
+    className={resizeRootClassName}
+    role="tabpanel"
+    aria-label="Vertical Resize Group with an Overflow Set"
+    direction={ResizeGroupDirection.vertical}
+    data={dataToRender}
+    onReduceData={onReduceData}
+    onRenderData={onRenderData}
+  />
+);

--- a/packages/react-next/src/components/Slider/examples/Slider.Basic.Example.tsx
+++ b/packages/react-next/src/components/Slider/examples/Slider.Basic.Example.tsx
@@ -3,48 +3,34 @@ import { Slider } from '@fluentui/react-next/lib/Slider';
 import { IStackTokens, Stack, IStackStyles } from '@fluentui/react-next/lib/Stack';
 
 const stackStyles: Partial<IStackStyles> = { root: { maxWidth: 300 } };
+const stackTokens: IStackTokens = { childrenGap: 20 };
+const sliderAriaValueText = (value: number) => `${value} percent`;
+const sliderValueFormat = (value: number) => `${value}%`;
 
-export interface ISliderBasicExampleState {
-  value: number;
-}
-
-/* eslint-disable react/jsx-no-bind */
-export class SliderBasicExample extends React.Component<{}, ISliderBasicExampleState> {
-  public state: ISliderBasicExampleState = { value: 0 };
-
-  public render(): JSX.Element {
-    const stackTokens: IStackTokens = { childrenGap: 20 };
-
-    return (
-      <Stack tokens={stackTokens} styles={stackStyles}>
-        <Slider />
-        <Slider
-          label="Snapping slider example"
-          min={0}
-          max={50}
-          step={10}
-          defaultValue={20}
-          showValue={true}
-          onChange={(value: number) => console.log(value)}
-          snapToStep
-        />
-        <Slider label="Disabled example" min={50} max={500} step={50} defaultValue={300} showValue={true} disabled />
-        <Slider
-          label="Controlled example"
-          max={10}
-          value={this.state.value}
-          onChange={(value: number) => this.setState({ value })}
-          showValue={true}
-        />
-        <Slider
-          label="Example with formatted value"
-          max={100}
-          ariaValueText={(value: number) => `${value} percent`}
-          valueFormat={(value: number) => `${value}%`}
-          showValue={true}
-        />
-        <Slider label="Origin from zero" min={-5} max={5} step={1} defaultValue={2} showValue originFromZero />
-      </Stack>
-    );
-  }
-}
+export const SliderBasicExample: React.FunctionComponent = () => {
+  const [sliderValue, setSliderValue] = React.useState(0);
+  const sliderOnChange = (value: number) => setSliderValue(value);
+  return (
+    <Stack tokens={stackTokens} styles={stackStyles}>
+      <Slider />
+      <Slider label="Snapping slider example" min={0} max={50} step={10} defaultValue={20} showValue snapToStep />
+      <Slider label="Disabled example" min={50} max={500} step={50} defaultValue={300} showValue disabled />
+      <Slider
+        label="Controlled example"
+        max={10}
+        value={sliderValue}
+        showValue
+        // eslint-disable-next-line react/jsx-no-bind
+        onChange={sliderOnChange}
+      />
+      <Slider
+        label="Example with formatted value"
+        max={100}
+        ariaValueText={sliderAriaValueText}
+        valueFormat={sliderValueFormat}
+        showValue
+      />
+      <Slider label="Origin from zero" min={-5} max={5} step={1} defaultValue={2} showValue originFromZero />
+    </Stack>
+  );
+};

--- a/packages/react-next/src/components/Slider/examples/Slider.Vertical.Example.tsx
+++ b/packages/react-next/src/components/Slider/examples/Slider.Vertical.Example.tsx
@@ -3,6 +3,7 @@ import { Slider } from '@fluentui/react-next/lib/Slider';
 import { IStackTokens, Stack, IStackStyles } from 'office-ui-fabric-react/lib/Stack';
 
 const stackStyles: Partial<IStackStyles> = { root: { height: 200 } };
+const stackTokens: IStackTokens = { childrenGap: 20 };
 
 export interface ISliderVerticalExampleState {
   value: number;
@@ -10,8 +11,6 @@ export interface ISliderVerticalExampleState {
 
 /* eslint-disable react/jsx-no-bind */
 export const SliderVerticalExample: React.FunctionComponent = () => {
-  const stackTokens: IStackTokens = { childrenGap: 20 };
-
   return (
     <Stack horizontal tokens={stackTokens} styles={stackStyles}>
       <Slider // prettier-ignore


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Updating `react-next's` examples to match the newer ones found inside of `office-ui-fabric-react`. 
The examples that were updated are within the components: `Checkbox` ,` FocusTrapZone`, `Keytips`, `ResizeGroup`, and `Slider`.

#### Focus areas to test
Checkbox, FocusTrapZone, Keytips, ResizeGroup, Slider
