### PR TITLE
fix(UIBuilder) maximize view

### DIFF
--- a/packages/fluentui/react-builder/src/components/CodeEditor.tsx
+++ b/packages/fluentui/react-builder/src/components/CodeEditor.tsx
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import { Editor } from '@fluentui/docs-components';
+
+import { JSONTreeElement } from './types';
+import { codeToTree } from '../utils/codeToTree';
+
+export type CodeEditorProps = {
+  code: string;
+  onCodeChange: (code: string, jsonTree: JSONTreeElement) => void;
+  onCodeError: (code: string, error: string) => void;
+};
+
+export const CodeEditor: React.FunctionComponent<CodeEditorProps> = ({ code, onCodeChange, onCodeError }) => {
+  const handleCodeChange = React.useCallback(
+    code => {
+      try {
+        onCodeChange(code, codeToTree(code));
+      } catch (e) {
+        onCodeError(code, e.message);
+      }
+    },
+    [onCodeChange, onCodeError],
+  );
+
+  return <Editor mode="jsx" height="auto" value={code} onChange={handleCodeChange} />;
+};

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useImmerReducer, Reducer } from 'use-immer';
 import { Text, Button } from '@fluentui/react-northstar';
 import { EventListener } from '@fluentui/react-component-event-listener';
-import { Editor, renderElementToJSX } from '@fluentui/docs-components';
+import { Editor as _Editor, renderElementToJSX } from '@fluentui/docs-components';
 
 import { componentInfoContext } from '../componentInfo/componentInfoContext';
 import { ComponentInfo } from '../componentInfo/types';
@@ -29,7 +29,6 @@ import { readTreeFromStore, readTreeFromURL, writeTreeToStore, writeTreeToURL } 
 import { DesignerMode, JSONTreeElement } from './types';
 import { ComponentTree } from './ComponentTree';
 import { GetShareableLink } from './GetShareableLink';
-import { codeToTree } from '../utils/codeToTree';
 import { ErrorBoundary } from './ErrorBoundary';
 
 const HEADER_HEIGHT = '3rem';
@@ -37,6 +36,14 @@ const HEADER_HEIGHT = '3rem';
 function debug(...args) {
   console.log('--Designer', ...args);
 }
+
+// Lazy load codeToTree - it depenends on babel which is not loaded in Fullscreen mode.
+let codeToTree: (code: string) => JSONTreeElement = null;
+
+const Editor = React.lazy(async () => {
+  codeToTree = (await import(/* webpackChunkName: "codetotree" */ '../utils/codeToTree')).codeToTree;
+  return { default: _Editor };
+});
 
 function getDefaultJSONTree(): JSONTreeElement {
   return { uuid: 'builder-root', type: 'div' };

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -527,7 +527,9 @@ export const Designer: React.FunctionComponent = () => {
               <div style={{ flex: '0 0 auto', maxHeight: '35vh', overflow: 'auto' }}>
                 {showCode && (
                   <div>
-                    <Editor mode="jsx" height="auto" value={code} onChange={handleSourceCodeChange} />
+                    <React.Suspense fallback={<div>Loading...</div>}>
+                      <Editor mode="jsx" height="auto" value={code} onChange={handleSourceCodeChange} />
+                    </React.Suspense>
                     {codeError && (
                       <pre
                         style={{


### PR DESCRIPTION
#### Description of changes

UIBuilder Maximize view failed to load because of missing babel.
Babel is not required for the maximize view but was a hard dependency in `Designer` - it is now lazily loaded only when code editor is opened.

#### Focus areas to test

- Code editor in UI Builder
- Maximize view
