### PR TITLE
Hooks: Add useWarnings hook; useControllableValue and testing fixes

### DIFF
--- a/change/@fluentui-eslint-plugin-2020-07-30-09-10-43-hook-updates.json
+++ b/change/@fluentui-eslint-plugin-2020-07-30-09-10-43-hook-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add testUtilities.{ts,tsx} to list of test files",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-30T16:10:05.721Z"
+}

--- a/change/@fluentui-react-next-2020-07-30-09-25-12-hook-updates.json
+++ b/change/@fluentui-react-next-2020-07-30-09-25-12-hook-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Use useWarnings hook",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-30T16:25:12.663Z"
+}

--- a/change/@uifabric-react-hooks-2020-07-30-09-10-43-hook-updates.json
+++ b/change/@uifabric-react-hooks-2020-07-30-09-10-43-hook-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add useWarnings hook; update useControllableValue to accept updater function and return a callback with constant identity",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-30T16:10:39.996Z"
+}

--- a/change/@uifabric-utilities-2020-07-30-09-10-43-hook-updates.json
+++ b/change/@uifabric-utilities-2020-07-30-09-10-43-hook-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix warnControlledUsage doc comment",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-07-30T16:10:43.525Z"
+}

--- a/packages/eslint-plugin/src/utils/configHelpers.js
+++ b/packages/eslint-plugin/src/utils/configHelpers.js
@@ -4,7 +4,12 @@ const fs = require('fs');
 const path = require('path');
 const jju = require('jju');
 
