### PR TITLE
DetailsList/GroupedList: Passing focusZone props down to GroupedList when groups used

### DIFF
--- a/change/office-ui-fabric-react-2020-07-31-12-06-55-detailslist-groupedlist.json
+++ b/change/office-ui-fabric-react-2020-07-31-12-06-55-detailslist-groupedlist.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add focuszone props to GroupedList and change details list to only use a single focus zone",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-07-31T19:06:55.073Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4788,6 +4788,7 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
         eventName: string;
         callback: (context: IDragDropContext, event?: any) => void;
     }[];
+    focusZoneProps?: IFocusZoneProps;
     getGroupHeight?: (group: IGroup, groupIndex: number) => number;
     groupProps?: IGroupRenderProps;
     groups?: IGroup[];

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -35,7 +35,7 @@ import { IDetailsFooterProps } from '../DetailsList/DetailsFooter.types';
 import { DetailsRowBase } from '../DetailsList/DetailsRow.base';
 import { DetailsRow } from '../DetailsList/DetailsRow';
 import { IDetailsRowProps } from '../DetailsList/DetailsRow.types';
-import { IFocusZone, FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { IFocusZone, FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
 import { IObjectWithKey, ISelection, Selection, SelectionMode, SelectionZone } from '../../utilities/selection/index';
 
 import { DragDropHelper } from '../../utilities/dragdrop/DragDropHelper';
@@ -392,8 +392,18 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       className,
     });
 
+    const focusZoneProps: IFocusZoneProps = {
+      componentRef: this._focusZone,
+      className: classNames.focusZone,
+      direction: FocusZoneDirection.vertical,
+      shouldEnterInnerZone: this._isRightArrow,
+      onActiveElementChanged: this._onActiveRowChanged,
+      onBlur: this._onBlur,
+    };
+
     const list = groups ? (
       <GroupedList
+        focusZoneProps={focusZoneProps}
         componentRef={this._groupedList}
         groups={groups}
         groupProps={groupProps ? this._getGroupProps(groupProps) : undefined}
@@ -412,15 +422,17 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
         compact={compact}
       />
     ) : (
-      <List
-        ref={this._list}
-        role="presentation"
-        items={items}
-        onRenderCell={this._onRenderListCell(0)}
-        usePageCache={usePageCache}
-        onShouldVirtualize={onShouldVirtualize}
-        {...additionalListProps}
-      />
+      <FocusZone {...focusZoneProps}>
+        <List
+          ref={this._list}
+          role="presentation"
+          items={items}
+          onRenderCell={this._onRenderListCell(0)}
+          usePageCache={usePageCache}
+          onShouldVirtualize={onShouldVirtualize}
+          {...additionalListProps}
+        />
+      </FocusZone>
     );
 
     return (
@@ -481,31 +493,22 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
               )}
           </div>
           <div onKeyDown={this._onContentKeyDown} role="presentation" className={classNames.contentWrapper}>
