### PR TITLE
fix(Popup): share layers logic between Fabric + Fluent N*

### DIFF
--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -16,7 +16,7 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "lodash": "^4.17.15",
-    "office-ui-fabric-react": "^7.137.4",
+    "office-ui-fabric-react": "^7.138.0",
     "puppeteer": "^1.13.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -16,6 +16,7 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "lodash": "^4.17.15",
+    "office-ui-fabric-react": "^7.137.4",
     "puppeteer": "^1.13.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",

--- a/packages/fluentui/e2e/tests/fabricLayerInPopup-example.tsx
+++ b/packages/fluentui/e2e/tests/fabricLayerInPopup-example.tsx
@@ -1,0 +1,65 @@
+import { Button, Popup, Flex, Ref } from '@fluentui/react-northstar';
+import { ContextualMenu } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+const selectors = {
+  buttonInPopup: 'button-in-popup',
+  menuTrigger: 'menu-trigger',
+  popupTrigger: 'popup-trigger',
+};
+
+const FabricLayerInPopupExample = () => {
+  const [menuOpen, setMenuOpen] = React.useState(false);
+  const [popupOpen, setPopupOpen] = React.useState(false);
+  const buttonRef = React.useRef(null);
+
+  return (
+    <>
+      <Popup
+        content={
+          <Flex vAlign="center" column>
+            <Ref innerRef={buttonRef}>
+              <Button
+                content="Open Fabric Menu"
+                id={selectors.menuTrigger}
+                onClick={() => {
+                  setMenuOpen(state => !state);
+                }}
+              />
+            </Ref>
+            <Button id={selectors.buttonInPopup} content="A button" />
+            <ContextualMenu
+              items={[
+                {
+                  key: 'item-1',
+                  text: 'item-1',
+                  onClick: () => console.log('Item 1: click'),
+                },
+                {
+                  key: 'item-2',
+                  text: 'item-2',
+                  onClick: () => console.log('Item 2: click'),
+                },
+              ]}
+              hidden={!menuOpen}
+              onDismiss={() => {
+                setMenuOpen(false);
+                console.log('Menu: dismiss');
+              }}
+              target={buttonRef}
+            />
+          </Flex>
+        }
+        onOpenChange={(e, data) => setPopupOpen(data.open)}
+        open={popupOpen}
+        position="below"
+        trigger={<Button content="Open N* Popup" id={selectors.popupTrigger} />}
+      />
+      <div id="outside" style={{ border: '1px solid green', position: 'fixed', top: 5, right: 5 }}>
+        An element outside
+      </div>
+    </>
+  );
+};
+
+export default FabricLayerInPopupExample;

--- a/packages/fluentui/e2e/tests/fabricLayerInPopup-test.ts
+++ b/packages/fluentui/e2e/tests/fabricLayerInPopup-test.ts
@@ -1,0 +1,46 @@
+import { popupContentClassName } from '@fluentui/react-northstar';
+
+const buttonInPopup = '#button-in-popup';
+const menu = '.ms-ContextualMenu-Callout';
+const menuTrigger = '#menu-trigger';
+const outside = '#outside';
+const popupContent = `.${popupContentClassName}`;
+const popupTrigger = '#popup-trigger';
+
+describe('Fabric Layer in Popup', () => {
+  beforeEach(async () => {
+    await e2e.gotoTestCase(__filename, popupTrigger);
+  });
+
+  it('opens a Popup and then a Menu', async () => {
+    await e2e.clickOn(popupTrigger);
+    await e2e.exists(popupContent);
+    await e2e.expectHidden(menu);
+
+    await e2e.clickOn(menuTrigger);
+    await e2e.exists(popupContent);
+    await e2e.exists(menu);
+  });
+
+  it('closes both on an outside click', async () => {
+    await e2e.clickOn(popupTrigger);
+    await e2e.clickOn(menuTrigger);
+    await e2e.exists(popupContent);
+    await e2e.exists(menu);
+
+    await e2e.clickOn(outside);
+    await e2e.expectHidden(popupContent);
+    await e2e.expectHidden(menu);
+  });
+
+  it('closes a Menu on click inside Popup', async () => {
+    await e2e.clickOn(popupTrigger);
+    await e2e.clickOn(menuTrigger);
+    await e2e.exists(popupContent);
+    await e2e.exists(menu);
+
+    await e2e.clickOn(buttonInPopup);
+    await e2e.exists(popupContent);
+    await e2e.expectHidden(menu);
+  });
+});

--- a/packages/fluentui/e2e/tsconfig.json
+++ b/packages/fluentui/e2e/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../../scripts/typescript/tsconfig.fluentui",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "isolatedModules": false,
     "module": "esnext",
     "types": ["node", "jest", "webpack-env"],
     "skipLibCheck": true

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.10.4",
     "@fluentui/accessibility": "^0.51.0",
     "@fluentui/date-time-utilities": "^7.8.1",
