### PR TITLE
omit: perf improvements, better api, export from index

### DIFF
--- a/change/@uifabric-utilities-2020-08-03-12-26-01-fix-omit.json
+++ b/change/@uifabric-utilities-2020-08-03-12-26-01-fix-omit.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "omit: changed to for in for more perf improvement.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T19:26:01.457Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -976,6 +976,9 @@ export const olProperties: Record<string, number>;
 
 export { Omit }
 
+// @public
+export function omit<TObj extends Record<string, any>>(obj: TObj, exclusions: (keyof TObj)[]): TObj;
+
 // @public (undocumented)
 export function on(element: Element | Window, eventName: string, callback: (ev: Event) => void, options?: boolean): () => void;
 

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -53,7 +53,7 @@ export * from './memoize';
 export * from './merge';
 export * from './mobileDetector';
 export * from './modalize';
-export { assign, filteredAssign, mapEnumByName, shallowCompare, values } from './object';
+export { assign, filteredAssign, mapEnumByName, shallowCompare, values, omit } from './object';
 export * from './osDetector';
 export * from './overflow';
 export * from './properties';

--- a/packages/utilities/src/object.test.ts
+++ b/packages/utilities/src/object.test.ts
@@ -71,6 +71,6 @@ describe('values', () => {
 
 describe('omit', () => {
   it('can omit excluded props and leave non-excluded alone', () => {
-    expect(omit({ a: 1, b: 2 }, { a: 1 })).toEqual({ b: 2 });
+    expect(omit({ a: 1, b: 2 }, ['a'])).toEqual({ b: 2 });
   });
 });

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -115,15 +115,15 @@ export function values<T>(obj: any): T[] {
  * https://jsperf.com/omit-vs-rest-vs-reduce/1
  *
  * @param obj - The object to clone
- * @param exclusions - The object of keys to exclude
+ * @param exclusions - The array of keys to exclude
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function omit<TObj extends Record<string, any>>(obj: TObj, exclusions: Record<string, any>): TObj {
+export function omit<TObj extends Record<string, any>>(obj: TObj, exclusions: (keyof TObj)[]): TObj {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {};
 
   for (const key in obj) {
-    if (!exclusions[key] && obj.hasOwnProperty(key)) {
+    if (exclusions.indexOf(key) === -1 && obj.hasOwnProperty(key)) {
       result[key] = obj[key];
     }
   }

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -122,8 +122,8 @@ export function omit<TObj extends Record<string, any>>(obj: TObj, exclusions: Re
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const result: Record<string, any> = {};
 
-  for (const key of Object.keys(obj)) {
-    if (!exclusions[key]) {
+  for (const key in obj) {
+    if (!exclusions[key] && obj.hasOwnProperty(key)) {
       result[key] = obj[key];
     }
   }


### PR DESCRIPTION
Changes omit to use `for in` loop and array/indexOf for matching exclusions. This seems fastest for small sets of exclusions (and is also the most ergonomic api.)

Updated jsperf test here: https://jsperf.com/omit-vs-rest-vs-reduce/10

![image](https://user-images.githubusercontent.com/1110944/89221017-6630d900-d587-11ea-95fd-afcd219081c4.png)

I'm really confused why my initial tests were not reporting indexOf faster, but now i'm seeing that being faster.

Also realized that the omit I recently checked in was not being exported. Changing the API to take in an array of exclusions first.