-            <FocusZone
-              componentRef={this._focusZone}
-              className={classNames.focusZone}
-              direction={FocusZoneDirection.vertical}
-              shouldEnterInnerZone={this._isRightArrow}
-              onActiveElementChanged={this._onActiveRowChanged}
-              onBlur={this._onBlur}
-            >
-              {!this.props.disableSelectionZone ? (
-                <SelectionZone
-                  ref={this._selectionZone}
-                  selection={selection}
-                  selectionPreservedOnEmptyClick={selectionPreservedOnEmptyClick}
-                  selectionMode={selectionMode}
-                  onItemInvoked={onItemInvoked}
-                  onItemContextMenu={onItemContextMenu}
-                  enterModalOnTouch={this.props.enterModalSelectionOnTouch}
-                  {...(selectionZoneProps || {})}
-                >
-                  {list}
-                </SelectionZone>
-              ) : (
-                list
-              )}
-            </FocusZone>
+            {!this.props.disableSelectionZone ? (
+              <SelectionZone
+                ref={this._selectionZone}
+                selection={selection}
+                selectionPreservedOnEmptyClick={selectionPreservedOnEmptyClick}
+                selectionMode={selectionMode}
+                onItemInvoked={onItemInvoked}
+                onItemContextMenu={onItemContextMenu}
+                enterModalOnTouch={this.props.enterModalSelectionOnTouch}
+                {...(selectionZoneProps || {})}
+              >
+                {list}
+              </SelectionZone>
+            ) : (
+              list
+            )}
           </div>
           {onRenderDetailsFooter(
             {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -523,33 +523,33 @@ exports[`DetailsList renders List correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone8"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone8"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -1723,33 +1723,33 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -2329,33 +2329,33 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone14"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone14"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -3315,33 +3315,33 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone11"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone11"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -4530,33 +4530,33 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone5"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone5"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -4981,675 +4981,663 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone17"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                ms-GroupedList
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  position: relative;
+                }
+                & .ms-List-cell {
+                  min-height: 38px;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-automationid="GroupedList"
+            data-focuszone-id="FocusZone17"
+            data-is-scrollable="false"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  ms-GroupedList
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 12px;
-                    font-weight: 400;
-                    position: relative;
-                  }
-                  & .ms-List-cell {
-                    min-height: 38px;
-                  }
-              data-automationid="GroupedList"
-              data-focuszone-id="FocusZone18"
-              data-is-scrollable="false"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
+              className="ms-List"
               role="presentation"
             >
               <div
-                className="ms-List"
+                className="ms-List-surface"
                 role="presentation"
               >
                 <div
-                  className="ms-List-surface"
+                  className="ms-List-page"
                   role="presentation"
+                  style={Object {}}
                 >
                   <div
-                    className="ms-List-page"
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
                     role="presentation"
-                    style={Object {}}
                   >
                     <div
-                      className="ms-List-cell"
-                      data-automationid="ListCell"
-                      data-list-index={0}
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
                       role="presentation"
                     >
                       <div
+                        aria-expanded={true}
+                        aria-label="Group 0"
+                        aria-level={1}
+                        aria-posinset={1}
+                        aria-setsize={2}
                         className=
-                            ms-GroupedList-group
+                            ms-GroupHeader
                             {
-                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              border-bottom: 1px solid #ffffff;
+                              cursor: default;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              outline: transparent;
+                              position: relative;
+                              user-select: none;
                             }
-                        role="presentation"
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            &:hover .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                              opacity: 1;
+                              transform: rotate(0.2deg) scale(1);
+                              transition-delay: 0.367s;
+                              transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                            }
+                            .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                              opacity: 0;
+                            }
+                        data-is-focusable={true}
+                        onClick={[Function]}
+                        onKeyUp={[Function]}
+                        style={Object {}}
                       >
                         <div
-                          aria-expanded={true}
-                          aria-label="Group 0"
-                          aria-level={1}
-                          aria-posinset={1}
-                          aria-setsize={2}
                           className=
-                              ms-GroupHeader
+
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                border-bottom: 1px solid #ffffff;
-                                cursor: default;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 14px;
-                                font-weight: 400;
-                                outline: transparent;
-                                position: relative;
-                                user-select: none;
+                                align-items: center;
+                                display: flex;
+                                height: 48px;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #ffffff;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #605e5c;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #201f1e;
-                              }
-                              &:hover .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                opacity: 1;
-                                transform: rotate(0.2deg) scale(1);
-                                transition-delay: 0.367s;
-                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                              }
-                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                opacity: 0;
-                              }
-                          data-is-focusable={true}
-                          onClick={[Function]}
-                          onKeyUp={[Function]}
-                          style={Object {}}
                         >
                           <div
                             className=
-
+                                ms-GroupHeader-dropIcon
                                 {
-                                  align-items: center;
-                                  display: flex;
-                                  height: 48px;
+                                  color: #605e5c;
+                                  font-size: 20px;
+                                  left: -26px;
+                                  opacity: 0;
+                                  position: absolute;
+                                  transform-origin: 10px 10px;
+                                  transform: rotate(0.2deg) scale(0.65);
+                                  transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                }
+                                .ms-Icon--Tag {
+                                  position: absolute;
                                 }
                           >
-                            <div
+                            <i
+                              aria-hidden={true}
                               className=
-                                  ms-GroupHeader-dropIcon
-                                  {
-                                    color: #605e5c;
-                                    font-size: 20px;
-                                    left: -26px;
-                                    opacity: 0;
-                                    position: absolute;
-                                    transform-origin: 10px 10px;
-                                    transform: rotate(0.2deg) scale(0.65);
-                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                  }
-                                  .ms-Icon--Tag {
-                                    position: absolute;
-                                  }
-                            >
-                              <i
-                                aria-hidden={true}
-                                className=
 
-                                    {
-                                      -moz-osx-font-smoothing: grayscale;
-                                      -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
-                                      font-family: "FabricMDL2Icons";
-                                      font-style: normal;
-                                      font-weight: normal;
-                                      speak: none;
-                                    }
-                                data-icon-name="Tag"
-                              >
-                                
-                              </i>
-                            </div>
-                            <button
-                              aria-controls="GroupedListSection19"
-                              aria-expanded={true}
-                              aria-label="expand collapse group"
-                              className=
-                                  ms-GroupHeader-expand
                                   {
-                                    align-items: center;
-                                    background-color: transparent;
-                                    background: none;
-                                    border: none;
-                                    color: #605e5c;
-                                    cursor: default;
-                                    display: flex;
-                                    font-size: 12px;
-                                    height: 48px;
-                                    justify-content: center;
-                                    outline: transparent;
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                              data-icon-name="Tag"
+                            >
+                              
+                            </i>
+                          </div>
+                          <button
+                            aria-controls="GroupedListSection18"
+                            aria-expanded={true}
+                            aria-label="expand collapse group"
+                            className=
+                                ms-GroupHeader-expand
+                                {
+                                  align-items: center;
+                                  background-color: transparent;
+                                  background: none;
+                                  border: none;
+                                  color: #605e5c;
+                                  cursor: default;
+                                  display: flex;
+                                  font-size: 12px;
+                                  height: 48px;
+                                  justify-content: center;
+                                  outline: transparent;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  width: 36px;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #edebe9;
+                                }
+                                &:active {
+                                  background-color: #e1dfdd;
+                                }
+                            data-is-focusable={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons-3";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                    transform-origin: 50% 50%;
+                                    transform: rotate(90deg);
+                                    transition: transform .1s linear;
+                                  }
+                              data-icon-name="ChevronRightMed"
+                            >
+                              
+                            </i>
+                          </button>
+                          <div
+                            className=
+                                ms-GroupHeader-title
+                                {
+                                  cursor: pointer;
+                                  font-size: 16px;
+                                  font-weight: 600;
+                                  outline: 0px;
+                                  padding-left: 12px;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span>
+                              Group 0
+                            </span>
+                            <span
+                              className=
+
+                                  {
                                     padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
+                                    padding-left: 4px;
+                                    padding-right: 4px;
                                     padding-top: 0px;
-                                    position: relative;
-                                    width: 36px;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #ffffff;
-                                    bottom: 1px;
-                                    content: "";
-                                    left: 1px;
-                                    outline: 1px solid #605e5c;
-                                    position: absolute;
-                                    right: 1px;
-                                    top: 1px;
-                                    z-index: 1;
-                                  }
-                                  &:hover {
-                                    background-color: #edebe9;
-                                  }
-                                  &:active {
-                                    background-color: #e1dfdd;
-                                  }
-                              data-is-focusable={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <i
-                                aria-hidden={true}
-                                className=
-
-                                    {
-                                      -moz-osx-font-smoothing: grayscale;
-                                      -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
-                                      font-family: "FabricMDL2Icons-3";
-                                      font-style: normal;
-                                      font-weight: normal;
-                                      speak: none;
-                                      transform-origin: 50% 50%;
-                                      transform: rotate(90deg);
-                                      transition: transform .1s linear;
-                                    }
-                                data-icon-name="ChevronRightMed"
-                              >
-                                
-                              </i>
-                            </button>
-                            <div
-                              className=
-                                  ms-GroupHeader-title
-                                  {
-                                    cursor: pointer;
-                                    font-size: 16px;
-                                    font-weight: 600;
-                                    outline: 0px;
-                                    padding-left: 12px;
-                                    text-overflow: ellipsis;
-                                    white-space: nowrap;
                                   }
                             >
-                              <span>
-                                Group 0
-                              </span>
-                              <span
-                                className=
-
-                                    {
-                                      padding-bottom: 0px;
-                                      padding-left: 4px;
-                                      padding-right: 4px;
-                                      padding-top: 0px;
-                                    }
-                              >
-                                (
-                                2
-                                )
-                              </span>
-                            </div>
+                              (
+                              2
+                              )
+                            </span>
                           </div>
                         </div>
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection18"
+                        role="grid"
+                      >
                         <div
-                          className="ms-List"
-                          id="GroupedListSection19"
-                          role="grid"
+                          className="ms-List-surface"
+                          role="presentation"
                         >
                           <div
-                            className="ms-List-surface"
+                            className="ms-List-page"
                             role="presentation"
+                            style={Object {}}
                           >
                             <div
-                              className="ms-List-page"
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={0}
                               role="presentation"
-                              style={Object {}}
                             >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={0}
-                                role="presentation"
+                                aria-rowindex={1}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone20"
+                                data-is-focusable={true}
+                                data-item-index={0}
+                                data-selection-index={0}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
                               >
-                                <div
-                                  aria-rowindex={1}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone21"
-                                  data-is-focusable={true}
-                                  data-item-index={0}
-                                  data-selection-index={0}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
+                                <span
+                                  className="ms-GroupSpacer"
                                   style={
                                     Object {
-                                      "minWidth": 100,
+                                      "display": "inline-block",
+                                      "width": 36,
                                     }
                                   }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
                                 >
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
                                   <div
+                                    aria-colindex={1}
+                                    aria-readonly={true}
                                     className=
-                                        ms-DetailsRow-fields
+                                        ms-DetailsRow-cell
                                         {
-                                          align-items: stretch;
-                                          display: flex;
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
                                         }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={1}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="key"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
+                                        &::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                      }
-                                    >
-                                      0
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="key"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    0
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={1}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={1}
-                                role="presentation"
+                                aria-rowindex={2}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone21"
+                                data-is-focusable={true}
+                                data-item-index={1}
+                                data-selection-index={1}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
                               >
-                                <div
-                                  aria-rowindex={2}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone22"
-                                  data-is-focusable={true}
-                                  data-item-index={1}
-                                  data-selection-index={1}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
+                                <span
+                                  className="ms-GroupSpacer"
                                   style={
                                     Object {
-                                      "minWidth": 100,
+                                      "display": "inline-block",
+                                      "width": 36,
                                     }
                                   }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
                                 >
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
                                   <div
+                                    aria-colindex={1}
+                                    aria-readonly={true}
                                     className=
-                                        ms-DetailsRow-fields
+                                        ms-DetailsRow-cell
                                         {
-                                          align-items: stretch;
-                                          display: flex;
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
                                         }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={1}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="key"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
+                                        &::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                      }
-                                    >
-                                      1
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="key"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    1
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
                             </div>
                           </div>
@@ -5657,798 +5645,798 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                       </div>
                     </div>
                   </div>
+                </div>
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
                   <div
-                    className="ms-List-page"
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
                     role="presentation"
-                    style={Object {}}
                   >
                     <div
-                      className="ms-List-cell"
-                      data-automationid="ListCell"
-                      data-list-index={1}
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
                       role="presentation"
                     >
                       <div
+                        aria-expanded={true}
+                        aria-label="Group 1"
+                        aria-level={1}
+                        aria-posinset={2}
+                        aria-setsize={2}
                         className=
-                            ms-GroupedList-group
+                            ms-GroupHeader
                             {
-                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              border-bottom: 1px solid #ffffff;
+                              cursor: default;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              outline: transparent;
+                              position: relative;
+                              user-select: none;
                             }
-                        role="presentation"
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            &:hover .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                              opacity: 1;
+                              transform: rotate(0.2deg) scale(1);
+                              transition-delay: 0.367s;
+                              transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                            }
+                            .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                              opacity: 0;
+                            }
+                        data-is-focusable={true}
+                        onClick={[Function]}
+                        onKeyUp={[Function]}
+                        style={Object {}}
                       >
                         <div
-                          aria-expanded={true}
-                          aria-label="Group 1"
-                          aria-level={1}
-                          aria-posinset={2}
-                          aria-setsize={2}
                           className=
-                              ms-GroupHeader
+
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                border-bottom: 1px solid #ffffff;
-                                cursor: default;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 14px;
-                                font-weight: 400;
-                                outline: transparent;
-                                position: relative;
-                                user-select: none;
+                                align-items: center;
+                                display: flex;
+                                height: 48px;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #ffffff;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #605e5c;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #201f1e;
-                              }
-                              &:hover .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                opacity: 1;
-                                transform: rotate(0.2deg) scale(1);
-                                transition-delay: 0.367s;
-                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                              }
-                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                opacity: 0;
-                              }
-                          data-is-focusable={true}
-                          onClick={[Function]}
-                          onKeyUp={[Function]}
-                          style={Object {}}
                         >
                           <div
                             className=
-
+                                ms-GroupHeader-dropIcon
                                 {
-                                  align-items: center;
-                                  display: flex;
-                                  height: 48px;
+                                  color: #605e5c;
+                                  font-size: 20px;
+                                  left: -26px;
+                                  opacity: 0;
+                                  position: absolute;
+                                  transform-origin: 10px 10px;
+                                  transform: rotate(0.2deg) scale(0.65);
+                                  transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                }
+                                .ms-Icon--Tag {
+                                  position: absolute;
                                 }
                           >
-                            <div
+                            <i
+                              aria-hidden={true}
                               className=
-                                  ms-GroupHeader-dropIcon
-                                  {
-                                    color: #605e5c;
-                                    font-size: 20px;
-                                    left: -26px;
-                                    opacity: 0;
-                                    position: absolute;
-                                    transform-origin: 10px 10px;
-                                    transform: rotate(0.2deg) scale(0.65);
-                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                  }
-                                  .ms-Icon--Tag {
-                                    position: absolute;
-                                  }
-                            >
-                              <i
-                                aria-hidden={true}
-                                className=
 
-                                    {
-                                      -moz-osx-font-smoothing: grayscale;
-                                      -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
-                                      font-family: "FabricMDL2Icons";
-                                      font-style: normal;
-                                      font-weight: normal;
-                                      speak: none;
-                                    }
-                                data-icon-name="Tag"
-                              >
-                                
-                              </i>
-                            </div>
-                            <button
-                              aria-controls="GroupedListSection20"
-                              aria-expanded={true}
-                              aria-label="expand collapse group"
-                              className=
-                                  ms-GroupHeader-expand
                                   {
-                                    align-items: center;
-                                    background-color: transparent;
-                                    background: none;
-                                    border: none;
-                                    color: #605e5c;
-                                    cursor: default;
-                                    display: flex;
-                                    font-size: 12px;
-                                    height: 48px;
-                                    justify-content: center;
-                                    outline: transparent;
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                              data-icon-name="Tag"
+                            >
+                              
+                            </i>
+                          </div>
+                          <button
+                            aria-controls="GroupedListSection19"
+                            aria-expanded={true}
+                            aria-label="expand collapse group"
+                            className=
+                                ms-GroupHeader-expand
+                                {
+                                  align-items: center;
+                                  background-color: transparent;
+                                  background: none;
+                                  border: none;
+                                  color: #605e5c;
+                                  cursor: default;
+                                  display: flex;
+                                  font-size: 12px;
+                                  height: 48px;
+                                  justify-content: center;
+                                  outline: transparent;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  width: 36px;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #edebe9;
+                                }
+                                &:active {
+                                  background-color: #e1dfdd;
+                                }
+                            data-is-focusable={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons-3";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                    transform-origin: 50% 50%;
+                                    transform: rotate(90deg);
+                                    transition: transform .1s linear;
+                                  }
+                              data-icon-name="ChevronRightMed"
+                            >
+                              
+                            </i>
+                          </button>
+                          <div
+                            className=
+                                ms-GroupHeader-title
+                                {
+                                  cursor: pointer;
+                                  font-size: 16px;
+                                  font-weight: 600;
+                                  outline: 0px;
+                                  padding-left: 12px;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span>
+                              Group 1
+                            </span>
+                            <span
+                              className=
+
+                                  {
                                     padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
+                                    padding-left: 4px;
+                                    padding-right: 4px;
                                     padding-top: 0px;
-                                    position: relative;
-                                    width: 36px;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #ffffff;
-                                    bottom: 1px;
-                                    content: "";
-                                    left: 1px;
-                                    outline: 1px solid #605e5c;
-                                    position: absolute;
-                                    right: 1px;
-                                    top: 1px;
-                                    z-index: 1;
-                                  }
-                                  &:hover {
-                                    background-color: #edebe9;
-                                  }
-                                  &:active {
-                                    background-color: #e1dfdd;
-                                  }
-                              data-is-focusable={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              <i
-                                aria-hidden={true}
-                                className=
-
-                                    {
-                                      -moz-osx-font-smoothing: grayscale;
-                                      -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
-                                      font-family: "FabricMDL2Icons-3";
-                                      font-style: normal;
-                                      font-weight: normal;
-                                      speak: none;
-                                      transform-origin: 50% 50%;
-                                      transform: rotate(90deg);
-                                      transition: transform .1s linear;
-                                    }
-                                data-icon-name="ChevronRightMed"
-                              >
-                                
-                              </i>
-                            </button>
-                            <div
-                              className=
-                                  ms-GroupHeader-title
-                                  {
-                                    cursor: pointer;
-                                    font-size: 16px;
-                                    font-weight: 600;
-                                    outline: 0px;
-                                    padding-left: 12px;
-                                    text-overflow: ellipsis;
-                                    white-space: nowrap;
                                   }
                             >
-                              <span>
-                                Group 1
-                              </span>
-                              <span
-                                className=
-
-                                    {
-                                      padding-bottom: 0px;
-                                      padding-left: 4px;
-                                      padding-right: 4px;
-                                      padding-top: 0px;
-                                    }
-                              >
-                                (
-                                3
-                                )
-                              </span>
-                            </div>
+                              (
+                              3
+                              )
+                            </span>
                           </div>
                         </div>
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection19"
+                        role="grid"
+                      >
                         <div
-                          className="ms-List"
-                          id="GroupedListSection20"
-                          role="grid"
+                          className="ms-List-surface"
+                          role="presentation"
                         >
                           <div
-                            className="ms-List-surface"
+                            className="ms-List-page"
                             role="presentation"
+                            style={Object {}}
                           >
                             <div
-                              className="ms-List-page"
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={2}
                               role="presentation"
-                              style={Object {}}
                             >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={2}
-                                role="presentation"
+                                aria-rowindex={3}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone22"
+                                data-is-focusable={true}
+                                data-item-index={2}
+                                data-selection-index={2}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
                               >
-                                <div
-                                  aria-rowindex={3}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone23"
-                                  data-is-focusable={true}
-                                  data-item-index={2}
-                                  data-selection-index={2}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
+                                <span
+                                  className="ms-GroupSpacer"
                                   style={
                                     Object {
-                                      "minWidth": 100,
+                                      "display": "inline-block",
+                                      "width": 36,
                                     }
                                   }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
                                 >
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
                                   <div
+                                    aria-colindex={1}
+                                    aria-readonly={true}
                                     className=
-                                        ms-DetailsRow-fields
+                                        ms-DetailsRow-cell
                                         {
-                                          align-items: stretch;
-                                          display: flex;
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
                                         }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={1}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="key"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
+                                        &::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                      }
-                                    >
-                                      2
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="key"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    2
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={3}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={3}
-                                role="presentation"
+                                aria-rowindex={4}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone23"
+                                data-is-focusable={true}
+                                data-item-index={3}
+                                data-selection-index={3}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
                               >
-                                <div
-                                  aria-rowindex={4}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone24"
-                                  data-is-focusable={true}
-                                  data-item-index={3}
-                                  data-selection-index={3}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
+                                <span
+                                  className="ms-GroupSpacer"
                                   style={
                                     Object {
-                                      "minWidth": 100,
+                                      "display": "inline-block",
+                                      "width": 36,
                                     }
                                   }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
                                 >
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
                                   <div
+                                    aria-colindex={1}
+                                    aria-readonly={true}
                                     className=
-                                        ms-DetailsRow-fields
+                                        ms-DetailsRow-cell
                                         {
-                                          align-items: stretch;
-                                          display: flex;
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
                                         }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={1}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="key"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
+                                        &::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                      }
-                                    >
-                                      3
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="key"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    3
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={4}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={4}
-                                role="presentation"
+                                aria-rowindex={5}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone24"
+                                data-is-focusable={true}
+                                data-item-index={4}
+                                data-selection-index={4}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
                               >
-                                <div
-                                  aria-rowindex={5}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone25"
-                                  data-is-focusable={true}
-                                  data-item-index={4}
-                                  data-selection-index={4}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
+                                <span
+                                  className="ms-GroupSpacer"
                                   style={
                                     Object {
-                                      "minWidth": 100,
+                                      "display": "inline-block",
+                                      "width": 36,
                                     }
                                   }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
                                 >
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
                                   <div
+                                    aria-colindex={1}
+                                    aria-readonly={true}
                                     className=
-                                        ms-DetailsRow-fields
+                                        ms-DetailsRow-cell
                                         {
-                                          align-items: stretch;
-                                          display: flex;
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
                                         }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={1}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="key"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
+                                        &::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                      }
-                                    >
-                                      4
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="key"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    4
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
                             </div>
                           </div>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -735,33 +735,33 @@ exports[`DetailsRow renders details list row correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -1572,33 +1572,33 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone11"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone11"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -2920,33 +2920,33 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone5"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone5"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"
@@ -3757,33 +3757,33 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone8"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone8"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -334,33 +334,33 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -111,12 +111,12 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     const { version } = listProps;
 
-    const { isInnerZoneKeystroke = this._isInnerZoneKeystroke, shouldEnterInnerZone } = focusZoneProps;
+    const { shouldEnterInnerZone = this._isInnerZoneKeystroke } = focusZoneProps;
 
     return (
       <FocusZone
         {...focusZoneProps}
-        shouldEnterInnerZone={shouldEnterInnerZone || isInnerZoneKeystroke}
+        shouldEnterInnerZone={shouldEnterInnerZone}
         direction={FocusZoneDirection.vertical}
         className={css(this._classNames.root, focusZoneProps.className)}
         data-automationid="GroupedList"

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -115,13 +115,13 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     return (
       <FocusZone
-        {...focusZoneProps}
-        shouldEnterInnerZone={shouldEnterInnerZone}
         direction={FocusZoneDirection.vertical}
-        className={css(this._classNames.root, focusZoneProps.className)}
         data-automationid="GroupedList"
         data-is-scrollable="false"
         role="presentation"
+        {...focusZoneProps}
+        shouldEnterInnerZone={shouldEnterInnerZone}
+        className={css(this._classNames.root, focusZoneProps.className)}
       >
         {!groups ? (
           this._renderGroup(undefined, 0)

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -111,12 +111,12 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     const { version } = listProps;
 
-    const { isInnerZoneKeystroke = this._isInnerZoneKeystroke } = focusZoneProps;
+    const { isInnerZoneKeystroke = this._isInnerZoneKeystroke, shouldEnterInnerZone } = focusZoneProps;
 
     return (
       <FocusZone
         {...focusZoneProps}
-        isInnerZoneKeystroke={isInnerZoneKeystroke}
+        shouldEnterInnerZone={shouldEnterInnerZone || isInnerZoneKeystroke}
         direction={FocusZoneDirection.vertical}
         className={css(this._classNames.root, focusZoneProps.className)}
         data-automationid="GroupedList"

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -7,7 +7,7 @@ import {
   IGroupedListStyleProps,
   IGroupedListStyles,
 } from './GroupedList.types';
-import { initializeComponentRef, classNamesFunction, KeyCodes, getRTLSafeKeyCode } from '../../Utilities';
+import { initializeComponentRef, classNamesFunction, KeyCodes, getRTLSafeKeyCode, css } from '../../Utilities';
 import { GroupedListSection } from './GroupedListSection';
 import { List, ScrollToMode, IListProps } from '../../List';
 import { SelectionMode } from '../../utilities/selection/index';
@@ -92,7 +92,16 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   public render(): JSX.Element {
-    const { className, usePageCache, onShouldVirtualize, theme, styles, compact, listProps = {} } = this.props;
+    const {
+      className,
+      usePageCache,
+      onShouldVirtualize,
+      theme,
+      styles,
+      compact,
+      listProps = {},
+      focusZoneProps = {},
+    } = this.props;
     const { groups } = this.state;
     this._classNames = getClassNames(styles, {
       theme: theme!,
@@ -102,11 +111,14 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     const { version } = listProps;
 
+    const { isInnerZoneKeystroke = this._isInnerZoneKeystroke } = focusZoneProps;
+
     return (
       <FocusZone
-        isInnerZoneKeystroke={this._isInnerZoneKeystroke}
+        {...focusZoneProps}
+        isInnerZoneKeystroke={isInnerZoneKeystroke}
         direction={FocusZoneDirection.vertical}
-        className={this._classNames.root}
+        className={css(this._classNames.root, focusZoneProps.className)}
         data-automationid="GroupedList"
         data-is-scrollable="false"
         role="presentation"

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { GroupedListBase } from './GroupedList.base';
 import { IList, IListProps } from '../../List';
+import { IFocusZoneProps } from '../../FocusZone';
 import { IRefObject, IRenderFunction } from '../../Utilities';
 import { IDragDropContext, IDragDropEvents, IDragDropHelper } from '../../utilities/dragdrop/index';
 import { ISelection, SelectionMode } from '../../utilities/selection/index';
@@ -79,6 +80,9 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
 
   /** List of items to render. */
   items: any[];
+
+  /** Optional properties to pass through to the FocusZone. */
+  focusZoneProps?: IFocusZoneProps;
 
   /** Optional properties to pass through to the list components being rendered. */
   listProps?: IListProps;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -1179,33 +1179,33 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
-                  }
-              data-focuszone-id="FocusZone2"
-              onBlur={[Function]}
-              onFocus={[Function]}
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
+                className=
+                    ms-FocusZone
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: inline-block;
+                      min-height: 1px;
+                      min-width: 100%;
+                    }
+                data-focuszone-id="FocusZone2"
+                onBlur={[Function]}
+                onFocus={[Function]}
                 onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
                 onMouseDownCapture={[Function]}
-                role="presentation"
               >
                 <div
                   className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -1119,33 +1119,33 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1464,33 +1464,33 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone15"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone15"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -760,33 +760,33 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone2"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone2"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -971,33 +971,33 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
-                  }
-              data-focuszone-id="FocusZone5"
-              onBlur={[Function]}
-              onFocus={[Function]}
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
+                className=
+                    ms-FocusZone
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: inline-block;
+                      min-height: 1px;
+                      min-width: 100%;
+                    }
+                data-focuszone-id="FocusZone5"
+                onBlur={[Function]}
+                onFocus={[Function]}
                 onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
                 onMouseDownCapture={[Function]}
-                role="presentation"
               >
                 <div
                   className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -972,33 +972,33 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
-                  }
-              data-focuszone-id="FocusZone5"
-              onBlur={[Function]}
-              onFocus={[Function]}
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
+                className=
+                    ms-FocusZone
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: inline-block;
+                      min-height: 1px;
+                      min-width: 100%;
+                    }
+                data-focuszone-id="FocusZone5"
+                onBlur={[Function]}
+                onFocus={[Function]}
                 onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
                 onMouseDownCapture={[Function]}
-                role="presentation"
               >
                 <div
                   className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -517,33 +517,33 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -738,33 +738,33 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -635,4462 +635,4450 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                ms-GroupedList
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  position: relative;
+                }
+                & .ms-List-cell {
+                  min-height: 38px;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-automationid="GroupedList"
+            data-focuszone-id="FocusZone2"
+            data-is-scrollable="false"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  ms-GroupedList
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 12px;
-                    font-weight: 400;
-                    position: relative;
-                  }
-                  & .ms-List-cell {
-                    min-height: 38px;
-                  }
-              data-automationid="GroupedList"
-              data-focuszone-id="FocusZone3"
-              data-is-scrollable="false"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
+              className="ms-List"
               role="presentation"
             >
               <div
-                className="ms-List"
+                className="ms-List-surface"
                 role="presentation"
               >
                 <div
-                  className="ms-List-surface"
+                  className="ms-List-page"
                   role="presentation"
+                  style={Object {}}
                 >
                   <div
-                    className="ms-List-page"
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
                     role="presentation"
-                    style={Object {}}
                   >
                     <div
-                      className="ms-List-cell"
-                      data-automationid="ListCell"
-                      data-list-index={0}
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
                       role="presentation"
                     >
                       <div
                         className=
-                            ms-GroupedList-group
+
                             {
-                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                              background: #faf9f8;
+                              border-bottom: 1px solid #d2d0ce;
+                              border-top: 1px solid #d2d0ce;
+                              margin-bottom: 8px;
+                              margin-left: 0;
+                              margin-right: 0;
+                              margin-top: 8px;
+                              padding-bottom: 8px;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 8px;
+                              position: relative;
+                              z-index: 100;
                             }
-                        role="presentation"
                       >
                         <div
                           className=
 
                               {
-                                background: #faf9f8;
-                                border-bottom: 1px solid #d2d0ce;
-                                border-top: 1px solid #d2d0ce;
-                                margin-bottom: 8px;
-                                margin-left: 0;
-                                margin-right: 0;
-                                margin-top: 8px;
-                                padding-bottom: 8px;
-                                padding-left: 8px;
-                                padding-right: 8px;
-                                padding-top: 8px;
-                                position: relative;
-                                z-index: 100;
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 20px;
+                                font-weight: 600;
+                                padding-bottom: 4px;
+                                padding-left: 0;
+                                padding-right: 0;
+                                padding-top: 4px;
                               }
                         >
-                          <div
-                            className=
-
-                                {
-                                  -moz-osx-font-smoothing: grayscale;
-                                  -webkit-font-smoothing: antialiased;
-                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                  font-size: 20px;
-                                  font-weight: 600;
-                                  padding-bottom: 4px;
-                                  padding-left: 0;
-                                  padding-right: 0;
-                                  padding-top: 4px;
-                                }
-                          >
-                            Custom header for group 0
-                          </div>
-                          <div
-                            className=
-
-                                {
-                                  margin-bottom: 4px;
-                                  margin-left: -8px;
-                                  margin-right: -8px;
-                                  margin-top: 4px;
-                                }
-                          >
-                            <button
-                              className=
-                                  ms-Link
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    background-color: transparent;
-                                    background: none;
-                                    border-bottom: 1px solid transparent;
-                                    border: none;
-                                    color: #0078d4;
-                                    cursor: pointer;
-                                    display: inline;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: inherit;
-                                    font-weight: inherit;
-                                    margin-bottom: 0;
-                                    margin-left: 8px;
-                                    margin-right: 8px;
-                                    margin-top: 0;
-                                    outline: none;
-                                    overflow: inherit;
-                                    padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
-                                    padding-top: 0px;
-                                    text-align: left;
-                                    text-decoration: none;
-                                    text-overflow: inherit;
-                                    user-select: text;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus {
-                                    box-shadow: 0 0 0 1px #605e5c inset;
-                                    outline: 1px auto #605e5c;
-                                  }
-                                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                                    outline: 1px solid WindowText;
-                                  }
-                                  @media screen and (-ms-high-contrast: active){& {
-                                    border-bottom: none;
-                                  }
-                                  @media screen and (-ms-high-contrast: white-on-black){& {
-                                    color: #FFFF00;
-                                  }
-                                  @media screen and (-ms-high-contrast: black-on-white){& {
-                                    color: #00009F;
-                                  }
-                                  &:active {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:hover {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:active:hover {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:focus {
-                                    color: #0078d4;
-                                  }
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              Select group
-                            </button>
-                            <button
-                              className=
-                                  ms-Link
-                                  {
-                                    -moz-osx-font-smoothing: grayscale;
-                                    -webkit-font-smoothing: antialiased;
-                                    background-color: transparent;
-                                    background: none;
-                                    border-bottom: 1px solid transparent;
-                                    border: none;
-                                    color: #0078d4;
-                                    cursor: pointer;
-                                    display: inline;
-                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                    font-size: inherit;
-                                    font-weight: inherit;
-                                    margin-bottom: 0;
-                                    margin-left: 8px;
-                                    margin-right: 8px;
-                                    margin-top: 0;
-                                    outline: none;
-                                    overflow: inherit;
-                                    padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
-                                    padding-top: 0px;
-                                    text-align: left;
-                                    text-decoration: none;
-                                    text-overflow: inherit;
-                                    user-select: text;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus {
-                                    box-shadow: 0 0 0 1px #605e5c inset;
-                                    outline: 1px auto #605e5c;
-                                  }
-                                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                                    outline: 1px solid WindowText;
-                                  }
-                                  @media screen and (-ms-high-contrast: active){& {
-                                    border-bottom: none;
-                                  }
-                                  @media screen and (-ms-high-contrast: white-on-black){& {
-                                    color: #FFFF00;
-                                  }
-                                  @media screen and (-ms-high-contrast: black-on-white){& {
-                                    color: #00009F;
-                                  }
-                                  &:active {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:hover {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:active:hover {
-                                    color: #004578;
-                                    text-decoration: underline;
-                                  }
-                                  &:focus {
-                                    color: #0078d4;
-                                  }
-                              onClick={[Function]}
-                              type="button"
-                            >
-                              Collapse group
-                            </button>
-                          </div>
-                        </div>
-                        <div
-                          className="ms-List"
-                          id="GroupedListSection4"
-                          role="grid"
-                        >
-                          <div
-                            className="ms-List-surface"
-                            role="presentation"
-                          >
-                            <div
-                              className="ms-List-page"
-                              role="presentation"
-                              style={Object {}}
-                            >
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={0}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={1}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone5"
-                                  data-is-focusable={true}
-                                  data-item-index={0}
-                                  data-selection-index={0}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={1}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={2}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone6"
-                                  data-is-focusable={true}
-                                  data-item-index={1}
-                                  data-selection-index={1}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={2}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={3}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone7"
-                                  data-is-focusable={true}
-                                  data-item-index={2}
-                                  data-selection-index={2}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={3}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={4}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone8"
-                                  data-is-focusable={true}
-                                  data-item-index={3}
-                                  data-selection-index={3}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={4}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={5}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone9"
-                                  data-is-focusable={true}
-                                  data-item-index={4}
-                                  data-selection-index={4}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={5}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={6}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone10"
-                                  data-is-focusable={true}
-                                  data-item-index={5}
-                                  data-selection-index={5}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={6}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={7}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone11"
-                                  data-is-focusable={true}
-                                  data-item-index={6}
-                                  data-selection-index={6}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={7}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={8}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone12"
-                                  data-is-focusable={true}
-                                  data-item-index={7}
-                                  data-selection-index={7}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={8}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={9}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone13"
-                                  data-is-focusable={true}
-                                  data-item-index={8}
-                                  data-selection-index={8}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                              <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={9}
-                                role="presentation"
-                              >
-                                <div
-                                  aria-rowindex={10}
-                                  aria-selected={false}
-                                  className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
-                                        box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
-                                        min-height: 42px;
-                                        min-width: 100%;
-                                        outline: transparent;
-                                        padding-bottom: 0px;
-                                        padding-left: 0px;
-                                        padding-right: 0px;
-                                        padding-top: 0px;
-                                        position: relative;
-                                        text-align: left;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        white-space: nowrap;
-                                      }
-                                      &::-moz-focus-inner {
-                                        border: 0;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus:after {
-                                        border: 1px solid #605e5c;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        outline: 1px solid #ffffff;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                        z-index: 1;
-                                      }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
-                                      }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
-                                      }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
-                                      }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone14"
-                                  data-is-focusable={true}
-                                  data-item-index={9}
-                                  data-selection-index={9}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 100,
-                                    }
-                                  }
-                                >
-                                  <div
-                                    aria-colindex={1}
-                                    className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
-                                        {
-                                          box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
-                                          outline: transparent;
-                                          overflow: hidden;
-                                          padding-bottom: 0px;
-                                          padding-left: 0px;
-                                          padding-right: 0px;
-                                          padding-top: 1px;
-                                          position: relative;
-                                          text-overflow: ellipsis;
-                                          vertical-align: top;
-                                          white-space: nowrap;
-                                        }
-                                        &::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus:after {
-                                          border: 1px solid #605e5c;
-                                          bottom: 0px;
-                                          content: "";
-                                          left: 0px;
-                                          outline: 1px solid #ffffff;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: 0px;
-                                          z-index: 1;
-                                        }
-                                        & > button {
-                                          max-width: 100%;
-                                        }
-                                        & [data-is-focusable='true'] {
-                                          outline: transparent;
-                                          position: relative;
-                                        }
-                                        & [data-is-focusable='true']::-moz-focus-inner {
-                                          border: 0;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
-                                    style={
-                                      Object {
-                                        "display": "inline-block",
-                                        "width": 36,
-                                      }
-                                    }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
-                                  >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="thumbnail"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      //placehold.it/150x150
-                                    </div>
-                                  </div>
-                                  <span
-                                    aria-checked={false}
-                                    className=
-
-                                        {
-                                          bottom: 0px;
-                                          display: none;
-                                          left: 0px;
-                                          position: absolute;
-                                          right: 0px;
-                                          top: -1px;
-                                        }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
-                                </div>
-                              </div>
-                            </div>
-                          </div>
+                          Custom header for group 0
                         </div>
                         <div
                           className=
 
                               {
-                                background: #faf9f8;
-                                border-bottom: 1px solid #d2d0ce;
-                                border-top: 1px solid #d2d0ce;
-                                margin-bottom: 8px;
-                                margin-left: 0;
-                                margin-right: 0;
-                                margin-top: 8px;
-                                padding-bottom: 8px;
-                                padding-left: 8px;
-                                padding-right: 8px;
-                                padding-top: 8px;
-                                position: relative;
-                                z-index: 100;
+                                margin-bottom: 4px;
+                                margin-left: -8px;
+                                margin-right: -8px;
+                                margin-top: 4px;
                               }
                         >
-                          <em>
-                            Custom footer for group 0
-                          </em>
+                          <button
+                            className=
+                                ms-Link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  background: none;
+                                  border-bottom: 1px solid transparent;
+                                  border: none;
+                                  color: #0078d4;
+                                  cursor: pointer;
+                                  display: inline;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: inherit;
+                                  font-weight: inherit;
+                                  margin-bottom: 0;
+                                  margin-left: 8px;
+                                  margin-right: 8px;
+                                  margin-top: 0;
+                                  outline: none;
+                                  overflow: inherit;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 0px;
+                                  text-align: left;
+                                  text-decoration: none;
+                                  text-overflow: inherit;
+                                  user-select: text;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus {
+                                  box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                                  outline: 1px solid WindowText;
+                                }
+                                @media screen and (-ms-high-contrast: active){& {
+                                  border-bottom: none;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){& {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){& {
+                                  color: #00009F;
+                                }
+                                &:active {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:hover {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:active:hover {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:focus {
+                                  color: #0078d4;
+                                }
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            Select group
+                          </button>
+                          <button
+                            className=
+                                ms-Link
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  background-color: transparent;
+                                  background: none;
+                                  border-bottom: 1px solid transparent;
+                                  border: none;
+                                  color: #0078d4;
+                                  cursor: pointer;
+                                  display: inline;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: inherit;
+                                  font-weight: inherit;
+                                  margin-bottom: 0;
+                                  margin-left: 8px;
+                                  margin-right: 8px;
+                                  margin-top: 0;
+                                  outline: none;
+                                  overflow: inherit;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 0px;
+                                  text-align: left;
+                                  text-decoration: none;
+                                  text-overflow: inherit;
+                                  user-select: text;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus {
+                                  box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
+                                }
+                                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                                  outline: 1px solid WindowText;
+                                }
+                                @media screen and (-ms-high-contrast: active){& {
+                                  border-bottom: none;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){& {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){& {
+                                  color: #00009F;
+                                }
+                                &:active {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:hover {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:active:hover {
+                                  color: #004578;
+                                  text-decoration: underline;
+                                }
+                                &:focus {
+                                  color: #0078d4;
+                                }
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            Collapse group
+                          </button>
                         </div>
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection3"
+                        role="grid"
+                      >
+                        <div
+                          className="ms-List-surface"
+                          role="presentation"
+                        >
+                          <div
+                            className="ms-List-page"
+                            role="presentation"
+                            style={Object {}}
+                          >
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={0}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={1}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone4"
+                                data-is-focusable={true}
+                                data-item-index={0}
+                                data-selection-index={0}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={1}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={2}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone5"
+                                data-is-focusable={true}
+                                data-item-index={1}
+                                data-selection-index={1}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={2}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={3}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone6"
+                                data-is-focusable={true}
+                                data-item-index={2}
+                                data-selection-index={2}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={3}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={4}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone7"
+                                data-is-focusable={true}
+                                data-item-index={3}
+                                data-selection-index={3}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={4}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={5}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone8"
+                                data-is-focusable={true}
+                                data-item-index={4}
+                                data-selection-index={4}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={5}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={6}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone9"
+                                data-is-focusable={true}
+                                data-item-index={5}
+                                data-selection-index={5}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={6}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={7}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone10"
+                                data-is-focusable={true}
+                                data-item-index={6}
+                                data-selection-index={6}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={7}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={8}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone11"
+                                data-is-focusable={true}
+                                data-item-index={7}
+                                data-selection-index={7}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={8}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={9}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone12"
+                                data-is-focusable={true}
+                                data-item-index={8}
+                                data-selection-index={8}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={9}
+                              role="presentation"
+                            >
+                              <div
+                                aria-rowindex={10}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone13"
+                                data-is-focusable={true}
+                                data-item-index={9}
+                                data-selection-index={9}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 100,
+                                  }
+                                }
+                              >
+                                <div
+                                  aria-colindex={1}
+                                  className=
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
+                                      {
+                                        box-sizing: border-box;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
+                                        min-height: 42px;
+                                        outline: transparent;
+                                        overflow: hidden;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 1px;
+                                        position: relative;
+                                        text-overflow: ellipsis;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 0px;
+                                        content: "";
+                                        left: 0px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: 0px;
+                                        z-index: 1;
+                                      }
+                                      & > button {
+                                        max-width: 100%;
+                                      }
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
+                                      }
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
+                                >
+                                  <div
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
+                                    className=
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
+                                        {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
+                                          box-sizing: border-box;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
+                                          outline: transparent;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="thumbnail"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    //placehold.it/150x150
+                                  </div>
+                                </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className=
+
+                            {
+                              background: #faf9f8;
+                              border-bottom: 1px solid #d2d0ce;
+                              border-top: 1px solid #d2d0ce;
+                              margin-bottom: 8px;
+                              margin-left: 0;
+                              margin-right: 0;
+                              margin-top: 8px;
+                              padding-bottom: 8px;
+                              padding-left: 8px;
+                              padding-right: 8px;
+                              padding-top: 8px;
+                              position: relative;
+                              z-index: 100;
+                            }
+                      >
+                        <em>
+                          Custom footer for group 0
+                        </em>
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="ms-List-page"
-                    role="presentation"
-                    style={
-                      Object {
-                        "height": 18411,
-                      }
-                    }
-                  />
                 </div>
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={
+                    Object {
+                      "height": 18411,
+                    }
+                  }
+                />
               </div>
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -523,33 +523,33 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1330,33 +1330,33 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone7"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone7"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1177,33 +1177,33 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
-                  }
-              data-focuszone-id="FocusZone9"
-              onBlur={[Function]}
-              onFocus={[Function]}
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
+                className=
+                    ms-FocusZone
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: inline-block;
+                      min-height: 1px;
+                      min-width: 100%;
+                    }
+                data-focuszone-id="FocusZone9"
+                onBlur={[Function]}
+                onFocus={[Function]}
                 onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
                 onMouseDownCapture={[Function]}
-                role="presentation"
               >
                 <div
                   className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1168,520 +1168,577 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone7"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  ms-GroupedList
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 12px;
+                    font-weight: 400;
+                    position: relative;
+                  }
+                  & .ms-List-cell {
+                    min-height: 38px;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-automationid="GroupedList"
+              data-focuszone-id="FocusZone7"
+              data-is-scrollable="false"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
               role="presentation"
             >
               <div
-                className=
-                    ms-FocusZone
-                    ms-GroupedList
-                    &:focus {
-                      outline: none;
-                    }
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      position: relative;
-                    }
-                    & .ms-List-cell {
-                      min-height: 38px;
-                    }
-                data-automationid="GroupedList"
-                data-focuszone-id="FocusZone8"
-                data-is-scrollable="false"
-                onFocus={[Function]}
-                onKeyDown={[Function]}
-                onMouseDownCapture={[Function]}
+                className="ms-List"
                 role="presentation"
               >
                 <div
-                  className="ms-List"
+                  className="ms-List-surface"
                   role="presentation"
                 >
                   <div
-                    className="ms-List-surface"
+                    className="ms-List-page"
                     role="presentation"
+                    style={Object {}}
                   >
                     <div
-                      className="ms-List-page"
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={0}
                       role="presentation"
-                      style={Object {}}
                     >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={0}
+                        className=
+                            ms-GroupedList-group
+                            {
+                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                            }
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
+                          aria-label="Color: \\"red\\""
+                          aria-level={1}
+                          aria-posinset={1}
+                          aria-setsize={3}
                           className=
-                              ms-GroupedList-group
+                              ms-GroupHeader
                               {
-                                transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                border-bottom: 1px solid #ffffff;
+                                cursor: default;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                outline: transparent;
+                                position: relative;
+                                user-select: none;
                               }
-                          role="presentation"
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background: #f3f2f1;
+                                color: #201f1e;
+                              }
+                              &:hover .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                                opacity: 1;
+                                transform: rotate(0.2deg) scale(1);
+                                transition-delay: 0.367s;
+                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                              }
+                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                                opacity: 0;
+                              }
+                          data-is-focusable={true}
+                          onClick={[Function]}
+                          onKeyUp={[Function]}
+                          style={Object {}}
                         >
                           <div
-                            aria-expanded={true}
-                            aria-label="Color: \\"red\\""
-                            aria-level={1}
-                            aria-posinset={1}
-                            aria-setsize={3}
                             className=
-                                ms-GroupHeader
-                                {
-                                  -moz-osx-font-smoothing: grayscale;
-                                  -webkit-font-smoothing: antialiased;
-                                  border-bottom: 1px solid #ffffff;
-                                  cursor: default;
-                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                  font-size: 14px;
-                                  font-weight: 400;
-                                  outline: transparent;
-                                  position: relative;
-                                  user-select: none;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid #ffffff;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                &:hover {
-                                  background: #f3f2f1;
-                                  color: #201f1e;
-                                }
-                                &:hover .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                  opacity: 1;
-                                  transform: rotate(0.2deg) scale(1);
-                                  transition-delay: 0.367s;
-                                  transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                }
-                                .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                  opacity: 0;
-                                }
-                            data-is-focusable={true}
-                            onClick={[Function]}
-                            onKeyUp={[Function]}
-                            style={Object {}}
-                          >
-                            <div
-                              className=
 
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: 48px;
+                                }
+                          >
+                            <button
+                              aria-checked={false}
+                              className=
+                                  ms-GroupHeader-check
                                   {
                                     align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    cursor: default;
                                     display: flex;
                                     height: 48px;
+                                    justify-content: center;
+                                    margin-top: -1px;
+                                    opacity: 0;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 1px;
+                                    position: relative;
+                                    width: 48px;
                                   }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    opacity: 1;
+                                  }
+                              data-is-focusable={false}
+                              data-selection-toggle={true}
+                              onClick={[Function]}
+                              role="checkbox"
+                              type="button"
                             >
-                              <button
-                                aria-checked={false}
+                              <div
                                 className=
-                                    ms-GroupHeader-check
+                                    ms-Check
                                     {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      cursor: default;
-                                      display: flex;
-                                      height: 48px;
-                                      justify-content: center;
-                                      margin-top: -1px;
-                                      opacity: 0;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 1px;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 14px;
+                                      font-weight: 400;
+                                      height: 18px;
+                                      line-height: 1;
                                       position: relative;
-                                      width: 48px;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      width: 18px;
                                     }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
+                                    &:before {
+                                      background: #ffffff;
+                                      border-radius: 50%;
                                       bottom: 1px;
                                       content: "";
                                       left: 1px;
-                                      outline: 1px solid #605e5c;
+                                      opacity: 1;
                                       position: absolute;
                                       right: 1px;
                                       top: 1px;
-                                      z-index: 1;
                                     }
-                                    .ms-Fabric--isFocusVisible &:focus {
+                                    .ms-Check-checkHost:hover & {
                                       opacity: 1;
                                     }
-                                data-is-focusable={false}
-                                data-selection-toggle={true}
-                                onClick={[Function]}
-                                role="checkbox"
-                                type="button"
-                              >
-                                <div
-                                  className=
-                                      ms-Check
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 14px;
-                                        font-weight: 400;
-                                        height: 18px;
-                                        line-height: 1;
-                                        position: relative;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        width: 18px;
-                                      }
-                                      &:before {
-                                        background: #ffffff;
-                                        border-radius: 50%;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        opacity: 1;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                      }
-                                      .ms-Check-checkHost:hover & {
-                                        opacity: 1;
-                                      }
-                                      .ms-Check-checkHost:focus & {
-                                        opacity: 1;
-                                      }
-                                      &:hover {
-                                        opacity: 1;
-                                      }
-                                      &:focus {
-                                        opacity: 1;
-                                      }
-                                >
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-circle
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 18px;
-                                          height: 18px;
-                                          left: 0px;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          color: WindowText;
-                                        }
-                                    data-icon-name="CircleRing"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    .ms-Check-checkHost:focus & {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-check
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 16px;
-                                          height: 18px;
-                                          left: .5px;
-                                          opacity: 0;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        &:hover {
-                                          opacity: 1;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          -ms-high-contrast-adjust: none;
-                                        }
-                                    data-icon-name="StatusCircleCheckmark"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    &:hover {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                </div>
-                              </button>
-                              <div
-                                className=
-                                    ms-GroupHeader-dropIcon
-                                    {
-                                      color: #605e5c;
-                                      font-size: 20px;
-                                      left: -26px;
-                                      opacity: 0;
-                                      position: absolute;
-                                      transform-origin: 10px 10px;
-                                      transform: rotate(0.2deg) scale(0.65);
-                                      transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                    }
-                                    .ms-Icon--Tag {
-                                      position: absolute;
+                                    &:focus {
+                                      opacity: 1;
                                     }
                               >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-circle
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
                                         font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
                                       }
-                                  data-icon-name="Tag"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 18px;
+                                        height: 18px;
+                                        left: 0px;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        color: WindowText;
+                                      }
+                                  data-icon-name="CircleRing"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </div>
-                              <button
-                                aria-controls="GroupedListSection9"
-                                aria-expanded={true}
-                                aria-label="expand collapse group"
-                                className=
-                                    ms-GroupHeader-expand
-                                    {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      color: #605e5c;
-                                      cursor: default;
-                                      display: flex;
-                                      font-size: 12px;
-                                      height: 48px;
-                                      justify-content: center;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 0px;
-                                      position: relative;
-                                      width: 36px;
-                                    }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
-                                      bottom: 1px;
-                                      content: "";
-                                      left: 1px;
-                                      outline: 1px solid #605e5c;
-                                      position: absolute;
-                                      right: 1px;
-                                      top: 1px;
-                                      z-index: 1;
-                                    }
-                                    &:hover {
-                                      background-color: #edebe9;
-                                    }
-                                    &:active {
-                                      background-color: #e1dfdd;
-                                    }
-                                data-is-focusable={false}
-                                onClick={[Function]}
-                                type="button"
-                              >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-check
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
-                                        font-family: "FabricMDL2Icons-3";
+                                        font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
-                                        transform-origin: 50% 50%;
-                                        transform: rotate(90deg);
-                                        transition: transform .1s linear;
                                       }
-                                  data-icon-name="ChevronRightMed"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 16px;
+                                        height: 18px;
+                                        left: .5px;
+                                        opacity: 0;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      &:hover {
+                                        opacity: 1;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        -ms-high-contrast-adjust: none;
+                                      }
+                                  data-icon-name="StatusCircleCheckmark"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </button>
-                              <div
+                              </div>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-dropIcon
+                                  {
+                                    color: #605e5c;
+                                    font-size: 20px;
+                                    left: -26px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    transform-origin: 10px 10px;
+                                    transform: rotate(0.2deg) scale(0.65);
+                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                  }
+                                  .ms-Icon--Tag {
+                                    position: absolute;
+                                  }
+                            >
+                              <i
+                                aria-hidden={true}
                                 className=
-                                    ms-GroupHeader-title
+
                                     {
-                                      cursor: pointer;
-                                      font-size: 16px;
-                                      font-weight: 600;
-                                      outline: 0px;
-                                      padding-left: 12px;
-                                      text-overflow: ellipsis;
-                                      white-space: nowrap;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                    }
+                                data-icon-name="Tag"
+                              >
+                                
+                              </i>
+                            </div>
+                            <button
+                              aria-controls="GroupedListSection8"
+                              aria-expanded={true}
+                              aria-label="expand collapse group"
+                              className=
+                                  ms-GroupHeader-expand
+                                  {
+                                    align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    color: #605e5c;
+                                    cursor: default;
+                                    display: flex;
+                                    font-size: 12px;
+                                    height: 48px;
+                                    justify-content: center;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    position: relative;
+                                    width: 36px;
+                                  }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  &:hover {
+                                    background-color: #edebe9;
+                                  }
+                                  &:active {
+                                    background-color: #e1dfdd;
+                                  }
+                              data-is-focusable={false}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <i
+                                aria-hidden={true}
+                                className=
+
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons-3";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                      transform-origin: 50% 50%;
+                                      transform: rotate(90deg);
+                                      transition: transform .1s linear;
+                                    }
+                                data-icon-name="ChevronRightMed"
+                              >
+                                
+                              </i>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-title
+                                  {
+                                    cursor: pointer;
+                                    font-size: 16px;
+                                    font-weight: 600;
+                                    outline: 0px;
+                                    padding-left: 12px;
+                                    text-overflow: ellipsis;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span>
+                                Color: "red"
+                              </span>
+                              <span
+                                className=
+
+                                    {
+                                      padding-bottom: 0px;
+                                      padding-left: 4px;
+                                      padding-right: 4px;
+                                      padding-top: 0px;
                                     }
                               >
-                                <span>
-                                  Color: "red"
-                                </span>
-                                <span
-                                  className=
-
-                                      {
-                                        padding-bottom: 0px;
-                                        padding-left: 4px;
-                                        padding-right: 4px;
-                                        padding-top: 0px;
-                                      }
-                                >
-                                  (
-                                  2
-                                  )
-                                </span>
-                              </div>
+                                (
+                                2
+                                )
+                              </span>
                             </div>
                           </div>
+                        </div>
+                        <div
+                          className="ms-List"
+                          id="GroupedListSection8"
+                          role="grid"
+                        >
                           <div
-                            className="ms-List"
-                            id="GroupedListSection9"
-                            role="grid"
+                            className="ms-List-surface"
+                            role="presentation"
                           >
                             <div
-                              className="ms-List-surface"
+                              className="ms-List-page"
                               role="presentation"
+                              style={Object {}}
                             >
                               <div
-                                className="ms-List-page"
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={0}
                                 role="presentation"
-                                style={Object {}}
                               >
                                 <div
-                                  className="ms-List-cell"
-                                  data-automationid="ListCell"
-                                  data-list-index={0}
-                                  role="presentation"
+                                  aria-rowindex={1}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone11"
+                                  data-is-focusable={true}
+                                  data-item-index={0}
+                                  data-selection-index={0}
+                                  data-selection-touch-invoke={true}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
                                 >
                                   <div
-                                    aria-rowindex={1}
-                                    aria-selected={false}
+                                    aria-colindex={1}
                                     className=
-                                        ms-FocusZone
-                                        ms-DetailsRow
-                                        is-contentUnselectable
-                                        &:focus {
-                                          outline: none;
-                                        }
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
                                         {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          animation-duration: 0.367s;
-                                          animation-fill-mode: both;
-                                          animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                          background: #ffffff;
-                                          border-bottom: 1px solid #f3f2f1;
                                           box-sizing: border-box;
-                                          color: #605e5c;
-                                          cursor: default;
-                                          display: inline-flex;
-                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                          font-size: 12px;
-                                          font-weight: 400;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
                                           min-height: 42px;
-                                          min-width: 100%;
                                           outline: transparent;
+                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 0px;
+                                          padding-top: 1px;
                                           position: relative;
-                                          text-align: left;
-                                          user-select: none;
+                                          text-overflow: ellipsis;
                                           vertical-align: top;
                                           white-space: nowrap;
                                         }
@@ -1690,64 +1747,241 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                         .ms-Fabric--isFocusVisible &:focus:after {
                                           border: 1px solid #605e5c;
-                                          bottom: 1px;
+                                          bottom: 0px;
                                           content: "";
-                                          left: 1px;
+                                          left: 0px;
                                           outline: 1px solid #ffffff;
                                           position: absolute;
-                                          right: 1px;
-                                          top: 1px;
+                                          right: 0px;
+                                          top: 0px;
                                           z-index: 1;
                                         }
-                                        .ms-List-cell:first-child &:before {
-                                          display: none;
+                                        & > button {
+                                          max-width: 100%;
                                         }
-                                        &:hover {
-                                          background: #f3f2f1;
-                                          color: #323130;
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
                                         }
-                                        &:hover .is-row-header {
-                                          color: #201f1e;
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                        &:hover .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                    data-automationid="DetailsRow"
-                                    data-focuszone-id="FocusZone12"
-                                    data-is-focusable={true}
-                                    data-item-index={0}
-                                    data-selection-index={0}
-                                    data-selection-touch-invoke={true}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseDownCapture={[Function]}
-                                    role="row"
-                                    style={
-                                      Object {
-                                        "minWidth": 200,
-                                      }
-                                    }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
                                   >
                                     <div
-                                      aria-colindex={1}
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
                                       className=
-                                          ms-DetailsRow-cell
-                                          ms-DetailsRow-cellCheck
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
                                           {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
                                             box-sizing: border-box;
-                                            display: inline-block;
-                                            flex-shrink: 0;
-                                            margin-top: -1px;
-                                            min-height: 42px;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
                                             outline: transparent;
-                                            overflow: hidden;
                                             padding-bottom: 0px;
                                             padding-left: 0px;
                                             padding-right: 0px;
-                                            padding-top: 1px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
                                             position: relative;
                                             text-overflow: ellipsis;
                                             vertical-align: top;
@@ -1777,390 +2011,213 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           & [data-is-focusable='true']::-moz-focus-inner {
                                             border: 0;
                                           }
-                                      data-selection-toggle={true}
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
                                       role="gridcell"
-                                    >
-                                      <div
-                                        aria-checked={false}
-                                        aria-label="Row checkbox"
-                                        className=
-                                            ms-DetailsRow-check
-                                            ms-Check-checkHost
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              align-items: center;
-                                              background-color: transparent;
-                                              background: none;
-                                              border: none;
-                                              box-sizing: border-box;
-                                              cursor: default;
-                                              display: flex;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 12px;
-                                              font-weight: 400;
-                                              height: 42px;
-                                              justify-content: center;
-                                              margin-bottom: 0px;
-                                              margin-left: 0px;
-                                              margin-right: 0px;
-                                              margin-top: 0px;
-                                              opacity: 0;
-                                              outline: transparent;
-                                              padding-bottom: 0px;
-                                              padding-left: 0px;
-                                              padding-right: 0px;
-                                              padding-top: 0px;
-                                              position: relative;
-                                              vertical-align: top;
-                                              width: 48px;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #ffffff;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              outline: 1px solid #605e5c;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                              z-index: 1;
-                                            }
-                                        data-automationid="DetailsRowCheck"
-                                        data-selection-toggle={true}
-                                        role="checkbox"
-                                      >
-                                        <div
-                                          className=
-                                              ms-Check
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                                font-size: 14px;
-                                                font-weight: 400;
-                                                height: 18px;
-                                                line-height: 1;
-                                                position: relative;
-                                                user-select: none;
-                                                vertical-align: top;
-                                                width: 18px;
-                                              }
-                                              &:before {
-                                                background: #ffffff;
-                                                border-radius: 50%;
-                                                bottom: 1px;
-                                                content: "";
-                                                left: 1px;
-                                                opacity: 1;
-                                                position: absolute;
-                                                right: 1px;
-                                                top: 1px;
-                                              }
-                                              .ms-Check-checkHost:hover & {
-                                                opacity: 1;
-                                              }
-                                              .ms-Check-checkHost:focus & {
-                                                opacity: 1;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              &:focus {
-                                                opacity: 1;
-                                              }
-                                        >
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-circle
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 18px;
-                                                  height: 18px;
-                                                  left: 0px;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  color: WindowText;
-                                                }
-                                            data-icon-name="CircleRing"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-check
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 16px;
-                                                  height: 18px;
-                                                  left: .5px;
-                                                  opacity: 0;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                &:hover {
-                                                  opacity: 1;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  -ms-high-contrast-adjust: none;
-                                                }
-                                            data-icon-name="StatusCircleCheckmark"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <span
-                                      className="ms-GroupSpacer"
                                       style={
                                         Object {
-                                          "display": "inline-block",
-                                          "width": 36,
+                                          "width": 120,
                                         }
                                       }
-                                    />
-                                    <div
-                                      className=
-                                          ms-DetailsRow-fields
-                                          {
-                                            align-items: stretch;
-                                            display: flex;
-                                          }
-                                      data-automationid="DetailsRowFields"
-                                      role="presentation"
                                     >
                                       <div
-                                        aria-colindex={2}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="name"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
+                                        data-is-focusable={true}
                                       >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          a
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-colindex={3}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="color"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          red
-                                        </div>
+                                        a
                                       </div>
                                     </div>
-                                    <span
-                                      aria-checked={false}
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
                                       className=
-
+                                          ms-DetailsRow-cell
                                           {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
                                             bottom: 0px;
-                                            display: none;
+                                            content: "";
                                             left: 0px;
+                                            outline: 1px solid #ffffff;
                                             position: absolute;
                                             right: 0px;
-                                            top: -1px;
+                                            top: 0px;
+                                            z-index: 1;
                                           }
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    />
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="color"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        data-is-focusable={true}
+                                      >
+                                        red
+                                      </div>
+                                    </div>
                                   </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
                                 </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={1}
+                                role="presentation"
+                              >
                                 <div
-                                  className="ms-List-cell"
-                                  data-automationid="ListCell"
-                                  data-list-index={1}
-                                  role="presentation"
+                                  aria-rowindex={2}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone12"
+                                  data-is-focusable={true}
+                                  data-item-index={1}
+                                  data-selection-index={1}
+                                  data-selection-touch-invoke={true}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
                                 >
                                   <div
-                                    aria-rowindex={2}
-                                    aria-selected={false}
+                                    aria-colindex={1}
                                     className=
-                                        ms-FocusZone
-                                        ms-DetailsRow
-                                        is-contentUnselectable
-                                        &:focus {
-                                          outline: none;
-                                        }
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
                                         {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          animation-duration: 0.367s;
-                                          animation-fill-mode: both;
-                                          animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                          background: #ffffff;
-                                          border-bottom: 1px solid #f3f2f1;
                                           box-sizing: border-box;
-                                          color: #605e5c;
-                                          cursor: default;
-                                          display: inline-flex;
-                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                          font-size: 12px;
-                                          font-weight: 400;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
                                           min-height: 42px;
-                                          min-width: 100%;
                                           outline: transparent;
+                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 0px;
+                                          padding-top: 1px;
                                           position: relative;
-                                          text-align: left;
-                                          user-select: none;
+                                          text-overflow: ellipsis;
                                           vertical-align: top;
                                           white-space: nowrap;
                                         }
@@ -2169,64 +2226,241 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                         .ms-Fabric--isFocusVisible &:focus:after {
                                           border: 1px solid #605e5c;
-                                          bottom: 1px;
+                                          bottom: 0px;
                                           content: "";
-                                          left: 1px;
+                                          left: 0px;
                                           outline: 1px solid #ffffff;
                                           position: absolute;
-                                          right: 1px;
-                                          top: 1px;
+                                          right: 0px;
+                                          top: 0px;
                                           z-index: 1;
                                         }
-                                        .ms-List-cell:first-child &:before {
-                                          display: none;
+                                        & > button {
+                                          max-width: 100%;
                                         }
-                                        &:hover {
-                                          background: #f3f2f1;
-                                          color: #323130;
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
                                         }
-                                        &:hover .is-row-header {
-                                          color: #201f1e;
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                        &:hover .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                    data-automationid="DetailsRow"
-                                    data-focuszone-id="FocusZone13"
-                                    data-is-focusable={true}
-                                    data-item-index={1}
-                                    data-selection-index={1}
-                                    data-selection-touch-invoke={true}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseDownCapture={[Function]}
-                                    role="row"
-                                    style={
-                                      Object {
-                                        "minWidth": 200,
-                                      }
-                                    }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
                                   >
                                     <div
-                                      aria-colindex={1}
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
                                       className=
-                                          ms-DetailsRow-cell
-                                          ms-DetailsRow-cellCheck
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
                                           {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
                                             box-sizing: border-box;
-                                            display: inline-block;
-                                            flex-shrink: 0;
-                                            margin-top: -1px;
-                                            min-height: 42px;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
                                             outline: transparent;
-                                            overflow: hidden;
                                             padding-bottom: 0px;
                                             padding-left: 0px;
                                             padding-right: 0px;
-                                            padding-top: 1px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
                                             position: relative;
                                             text-overflow: ellipsis;
                                             vertical-align: top;
@@ -2256,347 +2490,101 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           & [data-is-focusable='true']::-moz-focus-inner {
                                             border: 0;
                                           }
-                                      data-selection-toggle={true}
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
                                       role="gridcell"
-                                    >
-                                      <div
-                                        aria-checked={false}
-                                        aria-label="Row checkbox"
-                                        className=
-                                            ms-DetailsRow-check
-                                            ms-Check-checkHost
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              align-items: center;
-                                              background-color: transparent;
-                                              background: none;
-                                              border: none;
-                                              box-sizing: border-box;
-                                              cursor: default;
-                                              display: flex;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 12px;
-                                              font-weight: 400;
-                                              height: 42px;
-                                              justify-content: center;
-                                              margin-bottom: 0px;
-                                              margin-left: 0px;
-                                              margin-right: 0px;
-                                              margin-top: 0px;
-                                              opacity: 0;
-                                              outline: transparent;
-                                              padding-bottom: 0px;
-                                              padding-left: 0px;
-                                              padding-right: 0px;
-                                              padding-top: 0px;
-                                              position: relative;
-                                              vertical-align: top;
-                                              width: 48px;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #ffffff;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              outline: 1px solid #605e5c;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                              z-index: 1;
-                                            }
-                                        data-automationid="DetailsRowCheck"
-                                        data-selection-toggle={true}
-                                        role="checkbox"
-                                      >
-                                        <div
-                                          className=
-                                              ms-Check
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                                font-size: 14px;
-                                                font-weight: 400;
-                                                height: 18px;
-                                                line-height: 1;
-                                                position: relative;
-                                                user-select: none;
-                                                vertical-align: top;
-                                                width: 18px;
-                                              }
-                                              &:before {
-                                                background: #ffffff;
-                                                border-radius: 50%;
-                                                bottom: 1px;
-                                                content: "";
-                                                left: 1px;
-                                                opacity: 1;
-                                                position: absolute;
-                                                right: 1px;
-                                                top: 1px;
-                                              }
-                                              .ms-Check-checkHost:hover & {
-                                                opacity: 1;
-                                              }
-                                              .ms-Check-checkHost:focus & {
-                                                opacity: 1;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              &:focus {
-                                                opacity: 1;
-                                              }
-                                        >
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-circle
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 18px;
-                                                  height: 18px;
-                                                  left: 0px;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  color: WindowText;
-                                                }
-                                            data-icon-name="CircleRing"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-check
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 16px;
-                                                  height: 18px;
-                                                  left: .5px;
-                                                  opacity: 0;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                &:hover {
-                                                  opacity: 1;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  -ms-high-contrast-adjust: none;
-                                                }
-                                            data-icon-name="StatusCircleCheckmark"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <span
-                                      className="ms-GroupSpacer"
                                       style={
                                         Object {
-                                          "display": "inline-block",
-                                          "width": 36,
+                                          "width": 120,
                                         }
                                       }
-                                    />
-                                    <div
-                                      className=
-                                          ms-DetailsRow-fields
-                                          {
-                                            align-items: stretch;
-                                            display: flex;
-                                          }
-                                      data-automationid="DetailsRowFields"
-                                      role="presentation"
                                     >
                                       <div
-                                        aria-colindex={2}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="name"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
+                                        data-is-focusable={true}
                                       >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          b
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-colindex={3}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="color"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          red
-                                        </div>
+                                        b
                                       </div>
                                     </div>
-                                    <span
-                                      aria-checked={false}
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
                                       className=
-
+                                          ms-DetailsRow-cell
                                           {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
                                             bottom: 0px;
-                                            display: none;
+                                            content: "";
                                             left: 0px;
+                                            outline: 1px solid #ffffff;
                                             position: absolute;
                                             right: 0px;
-                                            top: -1px;
+                                            top: 0px;
+                                            z-index: 1;
                                           }
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    />
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="color"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        data-is-focusable={true}
+                                      >
+                                        red
+                                      </div>
+                                    </div>
                                   </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
                                 </div>
                               </div>
                             </div>
@@ -2604,866 +2592,935 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         </div>
                       </div>
                     </div>
+                  </div>
+                  <div
+                    className="ms-List-page"
+                    role="presentation"
+                    style={Object {}}
+                  >
                     <div
-                      className="ms-List-page"
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={1}
                       role="presentation"
-                      style={Object {}}
                     >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={1}
+                        className=
+                            ms-GroupedList-group
+                            {
+                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                            }
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
+                          aria-label="Color: \\"green\\""
+                          aria-level={1}
+                          aria-posinset={2}
+                          aria-setsize={3}
                           className=
-                              ms-GroupedList-group
+                              ms-GroupHeader
                               {
-                                transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                border-bottom: 1px solid #ffffff;
+                                cursor: default;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                outline: transparent;
+                                position: relative;
+                                user-select: none;
                               }
-                          role="presentation"
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background: #f3f2f1;
+                                color: #201f1e;
+                              }
+                              &:hover .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                                opacity: 1;
+                                transform: rotate(0.2deg) scale(1);
+                                transition-delay: 0.367s;
+                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                              }
+                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                                opacity: 0;
+                              }
+                          data-is-focusable={true}
+                          onClick={[Function]}
+                          onKeyUp={[Function]}
+                          style={Object {}}
                         >
                           <div
-                            aria-expanded={true}
-                            aria-label="Color: \\"green\\""
-                            aria-level={1}
-                            aria-posinset={2}
-                            aria-setsize={3}
                             className=
-                                ms-GroupHeader
-                                {
-                                  -moz-osx-font-smoothing: grayscale;
-                                  -webkit-font-smoothing: antialiased;
-                                  border-bottom: 1px solid #ffffff;
-                                  cursor: default;
-                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                  font-size: 14px;
-                                  font-weight: 400;
-                                  outline: transparent;
-                                  position: relative;
-                                  user-select: none;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid #ffffff;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                &:hover {
-                                  background: #f3f2f1;
-                                  color: #201f1e;
-                                }
-                                &:hover .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                  opacity: 1;
-                                  transform: rotate(0.2deg) scale(1);
-                                  transition-delay: 0.367s;
-                                  transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                }
-                                .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                  opacity: 0;
-                                }
-                            data-is-focusable={true}
-                            onClick={[Function]}
-                            onKeyUp={[Function]}
-                            style={Object {}}
-                          >
-                            <div
-                              className=
 
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: 48px;
+                                }
+                          >
+                            <button
+                              aria-checked={false}
+                              className=
+                                  ms-GroupHeader-check
                                   {
                                     align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    cursor: default;
                                     display: flex;
                                     height: 48px;
+                                    justify-content: center;
+                                    margin-top: -1px;
+                                    opacity: 0;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 1px;
+                                    position: relative;
+                                    width: 48px;
                                   }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    opacity: 1;
+                                  }
+                              data-is-focusable={false}
+                              data-selection-toggle={true}
+                              onClick={[Function]}
+                              role="checkbox"
+                              type="button"
                             >
-                              <button
-                                aria-checked={false}
+                              <div
                                 className=
-                                    ms-GroupHeader-check
+                                    ms-Check
                                     {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      cursor: default;
-                                      display: flex;
-                                      height: 48px;
-                                      justify-content: center;
-                                      margin-top: -1px;
-                                      opacity: 0;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 1px;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 14px;
+                                      font-weight: 400;
+                                      height: 18px;
+                                      line-height: 1;
                                       position: relative;
-                                      width: 48px;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      width: 18px;
                                     }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
+                                    &:before {
+                                      background: #ffffff;
+                                      border-radius: 50%;
                                       bottom: 1px;
                                       content: "";
                                       left: 1px;
-                                      outline: 1px solid #605e5c;
+                                      opacity: 1;
                                       position: absolute;
                                       right: 1px;
                                       top: 1px;
-                                      z-index: 1;
                                     }
-                                    .ms-Fabric--isFocusVisible &:focus {
+                                    .ms-Check-checkHost:hover & {
                                       opacity: 1;
                                     }
-                                data-is-focusable={false}
-                                data-selection-toggle={true}
-                                onClick={[Function]}
-                                role="checkbox"
-                                type="button"
-                              >
-                                <div
-                                  className=
-                                      ms-Check
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 14px;
-                                        font-weight: 400;
-                                        height: 18px;
-                                        line-height: 1;
-                                        position: relative;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        width: 18px;
-                                      }
-                                      &:before {
-                                        background: #ffffff;
-                                        border-radius: 50%;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        opacity: 1;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                      }
-                                      .ms-Check-checkHost:hover & {
-                                        opacity: 1;
-                                      }
-                                      .ms-Check-checkHost:focus & {
-                                        opacity: 1;
-                                      }
-                                      &:hover {
-                                        opacity: 1;
-                                      }
-                                      &:focus {
-                                        opacity: 1;
-                                      }
-                                >
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-circle
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 18px;
-                                          height: 18px;
-                                          left: 0px;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          color: WindowText;
-                                        }
-                                    data-icon-name="CircleRing"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    .ms-Check-checkHost:focus & {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-check
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 16px;
-                                          height: 18px;
-                                          left: .5px;
-                                          opacity: 0;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        &:hover {
-                                          opacity: 1;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          -ms-high-contrast-adjust: none;
-                                        }
-                                    data-icon-name="StatusCircleCheckmark"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    &:hover {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                </div>
-                              </button>
-                              <div
-                                className=
-                                    ms-GroupHeader-dropIcon
-                                    {
-                                      color: #605e5c;
-                                      font-size: 20px;
-                                      left: -26px;
-                                      opacity: 0;
-                                      position: absolute;
-                                      transform-origin: 10px 10px;
-                                      transform: rotate(0.2deg) scale(0.65);
-                                      transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                    }
-                                    .ms-Icon--Tag {
-                                      position: absolute;
+                                    &:focus {
+                                      opacity: 1;
                                     }
                               >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-circle
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
                                         font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
                                       }
-                                  data-icon-name="Tag"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 18px;
+                                        height: 18px;
+                                        left: 0px;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        color: WindowText;
+                                      }
+                                  data-icon-name="CircleRing"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </div>
-                              <button
-                                aria-controls="GroupedListSection10"
-                                aria-expanded={true}
-                                aria-label="expand collapse group"
-                                className=
-                                    ms-GroupHeader-expand
-                                    {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      color: #605e5c;
-                                      cursor: default;
-                                      display: flex;
-                                      font-size: 12px;
-                                      height: 48px;
-                                      justify-content: center;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 0px;
-                                      position: relative;
-                                      width: 36px;
-                                    }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
-                                      bottom: 1px;
-                                      content: "";
-                                      left: 1px;
-                                      outline: 1px solid #605e5c;
-                                      position: absolute;
-                                      right: 1px;
-                                      top: 1px;
-                                      z-index: 1;
-                                    }
-                                    &:hover {
-                                      background-color: #edebe9;
-                                    }
-                                    &:active {
-                                      background-color: #e1dfdd;
-                                    }
-                                data-is-focusable={false}
-                                onClick={[Function]}
-                                type="button"
-                              >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-check
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
-                                        font-family: "FabricMDL2Icons-3";
+                                        font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
-                                        transform-origin: 50% 50%;
-                                        transform: rotate(90deg);
-                                        transition: transform .1s linear;
                                       }
-                                  data-icon-name="ChevronRightMed"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 16px;
+                                        height: 18px;
+                                        left: .5px;
+                                        opacity: 0;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      &:hover {
+                                        opacity: 1;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        -ms-high-contrast-adjust: none;
+                                      }
+                                  data-icon-name="StatusCircleCheckmark"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </button>
-                              <div
+                              </div>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-dropIcon
+                                  {
+                                    color: #605e5c;
+                                    font-size: 20px;
+                                    left: -26px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    transform-origin: 10px 10px;
+                                    transform: rotate(0.2deg) scale(0.65);
+                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                  }
+                                  .ms-Icon--Tag {
+                                    position: absolute;
+                                  }
+                            >
+                              <i
+                                aria-hidden={true}
                                 className=
-                                    ms-GroupHeader-title
+
                                     {
-                                      cursor: pointer;
-                                      font-size: 16px;
-                                      font-weight: 600;
-                                      outline: 0px;
-                                      padding-left: 12px;
-                                      text-overflow: ellipsis;
-                                      white-space: nowrap;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                    }
+                                data-icon-name="Tag"
+                              >
+                                
+                              </i>
+                            </div>
+                            <button
+                              aria-controls="GroupedListSection9"
+                              aria-expanded={true}
+                              aria-label="expand collapse group"
+                              className=
+                                  ms-GroupHeader-expand
+                                  {
+                                    align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    color: #605e5c;
+                                    cursor: default;
+                                    display: flex;
+                                    font-size: 12px;
+                                    height: 48px;
+                                    justify-content: center;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    position: relative;
+                                    width: 36px;
+                                  }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  &:hover {
+                                    background-color: #edebe9;
+                                  }
+                                  &:active {
+                                    background-color: #e1dfdd;
+                                  }
+                              data-is-focusable={false}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <i
+                                aria-hidden={true}
+                                className=
+
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons-3";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                      transform-origin: 50% 50%;
+                                      transform: rotate(90deg);
+                                      transition: transform .1s linear;
+                                    }
+                                data-icon-name="ChevronRightMed"
+                              >
+                                
+                              </i>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-title
+                                  {
+                                    cursor: pointer;
+                                    font-size: 16px;
+                                    font-weight: 600;
+                                    outline: 0px;
+                                    padding-left: 12px;
+                                    text-overflow: ellipsis;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span>
+                                Color: "green"
+                              </span>
+                              <span
+                                className=
+
+                                    {
+                                      padding-bottom: 0px;
+                                      padding-left: 4px;
+                                      padding-right: 4px;
+                                      padding-top: 0px;
                                     }
                               >
-                                <span>
-                                  Color: "green"
-                                </span>
-                                <span
-                                  className=
-
-                                      {
-                                        padding-bottom: 0px;
-                                        padding-left: 4px;
-                                        padding-right: 4px;
-                                        padding-top: 0px;
-                                      }
-                                >
-                                  (
-                                  0
-                                  )
-                                </span>
-                              </div>
+                                (
+                                0
+                                )
+                              </span>
                             </div>
                           </div>
+                        </div>
+                        <div
+                          className="ms-List"
+                          id="GroupedListSection9"
+                        >
                           <div
-                            className="ms-List"
-                            id="GroupedListSection10"
-                          >
-                            <div
-                              className="ms-List-surface"
-                              role="presentation"
-                            />
-                          </div>
+                            className="ms-List-surface"
+                            role="presentation"
+                          />
                         </div>
                       </div>
                     </div>
+                  </div>
+                  <div
+                    className="ms-List-page"
+                    role="presentation"
+                    style={Object {}}
+                  >
                     <div
-                      className="ms-List-page"
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={2}
                       role="presentation"
-                      style={Object {}}
                     >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={2}
+                        className=
+                            ms-GroupedList-group
+                            {
+                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                            }
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
+                          aria-label="Color: \\"blue\\""
+                          aria-level={1}
+                          aria-posinset={3}
+                          aria-setsize={3}
                           className=
-                              ms-GroupedList-group
+                              ms-GroupHeader
                               {
-                                transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                border-bottom: 1px solid #ffffff;
+                                cursor: default;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                outline: transparent;
+                                position: relative;
+                                user-select: none;
                               }
-                          role="presentation"
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background: #f3f2f1;
+                                color: #201f1e;
+                              }
+                              &:hover .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                                opacity: 1;
+                                transform: rotate(0.2deg) scale(1);
+                                transition-delay: 0.367s;
+                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                              }
+                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                                opacity: 0;
+                              }
+                          data-is-focusable={true}
+                          onClick={[Function]}
+                          onKeyUp={[Function]}
+                          style={Object {}}
                         >
                           <div
