### PR TITLE
Add hc styling to fix Toggle control

### DIFF
--- a/change/@fluentui-react-next-2020-08-04-09-58-27-a11y-toggle.json
+++ b/change/@fluentui-react-next-2020-08-04-09-58-27-a11y-toggle.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "update Toggle in react-next package",
+  "packageName": "@fluentui/react-next",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T16:58:27.560Z"
+}

--- a/change/@fluentui-react-next-2020-08-04-09-58-27-a11y-toggle.json
+++ b/change/@fluentui-react-next-2020-08-04-09-58-27-a11y-toggle.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "update Toggle in react-next package",
+  "comment": "Toggle: fix pill HC style when selected",
   "packageName": "@fluentui/react-next",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/office-ui-fabric-react-2020-08-03-14-14-33-a11y-toggle.json
+++ b/change/office-ui-fabric-react-2020-08-03-14-14-33-a11y-toggle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add hc styling to fix toggle",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-03T21:14:33.761Z"
+}

--- a/change/office-ui-fabric-react-2020-08-03-14-14-33-a11y-toggle.json
+++ b/change/office-ui-fabric-react-2020-08-03-14-14-33-a11y-toggle.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add hc styling to fix toggle",
+  "comment": "Toggle: fix pill HC style when selected",
   "packageName": "office-ui-fabric-react",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -1,4 +1,9 @@
-import { HighContrastSelector, getFocusStyle, FontWeights } from '../../Styling';
+import {
+  HighContrastSelector,
+  getFocusStyle,
+  FontWeights,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+} from '../../Styling';
 import { IToggleStyleProps, IToggleStyles } from './Toggle.types';
 
 const DEFAULT_PILL_WIDTH = 40;
@@ -129,8 +134,9 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
                 },
               ],
               [HighContrastSelector]: {
-                backgroundColor: 'WindowText',
+                backgroundColor: 'Highlight',
               },
+              ...getEdgeChromiumNoHighContrastAdjustSelector(),
             },
           },
         ],

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1340,7 +1340,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                 border-color: Highlight;
               }
               @media screen and (-ms-high-contrast: active){& {
-                background-color: WindowText;
+                background-color: Highlight;
+              }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           data-is-focusable={true}
           id="Toggle16"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -521,7 +521,10 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active){& {
-              background-color: WindowText;
+              background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Toggle4"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -115,7 +115,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 border-color: Highlight;
               }
               @media screen and (-ms-high-contrast: active){& {
-                background-color: WindowText;
+                background-color: Highlight;
+              }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           data-is-focusable={true}
           id="Toggle0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1106,7 +1106,10 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active){& {
-              background-color: WindowText;
+              background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Toggle21"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -114,7 +114,10 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active){& {
-              background-color: WindowText;
+              background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Toggle1"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -123,7 +123,10 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active){& {
-              background-color: WindowText;
+              background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Toggle0"
@@ -1402,7 +1405,10 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
             }
             @media screen and (-ms-high-contrast: active){& {
-              background-color: WindowText;
+              background-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         data-is-focusable={true}
         id="Toggle8"

--- a/packages/react-next/src/components/Toggle/Toggle.scss
+++ b/packages/react-next/src/components/Toggle/Toggle.scss
@@ -89,8 +89,10 @@ $DEFAULT_THUMB_SIZE: 12px;
     }
 
     @include high-contrast {
-      background-color: WindowText;
+      background-color: Highlight;
     }
+
+    @include high-contrast-edge-chromium-no-adjust;
   }
 
   &.disabled {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12298 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Toggle component does not support HC styling in Edge Chromium. This fix adds styling that will allow Toggle to adopt HC styling.

**Before**
![image](https://user-images.githubusercontent.com/66456876/89228292-32a87b80-d594-11ea-98a2-3b1cfa7f4c94.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89228817-2670ee00-d595-11ea-8bd5-64321f8a3aee.png)


#### Focus areas to test

(optional)
