### PR TITLE
Adding compose updates

### DIFF
--- a/change/@fluentui-react-compose-2020-07-28-14-16-10-feat-compose-staging.json
+++ b/change/@fluentui-react-compose-2020-07-28-14-16-10-feat-compose-staging.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding a re-worked compose helper under /lib/next. This should not modify the public api in any way, but will simply let us try the updates before we buy into them.",
+  "packageName": "@fluentui/react-compose",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-28T21:16:10.856Z"
+}

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -31,6 +31,7 @@
     "@types/react": "16.8.25",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",
+    "@uifabric/test-utilities": "^7.0.34",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6"

--- a/packages/react-compose/src/next/README.md
+++ b/packages/react-compose/src/next/README.md
@@ -1,0 +1,315 @@
+# @fluentui/react-compose
+
+Each Fluent UI React component is built from small building blocks, composed together in a way that is easy to customize and extend.
+
+Components are comprised of:
+
+- Default props
+- State/accessibility hooks
+- Styling hooks which provide class names for the parts of a component.
+- Render function: function which consumes the final state and styling and returns markup.
+
+The `compose` helper is a simple utility which lets us glue these parts together in a way that allows them to be easily extended.
+
+## How compose works
+
+Example usage:
+
+```jsx
+// compose a Foo component.
+const Foo = compose(
+  (state) => {
+    return <foo/>;
+  }, {
+  // Component has a name.
+  displayName: 'Foo',
+
+  // Component manages some state, behaviors, styling.
+  useHooks: [ (draftState) => newState | undefined ],
+
+  // Component has some default props.
+  defaultProps: { ... }
+});
+```
+
+Compose handles these concerns:
+
+1. draftState is created based on defaultProps and user input. Draft state allows you to directly manipulate a copy of the state without worrying about immutability mistakes or performance overhead of object spreading.
+2. Each hook is executed with draft state.
+3. Final state is passed to render function and result is returned.
+
+Additionally it allows the result to be extended through an attached `extend` helper:
+
+```jsx
+const AnotherComponent = MyComponent.extend({
+  useHooks: [ ...more hooks ],
+  defaultProps: { ...new defaults }
+})
+```
+
+The extend call creates a new component with new settings merged on top of the base settings. Doing this avoids extra wrapper component layers, while still reusing the component.
+
+### But why is extend important?
+
+Fluent UI components should have 2 separate layers; base components which are unstyled, and styled versions of those components. This gives developers 2 layers to use; use the styled component when building M365 experiences. Extend the unstyled component (e.g. `ButtonBase`) to use a different styling approach, or build a new, slightly augmented component extending the styled version (e.g. `Button`).
+
+## Getting started writing components
+
+### Write and review a spec
+
+Know what you're building. Do the research on the following:
+
+- What is the right component name? Consult guidance in Open UI.
+- What props are accepted? Are there standards in Open UI
+- What slots should be configurable?
+- How does customized styling work?
+
+### Build a base component
+
+A base component defines the render dom heirarchy, state management, and accessible behaviors. It does not provide styling. It does not attach dependencies. These are done in a separate layer, so that customers can always fall back to extending the base, should they wish to provide their own styling or subcomponent dependencies.
+
+Use `compose` to create the extendable base component. It takes in a render function and options:
+
+```jsx
+const MyComponentBase = compose<TProps, TState>(
+  (state, options) => {
+    return <div />;
+  }, {
+    displayName: 'MyComponentBase',
+    // ...
+  });
+```
+
+## Supporting component slots
+
+The root element should always be configurable by the customer using the `as` prop.
+
+Additionally components often have more than a root element; these additional subcomponents should be configurable by the customer as well. We customize these using slot props.
+
+Use the `getSlots` helper to parse out `as` prop, slots and native props. By default, it will return a `root` slot for you.
+
+```
+const MyComponentBase = compose((state, options) => {
+  const { slots, slotProps } = getSlots(state, options);
+
+  return <slots.root {...slotProps.root} />;
+}, {
+  displayName: 'MyComponentBase',
+  defaultProps: {
+    as: 'div',
+    icon: { as: FooComponent }
+  }
+]});
+```
+
+Add an `icon` slot:
+
+```jsx
+const MyComponentBase = compose(
+  (state, options) => {
+    const { slots, slotProps } = getSlots(state, options);
+
+    return (
+      <slots.root {...slotProps.root}>
+        <slots.icon {...slotProps.icon} />
+      </slots.root>
+    );
+  },
+  {
+    // Instruct merging on which props are shorthand.
+    shorthandProps: ['icon'],
+
+    defaultProps: {
+      // Define the default props for the icon.
+      icon: { as: 'span' },
+    },
+  },
+);
+```
+
+Note: the `shorthandProps` array option is required for compose to apply shorthand normalization logic for proper default props merging. (Because a shorthand prop can be a string, object, or JSX, you need to apply custom merge logic for these.)
+
+## Adding state hooks
+
+The `compose` options can provide a `useHooks` array to provide a way for components to inject hooks to preprocess state after receiving user props and before rendering the component.
+
+A draft state object will be created from userProps, allowing hooks to directly manipulate state without worrying about immutability and avoiding the overhead in recreating state objects.
+
+![](https://i.imgur.com/cSiEAIV.png)
+
+Example:
+
+A hook which uses an interval to inject value:
+
+```jsx
+const useIncrementingValue = draftState => {
+  const { step = 1 } = draftState; // get step from user.
+  const setInterval = useSetInterval();
+  const [value, setValue] = React.useState(0);
+
+  setInterval(
+    React.useCallback(() => {
+      setValue(v => v + step);
+    }, [step]),
+    1000,
+  );
+
+  // Plumb the managed value into draft state.
+  draftState.value = value;
+};
+```
+
+Can be added to the base component:
+
+```jsx
+const MyComponentBase = compose(
+  (state, options) => { ... },
+  {
+    useHooks: [
+      useIncrementingValue
+    ]
+  }
+});
+```
+
+Or as an example of extensibility, a user can also extend the component with the behavior without creating additional HOC layers:
+
+```jsx
+const MyComponent = MyComponentBase.extend({
+  useHooks: [useIncrementingValue],
+});
+```
+
+Some hooks should be created by a factory function so that inputs can be cached. For example, say the prop name and default incrementing step should be provided to a factory creating the hook. We use the `make` prefix to indicate a hook factory:
+
+```jsx
+const MyComponent = MyComponentBase.extend({
+  useHooks: [makeIncrementingValue({ propName: 'value', step: 1 })],
+});
+```
+
+## Create a styled component from the base
+
+We use the `extend` static to create styled variations of the base component:
+
+`MyComponent.scss`:
+
+```scss
+.root {
+  background: red;
+}
+.icon {
+  background: green;
+}
+```
+
+`MyComponent.tsx`:
+
+```jsx
+import * as styles from './MyComponent.scss';
+import { makeStyles } from '@fluentui/react-theme-provider';
+
+const MyComponent = MyComponentBase.extend({
+  useHooks: [
+    // hook to inject stylesheet as needed
+    makeStyles(styles),
+  ],
+});
+```
+
+The `makeStyles` helper injects styling on render as needed, in the correct window (respecting theme context.)
+
+### Tokenizing the component
+
+Tokens are simply css variables. They are replacement values in the stylesheet.
+
+As users wish to customize the component, they will want to provide new tokens.
+
+Your stylesheet needs to be adjusted respect the tokens:
+
+```
+.root {
+  background: var(--MyComponent-background, red);
+}
+.root:hover {
+  background: var(--MyComponent-hovered-background, pink);
+}
+```
+
+The user could now apply these overrides inline:
+
+```tsx
+<MyComponent style={{ '--MyComponent-background': 'blue' }} />
+```
+
+This gives a lot of power to the user; they no longer have to guess selectors to override and can override complex things inline, but it is still a guessing game. There is no type safety.
+
+To work through this, we want type safe tokens:
+
+```jsx
+<MyComponent tokens={{ background: 'blue', hoveredBackground: 'lightblue' }} />
+```
+
+There are a few helpers to make this easy:
+
+> TODO
+
+### Creating variants with tokens
+
+Component styling is not static; you need modifiers and enum values to create variations of the component in different states.
+
+Variants could be hardcoded in the styling, but they would not be easy to override in css due to specificity wars. We want variants to be easily overridable via the theme.
+
+```jsx
+export const MyComponentVariants = {
+  base: {
+    background: 'red',
+  },
+  primary: {
+    background: 'green',
+  },
+};
+```
+
+```jsx
+import * as styles from './MyComponent.scss';
+import { makeStyles, makeVariants } from '@fluentui/react-theme-provider';
+
+const MyComponent = MyComponentBase.extend({
+  displayName: 'MyComponent',
+  useHooks: [
+    // hook to inject stylesheet as needed
+    makeStyles(styles),
+    // hook to inject style variants
+    makeVariants(variants),
+  ],
+});
+```
+
+The makeVariants helper takes care of a lot of things for you so that you can't make a mistake:
+
+- Creates class names for variants on demand, only when necessary
+- Injects the correct classes to the root when matching state is provided
+- Respects variants defined in the theme
+
+```jsx
+<MyComponent /> // red background
+<MyComponent primary /> // green background
+
+<ThemeProvider
+  theme={{
+  components: {
+    MyComponent: {
+      variants: {
+        base: {
+         background: 'yellow'
+        }
+      }
+    }
+  }
+}}>
+  <MyComponent /> // yellow background
+</ThemeProvider>
+```
+
+### Processing inline tokens

--- a/packages/react-compose/src/next/applyHooks.tsx
+++ b/packages/react-compose/src/next/applyHooks.tsx
@@ -1,0 +1,11 @@
+import { GenericDictionary, ComposeOptions } from './types';
+
+export const applyHooks = <TProps, TState>(state: GenericDictionary, options: ComposeOptions<TProps, TState>) => {
+  if (options.useHooks?.length) {
+    for (const useHooks of options.useHooks) {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useHooks(state, options);
+    }
+  }
+  return state as TState;
+};

--- a/packages/react-compose/src/next/compose.test.tsx
+++ b/packages/react-compose/src/next/compose.test.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { compose } from './compose';
+import { safeMount } from '@uifabric/test-utilities';
+import { ShorthandProps } from './types';
+
+describe('compose', () => {
+  const Foo = compose<{ text?: string }>(
+    // render
+    (state: { text?: string }) => <div>{state.text}</div>,
+    // options
+    {
+      displayName: 'Foo',
+      defaultProps: { text: 'hello' },
+    },
+  );
+
+  it('can create a renderable component', () => {
+    expect(Foo.displayName);
+
+    safeMount(<Foo />, wrapper => {
+      expect(wrapper.html()).toEqual('<div>hello</div>');
+    });
+
+    safeMount(<Foo text="world" />, wrapper => {
+      expect(wrapper.html()).toEqual('<div>world</div>');
+    });
+  });
+
+  it('can create an extendable component', () => {
+    const Bar = Foo.extend<{ text?: string }>({
+      defaultProps: {
+        text: 'new text',
+      },
+    });
+
+    safeMount(<Bar />, wrapper => {
+      expect(wrapper.html()).toEqual('<div>new text</div>');
+    });
+  });
+
+  it('can simplify shorthand on merging', () => {
+    let lastSlotValue;
+
+    const Bar = compose<{ slot1?: ShorthandProps }>(
+      (state: { slot1?: ShorthandProps }) => {
+        lastSlotValue = state.slot1;
+        return <div />;
+      },
+      {
+        defaultProps: {
+          slot1: { as: 'span', children: 'hello' },
+        },
+        shorthandPropNames: ['slot1'],
+      },
+    );
+
+    safeMount(<Bar />, () => undefined);
+    expect(lastSlotValue).toEqual({ as: 'span', children: 'hello' });
+
+    safeMount(<Bar slot1={{ id: '123' }} />, () => undefined);
+    expect(lastSlotValue).toEqual({ as: 'span', id: '123', children: 'hello' });
+
+    safeMount(<Bar slot1="goodbye" />, () => undefined);
+    expect(lastSlotValue).toEqual({ as: 'span', children: 'goodbye' });
+
+    safeMount(<Bar slot1={<div />} />, () => undefined);
+    expect(lastSlotValue).toEqual({ as: 'span', children: <div /> });
+  });
+});

--- a/packages/react-compose/src/next/compose.tsx
+++ b/packages/react-compose/src/next/compose.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { ComposeOptions, ComposedComponent, ComposeInput, OPTIONS_NAME } from './types';
+import { mergeComposeOptions } from './mergeComposeOptions';
+import { mergeObjects } from './mergeObjects';
+import { applyHooks } from './applyHooks';
+import { simplifyShorthand } from './simplifyShorthand';
+
+export function compose<TProps, TState = TProps>(
+  render: ComposeInput<TProps, TState>,
+  options: ComposeOptions<TProps, TState>,
+) {
+  const composeOptions = mergeComposeOptions(render, options);
+
+  const Result: ComposedComponent<TProps, TState> = React.forwardRef<HTMLElement, TProps>(
+    (props: TProps, ref: React.Ref<HTMLElement>) =>
+      composeOptions.render!(
+        // get the state by applying the component's hooks.
+        applyHooks(
+          // create draft state.
+          mergeObjects(
+            // start draft state with ref.
+            { ref },
+
+            // merge default props.
+            composeOptions.defaultProps,
+
+            // merge along the user props, with simplified shorthand.
+            simplifyShorthand(
+              composeOptions.initialState ? composeOptions.initialState(props) : props,
+              composeOptions.shorthandPropNames,
+            ),
+          ),
+          composeOptions,
+        ),
+        composeOptions,
+      ),
+  ) as ComposedComponent<TProps, TState>;
+
+  // Assign statics.
+  Result.displayName = composeOptions.displayName;
+  Result[OPTIONS_NAME] = composeOptions;
+
+  Result.extend = function extend<TNewProps = TProps, TNewState = TState>(
+    extendOptions: ComposeOptions<TNewProps, TNewState>,
+  ) {
+    return compose<TNewProps, TNewState>(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      Result as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      extendOptions as any,
+    ) as ComposedComponent<TNewProps, TNewState>;
+  };
+
+  return Result;
+}

--- a/packages/react-compose/src/next/getSlots.tsx
+++ b/packages/react-compose/src/next/getSlots.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { getNativeElementProps } from '@uifabric/utilities';
+import { GenericDictionary } from './types';
+import { nullRender } from './nullRender';
+
+export const getSlots = (state: GenericDictionary, slotNames: string[] | undefined) => {
+  const slots: GenericDictionary = {
+    root: state.as || nullRender,
+  };
+  const slotProps: GenericDictionary = {
+    root: getNativeElementProps(state.as, state),
+  };
+
+  for (const name of slotNames!) {
+    const slotDefinition = state[name];
+
+    const slot = (slots[name] = slotDefinition.as && slotDefinition.children ? slotDefinition.as : nullRender);
+
+    if (slots[name] !== nullRender) {
+      const nativeElementProps = (slotProps[name] = getNativeElementProps(slot, slotDefinition));
+
+      if (typeof nativeElementProps.children === 'function') {
+        slots[name] = React.Fragment;
+        nativeElementProps.children = nativeElementProps.children(slots[name], nativeElementProps);
+      }
+    }
+  }
+
+  return { slots, slotProps };
+};

--- a/packages/react-compose/src/next/index.ts
+++ b/packages/react-compose/src/next/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './compose';
+export * from './getSlots';

--- a/packages/react-compose/src/next/mergeComposeOptions.tsx
+++ b/packages/react-compose/src/next/mergeComposeOptions.tsx
@@ -1,0 +1,18 @@
+import { ComposeInput, ComposeOptions, ComposedComponent, OPTIONS_NAME, ComposeRenderFunction } from './types';
+import { mergeObjects } from './mergeObjects';
+
+export function mergeComposeOptions<TProps, TState>(
+  render: ComposeInput<TProps, TState>,
+  options: ComposeOptions<TProps, TState>,
+): ComposeOptions<TProps, TState> {
+  const parentOptions: ComposeOptions<TProps, TState> = (render as ComposedComponent<TProps, TState>)[OPTIONS_NAME];
+
+  return {
+    ...parentOptions,
+    ...options,
+    shorthandPropNames: [...(parentOptions?.shorthandPropNames || []), ...(options.shorthandPropNames || [])],
+    render: (parentOptions?.render || render) as ComposeRenderFunction<TProps, TState>,
+    defaultProps: mergeObjects({}, parentOptions?.defaultProps, options.defaultProps) as TProps,
+    useHooks: [...(parentOptions?.useHooks || []), ...(options.useHooks || [])],
+  };
+}

--- a/packages/react-compose/src/next/mergeObjects.tsx
+++ b/packages/react-compose/src/next/mergeObjects.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { css } from '@uifabric/utilities';
+import { GenericDictionary } from './types';
+
+export const mergeObjects = (target: GenericDictionary, ...propSets: (GenericDictionary | undefined)[]) => {
+  for (const props of propSets) {
+    if (props) {
+      for (const propName of Object.keys(props)) {
+        const propValue = props[propName];
+
+        if (typeof propValue === 'object') {
+          target[propName] = target[propName] || {};
+
+          if (React.isValidElement(propValue)) {
+            target[propName] = propValue;
+          } else {
+            mergeObjects(target[propName], propValue);
+          }
+        } else if (propName === 'className') {
+          if (propValue) {
+            target[propName] = css(target[propName], propValue);
+          }
+        } else {
+          target[propName] = propValue;
+        }
+      }
+    }
+  }
+
+  return target;
+};

--- a/packages/react-compose/src/next/nullRender.tsx
+++ b/packages/react-compose/src/next/nullRender.tsx
@@ -1,0 +1,1 @@
+export const nullRender = () => null;

--- a/packages/react-compose/src/next/simplifyShorthand.tsx
+++ b/packages/react-compose/src/next/simplifyShorthand.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { GenericDictionary } from './types';
+
+export const simplifyShorthand = (props: GenericDictionary, shorthandPropNames?: string[]) => {
+  let newProps = props;
+
+  if (shorthandPropNames && shorthandPropNames.length) {
+    newProps = {
+      ...props,
+    };
+    for (const propName of shorthandPropNames) {
+      const propValue = props[propName];
+
+      if (propValue !== undefined && (typeof propValue !== 'object' || React.isValidElement(propValue))) {
+        newProps[propName] = { children: propValue };
+      }
+    }
+  }
+
+  return newProps;
+};

--- a/packages/react-compose/src/next/types.tsx
+++ b/packages/react-compose/src/next/types.tsx
@@ -1,0 +1,79 @@
+export const OPTIONS_NAME = '__options';
+
+/**
+ * Generic name to any dictionary.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type GenericDictionary = Record<string, any>;
+
+export type ComposedComponent<TProps, TState> = React.ForwardRefExoticComponent<TProps> & {
+  [OPTIONS_NAME]: ComposeOptions<TProps, TState>;
+  extend: <TNewProps = TProps, TNewState = TState>(
+    options: ComposeOptions<TNewProps, TNewState>,
+  ) => ComposedComponent<TNewProps, TNewState>;
+};
+
+export type ComposeRenderFunction<TProps, TState> = (
+  state: TState,
+  options: ComposeOptions<TProps, TState>,
+) => JSX.Element;
+
+export type ComposeInput<TProps, TState> = ComposedComponent<TProps, TState> | ComposeRenderFunction<TProps, TState>;
+
+export type ComposeHook<TProps, TState> = (props: GenericDictionary, options: ComposeOptions<TProps, TState>) => void;
+
+export type ComposeOptions<TProps, TState> = {
+  displayName?: string;
+
+  /**
+   * Default props to layer user props on before doing the deep merge.
+   */
+  defaultProps?: Partial<TProps>;
+
+  /**
+   * Defines the initial state to use. Defaults to user props. This provides a hook for the user to alter incoming
+   * user input before applying the deep merge, shorthand simplifications, and applying attached hooks.
+   */
+  initialState?: (props: TProps) => Partial<TState>;
+
+  /**
+   * Hooks to be executed. Each hook can directly manipulate the state object.
+   */
+  useHooks?: ComposeHook<TProps, TState>[];
+
+  /**
+   * Shorthand props which should be simplified prior to merging. Shorthand should always be in object notation,
+   * rather than literals, JSX, etc, before merging.
+   */
+  shorthandPropNames?: string[];
+
+  /**
+   * The render function to apply. This can be provided via options in component recomposition scenarios.
+   */
+  render?: ComposeRenderFunction<TProps, TState>;
+};
+
+export interface ComponentProps extends GenericDictionary {
+  as?: React.ElementType;
+  ref?: React.Ref<HTMLElement>;
+  className?: string;
+}
+
+//
+// Slot Prop / Shorthand types
+//
+
+export type ShorthandRenderFunction<TProps> = (Component: React.ElementType<TProps>, props: TProps) => React.ReactNode;
+
+export type ShorthandProps<TProps extends ComponentProps = {}> =
+  | React.ReactChild
+  | React.ReactNodeArray
+  | React.ReactPortal
+  | boolean
+  | number
+  | null
+  | undefined
+  | (TProps &
+      ComponentProps & {
+        children?: TProps['children'] | ShorthandRenderFunction<TProps>;
+      });