-                            aria-expanded={true}
-                            aria-label="Color: \\"blue\\""
-                            aria-level={1}
-                            aria-posinset={3}
-                            aria-setsize={3}
                             className=
-                                ms-GroupHeader
-                                {
-                                  -moz-osx-font-smoothing: grayscale;
-                                  -webkit-font-smoothing: antialiased;
-                                  border-bottom: 1px solid #ffffff;
-                                  cursor: default;
-                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                  font-size: 14px;
-                                  font-weight: 400;
-                                  outline: transparent;
-                                  position: relative;
-                                  user-select: none;
-                                }
-                                &::-moz-focus-inner {
-                                  border: 0;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus:after {
-                                  border: 1px solid #ffffff;
-                                  bottom: 1px;
-                                  content: "";
-                                  left: 1px;
-                                  outline: 1px solid #605e5c;
-                                  position: absolute;
-                                  right: 1px;
-                                  top: 1px;
-                                  z-index: 1;
-                                }
-                                &:hover {
-                                  background: #f3f2f1;
-                                  color: #201f1e;
-                                }
-                                &:hover .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                  opacity: 1;
-                                }
-                                & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                  opacity: 1;
-                                  transform: rotate(0.2deg) scale(1);
-                                  transition-delay: 0.367s;
-                                  transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                }
-                                .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                  opacity: 0;
-                                }
-                            data-is-focusable={true}
-                            onClick={[Function]}
-                            onKeyUp={[Function]}
-                            style={Object {}}
-                          >
-                            <div
-                              className=
 
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: 48px;
+                                }
+                          >
+                            <button
+                              aria-checked={false}
+                              className=
+                                  ms-GroupHeader-check
                                   {
                                     align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    cursor: default;
                                     display: flex;
                                     height: 48px;
+                                    justify-content: center;
+                                    margin-top: -1px;
+                                    opacity: 0;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 1px;
+                                    position: relative;
+                                    width: 48px;
                                   }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    opacity: 1;