-    "@fluentui/dom-utilities": "^1.1.0",
+    "@fluentui/dom-utilities": "^1.1.1",
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react-bindings": "^0.51.0",
     "@fluentui/react-component-event-listener": "^0.51.0",

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -8,6 +8,7 @@
     "@babel/runtime": "^7.10.4",
     "@fluentui/accessibility": "^0.51.0",
     "@fluentui/date-time-utilities": "^7.8.1",
+    "@fluentui/dom-utilities": "^1.1.0",
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react-bindings": "^0.51.0",
     "@fluentui/react-component-event-listener": "^0.51.0",

--- a/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Toolbar/ToolbarItem.tsx
@@ -208,7 +208,7 @@ export const ToolbarItem = compose<'button', ToolbarItemProps, ToolbarItemStyles
 
     const handleWrapperClick = (e: React.MouseEvent | React.KeyboardEvent) => {
       if (menu) {
-        if (doesNodeContainClick(menuRef.current, e.nativeEvent as MouseEvent, context.target)) {
+        if (doesNodeContainClick(menuRef.current, e.nativeEvent as MouseEvent, context.target, false)) {
           trySetMenuOpen(false, e);
         }
       }

--- a/packages/fluentui/react-northstar/src/utils/doesNodeContainClick.tsx
+++ b/packages/fluentui/react-northstar/src/utils/doesNodeContainClick.tsx
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import { elementContains } from '@fluentui/dom-utilities';
 
 /**
  * Determines if a click's coordinates are within the bounds of a node.
@@ -8,12 +9,14 @@ import * as _ from 'lodash';
  * @param node - A DOM node.
  * @param e - A SyntheticEvent or DOM Event.
  * @param target - A target document.
+ * @param allowVirtualParents - A setting for `elementContains()`.
  */
 export const doesNodeContainClick = (
   node: HTMLElement,
   e: MouseEvent,
   // eslint-disable-next-line no-undef
   target: Document = document,
+  allowVirtualParents: boolean = true,
 ): boolean => {
   if (_.some([e, node], _.isNil)) return false;
 
@@ -23,7 +26,7 @@ export const doesNodeContainClick = (
 
     if (target.querySelector('[data-suir-click-target=true]')) {
       _.invoke(e.target, 'removeAttribute', 'data-suir-click-target');
-      return node.contains(e.target as HTMLElement);
+      return elementContains(node, e.target as HTMLElement, allowVirtualParents);
     }
   }
 

--- a/packages/fluentui/react-northstar/test/specs/components/Portal/Portal-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Portal/Portal-test.tsx
@@ -62,7 +62,9 @@ describe('Portal', () => {
       const wrapper = mountWithProvider(<Portal content={<p id="inner" />} defaultOpen />);
       testPortalInnerIsOpen(wrapper, true);
 
-      domEvent.click('#inner');
+      act(() => {
+        domEvent.click('#inner');
+      });
       wrapper.update();
       testPortalInnerIsOpen(wrapper, true);
     });

--- a/packages/fluentui/react-northstar/test/specs/utils/doesNodeContainClick-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/utils/doesNodeContainClick-test.ts
@@ -27,30 +27,27 @@ describe('doesNodeContainClick', () => {
 
   describe('e.target', () => {
     test('returns node.contains(e.target) if exists', () => {
-      const node = makeNode();
+      const node = document.createElement('div');
       const target = document.createElement('div');
-      document.body.appendChild(target);
       const event = makeEvent({ target });
 
-      expect(node.contains).not.toHaveBeenCalled();
+      node.appendChild(target);
+      document.body.appendChild(node);
 
-      doesNodeContainClick(node, event);
+      expect(doesNodeContainClick(node, event)).toBe(true);
 
-      expect(node.contains).toHaveBeenCalledTimes(1);
-      expect(node.contains).toHaveBeenCalledWith(event.target);
-      document.body.removeChild(target);
+      document.body.removeChild(node);
     });
 
     test("does not call node.contains(e.target) if doesn't exist", () => {
-      const node = makeNode();
+      const node = document.createElement('div');
       const target = null;
       const event = makeEvent({ target });
 
-      expect(node.contains).not.toHaveBeenCalled();
+      document.body.appendChild(node);
+      expect(doesNodeContainClick(node, event)).toBe(false);
 
-      doesNodeContainClick(node, event);
-
-      expect(node.contains).not.toHaveBeenCalled();
+      document.body.removeChild(node);
     });
   });
 


### PR DESCRIPTION
#### Description of changes

> Introduced a new `@fluentui/dom-utilities` package to contain the `dom` sub-group from `@uifabric/utilities`. These functions handle the 'virtual' parent hierarchy functions which account for logic that uses React Portals, such as `Layer` and `Popup`. Updated `@uifabric/utilities` to depend on this new package and re-export all migrated functions from their new locations.

Done in #15039.

Updated `react-northstar` (legacy Fluent) so make its `Popup` use `setVirtualParent` and `elementContains`, which ensure that a Fluent `Popup` is not closed automatically when interacting with a Fabric `Layer`.

Updated the `local-sandbox` example to showcase usage of a Fabric `ContextualMenu` within a Fluent `Popup`.

#### Focus areas to test

Validate existing `Popup` flows from `react-northstar`. There does not appear to be much in the way of example projects in this repository using this framework.