### PR DESCRIPTION
The current `compose` helper has a lot of complexities that make it less simple than it should be. This PR adds a new version of `compose` to the `/next` folder. I did this explicitly to not change any of the existing code, so that we can play test these changes first in other components before committing. If it works well, and we want to move with it, then I will add more tests and replace the existing one. Otherwise, I'll delete it.

We all agree that components should be built from smaller building blocks; atomic hooks, behavior/state hooks, styling hooks, render functions, etc. None of this is contentious. None of this code prevents anyone from creating components from scratch, or reusing the parts of a component. However it's a little unclear about the best way to glue these together in a way that lets us augment existing things without rewriting them.

The scenario that started the ideas was to provide both unstyled and styled components; e.g. `ButtonBase` vs `Button`. The question we ask is: how can we "extend" the base to provide the styled version? Styling is more than just css; it's the slot defaults we use as well, as an unstyled component must not depend on a styled subcomponent or it inadvertently becomes partially styled.

We also know that wrapper components add performance overhead when done in bulk. While wrapper components can solve the concern, the add overhead when done in bulk. Having a utility which can re-scaffold new components while reusing the same essence of the original component can avoid this.

The existing compose had a number of problems:

* Typings complicated and hard to use
* Unclear on what it's doing and how much its doing
* No way to configure default props
* Slots support baked in
* Handled props baked in
* classes a separate concern when really could just be a hook
* only one state hook allowed
* Why is this even better than just rebuilding things from scratch?
* Naming is weird for recomposition; calling `compose` with an existing component is unclear on purpose.