+                                  }
+                              data-is-focusable={false}
+                              data-selection-toggle={true}
+                              onClick={[Function]}
+                              role="checkbox"
+                              type="button"
                             >
-                              <button
-                                aria-checked={false}
+                              <div
                                 className=
-                                    ms-GroupHeader-check
+                                    ms-Check
                                     {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      cursor: default;
-                                      display: flex;
-                                      height: 48px;
-                                      justify-content: center;
-                                      margin-top: -1px;
-                                      opacity: 0;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 1px;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 14px;
+                                      font-weight: 400;
+                                      height: 18px;
+                                      line-height: 1;
                                       position: relative;
-                                      width: 48px;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      width: 18px;
                                     }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
+                                    &:before {
+                                      background: #ffffff;
+                                      border-radius: 50%;
                                       bottom: 1px;
                                       content: "";
                                       left: 1px;
-                                      outline: 1px solid #605e5c;
+                                      opacity: 1;
                                       position: absolute;
                                       right: 1px;
                                       top: 1px;
-                                      z-index: 1;
                                     }
-                                    .ms-Fabric--isFocusVisible &:focus {
+                                    .ms-Check-checkHost:hover & {
                                       opacity: 1;
                                     }
-                                data-is-focusable={false}
-                                data-selection-toggle={true}
-                                onClick={[Function]}
-                                role="checkbox"
-                                type="button"
-                              >
-                                <div
-                                  className=
-                                      ms-Check
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 14px;
-                                        font-weight: 400;
-                                        height: 18px;
-                                        line-height: 1;
-                                        position: relative;
-                                        user-select: none;
-                                        vertical-align: top;
-                                        width: 18px;
-                                      }
-                                      &:before {
-                                        background: #ffffff;
-                                        border-radius: 50%;
-                                        bottom: 1px;
-                                        content: "";
-                                        left: 1px;
-                                        opacity: 1;
-                                        position: absolute;
-                                        right: 1px;
-                                        top: 1px;
-                                      }
-                                      .ms-Check-checkHost:hover & {
-                                        opacity: 1;
-                                      }
-                                      .ms-Check-checkHost:focus & {
-                                        opacity: 1;
-                                      }
-                                      &:hover {
-                                        opacity: 1;
-                                      }
-                                      &:focus {
-                                        opacity: 1;
-                                      }
-                                >
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-circle
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 18px;
-                                          height: 18px;
-                                          left: 0px;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          color: WindowText;
-                                        }
-                                    data-icon-name="CircleRing"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    .ms-Check-checkHost:focus & {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                  <i
-                                    aria-hidden={true}
-                                    className=
-                                        ms-Icon
-                                        ms-Check-check
-                                        {
-                                          display: inline-block;
-                                        }
-                                        {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          font-family: "FabricMDL2Icons";
-                                          font-style: normal;
-                                          font-weight: normal;
-                                          speak: none;
-                                        }
-                                        {
-                                          color: #605e5c;
-                                          font-size: 16px;
-                                          height: 18px;
-                                          left: .5px;
-                                          opacity: 0;
-                                          position: absolute;
-                                          text-align: center;
-                                          top: 0px;
-                                          vertical-align: middle;
-                                          width: 18px;
-                                        }
-                                        &:hover {
-                                          opacity: 1;
-                                        }
-                                        @media screen and (-ms-high-contrast: active){& {
-                                          -ms-high-contrast-adjust: none;
-                                        }
-                                    data-icon-name="StatusCircleCheckmark"
-                                    role="presentation"
-                                    style={
-                                      Object {
-                                        "fontFamily": "\\"FabricMDL2Icons\\"",
-                                      }
+                                    &:hover {
+                                      opacity: 1;
                                     }
-                                  >
-                                    
-                                  </i>
-                                </div>
-                              </button>
-                              <div
-                                className=
-                                    ms-GroupHeader-dropIcon
-                                    {
-                                      color: #605e5c;
-                                      font-size: 20px;
-                                      left: -26px;
-                                      opacity: 0;
-                                      position: absolute;
-                                      transform-origin: 10px 10px;
-                                      transform: rotate(0.2deg) scale(0.65);
-                                      transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                    }
-                                    .ms-Icon--Tag {
-                                      position: absolute;
+                                    &:focus {
+                                      opacity: 1;
                                     }
                               >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-circle
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
                                         font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
                                       }
-                                  data-icon-name="Tag"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 18px;
+                                        height: 18px;
+                                        left: 0px;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        color: WindowText;
+                                      }
+                                  data-icon-name="CircleRing"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </div>
-                              <button
-                                aria-controls="GroupedListSection11"
-                                aria-expanded={true}
-                                aria-label="expand collapse group"
-                                className=
-                                    ms-GroupHeader-expand
-                                    {
-                                      align-items: center;
-                                      background-color: transparent;
-                                      background: none;
-                                      border: none;
-                                      color: #605e5c;
-                                      cursor: default;
-                                      display: flex;
-                                      font-size: 12px;
-                                      height: 48px;
-                                      justify-content: center;
-                                      outline: transparent;
-                                      padding-bottom: 0px;
-                                      padding-left: 0px;
-                                      padding-right: 0px;
-                                      padding-top: 0px;
-                                      position: relative;
-                                      width: 36px;
-                                    }
-                                    &::-moz-focus-inner {
-                                      border: 0;
-                                    }
-                                    .ms-Fabric--isFocusVisible &:focus:after {
-                                      border: 1px solid #ffffff;
-                                      bottom: 1px;
-                                      content: "";
-                                      left: 1px;
-                                      outline: 1px solid #605e5c;
-                                      position: absolute;
-                                      right: 1px;
-                                      top: 1px;
-                                      z-index: 1;
-                                    }
-                                    &:hover {
-                                      background-color: #edebe9;
-                                    }
-                                    &:active {
-                                      background-color: #e1dfdd;
-                                    }
-                                data-is-focusable={false}
-                                onClick={[Function]}
-                                type="button"
-                              >
                                 <i
                                   aria-hidden={true}
                                   className=
-
+                                      ms-Icon
+                                      ms-Check-check
+                                      {
+                                        display: inline-block;
+                                      }
                                       {
                                         -moz-osx-font-smoothing: grayscale;
                                         -webkit-font-smoothing: antialiased;
-                                        display: inline-block;
-                                        font-family: "FabricMDL2Icons-3";
+                                        font-family: "FabricMDL2Icons";
                                         font-style: normal;
                                         font-weight: normal;
                                         speak: none;
-                                        transform-origin: 50% 50%;
-                                        transform: rotate(90deg);
-                                        transition: transform .1s linear;
                                       }
-                                  data-icon-name="ChevronRightMed"
+                                      {
+                                        color: #605e5c;
+                                        font-size: 16px;
+                                        height: 18px;
+                                        left: .5px;
+                                        opacity: 0;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      &:hover {
+                                        opacity: 1;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        -ms-high-contrast-adjust: none;
+                                      }
+                                  data-icon-name="StatusCircleCheckmark"
+                                  role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
-                                  
+                                  
                                 </i>
-                              </button>
-                              <div
+                              </div>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-dropIcon
+                                  {
+                                    color: #605e5c;
+                                    font-size: 20px;
+                                    left: -26px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    transform-origin: 10px 10px;
+                                    transform: rotate(0.2deg) scale(0.65);
+                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                  }
+                                  .ms-Icon--Tag {
+                                    position: absolute;
+                                  }
+                            >
+                              <i
+                                aria-hidden={true}
                                 className=
-                                    ms-GroupHeader-title
+
                                     {
-                                      cursor: pointer;
-                                      font-size: 16px;
-                                      font-weight: 600;
-                                      outline: 0px;
-                                      padding-left: 12px;
-                                      text-overflow: ellipsis;
-                                      white-space: nowrap;
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                    }
+                                data-icon-name="Tag"
+                              >
+                                
+                              </i>
+                            </div>
+                            <button
+                              aria-controls="GroupedListSection10"
+                              aria-expanded={true}
+                              aria-label="expand collapse group"
+                              className=
+                                  ms-GroupHeader-expand
+                                  {
+                                    align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    color: #605e5c;
+                                    cursor: default;
+                                    display: flex;
+                                    font-size: 12px;
+                                    height: 48px;
+                                    justify-content: center;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    position: relative;
+                                    width: 36px;
+                                  }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  &:hover {
+                                    background-color: #edebe9;
+                                  }
+                                  &:active {
+                                    background-color: #e1dfdd;
+                                  }
+                              data-is-focusable={false}
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <i
+                                aria-hidden={true}
+                                className=
+
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons-3";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                      transform-origin: 50% 50%;
+                                      transform: rotate(90deg);
+                                      transition: transform .1s linear;
+                                    }
+                                data-icon-name="ChevronRightMed"
+                              >
+                                
+                              </i>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-title
+                                  {
+                                    cursor: pointer;
+                                    font-size: 16px;
+                                    font-weight: 600;
+                                    outline: 0px;
+                                    padding-left: 12px;
+                                    text-overflow: ellipsis;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span>
+                                Color: "blue"
+                              </span>
+                              <span
+                                className=
+
+                                    {
+                                      padding-bottom: 0px;
+                                      padding-left: 4px;
+                                      padding-right: 4px;
+                                      padding-top: 0px;
                                     }
                               >
-                                <span>
-                                  Color: "blue"
-                                </span>
-                                <span
-                                  className=
-
-                                      {
-                                        padding-bottom: 0px;
-                                        padding-left: 4px;
-                                        padding-right: 4px;
-                                        padding-top: 0px;
-                                      }
-                                >
-                                  (
-                                  3
-                                  )
-                                </span>
-                              </div>
+                                (
+                                3
+                                )
+                              </span>
                             </div>
                           </div>
+                        </div>
+                        <div
+                          className="ms-List"
+                          id="GroupedListSection10"
+                          role="grid"
+                        >
                           <div
-                            className="ms-List"
-                            id="GroupedListSection11"
-                            role="grid"
+                            className="ms-List-surface"
+                            role="presentation"
                           >
                             <div
-                              className="ms-List-surface"
+                              className="ms-List-page"
                               role="presentation"
+                              style={Object {}}
                             >
                               <div
-                                className="ms-List-page"
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={2}
                                 role="presentation"
-                                style={Object {}}
                               >
                                 <div
-                                  className="ms-List-cell"
-                                  data-automationid="ListCell"
-                                  data-list-index={2}
-                                  role="presentation"
+                                  aria-rowindex={3}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone13"
+                                  data-is-focusable={true}
+                                  data-item-index={2}
+                                  data-selection-index={2}
+                                  data-selection-touch-invoke={true}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
                                 >
                                   <div
-                                    aria-rowindex={3}
-                                    aria-selected={false}
+                                    aria-colindex={1}
                                     className=
-                                        ms-FocusZone
-                                        ms-DetailsRow
-                                        is-contentUnselectable
-                                        &:focus {
-                                          outline: none;
-                                        }
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
                                         {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          animation-duration: 0.367s;
-                                          animation-fill-mode: both;
-                                          animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                          background: #ffffff;
-                                          border-bottom: 1px solid #f3f2f1;
                                           box-sizing: border-box;
-                                          color: #605e5c;
-                                          cursor: default;
-                                          display: inline-flex;
-                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                          font-size: 12px;
-                                          font-weight: 400;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
                                           min-height: 42px;
-                                          min-width: 100%;
                                           outline: transparent;
+                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 0px;
+                                          padding-top: 1px;
                                           position: relative;
-                                          text-align: left;
-                                          user-select: none;
+                                          text-overflow: ellipsis;
                                           vertical-align: top;
                                           white-space: nowrap;
                                         }
@@ -3472,64 +3529,241 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                         .ms-Fabric--isFocusVisible &:focus:after {
                                           border: 1px solid #605e5c;
-                                          bottom: 1px;
+                                          bottom: 0px;
                                           content: "";
-                                          left: 1px;
+                                          left: 0px;
                                           outline: 1px solid #ffffff;
                                           position: absolute;
-                                          right: 1px;
-                                          top: 1px;
+                                          right: 0px;
+                                          top: 0px;
                                           z-index: 1;
                                         }
-                                        .ms-List-cell:first-child &:before {
-                                          display: none;
+                                        & > button {
+                                          max-width: 100%;
                                         }
-                                        &:hover {
-                                          background: #f3f2f1;
-                                          color: #323130;
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
                                         }
-                                        &:hover .is-row-header {
-                                          color: #201f1e;
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                        &:hover .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                    data-automationid="DetailsRow"
-                                    data-focuszone-id="FocusZone14"
-                                    data-is-focusable={true}
-                                    data-item-index={2}
-                                    data-selection-index={2}
-                                    data-selection-touch-invoke={true}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseDownCapture={[Function]}
-                                    role="row"
-                                    style={
-                                      Object {
-                                        "minWidth": 200,
-                                      }
-                                    }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
                                   >
                                     <div
-                                      aria-colindex={1}
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
                                       className=
-                                          ms-DetailsRow-cell
-                                          ms-DetailsRow-cellCheck
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
                                           {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
                                             box-sizing: border-box;
-                                            display: inline-block;
-                                            flex-shrink: 0;
-                                            margin-top: -1px;
-                                            min-height: 42px;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
                                             outline: transparent;
-                                            overflow: hidden;
                                             padding-bottom: 0px;
                                             padding-left: 0px;
                                             padding-right: 0px;
-                                            padding-top: 1px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
                                             position: relative;
                                             text-overflow: ellipsis;
                                             vertical-align: top;
@@ -3559,390 +3793,213 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           & [data-is-focusable='true']::-moz-focus-inner {
                                             border: 0;
                                           }
-                                      data-selection-toggle={true}
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
                                       role="gridcell"
-                                    >
-                                      <div
-                                        aria-checked={false}
-                                        aria-label="Row checkbox"
-                                        className=
-                                            ms-DetailsRow-check
-                                            ms-Check-checkHost
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              align-items: center;
-                                              background-color: transparent;
-                                              background: none;
-                                              border: none;
-                                              box-sizing: border-box;
-                                              cursor: default;
-                                              display: flex;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 12px;
-                                              font-weight: 400;
-                                              height: 42px;
-                                              justify-content: center;
-                                              margin-bottom: 0px;
-                                              margin-left: 0px;
-                                              margin-right: 0px;
-                                              margin-top: 0px;
-                                              opacity: 0;
-                                              outline: transparent;
-                                              padding-bottom: 0px;
-                                              padding-left: 0px;
-                                              padding-right: 0px;
-                                              padding-top: 0px;
-                                              position: relative;
-                                              vertical-align: top;
-                                              width: 48px;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #ffffff;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              outline: 1px solid #605e5c;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                              z-index: 1;
-                                            }
-                                        data-automationid="DetailsRowCheck"
-                                        data-selection-toggle={true}
-                                        role="checkbox"
-                                      >
-                                        <div
-                                          className=
-                                              ms-Check
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                                font-size: 14px;
-                                                font-weight: 400;
-                                                height: 18px;
-                                                line-height: 1;
-                                                position: relative;
-                                                user-select: none;
-                                                vertical-align: top;
-                                                width: 18px;
-                                              }
-                                              &:before {
-                                                background: #ffffff;
-                                                border-radius: 50%;
-                                                bottom: 1px;
-                                                content: "";
-                                                left: 1px;
-                                                opacity: 1;
-                                                position: absolute;
-                                                right: 1px;
-                                                top: 1px;
-                                              }
-                                              .ms-Check-checkHost:hover & {
-                                                opacity: 1;
-                                              }
-                                              .ms-Check-checkHost:focus & {
-                                                opacity: 1;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              &:focus {
-                                                opacity: 1;
-                                              }
-                                        >
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-circle
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 18px;
-                                                  height: 18px;
-                                                  left: 0px;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  color: WindowText;
-                                                }
-                                            data-icon-name="CircleRing"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-check
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 16px;
-                                                  height: 18px;
-                                                  left: .5px;
-                                                  opacity: 0;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                &:hover {
-                                                  opacity: 1;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  -ms-high-contrast-adjust: none;
-                                                }
-                                            data-icon-name="StatusCircleCheckmark"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <span
-                                      className="ms-GroupSpacer"
                                       style={
                                         Object {
-                                          "display": "inline-block",
-                                          "width": 36,
+                                          "width": 120,
                                         }
                                       }
-                                    />
-                                    <div
-                                      className=
-                                          ms-DetailsRow-fields
-                                          {
-                                            align-items: stretch;
-                                            display: flex;
-                                          }
-                                      data-automationid="DetailsRowFields"
-                                      role="presentation"
                                     >
                                       <div
-                                        aria-colindex={2}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="name"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
+                                        data-is-focusable={true}
                                       >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          c
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-colindex={3}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="color"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          blue
-                                        </div>
+                                        c
                                       </div>
                                     </div>
-                                    <span
-                                      aria-checked={false}
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
                                       className=
-
+                                          ms-DetailsRow-cell
                                           {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
                                             bottom: 0px;
-                                            display: none;
+                                            content: "";
                                             left: 0px;
+                                            outline: 1px solid #ffffff;
                                             position: absolute;
                                             right: 0px;
-                                            top: -1px;
+                                            top: 0px;
+                                            z-index: 1;
                                           }
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    />
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="color"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        data-is-focusable={true}
+                                      >
+                                        blue
+                                      </div>
+                                    </div>
                                   </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
                                 </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={3}
+                                role="presentation"
+                              >
                                 <div
-                                  className="ms-List-cell"
-                                  data-automationid="ListCell"
-                                  data-list-index={3}
-                                  role="presentation"
+                                  aria-rowindex={4}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone14"
+                                  data-is-focusable={true}
+                                  data-item-index={3}
+                                  data-selection-index={3}
+                                  data-selection-touch-invoke={true}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
                                 >
                                   <div
-                                    aria-rowindex={4}
-                                    aria-selected={false}
+                                    aria-colindex={1}
                                     className=
-                                        ms-FocusZone
-                                        ms-DetailsRow
-                                        is-contentUnselectable
-                                        &:focus {
-                                          outline: none;
-                                        }
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
                                         {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          animation-duration: 0.367s;
-                                          animation-fill-mode: both;
-                                          animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                          background: #ffffff;
-                                          border-bottom: 1px solid #f3f2f1;
                                           box-sizing: border-box;
-                                          color: #605e5c;
-                                          cursor: default;
-                                          display: inline-flex;
-                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                          font-size: 12px;
-                                          font-weight: 400;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
                                           min-height: 42px;
-                                          min-width: 100%;
                                           outline: transparent;
+                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 0px;
+                                          padding-top: 1px;
                                           position: relative;
-                                          text-align: left;
-                                          user-select: none;
+                                          text-overflow: ellipsis;
                                           vertical-align: top;
                                           white-space: nowrap;
                                         }
@@ -3951,64 +4008,241 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                         .ms-Fabric--isFocusVisible &:focus:after {
                                           border: 1px solid #605e5c;
-                                          bottom: 1px;
+                                          bottom: 0px;
                                           content: "";
-                                          left: 1px;
+                                          left: 0px;
                                           outline: 1px solid #ffffff;
                                           position: absolute;
-                                          right: 1px;
-                                          top: 1px;
+                                          right: 0px;
+                                          top: 0px;
                                           z-index: 1;
                                         }
-                                        .ms-List-cell:first-child &:before {
-                                          display: none;
+                                        & > button {
+                                          max-width: 100%;
                                         }
-                                        &:hover {
-                                          background: #f3f2f1;
-                                          color: #323130;
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
                                         }
-                                        &:hover .is-row-header {
-                                          color: #201f1e;
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                        &:hover .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                    data-automationid="DetailsRow"
-                                    data-focuszone-id="FocusZone15"
-                                    data-is-focusable={true}
-                                    data-item-index={3}
-                                    data-selection-index={3}
-                                    data-selection-touch-invoke={true}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseDownCapture={[Function]}
-                                    role="row"
-                                    style={
-                                      Object {
-                                        "minWidth": 200,
-                                      }
-                                    }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
                                   >
                                     <div
-                                      aria-colindex={1}
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
                                       className=
-                                          ms-DetailsRow-cell
-                                          ms-DetailsRow-cellCheck
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
                                           {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
                                             box-sizing: border-box;
-                                            display: inline-block;
-                                            flex-shrink: 0;
-                                            margin-top: -1px;
-                                            min-height: 42px;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
                                             outline: transparent;
-                                            overflow: hidden;
                                             padding-bottom: 0px;
                                             padding-left: 0px;
                                             padding-right: 0px;
-                                            padding-top: 1px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
                                             position: relative;
                                             text-overflow: ellipsis;
                                             vertical-align: top;
@@ -4038,390 +4272,213 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           & [data-is-focusable='true']::-moz-focus-inner {
                                             border: 0;
                                           }
-                                      data-selection-toggle={true}
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
                                       role="gridcell"
-                                    >
-                                      <div
-                                        aria-checked={false}
-                                        aria-label="Row checkbox"
-                                        className=
-                                            ms-DetailsRow-check
-                                            ms-Check-checkHost
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              align-items: center;
-                                              background-color: transparent;
-                                              background: none;
-                                              border: none;
-                                              box-sizing: border-box;
-                                              cursor: default;
-                                              display: flex;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 12px;
-                                              font-weight: 400;
-                                              height: 42px;
-                                              justify-content: center;
-                                              margin-bottom: 0px;
-                                              margin-left: 0px;
-                                              margin-right: 0px;
-                                              margin-top: 0px;
-                                              opacity: 0;
-                                              outline: transparent;
-                                              padding-bottom: 0px;
-                                              padding-left: 0px;
-                                              padding-right: 0px;
-                                              padding-top: 0px;
-                                              position: relative;
-                                              vertical-align: top;
-                                              width: 48px;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #ffffff;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              outline: 1px solid #605e5c;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                              z-index: 1;
-                                            }
-                                        data-automationid="DetailsRowCheck"
-                                        data-selection-toggle={true}
-                                        role="checkbox"
-                                      >
-                                        <div
-                                          className=
-                                              ms-Check
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                                font-size: 14px;
-                                                font-weight: 400;
-                                                height: 18px;
-                                                line-height: 1;
-                                                position: relative;
-                                                user-select: none;
-                                                vertical-align: top;
-                                                width: 18px;
-                                              }
-                                              &:before {
-                                                background: #ffffff;
-                                                border-radius: 50%;
-                                                bottom: 1px;
-                                                content: "";
-                                                left: 1px;
-                                                opacity: 1;
-                                                position: absolute;
-                                                right: 1px;
-                                                top: 1px;
-                                              }
-                                              .ms-Check-checkHost:hover & {
-                                                opacity: 1;
-                                              }
-                                              .ms-Check-checkHost:focus & {
-                                                opacity: 1;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              &:focus {
-                                                opacity: 1;
-                                              }
-                                        >
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-circle
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 18px;
-                                                  height: 18px;
-                                                  left: 0px;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  color: WindowText;
-                                                }
-                                            data-icon-name="CircleRing"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-check
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 16px;
-                                                  height: 18px;
-                                                  left: .5px;
-                                                  opacity: 0;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                &:hover {
-                                                  opacity: 1;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  -ms-high-contrast-adjust: none;
-                                                }
-                                            data-icon-name="StatusCircleCheckmark"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <span
-                                      className="ms-GroupSpacer"
                                       style={
                                         Object {
-                                          "display": "inline-block",
-                                          "width": 36,
+                                          "width": 120,
                                         }
                                       }
-                                    />
-                                    <div
-                                      className=
-                                          ms-DetailsRow-fields
-                                          {
-                                            align-items: stretch;
-                                            display: flex;
-                                          }
-                                      data-automationid="DetailsRowFields"
-                                      role="presentation"
                                     >
                                       <div
-                                        aria-colindex={2}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="name"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
+                                        data-is-focusable={true}
                                       >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          d
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-colindex={3}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="color"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          blue
-                                        </div>
+                                        d
                                       </div>
                                     </div>
-                                    <span
-                                      aria-checked={false}
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
                                       className=
-
+                                          ms-DetailsRow-cell
                                           {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
                                             bottom: 0px;
-                                            display: none;
+                                            content: "";
                                             left: 0px;
+                                            outline: 1px solid #ffffff;
                                             position: absolute;
                                             right: 0px;
-                                            top: -1px;
+                                            top: 0px;
+                                            z-index: 1;
                                           }
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    />
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="color"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        data-is-focusable={true}
+                                      >
+                                        blue
+                                      </div>
+                                    </div>
                                   </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
                                 </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={4}
+                                role="presentation"
+                              >
                                 <div
-                                  className="ms-List-cell"
-                                  data-automationid="ListCell"
-                                  data-list-index={4}
-                                  role="presentation"
+                                  aria-rowindex={5}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone15"
+                                  data-is-focusable={true}
+                                  data-item-index={4}
+                                  data-selection-index={4}
+                                  data-selection-touch-invoke={true}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
                                 >
                                   <div
-                                    aria-rowindex={5}
-                                    aria-selected={false}
+                                    aria-colindex={1}
                                     className=
-                                        ms-FocusZone
-                                        ms-DetailsRow
-                                        is-contentUnselectable
-                                        &:focus {
-                                          outline: none;
-                                        }
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
                                         {
-                                          -moz-osx-font-smoothing: grayscale;
-                                          -webkit-font-smoothing: antialiased;
-                                          animation-duration: 0.367s;
-                                          animation-fill-mode: both;
-                                          animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                          animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                          background: #ffffff;
-                                          border-bottom: 1px solid #f3f2f1;
                                           box-sizing: border-box;
-                                          color: #605e5c;
-                                          cursor: default;
-                                          display: inline-flex;
-                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                          font-size: 12px;
-                                          font-weight: 400;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
                                           min-height: 42px;
-                                          min-width: 100%;
                                           outline: transparent;
+                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 0px;
+                                          padding-top: 1px;
                                           position: relative;
-                                          text-align: left;
-                                          user-select: none;
+                                          text-overflow: ellipsis;
                                           vertical-align: top;
                                           white-space: nowrap;
                                         }
@@ -4430,64 +4487,241 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                         .ms-Fabric--isFocusVisible &:focus:after {
                                           border: 1px solid #605e5c;
-                                          bottom: 1px;
+                                          bottom: 0px;
                                           content: "";
-                                          left: 1px;
+                                          left: 0px;
                                           outline: 1px solid #ffffff;
                                           position: absolute;
-                                          right: 1px;
-                                          top: 1px;
+                                          right: 0px;
+                                          top: 0px;
                                           z-index: 1;
                                         }
-                                        .ms-List-cell:first-child &:before {
-                                          display: none;
+                                        & > button {
+                                          max-width: 100%;
                                         }
-                                        &:hover {
-                                          background: #f3f2f1;
-                                          color: #323130;
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
                                         }
-                                        &:hover .is-row-header {
-                                          color: #201f1e;
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
                                         }
-                                        &:hover .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                        .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                          opacity: 1;
-                                        }
-                                    data-automationid="DetailsRow"
-                                    data-focuszone-id="FocusZone16"
-                                    data-is-focusable={true}
-                                    data-item-index={4}
-                                    data-selection-index={4}
-                                    data-selection-touch-invoke={true}
-                                    onFocus={[Function]}
-                                    onKeyDown={[Function]}
-                                    onMouseDownCapture={[Function]}
-                                    role="row"
-                                    style={
-                                      Object {
-                                        "minWidth": 200,
-                                      }
-                                    }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
                                   >
                                     <div
-                                      aria-colindex={1}
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
                                       className=
-                                          ms-DetailsRow-cell
-                                          ms-DetailsRow-cellCheck
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
                                           {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
                                             box-sizing: border-box;
-                                            display: inline-block;
-                                            flex-shrink: 0;
-                                            margin-top: -1px;
-                                            min-height: 42px;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
                                             outline: transparent;
-                                            overflow: hidden;
                                             padding-bottom: 0px;
                                             padding-left: 0px;
                                             padding-right: 0px;
-                                            padding-top: 1px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
                                             position: relative;
                                             text-overflow: ellipsis;
                                             vertical-align: top;
@@ -4517,347 +4751,101 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                           & [data-is-focusable='true']::-moz-focus-inner {
                                             border: 0;
                                           }
-                                      data-selection-toggle={true}
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
                                       role="gridcell"
-                                    >
-                                      <div
-                                        aria-checked={false}
-                                        aria-label="Row checkbox"
-                                        className=
-                                            ms-DetailsRow-check
-                                            ms-Check-checkHost
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              align-items: center;
-                                              background-color: transparent;
-                                              background: none;
-                                              border: none;
-                                              box-sizing: border-box;
-                                              cursor: default;
-                                              display: flex;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 12px;
-                                              font-weight: 400;
-                                              height: 42px;
-                                              justify-content: center;
-                                              margin-bottom: 0px;
-                                              margin-left: 0px;
-                                              margin-right: 0px;
-                                              margin-top: 0px;
-                                              opacity: 0;
-                                              outline: transparent;
-                                              padding-bottom: 0px;
-                                              padding-left: 0px;
-                                              padding-right: 0px;
-                                              padding-top: 0px;
-                                              position: relative;
-                                              vertical-align: top;
-                                              width: 48px;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #ffffff;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              outline: 1px solid #605e5c;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                              z-index: 1;
-                                            }
-                                        data-automationid="DetailsRowCheck"
-                                        data-selection-toggle={true}
-                                        role="checkbox"
-                                      >
-                                        <div
-                                          className=
-                                              ms-Check
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                                font-size: 14px;
-                                                font-weight: 400;
-                                                height: 18px;
-                                                line-height: 1;
-                                                position: relative;
-                                                user-select: none;
-                                                vertical-align: top;
-                                                width: 18px;
-                                              }
-                                              &:before {
-                                                background: #ffffff;
-                                                border-radius: 50%;
-                                                bottom: 1px;
-                                                content: "";
-                                                left: 1px;
-                                                opacity: 1;
-                                                position: absolute;
-                                                right: 1px;
-                                                top: 1px;
-                                              }
-                                              .ms-Check-checkHost:hover & {
-                                                opacity: 1;
-                                              }
-                                              .ms-Check-checkHost:focus & {
-                                                opacity: 1;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              &:focus {
-                                                opacity: 1;
-                                              }
-                                        >
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-circle
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 18px;
-                                                  height: 18px;
-                                                  left: 0px;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  color: WindowText;
-                                                }
-                                            data-icon-name="CircleRing"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                          <i
-                                            aria-hidden={true}
-                                            className=
-                                                ms-Icon
-                                                ms-Check-check
-                                                {
-                                                  display: inline-block;
-                                                }
-                                                {
-                                                  -moz-osx-font-smoothing: grayscale;
-                                                  -webkit-font-smoothing: antialiased;
-                                                  font-family: "FabricMDL2Icons";
-                                                  font-style: normal;
-                                                  font-weight: normal;
-                                                  speak: none;
-                                                }
-                                                {
-                                                  color: #605e5c;
-                                                  font-size: 16px;
-                                                  height: 18px;
-                                                  left: .5px;
-                                                  opacity: 0;
-                                                  position: absolute;
-                                                  text-align: center;
-                                                  top: 0px;
-                                                  vertical-align: middle;
-                                                  width: 18px;
-                                                }
-                                                &:hover {
-                                                  opacity: 1;
-                                                }
-                                                @media screen and (-ms-high-contrast: active){& {
-                                                  -ms-high-contrast-adjust: none;
-                                                }
-                                            data-icon-name="StatusCircleCheckmark"
-                                            role="presentation"
-                                            style={
-                                              Object {
-                                                "fontFamily": "\\"FabricMDL2Icons\\"",
-                                              }
-                                            }
-                                          >
-                                            
-                                          </i>
-                                        </div>
-                                      </div>
-                                    </div>
-                                    <span
-                                      className="ms-GroupSpacer"
                                       style={
                                         Object {
-                                          "display": "inline-block",
-                                          "width": 36,
+                                          "width": 120,
                                         }
                                       }
-                                    />
-                                    <div
-                                      className=
-                                          ms-DetailsRow-fields
-                                          {
-                                            align-items: stretch;
-                                            display: flex;
-                                          }
-                                      data-automationid="DetailsRowFields"
-                                      role="presentation"
                                     >
                                       <div
-                                        aria-colindex={2}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="name"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
+                                        data-is-focusable={true}
                                       >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          e
-                                        </div>
-                                      </div>
-                                      <div
-                                        aria-colindex={3}
-                                        aria-readonly={true}
-                                        className=
-                                            ms-DetailsRow-cell
-                                            {
-                                              box-sizing: border-box;
-                                              display: inline-block;
-                                              min-height: 42px;
-                                              outline: transparent;
-                                              overflow: hidden;
-                                              padding-bottom: 11px;
-                                              padding-left: 12px;
-                                              padding-top: 11px;
-                                              position: relative;
-                                              text-overflow: ellipsis;
-                                              vertical-align: top;
-                                              white-space: nowrap;
-                                            }
-                                            &::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            .ms-Fabric--isFocusVisible &:focus:after {
-                                              border: 1px solid #605e5c;
-                                              bottom: 0px;
-                                              content: "";
-                                              left: 0px;
-                                              outline: 1px solid #ffffff;
-                                              position: absolute;
-                                              right: 0px;
-                                              top: 0px;
-                                              z-index: 1;
-                                            }
-                                            & > button {
-                                              max-width: 100%;
-                                            }
-                                            & [data-is-focusable='true'] {
-                                              outline: transparent;
-                                              position: relative;
-                                            }
-                                            & [data-is-focusable='true']::-moz-focus-inner {
-                                              border: 0;
-                                            }
-                                            {
-                                              padding-right: 8px;
-                                            }
-                                        data-automation-key="color"
-                                        data-automationid="DetailsRowCell"
-                                        role="gridcell"
-                                        style={
-                                          Object {
-                                            "width": 120,
-                                          }
-                                        }
-                                      >
-                                        <div
-                                          data-is-focusable={true}
-                                        >
-                                          blue
-                                        </div>
+                                        e
                                       </div>
                                     </div>
-                                    <span
-                                      aria-checked={false}
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
                                       className=
-
+                                          ms-DetailsRow-cell
                                           {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
                                             bottom: 0px;
-                                            display: none;
+                                            content: "";
                                             left: 0px;
+                                            outline: 1px solid #ffffff;
                                             position: absolute;
                                             right: 0px;
-                                            top: -1px;
+                                            top: 0px;
+                                            z-index: 1;
                                           }
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    />
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="color"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      <div
+                                        data-is-focusable={true}
+                                      >
+                                        blue
+                                      </div>
+                                    </div>
                                   </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
                                 </div>
                               </div>
                             </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -825,520 +825,577 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                ms-GroupedList
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  position: relative;
+                }
+                & .ms-List-cell {
+                  min-height: 38px;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-automationid="GroupedList"
+            data-focuszone-id="FocusZone2"
+            data-is-scrollable="false"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  ms-GroupedList
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    -moz-osx-font-smoothing: grayscale;
-                    -webkit-font-smoothing: antialiased;
-                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                    font-size: 12px;
-                    font-weight: 400;
-                    position: relative;
-                  }
-                  & .ms-List-cell {
-                    min-height: 38px;
-                  }
-              data-automationid="GroupedList"
-              data-focuszone-id="FocusZone3"
-              data-is-scrollable="false"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
+              className="ms-List"
               role="presentation"
             >
               <div
-                className="ms-List"
+                className="ms-List-surface"
                 role="presentation"
               >
                 <div
-                  className="ms-List-surface"
+                  className="ms-List-page"
                   role="presentation"
+                  style={Object {}}
                 >
                   <div
-                    className="ms-List-page"
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
                     role="presentation"
-                    style={Object {}}
                   >
                     <div
-                      className="ms-List-cell"
-                      data-automationid="ListCell"
-                      data-list-index={0}
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
                       role="presentation"
                     >
                       <div
+                        aria-expanded={true}
+                        aria-label="0"
+                        aria-level={1}
+                        aria-posinset={1}
+                        aria-setsize={10}
                         className=
-                            ms-GroupedList-group
+                            ms-GroupHeader
                             {
-                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              border-bottom: 1px solid #ffffff;
+                              cursor: default;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              outline: transparent;
+                              position: relative;
+                              user-select: none;
                             }
-                        role="presentation"
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            &:hover .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                              opacity: 1;
+                            }
+                            & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                              opacity: 1;
+                              transform: rotate(0.2deg) scale(1);
+                              transition-delay: 0.367s;
+                              transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                            }
+                            .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                              opacity: 0;
+                            }
+                        data-is-focusable={true}
+                        onClick={[Function]}
+                        onKeyUp={[Function]}
+                        style={Object {}}
                       >
                         <div
-                          aria-expanded={true}
-                          aria-label="0"
-                          aria-level={1}
-                          aria-posinset={1}
-                          aria-setsize={10}
                           className=
-                              ms-GroupHeader
-                              {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                border-bottom: 1px solid #ffffff;
-                                cursor: default;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 14px;
-                                font-weight: 400;
-                                outline: transparent;
-                                position: relative;
-                                user-select: none;
-                              }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #ffffff;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #605e5c;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #201f1e;
-                              }
-                              &:hover .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
-                                opacity: 1;
-                              }
-                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
-                                opacity: 1;
-                                transform: rotate(0.2deg) scale(1);
-                                transition-delay: 0.367s;
-                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                              }
-                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
-                                opacity: 0;
-                              }
-                          data-is-focusable={true}
-                          onClick={[Function]}
-                          onKeyUp={[Function]}
-                          style={Object {}}
-                        >
-                          <div
-                            className=
 
