### PR TITLE
[Date-time] fix month start calculation for WeeklyDayPicker

### DIFF
--- a/change/@uifabric-date-time-2020-08-03-12-02-43-lorejoh12-fixMonthStartCalculation.json
+++ b/change/@uifabric-date-time-2020-08-03-12-02-43-lorejoh12-fixMonthStartCalculation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": " ",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T19:02:43.961Z"
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
@@ -11,7 +11,7 @@ export interface ICalendarDayMonthHeaderRowProps extends ICalendarDayGridProps {
 }
 
 export const CalendarMonthHeaderRow = (props: ICalendarDayMonthHeaderRowProps) => {
-  const { showWeekNumbers, strings, firstDayOfWeek, allFocusable, weeksToShow, weeks, classNames } = props;
+  const { showWeekNumbers, strings, allFocusable, weeksToShow, weeks, classNames } = props;
   const dayLabels = strings.shortDays.slice();
   const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);
   if (weeksToShow === 1 && firstOfMonthIndex >= 0) {
@@ -23,7 +23,7 @@ export const CalendarMonthHeaderRow = (props: ICalendarDayMonthHeaderRowProps) =
     <tr>
       {showWeekNumbers && <th className={classNames.dayCell} />}
       {dayLabels.map((val: string, index: number) => {
-        const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
+        const i = index % DAYS_IN_WEEK;
         const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
         return (
           <th


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixing a bug where the first day of the month was calculated incorrectly in the WeeklyDayPicker. The `weeks` array is already sorted by firstDayOfWeek (e.g. if FirstDayOfWeek == Monday, it'll start from Monday's date). So adding an additional offset by FirstDayOfWeek when calculating the first day of the month results in the index being wrong. Remove the additional (wrong) offset.

#### Focus areas to test

(optional)