This new update to `compose` attempts to address these concerns. It simplifies a lot. Lots has been removed. Here's what's changed.

First, the generics have been simplified to `<TProps, TState>`:

```jsx
const ButtonBase = compose<ButtonProps, ButtonState>( ... );
```

Second, hooks now can be provided in an array, each taking in "draft state" which can be directly mutated to adjust the state for the component:

```jsx
const ButtonBase = compose<...>(
  state => JSX,
  {
     useHooks: [
        useButtonState,
     ]
}
```

Hooks will be guaranteed to be called on every render in the same order. So in keeping them as an array, we can ensure less mistakes, symmetry on hooks definition, and with draft state, better perf and less immutability bugs. The hooks can be used to provide state, accessibility, and styling in a layered way.

Third, there is no more classes, slots, handledProps. There is only `defaultProps`, which take special consideration to shorthand.

Default slot values should be defined as defaultProps, just as any other default which may be overridable:

```jsx
const ButtonBase = compose<...>(
  state => JSX,
  {
     defaultProps: {
        as: 'button',
        icon: { as: 'span', children: <AddIcon /> }
     },
     shorthandProps: ['icon']
  });
```

Getting slots and slot props are done via a `getSlots` helper called in the render function, optionally, if your component supports slots.

And, lastly, compose provides an `extend` static, which helps with no extra utility imports. This means creating styled versions are very simple and really have no magic:

```tsx
const Button = ButtonBase.extend({
  useHooks: [
    makeStyles(styles, 'Button')
  ]
});
```

This creates a component copy (not a wrapper), which re-uses the state, accessibility, and render structure of ButtonBase, and adds styling opinions as overrides. We could use this, for example, to support multiple styling approaches without tying the component to a particular style implementation.