+                              {
+                                align-items: center;
+                                display: flex;
+                                height: 48px;
+                              }
+                        >
+                          <button
+                            aria-checked={false}
+                            className=
+                                ms-GroupHeader-check
                                 {
                                   align-items: center;
+                                  background-color: transparent;
+                                  background: none;
+                                  border: none;
+                                  cursor: default;
                                   display: flex;
                                   height: 48px;
+                                  justify-content: center;
+                                  margin-top: -1px;
+                                  opacity: 0;
+                                  outline: transparent;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 1px;
+                                  position: relative;
+                                  width: 48px;
                                 }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus {
+                                  opacity: 1;
+                                }
+                            data-is-focusable={false}
+                            data-selection-toggle={true}
+                            onClick={[Function]}
+                            role="checkbox"
+                            type="button"
                           >
-                            <button
-                              aria-checked={false}
+                            <div
                               className=
-                                  ms-GroupHeader-check
+                                  ms-Check
                                   {
-                                    align-items: center;
-                                    background-color: transparent;
-                                    background: none;
-                                    border: none;
-                                    cursor: default;
-                                    display: flex;
-                                    height: 48px;
-                                    justify-content: center;
-                                    margin-top: -1px;
-                                    opacity: 0;
-                                    outline: transparent;
-                                    padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
-                                    padding-top: 1px;
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: 14px;
+                                    font-weight: 400;
+                                    height: 18px;
+                                    line-height: 1;
                                     position: relative;
-                                    width: 48px;
+                                    user-select: none;
+                                    vertical-align: top;
+                                    width: 18px;
                                   }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #ffffff;
