### PR TITLE
Documentation fixes ResponsiveMode `Large` and `Small` to `large` and `small`

### DIFF
--- a/packages/react-next/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-next/src/components/Dropdown/Dropdown.types.ts
@@ -87,7 +87,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   /**
    * Pass in ResponsiveMode to manually overwrite the way the Dropdown renders.
    * ResponsiveMode.large would, for instance, disable the behavior where Dropdown options
-   * get rendered into a Panel while ResponsiveMode.Small would result in the Dropdown
+   * get rendered into a Panel while ResponsiveMode.small would result in the Dropdown
    * options always getting rendered in a Panel.
    */
   responsiveMode?: ResponsiveMode;

--- a/packages/react-next/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-next/src/components/Dropdown/Dropdown.types.ts
@@ -86,7 +86,7 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
 
   /**
    * Pass in ResponsiveMode to manually overwrite the way the Dropdown renders.
-   * ResponsiveMode.Large would, for instance, disable the behavior where Dropdown options
+   * ResponsiveMode.large would, for instance, disable the behavior where Dropdown options
    * get rendered into a Panel while ResponsiveMode.Small would result in the Dropdown
    * options always getting rendered in a Panel.
    */

--- a/packages/react-next/src/components/Dropdown/docs/DropdownOverview.md
+++ b/packages/react-next/src/components/Dropdown/docs/DropdownOverview.md
@@ -1,3 +1,3 @@
 A Dropdown is a list in which the selected item is always visible, and the others are visible on demand by clicking a drop-down button. They are used to simplify the design and make a choice within the UI. When closed, only the selected item is visible. When users click the drop-down button, all the options become visible. To change the value, users open the list and click another value or use the arrow keys (up and down) to select a new value.
 
-**Note:** Dropdown content automatically renders in a Panel on screens under 480px wide. To disable this behavior set `<Dropdown responsiveMode={ResponsiveMode.Large} ... />`
+**Note:** Dropdown content automatically renders in a Panel on screens under 480px wide. To disable this behavior set `<Dropdown responsiveMode={ResponsiveMode.large} ... />`


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`ResponsiveMode.Large` and `ResponsiveMode.Small` are wrong in docs, they should be `ResponsiveMode.large` and `ResponsiveMode.small`

#### Focus areas to test

This is only a documentation fix
