### PR TITLE
Adding raw version of acc spec generator 

### DIFF
--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -317,7 +317,7 @@ export const Designer: React.FunctionComponent = () => {
   const [components, setComponents] = React.useState([]);
 
   const componentsExcludedFromAccSpec = ['Flex', 'Box', 'FlexItem'];
-  let componentsForAccSpec = [];
+  const componentsForAccSpec = [];
 
   const jsonTreeToItems = (tree: any) => {
     tree.props?.children?.forEach(item => {
@@ -345,9 +345,7 @@ export const Designer: React.FunctionComponent = () => {
     const header = {
       items: ['Element', 'Control type', 'Screen reader ', 'Behavior', 'Comments'],
     };
-    {
-      return components.length > 0 && <Table header={header} rows={rows} aria-label="Specification component table" />;
-    }
+    return components.length > 0 && <Table header={header} rows={rows} aria-label="Specification component table" />;
   };
 
   React.useEffect(() => {

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as _ from 'lodash';
 import { useImmerReducer, Reducer } from 'use-immer';
-import { Text, Button } from '@fluentui/react-northstar';
+import { Text, Button, Table } from '@fluentui/react-northstar';
 import { EventListener } from '@fluentui/react-component-event-listener';
 import { Editor, renderElementToJSX } from '@fluentui/docs-components';
 
@@ -310,8 +310,45 @@ export const Designer: React.FunctionComponent = () => {
 
   const [{ mode, isExpanding, isSelecting }, setMode] = useMode();
   const [showJSONTree, handleShowJSONTreeChange] = React.useState(false);
+  const [showAccSpec, handleShowAccSpecChange] = React.useState(false);
 
   const [accessibilityErrors, setAccessibilityErrors] = React.useState({});
+
+  const [components, setComponents] = React.useState([]);
+
+  const componentsExcludedFromAccSpec = ['Flex', 'Box', 'FlexItem'];
+  let componentsForAccSpec = [];
+
+  const jsonTreeToItems = (tree: any) => {
+    tree.props?.children?.forEach(item => {
+      if (componentsExcludedFromAccSpec.indexOf(item.displayName) === -1) {
+        componentsForAccSpec.push({
+          name: item.displayName,
+        });
+      }
+      jsonTreeToItems(item);
+    });
+  };
+
+  const generateAccSpec = () => {
+    jsonTreeToItems(jsonTree);
+    setComponents(componentsForAccSpec);
+  };
+
+  const tableOfComponents = () => {
+    const rows = components.map((item, index) => {
+      return {
+        key: index,
+        items: ['', item.name, '', '', ''],
+      };
+    });
+    const header = {
+      items: ['Element', 'Control type', 'Screen reader ', 'Behavior', 'Comments'],
+    };
+    {
+      return components.length > 0 && <Table header={header} rows={rows} aria-label="Specification component table" />;
+    }
+  };
 
   React.useEffect(() => {
     if (state.jsonTreeOrigin === 'store') {
@@ -550,6 +587,8 @@ export const Designer: React.FunctionComponent = () => {
         onReset={handleReset}
         onUpload={handleUpload}
         onModeChange={setMode}
+        onShowAccSpecChange={handleShowAccSpecChange}
+        showAccSpec={showAccSpec}
         showCode={showCode}
         showJSONTree={showJSONTree}
         style={{ flex: '0 0 auto', width: '100%', height: HEADER_HEIGHT }}
@@ -702,6 +741,13 @@ export const Designer: React.FunctionComponent = () => {
                     <pre>{JSON.stringify(jsonTree, null, 2)}</pre>
                   </div>
                 )}
+              </div>
+            )}
+            {showAccSpec && (
+              <div style={{ flex: 1, padding: '1rem', color: '#543', background: '#ddd' }}>
+                <h3 style={{ margin: 0 }}>Accessibility specification</h3>
+                <Button content="generate Acc Spec" onClick={generateAccSpec} />
+                {tableOfComponents()}
               </div>
             )}
           </div>

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -744,7 +744,7 @@ export const Designer: React.FunctionComponent = () => {
             {showAccSpec && (
               <div style={{ flex: 1, padding: '1rem', color: '#543', background: '#ddd' }}>
                 <h3 style={{ margin: 0 }}>Accessibility specification</h3>
-                <Button content="generate Acc Spec" onClick={generateAccSpec} />
+                <Button content="Generate" onClick={generateAccSpec} />
                 {tableOfComponents()}
               </div>
             )}

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -11,11 +11,13 @@ export type ToolbarProps = {
   onUpload: (jsonTree: {}) => void;
   onShowCodeChange: (showCode: boolean) => void;
   onShowJSONTreeChange: (showJSONTree: boolean) => void;
+  onShowAccSpecChange: (showAccSpec: boolean) => void;
   eenabledVirtualCursor: boolean;
   onEnableVirtualCursor: (enableVirtualCursor: boolean) => void;
   mode: DesignerMode;
   showCode: boolean;
   showJSONTree: boolean;
+  showAccSpec: boolean;
   style?: React.CSSProperties;
 };
 
@@ -33,6 +35,8 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
   style,
   eenabledVirtualCursor,
   onEnableVirtualCursor,
+  onShowAccSpecChange,
+  showAccSpec,
 }) => {
   const uploadInputRef = React.useRef<HTMLInputElement>();
   return (
@@ -108,6 +112,16 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
           toggle
           checked={!!showJSONTree}
           onChange={(e, data) => onShowJSONTreeChange(data.checked)}
+        />
+        &emsp;
+        <Checkbox
+          label="Show Acc Spec"
+          toggle
+          checked={!!showAccSpec}
+          onChange={(e, data) => {
+            debugger;
+            onShowAccSpecChange(data.checked);
+          }}
         />
         &emsp;
         <input

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -119,7 +119,6 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
           toggle
           checked={!!showAccSpec}
           onChange={(e, data) => {
-            debugger;
             onShowAccSpecChange(data.checked);
           }}
         />


### PR DESCRIPTION

#### Description of changes

Adding "Show Acc Spec" checkbox. 
Then adding button "generate Acc Spec".  (added button, otherwise I had react failure complain about too many re rendering )
When user presses button then component are given into the table. 
Then next information based on the component should be filled in the table. 

(give an overview)
![image](https://user-images.githubusercontent.com/22620150/88927964-848d9080-d278-11ea-853f-33302b63e438.png)