-const testFiles = ['**/*{.,-}test.{ts,tsx}', '**/*.stories.tsx', '**/{test,tests,stories}/**'];
+const testFiles = [
+  '**/*{.,-}test.{ts,tsx}',
+  '**/*.stories.tsx',
+  '**/{test,tests,stories}/**',
+  '**/testUtilities.{ts,tsx}',
+];
 
 const docsFiles = ['**/*Page.tsx', '**/{docs,demo}/**', '**/*.doc.{ts,tsx}'];
 

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -16,6 +16,7 @@ Helpful hooks not provided by React itself. These hooks were built for use in Fl
 - [useRefEffect](#userefeffect) - Call a function with cleanup when a ref changes. Like `useEffect` with a dependency on a ref.
 - [useSetInterval](#usesetinterval) - Version of `setInterval` that automatically cleans up when component is unmounted
 - [useSetTimeout](#usesettimeout) - Version of `setTimeout` that automatically cleans up when component is unmounted
+- [useWarnings](#usewarnings) - Display debug-only warnings for invalid or deprecated props or other issues
 
 ## useBoolean
 
@@ -314,3 +315,24 @@ const MyComponent = () => {
   clearTimeout(id);
 };
 ```
+
+## useWarnings
+
+```ts
+function useWarnings<P>(options: IWarningOptions<P>): void;
+```
+
+Display console warnings when certain conditions are met. If using webpack, the warning code will automatically be stripped out in production mode.
+
+The following types of warnings are supported (see typings for details on how to specify all of these):
+
+- `other`: Generic string messages.
+- `conditionallyRequired`: Warns about props that are required if a condition is met.
+- `deprecations`: Warns when deprecated props are being used.
+- `mutuallyExclusive`: Warns when two props which are mutually exclusive are both being used.
+- `controlledUsage`: Warns on any of the following error conditions in a form component (mimicking the warnings React gives for these error conditions on an input element):
+  - A value prop is provided (indicated it's being used as controlled) without a change handler, and the component is not read-only
+  - Both the value and default value props are provided
+  - The component is attempting to switch between controlled and uncontrolled
+
+Note that all warnings except `controlledUsage` will only be shown on first render. New `controlledUsage` warnings may be shown later based on prop changes. All warnings are shown synchronously during render (not wrapped in `useEffect`) for easier tracing/debugging.

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -105,11 +105,13 @@ If the callback should ever change based on dependencies, use `React.useCallback
 ## useControllableValue
 
 ```ts
+// Without onChange
 function useControllableValue<TValue, TElement extends HTMLElement>(
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
-): Readonly<[TValue | undefined, (newValue: TValue | undefined) => void]>;
+): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>) => void]>;
 
+// With onChange
 function useControllableValue<
   TValue,
   TElement extends HTMLElement,
@@ -118,7 +120,9 @@ function useControllableValue<
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
   onChange: TCallback,
-): Readonly<[TValue | undefined, (newValue: TValue | undefined, ev: React.FormEvent<TElement>) => void]>;
+): Readonly<
+  [TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev: React.FormEvent<TElement>) => void]
+>;
 
 type ChangeCallback<TElement extends HTMLElement, TValue> = (
   ev: React.FormEvent<TElement> | undefined,
@@ -126,13 +130,20 @@ type ChangeCallback<TElement extends HTMLElement, TValue> = (
 ) => void;
 ```
 
-Hook to manage the current value for a component that could be either controlled or uncontrolled, such as a checkbox or input field.
+Hook to manage the current value for a component that could be either controlled or uncontrolled, such as a checkbox or input field. (See the [React docs](https://reactjs.org/docs/uncontrolled-components.html) about the distinction between controlled and uncontrolled components.)
 
-Its two required parameters are the `controlledValue` (the current value of the control in the controlled state), and the `defaultUncontrolledValue` (for the uncontrolled state). Optionally, you may pass a third `onChange` callback to be notified of any changes triggered by the control.
+Parameters:
 
-The return value will be a setter function that will set the internal state in the uncontrolled state, and invoke the `onChange` callback if present.
+- `controlledValue` (required): the current value if the component is controlled
+- `defaultUncontrolledValue` (required): the default value if the component is uncontrolled (will not be used if `controlledValue` is defined)
+- `onChange` (optional): callback to be notified of any changes triggered by the user
 
-See [React docs](https://reactjs.org/docs/uncontrolled-components.html) about the distinction between controlled and uncontrolled components.
+The returned value is an array with two elements:
+
+- The current value
+- A function that will update the internal state if uncontrolled, and invoke the `onChange` callback if present.
+  - Like the setter returned by `React.useState`, the identity of this callback will never change.
+  - Also like `React.useState`, you can call this function with either a value, or an updater function which takes the previous value as a parameter and returns the new value.
 
 ## useForceUpdate
 

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -5,6 +5,8 @@
 ```ts
 
 import { Async } from '@uifabric/utilities';
+import { ISettingsMap } from '@uifabric/utilities/lib/warn';
+import { IWarnControlledUsageParams } from '@uifabric/utilities/lib/warn';
 import * as React from 'react';
 import { Ref } from 'react';
 
@@ -16,6 +18,21 @@ export interface IUseBooleanCallbacks {
     setFalse: () => void;
     setTrue: () => void;
     toggle: () => void;
+}
+
+// @public (undocumented)
+export interface IWarningOptions<P> {
+    conditionallyRequired?: {
+        requiredProps: string[];
+        conditionalPropName: string;
+        condition: boolean;
+    }[];
+    controlledUsage?: Pick<IWarnControlledUsageParams<P>, 'valueProp' | 'defaultValueProp' | 'onChangeProp' | 'readOnlyProp'>;
+    deprecations?: ISettingsMap<P>;
+    mutuallyExclusive?: ISettingsMap<P>;
+    name: string;
+    other?: string[];
+    props: P;
 }
 
 // @public
@@ -34,10 +51,10 @@ export function useConst<T>(initialValue: T | (() => T)): T;
 export function useConstCallback<T extends (...args: any[]) => any>(callback: T): T;
 
 // @public
-export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined): Readonly<[TValue | undefined, (newValue: TValue | undefined) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>) => void]>;
 
 // @public (undocumented)
-export function useControllableValue<TValue, TElement extends HTMLElement, TCallback extends ChangeCallback<TElement, TValue> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: TCallback): Readonly<[TValue | undefined, (newValue: TValue | undefined, ev?: React.FormEvent<TElement>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement, TCallback extends ChangeCallback<TElement, TValue> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: TCallback): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
 
 // @public
 export function useForceUpdate(): () => void;
@@ -74,6 +91,9 @@ export type UseSetTimeoutReturnType = {
     setTimeout: (callback: () => void, duration: number) => number;
     clearTimeout: (id: number) => void;
 };
+
+// @public
+export function useWarnings<P>(options: IWarningOptions<P>): void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-hooks/src/index.ts
+++ b/packages/react-hooks/src/index.ts
@@ -12,3 +12,4 @@ export * from './usePrevious';
 export * from './useRefEffect';
 export * from './useSetInterval';
 export * from './useSetTimeout';
+export * from './useWarnings';

--- a/packages/react-hooks/src/testUtilities.tsx
+++ b/packages/react-hooks/src/testUtilities.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+
+/**
+ * Validate that value(s) returned by a hook do not change in identity.
+ * @param testDescription - Custom test description
+ * @param useHook - Function to invoke the hook and return an array of return values which
+ * should not change
+ * @param useHookAgain - If you want to verify that the return value doesn't change when hook
+ * parameters change, you can pass this second callback which calls the hook differently.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function validateHookValueNotChanged<TValues extends NonNullable<any>[]>(
+  testDescription: string,
+  useHook: () => TValues,
+  useHookAgain?: () => TValues,
+) {
+  it(testDescription || 'returns the same value(s) each time', () => {
+    let latestValues: TValues | undefined;
+    let callCount = 0;
+
+    const TestComponent: React.FunctionComponent = () => {
+      callCount++;
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      latestValues = callCount === 1 ? useHook() : (useHookAgain || useHook)();
+      return <div />;
+    };
+
+    const wrapper = mount(<TestComponent />);
+    expect(callCount).toBe(1);
+    const firstValues = latestValues;
+    expect(firstValues).toBeDefined();
+    latestValues = undefined;
+
+    wrapper.setProps({});
+    expect(callCount).toBe(2);
+    expect(latestValues).toBeDefined();
+    expect(latestValues).toHaveLength(firstValues!.length);
+
+    for (let i = 0; i < latestValues!.length; i++) {
+      try {
+        expect(latestValues![i]).toBe(firstValues![i]);
+      } catch (err) {
+        // Make a more informative error message
+        const valueText = latestValues![i].toString();
+        expect('').toBe(`Identity of value at index ${i} has changed. This might help identify it:\n${valueText}`);
+      }
+    }
+  });
+}

--- a/packages/react-hooks/src/useAsync.ts
+++ b/packages/react-hooks/src/useAsync.ts
@@ -6,10 +6,10 @@ import { useConst } from './useConst';
  * Hook to provide an Async instance that is automatically cleaned up on dismount.
  */
 export function useAsync() {
-  const asyncRef = useConst<Async>(() => new Async());
+  const async = useConst<Async>(() => new Async());
 
   // Function that returns a function in order to dispose the async instance on unmount
-  React.useEffect(() => () => asyncRef.dispose(), [asyncRef]);
+  React.useEffect(() => () => async.dispose(), [async]);
 
-  return asyncRef;
+  return async;
 }

--- a/packages/react-hooks/src/useBoolean.test.tsx
+++ b/packages/react-hooks/src/useBoolean.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import { useBoolean, IUseBooleanCallbacks } from './useBoolean';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useBoolean', () => {
   it('respects initial value', () => {
@@ -18,23 +19,9 @@ describe('useBoolean', () => {
     expect(value!).toBe(false);
   });
 
-  it('returns the same callbacks', () => {
-    let callbacks: IUseBooleanCallbacks;
-
-    const TestComponent: React.FunctionComponent = () => {
-      [, callbacks] = useBoolean(true);
-      return <div />;
-    };
-
-    const wrapper = mount(<TestComponent />);
-    const result1 = callbacks!;
-
-    // Re-render the component
-    wrapper.update();
-    // Callbacks should be the same
-    expect(callbacks!.setTrue).toBe(result1.setTrue);
-    expect(callbacks!.setFalse).toBe(result1.setFalse);
-    expect(callbacks!.toggle).toBe(result1.toggle);
+  validateHookValueNotChanged('returns the same callbacks', () => {
+    const [, { setTrue, setFalse, toggle }] = useBoolean(true);
+    return [setTrue, setFalse, toggle];
   });
 
   it('updates the value', () => {

--- a/packages/react-hooks/src/useConst.test.tsx
+++ b/packages/react-hooks/src/useConst.test.tsx
@@ -1,20 +1,14 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useConst } from './useConst';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useConst', () => {
-  it('returns the same value with value initializer', () => {
-    const TestComponent: React.FunctionComponent = () => {
-      const value = useConst(Math.random());
-      return <div>{value}</div>;
-    };
-    const wrapper = mount(<TestComponent />);
-    const firstValue = wrapper.text();
-    // Re-render the component
-    wrapper.update();
-    // Text should be the same
-    expect(wrapper.text()).toBe(firstValue);
-  });
+  validateHookValueNotChanged('returns the same value with value initializer', () => [useConst(Math.random())]);
+
+  validateHookValueNotChanged('returns the same value with function initializer', () => [
+    useConst(() => Math.random()),
+  ]);
 
   it('calls the function initializer only once', () => {
     const initializer = jest.fn(() => Math.random());

--- a/packages/react-hooks/src/useConstCallback.test.tsx
+++ b/packages/react-hooks/src/useConstCallback.test.tsx
@@ -1,23 +1,10 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useConstCallback } from './useConstCallback';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useConstCallback', () => {
-  it('returns the same callback', () => {
-    let lastCallback: () => string;
-    const TestComponent: React.FunctionComponent = () => {
-      const callback = useConstCallback(() => 'hi');
-      lastCallback = callback;
-      return <div>{callback()}</div>;
-    };
-
-    const wrapper = mount(<TestComponent />);
-    const initialCallback = lastCallback!;
-    // Re-render the component
-    wrapper.update();
-    // Callback should be the same
-    expect(lastCallback!).toBe(initialCallback);
-  });
+  validateHookValueNotChanged('returns the same callback', () => [useConstCallback(() => 'hi')]);
 
   it('does not call the callback', () => {
     const callback = jest.fn(() => 'hi');

--- a/packages/react-hooks/src/useControllableValue.test.tsx
+++ b/packages/react-hooks/src/useControllableValue.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useControllableValue } from './useControllableValue';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useControllableValue', () => {
   it('respects controlled value', () => {
@@ -56,4 +57,21 @@ describe('useControllableValue', () => {
     wrapper.setProps({ defaultValue: false });
     expect(resultValue!).toBe(true);
   });
+
+  validateHookValueNotChanged('returns the same setter callback', () => {
+    const [, setValue] = useControllableValue('hello', 'world');
+    return [setValue];
+  });
+
+  validateHookValueNotChanged(
+    'returns same setter callback even if param values change',
+    () => {
+      const [, setValue] = useControllableValue('a', 'b', () => undefined);
+      return [setValue];
+    },
+    () => {
+      const [, setValue] = useControllableValue('c', 'd', () => undefined);
+      return [setValue];
+    },
+  );
 });

--- a/packages/react-hooks/src/useForceUpdate.test.tsx
+++ b/packages/react-hooks/src/useForceUpdate.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useForceUpdate } from './useForceUpdate';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useForceUpdate', () => {
-  it('component updates when force update is called', () => {
+  it('updates component when called', () => {
     let renderCount = 0;
     const TestComponent: React.FunctionComponent = () => {
       const forceUpdate = useForceUpdate();
@@ -17,22 +18,5 @@ describe('useForceUpdate', () => {
     expect(renderCount).toBe(2);
   });
 
-  it('returns the same callback each time', () => {
-    let latestForceUpdate: (() => void) | undefined;
-    let renderCount = 0;
-
-    const TestComponent: React.FunctionComponent = props => {
-      latestForceUpdate = useForceUpdate();
-      renderCount++;
-      return <div />;
-    };
-
-    const wrapper = mount(<TestComponent />);
-    const firstForceUpate = latestForceUpdate;
-    latestForceUpdate = undefined;
-
-    wrapper.setProps({});
-    expect(renderCount).toBe(2);
-    expect(latestForceUpdate).toBe(firstForceUpate);
-  });
+  validateHookValueNotChanged('returns the same callback each time', () => [useForceUpdate()]);
 });

--- a/packages/react-hooks/src/useId.test.tsx
+++ b/packages/react-hooks/src/useId.test.tsx
@@ -2,36 +2,25 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import { resetIds } from '@uifabric/utilities';
 import { useId } from './useId';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useId', () => {
   afterEach(() => {
     resetIds();
   });
 
-  it('uses the same ID without prefix', () => {
+  it('uses prefix', () => {
+    let id: string | undefined;
     const TestComponent: React.FunctionComponent = () => {
-      const id = useId();
-      return <div id={id} />;
+      id = useId('foo');
+      return <div />;
     };
-    const wrapper = mount(<TestComponent />);
-    const firstId = wrapper.getDOMNode().id;
-    // Re-render the component
-    wrapper.update();
-    // ID should be the same
-    expect(wrapper.getDOMNode().id).toBe(firstId);
+    mount(<TestComponent />);
+    expect(id).toBeDefined();
+    expect(id).toMatch(/^foo/);
   });
 
-  it('uses the same ID with prefix', () => {
-    const TestComponent: React.FunctionComponent = () => {
-      const id = useId('foo');
-      return <div id={id} />;
-    };
-    const wrapper = mount(<TestComponent />);
-    const firstId = wrapper.getDOMNode().id;
-    expect(firstId).toMatch(/^foo/);
-    // Re-render the component
-    wrapper.update();
-    // ID should be the same
-    expect(wrapper.getDOMNode().id).toBe(firstId);
-  });
+  validateHookValueNotChanged('uses the same ID without prefix', () => [useId()]);
+
+  validateHookValueNotChanged('uses the same ID with prefix', () => [useId('foo')]);
 });

--- a/packages/react-hooks/src/useSetInterval.test.tsx
+++ b/packages/react-hooks/src/useSetInterval.test.tsx
@@ -1,12 +1,24 @@
 import * as React from 'react';
-import { useSetInterval, UseSetIntervalReturnType } from './useSetInterval';
+import { useSetInterval } from './useSetInterval';
 import { safeMount } from '@uifabric/test-utilities';
+import { validateHookValueNotChanged } from './testUtilities';
 
 describe('useSetInterval', () => {
   // Initialization
   let timesCalled = 0;
 
-  jest.useFakeTimers();
+  beforeAll(() => {
+    jest.useFakeTimers();
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  afterEach(() => {
+    timesCalled = 0;
+  });
+
   const TestComponent = React.forwardRef((props: unknown, ref: React.Ref<{ clearInterval: () => void }>) => {
     const { setInterval, clearInterval } = useSetInterval();
     const { current: state } = React.useRef<{ id: number }>({ id: 0 });
@@ -26,11 +38,6 @@ describe('useSetInterval', () => {
     return <div />;
   });
 
-  // Cleanup
-  afterEach(() => {
-    timesCalled = 0;
-  });
-
   it('updates value when mounted', () => {
     safeMount(<TestComponent />, () => {
       expect(timesCalled).toEqual(0);
@@ -45,28 +52,9 @@ describe('useSetInterval', () => {
     });
   });
 
-  it('does not regenerate methods on multiple calls', () => {
-    let lastResult: UseSetIntervalReturnType | undefined;
-
-    const Test = () => {
-      lastResult = useSetInterval();
-      return null;
-    };
-
-    safeMount(<Test />, wrapper => {
-      const result1 = lastResult!;
-      lastResult = undefined;
-
-      // Cause a re-render.
-      wrapper.setProps({});
-
-      const result2 = lastResult!;
-
-      expect(result1.setInterval).toBeTruthy();
-      expect(result1.clearInterval).toBeTruthy();
-      expect(result1.setInterval).toBe(result2.setInterval);
-      expect(result1.clearInterval).toBe(result2.clearInterval);
-    });
+  validateHookValueNotChanged('returns the same callbacks each time', () => {
+    const { setInterval, clearInterval } = useSetInterval();
+    return [setInterval, clearInterval];
   });
 
   it('does not execute the interval when unmounted', () => {

--- a/packages/react-hooks/src/useWarnings.test.tsx
+++ b/packages/react-hooks/src/useWarnings.test.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import { mount } from 'enzyme';
+import { setWarningCallback } from '@uifabric/utilities';
+import { IWarningOptions, useWarnings } from './useWarnings';
+
+// These tests don't cover the core warning utilities (which have their own tests), just the
+// integration with the hook and usage within function components.
+describe('useWarnings', () => {
+  const warn = jest.fn();
+  const getLastWarning = (): string => warn.mock.calls.slice(-1)[0][0];
+
+  let warningOptions: Omit<IWarningOptions<ITestComponentProps>, 'name' | 'props'> | undefined;
+
+  interface ITestComponentProps {
+    value?: string;
+    defaultValue?: string;
+    onChange?: () => void;
+    readOnly?: boolean;
+    deprecated?: number;
+  }
+
+  let renderCount = 0;
+  const TestComponent: React.FunctionComponent<ITestComponentProps> = props => {
+    useWarnings({ ...warningOptions!, name: 'TestComponent', props });
+    renderCount++;
+    return <div />;
+  };
+
+  function validateWarnOnFirstRender(props: ITestComponentProps, warningMessage: string) {
+    const wrapper = mount(<TestComponent {...props} />);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenLastCalledWith(warningMessage);
+
+    // ensure all the props change in case there was a dep on any of them where there shouldn't be
+    wrapper.setProps({
+      value: 'new',
+      defaultValue: 'updated',
+      deprecated: (props.deprecated || 0) + 1,
+      onChange: () => undefined,
+      readOnly: !props.readOnly,
+    });
+    expect(renderCount).toBe(2);
+    expect(warn).toHaveBeenCalledTimes(1);
+  }
+
+  beforeEach(() => {
+    setWarningCallback(warn);
+  });
+
+  afterEach(() => {
+    warn.mockReset();
+    renderCount = 0;
+    setWarningCallback(undefined);
+    warningOptions = undefined;
+  });
+
+  it('only does generic warnings on first render', () => {
+    warningOptions = { other: ['oh no'] };
+    validateWarnOnFirstRender({}, 'oh no');
+  });
+
+  it('only warns for conditionally required props on first render', () => {
+    warningOptions = {
+      conditionallyRequired: [{ requiredProps: ['onChange'], conditionalPropName: 'value', condition: true }],
+    };
+    validateWarnOnFirstRender({ value: 'hi' }, "TestComponent property 'onChange' is required when 'value' is used.'");
+  });
+
+  it('only warns for deprecations on first render', () => {
+    warningOptions = { deprecations: { deprecated: 'n/a' } };
+    validateWarnOnFirstRender(
+      { deprecated: 1 },
+      "TestComponent property 'deprecated' was used but has been deprecated. Use 'n/a' instead.",
+    );
+  });
+
+  it('only warns for mutually exclusive on first render', () => {
+    warningOptions = { mutuallyExclusive: { value: 'defaultValue' } };
+    validateWarnOnFirstRender(
+      { value: 'foo', defaultValue: 'bar' },
+      "TestComponent property 'value' is mutually exclusive with 'defaultValue'. Use one or the other.",
+    );
+  });
+
+  it('warns for controlled usage whenever props update', () => {
+    warningOptions = {
+      controlledUsage: {
+        valueProp: 'value',
+        defaultValueProp: 'defaultValue',
+        onChangeProp: 'onChange',
+        readOnlyProp: 'readOnly',
+      },
+    };
+
+    const wrapper = mount(<TestComponent value="foo" />);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(getLastWarning()).toMatch(
+      "Warning: You provided a 'value' prop to a TestComponent without an 'onChange' handler.",
+    );
+
+    // doesn't call again if prop values don't change
+    wrapper.setProps({});
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // doesn't call again if the message would be the same
+    wrapper.setProps({ value: 'bar' });
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // calls again for a new message
+    wrapper.setProps({ value: undefined, defaultValue: 'foo' });
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(getLastWarning()).toMatch('Warning: A component is changing a controlled TestComponent');
+  });
+});

--- a/packages/react-hooks/src/useWarnings.ts
+++ b/packages/react-hooks/src/useWarnings.ts
@@ -84,6 +84,8 @@ export function useWarnings<P>(options: IWarningOptions<P>) {
 
     // Warn synchronously (not in useEffect) on first render to make debugging easier.
     if (!hasWarnedRef.current) {
+      hasWarnedRef.current = true;
+
       for (const warning of other) {
         warn(warning);
       }

--- a/packages/react-hooks/src/useWarnings.ts
+++ b/packages/react-hooks/src/useWarnings.ts
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import {
+  ISettingsMap,
+  IWarnControlledUsageParams,
+  warn,
+  warnControlledUsage,
+  warnConditionallyRequiredProps,
+  warnDeprecations,
+  warnMutuallyExclusive,
+} from '@uifabric/utilities/lib/warn';
+import { usePrevious } from './usePrevious';
+import { useId } from './useId';
+
+export interface IWarningOptions<P> {
+  /** Name of the component */
+  name: string;
+
+  /** Current component props */
+  props: P;
+
+  /** Generic messages */
+  other?: string[];
+
+  /** Warns when props are required if a condition is met */
+  conditionallyRequired?: {
+    /** Props required when the condition is met */
+    requiredProps: string[];
+    /** Name of the prop that the condition is based on */
+    conditionalPropName: string;
+    /** Whether the condition is met */
+    condition: boolean;
+  }[];
+
+  /**
+   * Warns when deprecated props are being used. Each key is a prop name and each value is
+   * either undefined or a replacement prop name.
+   */
+  deprecations?: ISettingsMap<P>;
+
+  /**
+   * Warns when two props which are mutually exclusive are both being used.
+   * The key is one prop name and the value is the other.
+   */
+  mutuallyExclusive?: ISettingsMap<P>;
+
+  /**
+   * Check for and warn on the following error conditions with a form component:
+   * - A value prop is provided (indicated it's being used as controlled) without a change handler,
+   *    and the component is not read-only
+   * - Both the value and defaultValue props are provided
+   * - The component is attempting to switch between controlled and uncontrolled
+   *
+   * The messages mimic the warnings React gives for these error conditions on input elements.
+   * The warning will only be displayed once per component instance.
+   */
+  controlledUsage?: Pick<
+    IWarnControlledUsageParams<P>,
+    'valueProp' | 'defaultValueProp' | 'onChangeProp' | 'readOnlyProp'
+  >;
+}
+
+/**
+ * Only in development mode, display console warnings when certain conditions are met.
+ * Note that all warnings except `controlledUsage` will only be shown on first render
+ * (new `controlledUsage` warnings may be shown later due to prop changes).
+ */
+export function useWarnings<P>(options: IWarningOptions<P>) {
+  if (process.env.NODE_ENV !== 'production') {
+    const {
+      name,
+      props,
+      other = [],
+      conditionallyRequired,
+      deprecations,
+      mutuallyExclusive,
+      controlledUsage,
+    } = options;
+
+    /* eslint-disable react-hooks/rules-of-hooks -- build-time conditional */
+    const hasWarnedRef = React.useRef(false);
+    const componentId = useId();
+    const oldProps = usePrevious(props);
+    /* eslint-enable react-hooks/rules-of-hooks */
+
+    // Warn synchronously (not in useEffect) on first render to make debugging easier.
+    if (!hasWarnedRef.current) {
+      for (const warning of other) {
+        warn(warning);
+      }
+
+      if (conditionallyRequired) {
+        for (const req of conditionallyRequired) {
+          warnConditionallyRequiredProps(name, props, req.requiredProps, req.conditionalPropName, req.condition);
+        }
+      }
+
+      deprecations && warnDeprecations(name, props, deprecations);
+
+      mutuallyExclusive && warnMutuallyExclusive(name, props, mutuallyExclusive);
+    }
+
+    // Controlled usage warnings may be displayed on either first or subsequent renders due to
+    // prop changes. Note that it's safe to run this synchronously (not in useEffect) even in
+    // concurrent mode because `warnControlledUsage` internally tracks which warnings have been
+    // displayed for each component instance (so nothing will be displayed twice).
+    controlledUsage && warnControlledUsage({ ...controlledUsage, componentId, props, componentName: name, oldProps });
+  }
+}

--- a/packages/react-hooks/src/useWarnings.ts
+++ b/packages/react-hooks/src/useWarnings.ts
@@ -9,7 +9,7 @@ import {
   warnMutuallyExclusive,
 } from '@uifabric/utilities/lib/warn';
 import { usePrevious } from './usePrevious';
-import { useId } from './useId';
+import { useConst } from './useConst';
 
 export interface IWarningOptions<P> {
   /** Name of the component */
@@ -59,6 +59,8 @@ export interface IWarningOptions<P> {
   >;
 }
 
+let warningId = 0;
+
 /**
  * Only in development mode, display console warnings when certain conditions are met.
  * Note that all warnings except `controlledUsage` will only be shown on first render
@@ -78,7 +80,7 @@ export function useWarnings<P>(options: IWarningOptions<P>) {
 
     /* eslint-disable react-hooks/rules-of-hooks -- build-time conditional */
     const hasWarnedRef = React.useRef(false);
-    const componentId = useId();
+    const componentId = useConst(() => `useWarnings_${warningId++}`);
     const oldProps = usePrevious(props);
     /* eslint-enable react-hooks/rules-of-hooks */
 

--- a/packages/react-next/src/components/Checkbox/useCheckbox.ts
+++ b/packages/react-next/src/components/Checkbox/useCheckbox.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { mergeSlotProp } from '@fluentui/react-compose';
-import { useControllableValue, useId, useMergedRefs } from '@uifabric/react-hooks';
+import { useControllableValue, useId, useMergedRefs, useWarnings } from '@uifabric/react-hooks';
 import { ICheckboxProps, ICheckboxState } from './Checkbox.types';
-import { useFocusRects, warnMutuallyExclusive } from '../../Utilities';
+import { useFocusRects } from '../../Utilities';
 
 export const useCheckbox = (props: ICheckboxProps, forwardedRef: React.Ref<HTMLDivElement>): ICheckboxState => {
   const {
@@ -84,13 +84,14 @@ export const useCheckbox = (props: ICheckboxProps, forwardedRef: React.Ref<HTMLD
 
 function useDebugWarning(props: ICheckboxProps) {
   if (process.env.NODE_ENV !== 'production') {
-    // This is a build-time conditional that will be constant at runtime
-    React.useEffect(() => {
-      warnMutuallyExclusive('Checkbox', props, {
+    useWarnings({
+      name: 'Checkbox',
+      props,
+      mutuallyExclusive: {
         checked: 'defaultChecked',
         indeterminate: 'defaultIndeterminate',
-      });
-    }, []);
+      },
+    });
   }
 }
 

--- a/packages/react-next/src/components/Persona/Persona.base.tsx
+++ b/packages/react-next/src/components/Persona/Persona.base.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { warnDeprecations, classNamesFunction, divProperties, getNativeProps, IRenderFunction } from '../../Utilities';
+import {
+  classNamesFunction,
+  divProperties,
+  getNativeProps,
+  IRenderFunction,
+  getPropsWithDefaults,
+} from '../../Utilities';
 import { TooltipHost, TooltipOverflowMode, DirectionalHint } from '../../Tooltip';
 import { PersonaCoin } from './PersonaCoin/PersonaCoin';
 import {
@@ -10,7 +16,7 @@ import {
   PersonaSize,
   IPersonaCoinProps,
 } from './Persona.types';
-import { getPropsWithDefaults } from '../../Utilities';
+import { useWarnings } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IPersonaStyleProps, IPersonaStyles>();
 
@@ -20,12 +26,14 @@ const DEFAULT_PROPS = {
   imageAlt: '',
 };
 
-function useWarnDeprecations(props: IPersonaProps) {
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
-      warnDeprecations('Persona', props, { primaryText: 'text' });
-    }
-  }, []);
+function useDebugWarnings(props: IPersonaProps) {
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: 'Persona',
+      props,
+      deprecations: { primaryText: 'text' },
+    });
+  }
 }
 
 /**
@@ -36,7 +44,7 @@ export const PersonaBase = React.forwardRef(
   (propsWithoutDefaults: IPersonaProps, forwardedRef: React.Ref<HTMLDivElement>) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    useWarnDeprecations(props);
+    useDebugWarnings(props);
 
     /**
      * Deprecation helper for getting text.

--- a/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import {
-  warnDeprecations,
   classNamesFunction,
   divProperties,
   getInitials,
   getNativeProps,
   getRTL,
+  getPropsWithDefaults,
 } from '../../../Utilities';
 import { mergeStyles } from '../../../Styling';
 import { PersonaPresence } from '../PersonaPresence/index';
@@ -21,7 +21,7 @@ import {
 } from '../Persona.types';
 import { getPersonaInitialsColor } from '../PersonaInitialsColor';
 import { sizeToPixels } from '../PersonaConsts';
-import { getPropsWithDefaults } from '@fluentui/react-next';
+import { useWarnings } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IPersonaCoinStyleProps, IPersonaCoinStyles>({
   // There can be many PersonaCoin rendered with different sizes.
@@ -35,12 +35,14 @@ const DEFAULT_PROPS = {
   imageAlt: '',
 };
 
-function useWarnDeprecation(props: IPersonaCoinProps) {
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
-      warnDeprecations('PersonaCoin', props, { primaryText: 'text' });
-    }
-  }, []);
+function useDebugWarnings(props: IPersonaCoinProps) {
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: 'PersonaCoin',
+      props,
+      deprecations: { primaryText: 'text' },
+    });
+  }
 }
 
 function useImageLoadState({ onPhotoLoadingStateChange, imageUrl }: IPersonaCoinProps) {
@@ -67,7 +69,7 @@ export const PersonaCoinBase = React.forwardRef(
   (propsWithoutDefaults: IPersonaCoinProps, forwardedRef: React.Ref<HTMLDivElement>) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    useWarnDeprecation(props);
+    useDebugWarnings(props);
 
     const [imageLoadState, onLoadingStateChange] = useImageLoadState(props);
 

--- a/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Async, divProperties, getNativeProps, warnDeprecations } from '../../Utilities';
+import { Async, divProperties, getNativeProps } from '../../Utilities';
 import { IResizeGroupProps, ResizeGroupDirection } from './ResizeGroup.types';
-import { useConst, useMergedRefs, useAsync, useOnEvent } from '@uifabric/react-hooks';
+import { useConst, useMergedRefs, useAsync, useOnEvent, useWarnings } from '@uifabric/react-hooks';
 
 const RESIZE_DELAY = 16;
 
@@ -453,12 +453,14 @@ function useResizingBehavior(props: IResizeGroupProps, rootRef: React.RefObject<
   ] as const;
 }
 
-function useDeprecationWarning(props: IResizeGroupProps) {
-  React.useEffect(() => {
-    warnDeprecations(COMPONENT_NAME, props, {
-      styles: 'className',
+function useDebugWarnings(props: IResizeGroupProps) {
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      deprecations: { styles: 'className' },
     });
-  }, []);
+  }
 }
 
 export const ResizeGroupBase = React.forwardRef((props: IResizeGroupProps, forwardedRef: React.Ref<HTMLDivElement>) => {
@@ -478,7 +480,7 @@ export const ResizeGroupBase = React.forwardRef((props: IResizeGroupProps, forwa
 
   React.useImperativeHandle(props.componentRef, () => ({ remeasure }), [remeasure]);
 
-  useDeprecationWarning(props);
+  useDebugWarnings(props);
 
   const { className, onRenderData } = props;
   const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties, ['data']);

--- a/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles, ISearchBox } from './SearchBox.types';
-import { warnDeprecations, KeyCodes, classNamesFunction, getNativeProps, inputProperties } from '../../Utilities';
-import { useBoolean, useControllableValue, useId, useMergedRefs } from '@uifabric/react-hooks';
+import { KeyCodes, classNamesFunction, getNativeProps, inputProperties } from '../../Utilities';
+import { useBoolean, useControllableValue, useId, useMergedRefs, useWarnings } from '@uifabric/react-hooks';
 import { IconButton } from '../../compat/Button';
 import { Icon } from '../../Icon';
 
@@ -140,9 +140,13 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
     ev.stopPropagation();
   };
 
-  warnDeprecations(COMPONENT_NAME, props, {
-    labelText: 'placeholder',
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      deprecations: { labelText: 'placeholder' },
+    });
+  }
 
   useComponentRef(props.componentRef, inputElementRef, hasFocus);
 

--- a/packages/react-next/src/components/Slider/Slider.base.tsx
+++ b/packages/react-next/src/components/Slider/Slider.base.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { warnMutuallyExclusive, FocusRects } from '../../Utilities';
+import { FocusRects } from '../../Utilities';
 import { ISliderProps } from './Slider.types';
 import { Label } from '../../Label';
 import { useSlider } from './useSlider';
+import { useWarnings } from '@uifabric/react-hooks';
 
 const COMPONENT_NAME = 'SliderBase';
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
@@ -12,9 +13,13 @@ export const SliderBase = React.forwardRef((props: ISliderProps, ref: React.Ref<
 
   const slotProps = useSlider(props, ref);
 
-  warnMutuallyExclusive(COMPONENT_NAME, props, {
-    value: 'defaultValue',
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      mutuallyExclusive: { value: 'defaultValue' },
+    });
+  }
 
   return (
     <div {...slotProps.root}>

--- a/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
@@ -16,7 +16,7 @@ import { getArrowButtonStyles } from './SpinButton.styles';
 import { ISpinButtonProps, ISpinButtonStyleProps, ISpinButtonStyles, KeyboardSpinDirection } from './SpinButton.types';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 import { KeytipData } from '../../KeytipData';
-import { useBoolean, useSetTimeout, useControllableValue } from '@uifabric/react-hooks';
+import { useBoolean, useSetTimeout, useControllableValue, useWarnings } from '@uifabric/react-hooks';
 
 interface ISpinButtonState {
   inputId: string;
@@ -92,6 +92,14 @@ export const SpinButtonBase = (props: ISpinButtonProps) => {
     props.value,
     props.defaultValue !== undefined ? props.defaultValue : String(min || '0'),
   );
+
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      mutuallyExclusive: { value: 'defaultValue' },
+    });
+  }
 
   useComponentRef(props, input, value);
   const callCalculatePrecision = (calculatePrecisionProps: ISpinButtonProps) => {

--- a/packages/react-next/src/components/Toggle/useToggle.ts
+++ b/packages/react-next/src/components/Toggle/useToggle.ts
@@ -1,14 +1,7 @@
 import * as React from 'react';
 import { ComposePreparedOptions } from '@fluentui/react-compose';
-import { useControllableValue, useId } from '@uifabric/react-hooks';
-import {
-  classNamesFunction,
-  getNativeProps,
-  inputProperties,
-  useFocusRects,
-  warnDeprecations,
-  warnMutuallyExclusive,
-} from '../../Utilities';
+import { useControllableValue, useId, useWarnings } from '@uifabric/react-hooks';
+import { classNamesFunction, getNativeProps, inputProperties, useFocusRects } from '../../Utilities';
 import { IToggle, IToggleProps, IToggleStyleProps, IToggleStyles } from './Toggle.types';
 
 const getClassNames = classNamesFunction<IToggleStyleProps, IToggleStyles>({ useStaticStyles: true });
@@ -80,14 +73,18 @@ export const useToggle = (
   useFocusRects(toggleButton);
   useComponentRef(props, checked, toggleButton);
 
-  warnDeprecations(COMPONENT_NAME, props, {
-    offAriaLabel: undefined,
-    onAriaLabel: 'ariaLabel',
-    onChanged: 'onChange',
-  });
-  warnMutuallyExclusive(COMPONENT_NAME, props, {
-    checked: 'defaultChecked',
-  });
+  if (process.env.NODE_ENV !== 'production') {
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      deprecations: {
+        offAriaLabel: undefined,
+        onAriaLabel: 'ariaLabel',
+        onChanged: 'onChange',
+      },
+      mutuallyExclusive: { checked: 'defaultChecked' },
+    });
+  }
 
   const onClick = (ev: React.MouseEvent<HTMLElement>) => {
     if (!disabled) {

--- a/packages/utilities/src/warn/warnControlledUsage.ts
+++ b/packages/utilities/src/warn/warnControlledUsage.ts
@@ -53,7 +53,6 @@ export interface IWarnControlledUsageParams<P> {
  *    and the component is not read-only
  * - Both the value and defaultValue props are provided
  * - The component is attempting to switch between controlled and uncontrolled
- * - The value or default value are null (unless allowNullValue is set)
  *
  * The messages mimic the warnings React gives for these error conditions on input elements.
  * The warning will only be displayed once per component ID.


### PR DESCRIPTION
### Pull request checklist

- [x] Include a change request file using `$ yarn change`

### Description of changes

This PR adds some hook features I wanted while working on function component conversions (or looking over previous conversions to enable the hooks lint rules).

#### Add `useWarnings` hook

I noticed when going through some of the existing converted function components that warnings (`warn____` utility functions) are not always being handled correctly, and require a lot of duplicated code to set up. So I added a hook wrapping all the warnings and ensuring they're shown only at appropriate times.

Also updated the components converted so far to use this new hook.

#### Update `useControllableValue` to always return the same callback and accept an updater function

In some ways, `useControllableValue` is similar to `React.useState`. I made two changes to the returned setter function (`setValueOrCallOnChange`) to match the behavior of the setter function returned by `useState`:
- Make it always have the same identity (to avoid re-creating callbacks or re-running effects unnecessarily down the line)
- Make it accept an updater callback (in addition to just a new value), so hook users can more easily calculate the new value based on the previous value

#### Shared constant return value validation

A lot of the hook tests involve validation that a callback or other return value stays constant between renders. I added a shared testing utility to handle this case and updated all the hook tests to use it where relevant.