### PR TITLE
fix: correct slider track margin to react to density level

### DIFF
--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -75,13 +75,13 @@ export const SliderStyles = css`
         right: calc(var(--track-overhang) * 1px);
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
-        margin-top: calc((var(--design-unit) + 2) * 1px);
+        margin-top: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         height: calc(var(--track-width) * 1px);
     }
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        margin-left: calc((var(--design-unit) + 2) * 1px);
+        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         width: calc(var(--track-width) * 1px);
         height: 100%;
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes a bug that causes the slider thumb element in the `fast-slider` component to become misaligned when the density level is changed (especially at negative values). This issue was addressed in the `fast-component` repository. `fast-component-msft` requires this fix as well. 

The fix is implemented by adding the `--density` value CSS variable to the `margin-top` of horizontally displayed `fast-slider` components as well as to the `margin-left` value of vertically displayed `fast-slider` components.