+                                  &:before {
+                                    background: #ffffff;
+                                    border-radius: 50%;
                                     bottom: 1px;
                                     content: "";
                                     left: 1px;
-                                    outline: 1px solid #605e5c;
+                                    opacity: 1;
                                     position: absolute;
                                     right: 1px;
                                     top: 1px;
-                                    z-index: 1;
                                   }
-                                  .ms-Fabric--isFocusVisible &:focus {
+                                  .ms-Check-checkHost:hover & {
                                     opacity: 1;
                                   }
-                              data-is-focusable={false}
-                              data-selection-toggle={true}
-                              onClick={[Function]}
-                              role="checkbox"
-                              type="button"
-                            >
-                              <div
-                                className=
-                                    ms-Check
-                                    {
-                                      -moz-osx-font-smoothing: grayscale;
-                                      -webkit-font-smoothing: antialiased;
-                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                      font-size: 14px;
-                                      font-weight: 400;
-                                      height: 18px;
-                                      line-height: 1;
-                                      position: relative;
-                                      user-select: none;
-                                      vertical-align: top;
-                                      width: 18px;
-                                    }
-                                    &:before {
-                                      background: #ffffff;
-                                      border-radius: 50%;
-                                      bottom: 1px;
-                                      content: "";
-                                      left: 1px;
-                                      opacity: 1;
-                                      position: absolute;
-                                      right: 1px;
-                                      top: 1px;
-                                    }
-                                    .ms-Check-checkHost:hover & {
-                                      opacity: 1;
-                                    }
-                                    .ms-Check-checkHost:focus & {
-                                      opacity: 1;
-                                    }
-                                    &:hover {
-                                      opacity: 1;
-                                    }
-                                    &:focus {
-                                      opacity: 1;
-                                    }
-                              >
-                                <i
-                                  aria-hidden={true}
-                                  className=
-                                      ms-Icon
-                                      ms-Check-circle
-                                      {
-                                        display: inline-block;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        font-family: "FabricMDL2Icons";
-                                        font-style: normal;
-                                        font-weight: normal;
-                                        speak: none;
-                                      }
-                                      {
-                                        color: #605e5c;
-                                        font-size: 18px;
-                                        height: 18px;
-                                        left: 0px;
-                                        position: absolute;
-                                        text-align: center;
-                                        top: 0px;
-                                        vertical-align: middle;
-                                        width: 18px;
-                                      }
-                                      @media screen and (-ms-high-contrast: active){& {
-                                        color: WindowText;
-                                      }
-                                  data-icon-name="CircleRing"
-                                  role="presentation"
-                                  style={
-                                    Object {
-                                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                                    }
+                                  .ms-Check-checkHost:focus & {
+                                    opacity: 1;
                                   }
-                                >
-                                  
-                                </i>
-                                <i
-                                  aria-hidden={true}
-                                  className=
-                                      ms-Icon
-                                      ms-Check-check
-                                      {
-                                        display: inline-block;
-                                      }
-                                      {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        font-family: "FabricMDL2Icons";
-                                        font-style: normal;
-                                        font-weight: normal;
-                                        speak: none;
-                                      }
-                                      {
-                                        color: #605e5c;
-                                        font-size: 16px;
-                                        height: 18px;
-                                        left: .5px;
-                                        opacity: 0;
-                                        position: absolute;
-                                        text-align: center;
-                                        top: 0px;
-                                        vertical-align: middle;
-                                        width: 18px;
-                                      }
-                                      &:hover {
-                                        opacity: 1;
-                                      }
-                                      @media screen and (-ms-high-contrast: active){& {
-                                        -ms-high-contrast-adjust: none;
-                                      }
-                                  data-icon-name="StatusCircleCheckmark"
-                                  role="presentation"
-                                  style={
-                                    Object {
-                                      "fontFamily": "\\"FabricMDL2Icons\\"",
-                                    }
+                                  &:hover {
+                                    opacity: 1;
                                   }
-                                >
-                                  
-                                </i>
-                              </div>
-                            </button>
-                            <div
-                              className=
-                                  ms-GroupHeader-dropIcon
-                                  {
-                                    color: #605e5c;
-                                    font-size: 20px;
-                                    left: -26px;
-                                    opacity: 0;
-                                    position: absolute;
-                                    transform-origin: 10px 10px;
-                                    transform: rotate(0.2deg) scale(0.65);
-                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
-                                  }
-                                  .ms-Icon--Tag {
-                                    position: absolute;
+                                  &:focus {
+                                    opacity: 1;
                                   }
                             >
                               <i
                                 aria-hidden={true}
                                 className=
-
+                                    ms-Icon
+                                    ms-Check-circle
+                                    {
+                                      display: inline-block;
+                                    }
                                     {
                                       -moz-osx-font-smoothing: grayscale;
                                       -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
                                       font-family: "FabricMDL2Icons";
                                       font-style: normal;
                                       font-weight: normal;
                                       speak: none;
                                     }
-                                data-icon-name="Tag"
+                                    {
+                                      color: #605e5c;
+                                      font-size: 18px;
+                                      height: 18px;
+                                      left: 0px;
+                                      position: absolute;
+                                      text-align: center;
+                                      top: 0px;
+                                      vertical-align: middle;
+                                      width: 18px;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){& {
+                                      color: WindowText;
+                                    }
+                                data-icon-name="CircleRing"
+                                role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
-                                
+                                
                               </i>
-                            </div>
-                            <button
-                              aria-controls="GroupedListSection4"
-                              aria-expanded={true}
-                              aria-label="expand collapse group"
-                              className=
-                                  ms-GroupHeader-expand
-                                  {
-                                    align-items: center;
-                                    background-color: transparent;
-                                    background: none;
-                                    border: none;
-                                    color: #605e5c;
-                                    cursor: default;
-                                    display: flex;
-                                    font-size: 12px;
-                                    height: 48px;
-                                    justify-content: center;
-                                    outline: transparent;
-                                    padding-bottom: 0px;
-                                    padding-left: 0px;
-                                    padding-right: 0px;
-                                    padding-top: 0px;
-                                    position: relative;
-                                    width: 36px;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #ffffff;
-                                    bottom: 1px;
-                                    content: "";
-                                    left: 1px;
-                                    outline: 1px solid #605e5c;
-                                    position: absolute;
-                                    right: 1px;
-                                    top: 1px;
-                                    z-index: 1;
-                                  }
-                                  &:hover {
-                                    background-color: #edebe9;
-                                  }
-                                  &:active {
-                                    background-color: #e1dfdd;
-                                  }
-                              data-is-focusable={false}
-                              onClick={[Function]}
-                              type="button"
-                            >
                               <i
                                 aria-hidden={true}
                                 className=
-
+                                    ms-Icon
+                                    ms-Check-check
+                                    {
+                                      display: inline-block;
+                                    }
                                     {
                                       -moz-osx-font-smoothing: grayscale;
                                       -webkit-font-smoothing: antialiased;
-                                      display: inline-block;
-                                      font-family: "FabricMDL2Icons-3";
+                                      font-family: "FabricMDL2Icons";
                                       font-style: normal;
                                       font-weight: normal;
                                       speak: none;
-                                      transform-origin: 50% 50%;
-                                      transform: rotate(90deg);
-                                      transition: transform .1s linear;
                                     }
-                                data-icon-name="ChevronRightMed"
+                                    {
+                                      color: #605e5c;
+                                      font-size: 16px;
+                                      height: 18px;
+                                      left: .5px;
+                                      opacity: 0;
+                                      position: absolute;
+                                      text-align: center;
+                                      top: 0px;
+                                      vertical-align: middle;
+                                      width: 18px;
+                                    }
+                                    &:hover {
+                                      opacity: 1;
+                                    }
+                                    @media screen and (-ms-high-contrast: active){& {
+                                      -ms-high-contrast-adjust: none;
+                                    }
+                                data-icon-name="StatusCircleCheckmark"
+                                role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
-                                
+                                
                               </i>
-                            </button>
-                            <div
+                            </div>
+                          </button>
+                          <div
+                            className=
+                                ms-GroupHeader-dropIcon
+                                {
+                                  color: #605e5c;
+                                  font-size: 20px;
+                                  left: -26px;
+                                  opacity: 0;
+                                  position: absolute;
+                                  transform-origin: 10px 10px;
+                                  transform: rotate(0.2deg) scale(0.65);
+                                  transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                }
+                                .ms-Icon--Tag {
+                                  position: absolute;
+                                }
+                          >
+                            <i
+                              aria-hidden={true}
                               className=
-                                  ms-GroupHeader-title
+
                                   {
-                                    cursor: pointer;
-                                    font-size: 16px;
-                                    font-weight: 600;
-                                    outline: 0px;
-                                    padding-left: 12px;
-                                    text-overflow: ellipsis;
-                                    white-space: nowrap;
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                  }
+                              data-icon-name="Tag"
+                            >
+                              
+                            </i>
+                          </div>
+                          <button
+                            aria-controls="GroupedListSection3"
+                            aria-expanded={true}
+                            aria-label="expand collapse group"
+                            className=
+                                ms-GroupHeader-expand
+                                {
+                                  align-items: center;
+                                  background-color: transparent;
+                                  background: none;
+                                  border: none;
+                                  color: #605e5c;
+                                  cursor: default;
+                                  display: flex;
+                                  font-size: 12px;
+                                  height: 48px;
+                                  justify-content: center;
+                                  outline: transparent;
+                                  padding-bottom: 0px;
+                                  padding-left: 0px;
+                                  padding-right: 0px;
+                                  padding-top: 0px;
+                                  position: relative;
+                                  width: 36px;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #ffffff;
+                                  bottom: 1px;
+                                  content: "";
+                                  left: 1px;
+                                  outline: 1px solid #605e5c;
+                                  position: absolute;
+                                  right: 1px;
+                                  top: 1px;
+                                  z-index: 1;
+                                }
+                                &:hover {
+                                  background-color: #edebe9;
+                                }
+                                &:active {
+                                  background-color: #e1dfdd;
+                                }
+                            data-is-focusable={false}
+                            onClick={[Function]}
+                            type="button"
+                          >
+                            <i
+                              aria-hidden={true}
+                              className=
+
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    display: inline-block;
+                                    font-family: "FabricMDL2Icons-3";
+                                    font-style: normal;
+                                    font-weight: normal;
+                                    speak: none;
+                                    transform-origin: 50% 50%;
+                                    transform: rotate(90deg);
+                                    transition: transform .1s linear;
+                                  }
+                              data-icon-name="ChevronRightMed"
+                            >
+                              
+                            </i>
+                          </button>
+                          <div
+                            className=
+                                ms-GroupHeader-title
+                                {
+                                  cursor: pointer;
+                                  font-size: 16px;
+                                  font-weight: 600;
+                                  outline: 0px;
+                                  padding-left: 12px;
+                                  text-overflow: ellipsis;
+                                  white-space: nowrap;
+                                }
+                          >
+                            <span>
+                              0
+                            </span>
+                            <span
+                              className=
+
+                                  {
+                                    padding-bottom: 0px;
+                                    padding-left: 4px;
+                                    padding-right: 4px;
+                                    padding-top: 0px;
                                   }
                             >
-                              <span>
-                                0
-                              </span>
-                              <span
-                                className=
-
-                                    {
-                                      padding-bottom: 0px;
-                                      padding-left: 4px;
-                                      padding-right: 4px;
-                                      padding-top: 0px;
-                                    }
-                              >
-                                (
-                                100
-                                )
-                              </span>
-                            </div>
+                              (
+                              100
+                              )
+                            </span>
                           </div>
                         </div>
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection3"
+                        role="grid"
+                      >
                         <div
-                          className="ms-List"
-                          id="GroupedListSection4"
-                          role="grid"
+                          className="ms-List-surface"
+                          role="presentation"
                         >
                           <div
-                            className="ms-List-surface"
+                            className="ms-List-page"
                             role="presentation"
+                            style={Object {}}
                           >
                             <div
-                              className="ms-List-page"
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={0}
                               role="presentation"
-                              style={Object {}}
                             >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={0}
-                                role="presentation"
+                                aria-rowindex={1}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone4"
+                                data-is-focusable={true}
+                                data-item-index={0}
+                                data-selection-index={0}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={1}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -1347,64 +1404,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone5"
-                                  data-is-focusable={true}
-                                  data-item-index={0}
-                                  data-selection-index={0}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -1434,382 +1668,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 0
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      0
-                                    </div>
+                                    Item 0
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    0
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={1}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={1}
-                                role="presentation"
+                                aria-rowindex={2}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone5"
+                                data-is-focusable={true}
+                                data-item-index={1}
+                                data-selection-index={1}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={2}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -1818,64 +1875,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone6"
-                                  data-is-focusable={true}
-                                  data-item-index={1}
-                                  data-selection-index={1}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -1905,382 +2139,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 1
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      1
-                                    </div>
+                                    Item 1
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    1
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={2}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={2}
-                                role="presentation"
+                                aria-rowindex={3}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone6"
+                                data-is-focusable={true}
+                                data-item-index={2}
+                                data-selection-index={2}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={3}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -2289,64 +2346,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone7"
-                                  data-is-focusable={true}
-                                  data-item-index={2}
-                                  data-selection-index={2}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -2376,382 +2610,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 2
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      2
-                                    </div>
+                                    Item 2
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    2
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={3}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={3}
-                                role="presentation"
+                                aria-rowindex={4}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone7"
+                                data-is-focusable={true}
+                                data-item-index={3}
+                                data-selection-index={3}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={4}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -2760,64 +2817,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone8"
-                                  data-is-focusable={true}
-                                  data-item-index={3}
-                                  data-selection-index={3}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -2847,382 +3081,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 3
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      3
-                                    </div>
+                                    Item 3
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    3
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={4}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={4}
-                                role="presentation"
+                                aria-rowindex={5}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone8"
+                                data-is-focusable={true}
+                                data-item-index={4}
+                                data-selection-index={4}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={5}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -3231,64 +3288,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone9"
-                                  data-is-focusable={true}
-                                  data-item-index={4}
-                                  data-selection-index={4}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -3318,382 +3552,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 4
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      4
-                                    </div>
+                                    Item 4
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    4
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={5}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={5}
-                                role="presentation"
+                                aria-rowindex={6}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone9"
+                                data-is-focusable={true}
+                                data-item-index={5}
+                                data-selection-index={5}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={6}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -3702,64 +3759,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone10"
-                                  data-is-focusable={true}
-                                  data-item-index={5}
-                                  data-selection-index={5}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -3789,382 +4023,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 5
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      5
-                                    </div>
+                                    Item 5
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    5
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={6}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={6}
-                                role="presentation"
+                                aria-rowindex={7}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone10"
+                                data-is-focusable={true}
+                                data-item-index={6}
+                                data-selection-index={6}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={7}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -4173,64 +4230,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone11"
-                                  data-is-focusable={true}
-                                  data-item-index={6}
-                                  data-selection-index={6}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -4260,382 +4494,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 6
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      6
-                                    </div>
+                                    Item 6
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    6
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={7}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={7}
-                                role="presentation"
+                                aria-rowindex={8}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone11"
+                                data-is-focusable={true}
+                                data-item-index={7}
+                                data-selection-index={7}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={8}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -4644,64 +4701,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone12"
-                                  data-is-focusable={true}
-                                  data-item-index={7}
-                                  data-selection-index={7}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -4731,382 +4965,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 7
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      7
-                                    </div>
+                                    Item 7
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    7
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={8}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={8}
-                                role="presentation"
+                                aria-rowindex={9}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone12"
+                                data-is-focusable={true}
+                                data-item-index={8}
+                                data-selection-index={8}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={9}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -5115,64 +5172,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone13"
-                                  data-is-focusable={true}
-                                  data-item-index={8}
-                                  data-selection-index={8}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -5202,382 +5436,205 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 8
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      8
-                                    </div>
+                                    Item 8
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    8
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={9}
+                              role="presentation"
+                            >
                               <div
-                                className="ms-List-cell"
-                                data-automationid="ListCell"
-                                data-list-index={9}
-                                role="presentation"
+                                aria-rowindex={10}
+                                aria-selected={false}
+                                className=
+                                    ms-FocusZone
+                                    ms-DetailsRow
+                                    is-contentUnselectable
+                                    &:focus {
+                                      outline: none;
+                                    }
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      animation-duration: 0.367s;
+                                      animation-fill-mode: both;
+                                      animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                      animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                      background: #ffffff;
+                                      border-bottom: 1px solid #f3f2f1;
+                                      box-sizing: border-box;
+                                      color: #605e5c;
+                                      cursor: default;
+                                      display: inline-flex;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 12px;
+                                      font-weight: 400;
+                                      min-height: 42px;
+                                      min-width: 100%;
+                                      outline: transparent;
+                                      padding-bottom: 0px;
+                                      padding-left: 0px;
+                                      padding-right: 0px;
+                                      padding-top: 0px;
+                                      position: relative;
+                                      text-align: left;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      white-space: nowrap;
+                                    }
+                                    &::-moz-focus-inner {
+                                      border: 0;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus:after {
+                                      border: 1px solid #605e5c;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      outline: 1px solid #ffffff;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                      z-index: 1;
+                                    }
+                                    .ms-List-cell:first-child &:before {
+                                      display: none;
+                                    }
+                                    &:hover {
+                                      background: #f3f2f1;
+                                      color: #323130;
+                                    }
+                                    &:hover .is-row-header {
+                                      color: #201f1e;
+                                    }
+                                    &:hover .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                    .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                      opacity: 1;
+                                    }
+                                data-automationid="DetailsRow"
+                                data-focuszone-id="FocusZone13"
+                                data-is-focusable={true}
+                                data-item-index={9}
+                                data-selection-index={9}
+                                data-selection-touch-invoke={true}
+                                onFocus={[Function]}
+                                onKeyDown={[Function]}
+                                onMouseDownCapture={[Function]}
+                                role="row"
+                                style={
+                                  Object {
+                                    "minWidth": 200,
+                                  }
+                                }
                               >
                                 <div
-                                  aria-rowindex={10}
-                                  aria-selected={false}
+                                  aria-colindex={1}
                                   className=
-                                      ms-FocusZone
-                                      ms-DetailsRow
-                                      is-contentUnselectable
-                                      &:focus {
-                                        outline: none;
-                                      }
+                                      ms-DetailsRow-cell
+                                      ms-DetailsRow-cellCheck
                                       {
-                                        -moz-osx-font-smoothing: grayscale;
-                                        -webkit-font-smoothing: antialiased;
-                                        animation-duration: 0.367s;
-                                        animation-fill-mode: both;
-                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                        background: #ffffff;
-                                        border-bottom: 1px solid #f3f2f1;
                                         box-sizing: border-box;
-                                        color: #605e5c;
-                                        cursor: default;
-                                        display: inline-flex;
-                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                        font-size: 12px;
-                                        font-weight: 400;
+                                        display: inline-block;
+                                        flex-shrink: 0;
+                                        margin-top: -1px;
                                         min-height: 42px;
-                                        min-width: 100%;
                                         outline: transparent;
+                                        overflow: hidden;
                                         padding-bottom: 0px;
                                         padding-left: 0px;
                                         padding-right: 0px;
-                                        padding-top: 0px;
+                                        padding-top: 1px;
                                         position: relative;
-                                        text-align: left;
-                                        user-select: none;
+                                        text-overflow: ellipsis;
                                         vertical-align: top;
                                         white-space: nowrap;
                                       }
@@ -5586,64 +5643,241 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                       .ms-Fabric--isFocusVisible &:focus:after {
                                         border: 1px solid #605e5c;
-                                        bottom: 1px;
+                                        bottom: 0px;
                                         content: "";
-                                        left: 1px;
+                                        left: 0px;
                                         outline: 1px solid #ffffff;
                                         position: absolute;
-                                        right: 1px;
-                                        top: 1px;
+                                        right: 0px;
+                                        top: 0px;
                                         z-index: 1;
                                       }
-                                      .ms-List-cell:first-child &:before {
-                                        display: none;
+                                      & > button {
+                                        max-width: 100%;
                                       }
-                                      &:hover {
-                                        background: #f3f2f1;
-                                        color: #323130;
+                                      & [data-is-focusable='true'] {
+                                        outline: transparent;
+                                        position: relative;
                                       }
-                                      &:hover .is-row-header {
-                                        color: #201f1e;
+                                      & [data-is-focusable='true']::-moz-focus-inner {
+                                        border: 0;
                                       }
-                                      &:hover .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                        opacity: 1;
-                                      }
-                                  data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone14"
-                                  data-is-focusable={true}
-                                  data-item-index={9}
-                                  data-selection-index={9}
-                                  data-selection-touch-invoke={true}
-                                  onFocus={[Function]}
-                                  onKeyDown={[Function]}
-                                  onMouseDownCapture={[Function]}
-                                  role="row"
-                                  style={
-                                    Object {
-                                      "minWidth": 200,
-                                    }
-                                  }
+                                  data-selection-toggle={true}
+                                  role="gridcell"
                                 >
                                   <div
-                                    aria-colindex={1}
+                                    aria-checked={false}
+                                    aria-label="Row checkbox"
                                     className=
-                                        ms-DetailsRow-cell
-                                        ms-DetailsRow-cellCheck
+                                        ms-DetailsRow-check
+                                        ms-Check-checkHost
                                         {
+                                          -moz-osx-font-smoothing: grayscale;
+                                          -webkit-font-smoothing: antialiased;
+                                          align-items: center;
+                                          background-color: transparent;
+                                          background: none;
+                                          border: none;
                                           box-sizing: border-box;
-                                          display: inline-block;
-                                          flex-shrink: 0;
-                                          margin-top: -1px;
-                                          min-height: 42px;
+                                          cursor: default;
+                                          display: flex;
+                                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                          font-size: 12px;
+                                          font-weight: 400;
+                                          height: 42px;
+                                          justify-content: center;
+                                          margin-bottom: 0px;
+                                          margin-left: 0px;
+                                          margin-right: 0px;
+                                          margin-top: 0px;
+                                          opacity: 0;
                                           outline: transparent;
-                                          overflow: hidden;
                                           padding-bottom: 0px;
                                           padding-left: 0px;
                                           padding-right: 0px;
-                                          padding-top: 1px;
+                                          padding-top: 0px;
+                                          position: relative;
+                                          vertical-align: top;
+                                          width: 48px;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #ffffff;
+                                          bottom: 1px;
+                                          content: "";
+                                          left: 1px;
+                                          outline: 1px solid #605e5c;
+                                          position: absolute;
+                                          right: 1px;
+                                          top: 1px;
+                                          z-index: 1;
+                                        }
+                                    data-automationid="DetailsRowCheck"
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  >
+                                    <div
+                                      className=
+                                          ms-Check
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 14px;
+                                            font-weight: 400;
+                                            height: 18px;
+                                            line-height: 1;
+                                            position: relative;
+                                            user-select: none;
+                                            vertical-align: top;
+                                            width: 18px;
+                                          }
+                                          &:before {
+                                            background: #ffffff;
+                                            border-radius: 50%;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            opacity: 1;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                          }
+                                          .ms-Check-checkHost:hover & {
+                                            opacity: 1;
+                                          }
+                                          .ms-Check-checkHost:focus & {
+                                            opacity: 1;
+                                          }
+                                          &:hover {
+                                            opacity: 1;
+                                          }
+                                          &:focus {
+                                            opacity: 1;
+                                          }
+                                    >
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-circle
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 18px;
+                                              height: 18px;
+                                              left: 0px;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              color: WindowText;
+                                            }
+                                        data-icon-name="CircleRing"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                      <i
+                                        aria-hidden={true}
+                                        className=
+                                            ms-Icon
+                                            ms-Check-check
+                                            {
+                                              display: inline-block;
+                                            }
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: "FabricMDL2Icons";
+                                              font-style: normal;
+                                              font-weight: normal;
+                                              speak: none;
+                                            }
+                                            {
+                                              color: #605e5c;
+                                              font-size: 16px;
+                                              height: 18px;
+                                              left: .5px;
+                                              opacity: 0;
+                                              position: absolute;
+                                              text-align: center;
+                                              top: 0px;
+                                              vertical-align: middle;
+                                              width: 18px;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            @media screen and (-ms-high-contrast: active){& {
+                                              -ms-high-contrast-adjust: none;
+                                            }
+                                        data-icon-name="StatusCircleCheckmark"
+                                        role="presentation"
+                                        style={
+                                          Object {
+                                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                                          }
+                                        }
+                                      >
+                                        
+                                      </i>
+                                    </div>
+                                  </div>
+                                </div>
+                                <span
+                                  className="ms-GroupSpacer"
+                                  style={
+                                    Object {
+                                      "display": "inline-block",
+                                      "width": 36,
+                                    }
+                                  }
+                                />
+                                <div
+                                  className=
+                                      ms-DetailsRow-fields
+                                      {
+                                        align-items: stretch;
+                                        display: flex;
+                                      }
+                                  data-automationid="DetailsRowFields"
+                                  role="presentation"
+                                >
+                                  <div
+                                    aria-colindex={2}
+                                    aria-readonly={true}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
                                           position: relative;
                                           text-overflow: ellipsis;
                                           vertical-align: top;
@@ -5673,339 +5907,93 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         & [data-is-focusable='true']::-moz-focus-inner {
                                           border: 0;
                                         }
-                                    data-selection-toggle={true}
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="name"
+                                    data-automationid="DetailsRowCell"
                                     role="gridcell"
-                                  >
-                                    <div
-                                      aria-checked={false}
-                                      aria-label="Row checkbox"
-                                      className=
-                                          ms-DetailsRow-check
-                                          ms-Check-checkHost
-                                          {
-                                            -moz-osx-font-smoothing: grayscale;
-                                            -webkit-font-smoothing: antialiased;
-                                            align-items: center;
-                                            background-color: transparent;
-                                            background: none;
-                                            border: none;
-                                            box-sizing: border-box;
-                                            cursor: default;
-                                            display: flex;
-                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                            font-size: 12px;
-                                            font-weight: 400;
-                                            height: 42px;
-                                            justify-content: center;
-                                            margin-bottom: 0px;
-                                            margin-left: 0px;
-                                            margin-right: 0px;
-                                            margin-top: 0px;
-                                            opacity: 0;
-                                            outline: transparent;
-                                            padding-bottom: 0px;
-                                            padding-left: 0px;
-                                            padding-right: 0px;
-                                            padding-top: 0px;
-                                            position: relative;
-                                            vertical-align: top;
-                                            width: 48px;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #ffffff;
-                                            bottom: 1px;
-                                            content: "";
-                                            left: 1px;
-                                            outline: 1px solid #605e5c;
-                                            position: absolute;
-                                            right: 1px;
-                                            top: 1px;
-                                            z-index: 1;
-                                          }
-                                      data-automationid="DetailsRowCheck"
-                                      data-selection-toggle={true}
-                                      role="checkbox"
-                                    >
-                                      <div
-                                        className=
-                                            ms-Check
-                                            {
-                                              -moz-osx-font-smoothing: grayscale;
-                                              -webkit-font-smoothing: antialiased;
-                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                              font-size: 14px;
-                                              font-weight: 400;
-                                              height: 18px;
-                                              line-height: 1;
-                                              position: relative;
-                                              user-select: none;
-                                              vertical-align: top;
-                                              width: 18px;
-                                            }
-                                            &:before {
-                                              background: #ffffff;
-                                              border-radius: 50%;
-                                              bottom: 1px;
-                                              content: "";
-                                              left: 1px;
-                                              opacity: 1;
-                                              position: absolute;
-                                              right: 1px;
-                                              top: 1px;
-                                            }
-                                            .ms-Check-checkHost:hover & {
-                                              opacity: 1;
-                                            }
-                                            .ms-Check-checkHost:focus & {
-                                              opacity: 1;
-                                            }
-                                            &:hover {
-                                              opacity: 1;
-                                            }
-                                            &:focus {
-                                              opacity: 1;
-                                            }
-                                      >
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-circle
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 18px;
-                                                height: 18px;
-                                                left: 0px;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                color: WindowText;
-                                              }
-                                          data-icon-name="CircleRing"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                        <i
-                                          aria-hidden={true}
-                                          className=
-                                              ms-Icon
-                                              ms-Check-check
-                                              {
-                                                display: inline-block;
-                                              }
-                                              {
-                                                -moz-osx-font-smoothing: grayscale;
-                                                -webkit-font-smoothing: antialiased;
-                                                font-family: "FabricMDL2Icons";
-                                                font-style: normal;
-                                                font-weight: normal;
-                                                speak: none;
-                                              }
-                                              {
-                                                color: #605e5c;
-                                                font-size: 16px;
-                                                height: 18px;
-                                                left: .5px;
-                                                opacity: 0;
-                                                position: absolute;
-                                                text-align: center;
-                                                top: 0px;
-                                                vertical-align: middle;
-                                                width: 18px;
-                                              }
-                                              &:hover {
-                                                opacity: 1;
-                                              }
-                                              @media screen and (-ms-high-contrast: active){& {
-                                                -ms-high-contrast-adjust: none;
-                                              }
-                                          data-icon-name="StatusCircleCheckmark"
-                                          role="presentation"
-                                          style={
-                                            Object {
-                                              "fontFamily": "\\"FabricMDL2Icons\\"",
-                                            }
-                                          }
-                                        >
-                                          
-                                        </i>
-                                      </div>
-                                    </div>
-                                  </div>
-                                  <span
-                                    className="ms-GroupSpacer"
                                     style={
                                       Object {
-                                        "display": "inline-block",
-                                        "width": 36,
+                                        "width": 120,
                                       }
                                     }
-                                  />
-                                  <div
-                                    className=
-                                        ms-DetailsRow-fields
-                                        {
-                                          align-items: stretch;
-                                          display: flex;
-                                        }
-                                    data-automationid="DetailsRowFields"
-                                    role="presentation"
                                   >
-                                    <div
-                                      aria-colindex={2}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="name"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      Item 9
-                                    </div>
-                                    <div
-                                      aria-colindex={3}
-                                      aria-readonly={true}
-                                      className=
-                                          ms-DetailsRow-cell
-                                          {
-                                            box-sizing: border-box;
-                                            display: inline-block;
-                                            min-height: 42px;
-                                            outline: transparent;
-                                            overflow: hidden;
-                                            padding-bottom: 11px;
-                                            padding-left: 12px;
-                                            padding-top: 11px;
-                                            position: relative;
-                                            text-overflow: ellipsis;
-                                            vertical-align: top;
-                                            white-space: nowrap;
-                                          }
-                                          &::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          .ms-Fabric--isFocusVisible &:focus:after {
-                                            border: 1px solid #605e5c;
-                                            bottom: 0px;
-                                            content: "";
-                                            left: 0px;
-                                            outline: 1px solid #ffffff;
-                                            position: absolute;
-                                            right: 0px;
-                                            top: 0px;
-                                            z-index: 1;
-                                          }
-                                          & > button {
-                                            max-width: 100%;
-                                          }
-                                          & [data-is-focusable='true'] {
-                                            outline: transparent;
-                                            position: relative;
-                                          }
-                                          & [data-is-focusable='true']::-moz-focus-inner {
-                                            border: 0;
-                                          }
-                                          {
-                                            padding-right: 8px;
-                                          }
-                                      data-automation-key="value"
-                                      data-automationid="DetailsRowCell"
-                                      role="gridcell"
-                                      style={
-                                        Object {
-                                          "width": 120,
-                                        }
-                                      }
-                                    >
-                                      9
-                                    </div>
+                                    Item 9
                                   </div>
-                                  <span
-                                    aria-checked={false}
+                                  <div
+                                    aria-colindex={3}
+                                    aria-readonly={true}
                                     className=
-
+                                        ms-DetailsRow-cell
                                         {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 11px;
+                                          padding-left: 12px;
+                                          padding-top: 11px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
                                           bottom: 0px;
-                                          display: none;
+                                          content: "";
                                           left: 0px;
+                                          outline: 1px solid #ffffff;
                                           position: absolute;
                                           right: 0px;
-                                          top: -1px;
+                                          top: 0px;
+                                          z-index: 1;
                                         }
-                                    data-selection-toggle={true}
-                                    role="checkbox"
-                                  />
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        {
+                                          padding-right: 8px;
+                                        }
+                                    data-automation-key="value"
+                                    data-automationid="DetailsRowCell"
+                                    role="gridcell"
+                                    style={
+                                      Object {
+                                        "width": 120,
+                                      }
+                                    }
+                                  >
+                                    9
+                                  </div>
                                 </div>
+                                <span
+                                  aria-checked={false}
+                                  className=
+
+                                      {
+                                        bottom: 0px;
+                                        display: none;
+                                        left: 0px;
+                                        position: absolute;
+                                        right: 0px;
+                                        top: -1px;
+                                      }
+                                  data-selection-toggle={true}
+                                  role="checkbox"
+                                />
                               </div>
                             </div>
                           </div>
@@ -6013,16 +6001,16 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       </div>
                     </div>
                   </div>
-                  <div
-                    className="ms-List-page"
-                    role="presentation"
-                    style={
-                      Object {
-                        "height": 38178,
-                      }
-                    }
-                  />
                 </div>
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={
+                    Object {
+                      "height": 38178,
+                    }
+                  }
+                />
               </div>
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -626,33 +626,33 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -498,33 +498,33 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone2"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone2"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -495,33 +495,33 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone2"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone2"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -504,33 +504,33 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
           role="presentation"
         >
           <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-                {
-                  display: inline-block;
-                  min-height: 1px;
-                  min-width: 100%;
-                }
-            data-focuszone-id="FocusZone2"
-            onBlur={[Function]}
-            onFocus={[Function]}
+            className="ms-SelectionZone"
+            onClick={[Function]}
+            onContextMenu={[Function]}
+            onDoubleClick={[Function]}
+            onFocusCapture={[Function]}
             onKeyDown={[Function]}
+            onKeyDownCapture={[Function]}
+            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
+            role="presentation"
           >
             <div
-              className="ms-SelectionZone"
-              onClick={[Function]}
-              onContextMenu={[Function]}
-              onDoubleClick={[Function]}
-              onFocusCapture={[Function]}
+              className=
+                  ms-FocusZone
+                  &:focus {
+                    outline: none;
+                  }
+                  {
+                    display: inline-block;
+                    min-height: 1px;
+                    min-width: 100%;
+                  }
+              data-focuszone-id="FocusZone2"
+              onBlur={[Function]}
+              onFocus={[Function]}
               onKeyDown={[Function]}
-              onKeyDownCapture={[Function]}
-              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
-              role="presentation"
             >
               <div
                 className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -463,33 +463,33 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
             role="presentation"
           >
             <div
-              className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
-                  }
-                  {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
-                  }
-              data-focuszone-id="FocusZone3"
-              onBlur={[Function]}
-              onFocus={[Function]}
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
+                className=
+                    ms-FocusZone
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      display: inline-block;
+                      min-height: 1px;
+                      min-width: 100%;
+                    }
+                data-focuszone-id="FocusZone3"
+                onBlur={[Function]}
+                onFocus={[Function]}
                 onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
                 onMouseDownCapture={[Function]}
-                role="presentation"
               >
                 <div
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -475,33 +475,33 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Weights.Example.tsx.shot
@@ -475,33 +475,33 @@ exports[`Component Examples renders Text.Weights.Example.tsx correctly 1`] = `
         role="presentation"
       >
         <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-              {
-                display: inline-block;
-                min-height: 1px;
-                min-width: 100%;
-              }
-          data-focuszone-id="FocusZone2"
-          onBlur={[Function]}
-          onFocus={[Function]}
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
           onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
           onMouseDownCapture={[Function]}
+          role="presentation"
         >
           <div
-            className="ms-SelectionZone"
-            onClick={[Function]}
-            onContextMenu={[Function]}
-            onDoubleClick={[Function]}
-            onFocusCapture={[Function]}
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone2"
+            onBlur={[Function]}
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            onKeyDownCapture={[Function]}
-            onMouseDown={[Function]}
             onMouseDownCapture={[Function]}
-            role="presentation"
           >
             <div
               className="ms-List"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #14275
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Seems nested FocusZones don't work with `onActiveItemChanged` when applied to the outer focuszone, causing an issue in DetailsList when that callback is called. 

https://codepen.io/ngyukman/pen/JjGQgVe?editors=1011

In the past DetailsList wrapped the same FocusZone around the List and GroupedList. As we're moving to GroupedList being its own focus managed control, I moved the DetailsList FocusZone to only wrap the list, and passed the FocusZone props to a new focusZoneProps in GroupedList.

#### Focus areas to test

(optional)
