### PR TITLE
Removing unused default props from TeachingBubbleContent

### DIFF
--- a/change/office-ui-fabric-react-2020-07-29-13-56-05-fix-teachingBubble.json
+++ b/change/office-ui-fabric-react-2020-07-29-13-56-05-fix-teachingBubble.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Removing unused default props from TeachingBubbleContent.",
+  "packageName": "office-ui-fabric-react",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-29T20:56:05.714Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9438,15 +9438,6 @@ export class TeachingBubbleContentBase extends React.Component<ITeachingBubblePr
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    static defaultProps: {
-        hasCondensedHeadline: boolean;
-        imageProps: {
-            imageFit: ImageFit;
-            width: number;
-            height: number;
-        };
-    };
-    // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -3,23 +3,13 @@ import { initializeComponentRef, classNamesFunction, KeyCodes } from '../../Util
 import { ITeachingBubbleProps, ITeachingBubbleStyleProps, ITeachingBubbleStyles } from './TeachingBubble.types';
 import { ITeachingBubbleState } from './TeachingBubble.base';
 import { PrimaryButton, DefaultButton, IconButton } from '../../Button';
-import { Image, ImageFit } from '../../Image';
+import { Image } from '../../Image';
 import { Stack } from '../../Stack';
 import { FocusTrapZone } from '../../FocusTrapZone';
 
 const getClassNames = classNamesFunction<ITeachingBubbleStyleProps, ITeachingBubbleStyles>();
 
 export class TeachingBubbleContentBase extends React.Component<ITeachingBubbleProps, ITeachingBubbleState> {
-  // Specify default props values
-  public static defaultProps = {
-    hasCondensedHeadline: false,
-    imageProps: {
-      imageFit: ImageFit.cover,
-      width: 364,
-      height: 130,
-    },
-  };
-
   public rootElement = React.createRef<HTMLDivElement>();
 
   constructor(props: ITeachingBubbleProps) {


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Removing default props for both hasCondensedHeadline and imageProps within OUFR's `TeachingBubbleContent`.
hasCondensedHeadline should already default to false without default props implemented and imageProps doesn't exist anywhere inside of `TeachingBubble's` types.

#### Focus areas to test
`TeachingBubbleContent`
