### PR TITLE
Adding `omit` utility to object utilities.

### DIFF
--- a/change/@uifabric-utilities-2020-07-31-10-14-28-feat-omit.json
+++ b/change/@uifabric-utilities-2020-07-31-10-14-28-feat-omit.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding omit utility as a tiny helper for cloning an object but omitting a few values. This is significantly faster than object spreading or using reduce.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-31T17:14:28.977Z"
+}

--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -1,4 +1,4 @@
-import { assign, filteredAssign, mapEnumByName, values } from './object';
+import { assign, filteredAssign, mapEnumByName, values, omit } from './object';
 
 describe('assign', () => {
   it('can copy an object', () => {
@@ -66,5 +66,11 @@ describe('values', () => {
     expect(objValues).toContain(1);
     expect(objValues).toContain(2);
     expect(objValues).toContain(3);
+  });
+});
+
+describe('omit', () => {
+  it('can omit excluded props and leave non-excluded alone', () => {
+    expect(omit({ a: 1, b: 2 }, { a: 1 })).toEqual({ b: 2 });
   });
 });

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -103,3 +103,30 @@ export function values<T>(obj: any): T[] {
     return arr;
   }, []);
 }
+
+/**
+ * Tiny helper to do the minimal amount of work in duplicating an object but omitting some
+ * props. This ends up faster than using object ...rest or reduce to filter.
+ *
+ * This behaves very much like filteredAssign, but does not merge many objects together,
+ * uses an exclusion object map, and avoids spreads all for optimal performance.
+ *
+ * See perf test for background:
+ * https://jsperf.com/omit-vs-rest-vs-reduce/1
+ *
+ * @param obj - The object to clone
+ * @param exclusions - The object of keys to exclude
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function omit<TObj extends Record<string, any>>(obj: TObj, exclusions: Record<string, any>): TObj {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: Record<string, any> = {};
+
+  for (const key of Object.keys(obj)) {
+    if (!exclusions[key]) {
+      result[key] = obj[key];
+    }
+  }
+
+  return result as TObj;
+}


### PR DESCRIPTION
Super simple helper which clones an object, but omits a few keys.

See perf compare here:
https://jsperf.com/omit-vs-rest-vs-reduce/1

![image](https://user-images.githubusercontent.com/1110944/89060090-39768a80-d317-11ea-9ca0-d2d5d620d036.png)

FWIW, I was looking at lodash's approach. First, their v4 omit would not be as efficient because it takes the keys in as an array (going back to calling indexOf for each prop being cloned.) Second, their v5 release (started in 2018 and still seems in progress) has planned to remove omit, essentially for the reasoning that you should use `pick` to explicitly opt into what you want to clone. See discussion here: https://github.com/lodash/lodash/issues/2930#issuecomment-272298477 I am not sure about the drop reasoning, need to dig more in, but I'm seeing numerous real-world cases where we want to create a clone of "everything except these few things" where the utility does not know what the "other things" to pick are.


