### PR TITLE
Remove all usage of string refs

### DIFF
--- a/change/office-ui-fabric-react-2020-08-04-19-34-17-v8-string-refs.json
+++ b/change/office-ui-fabric-react-2020-08-04-19-34-17-v8-string-refs.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Remove all usage of string refs in OUFR",
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T19:34:17.002Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8124,7 +8124,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
     getTotalListHeight(): number;
     // (undocumented)
-    readonly PageRefs: Readonly<Record<string, unknown>>;
+    readonly pageRefs: Readonly<Record<string, unknown>>;
     // (undocumented)
     render(): JSX.Element | null;
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1307,10 +1307,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     // (undocumented)
     getStartItemIndexInView(): number;
     // (undocumented)
-    refs: {
-        [key: string]: React.ReactInstance;
-    };
-    // (undocumented)
     render(): JSX.Element;
     // (undocumented)
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
@@ -8128,9 +8124,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
     getTotalListHeight(): number;
     // (undocumented)
-    refs: {
-        [key: string]: React.ReactInstance;
-    };
+    readonly PageRefs: Readonly<Record<string, unknown>>;
     // (undocumented)
     render(): JSX.Element | null;
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -33,15 +33,13 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     compact: false,
   };
 
-  public refs: {
-    [key: string]: React.ReactInstance;
-  };
-
   private _classNames: IProcessedStyleSet<IGroupedListStyles>;
 
   private _list = React.createRef<List>();
 
   private _isSomeGroupExpanded: boolean;
+
+  private _groupRefs: Record<string, GroupedListSection | null> = {};
 
   constructor(props: IGroupedListProps) {
     super(props);
@@ -195,7 +193,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     return (
       <GroupedListSection
-        ref={'group_' + groupIndex}
+        // eslint-disable-next-line react/jsx-no-bind
+        ref={ref => (this._groupRefs['group_' + groupIndex] = ref)}
         key={this._getGroupKey(group, groupIndex)}
         dragDropEvents={dragDropEvents}
         dragDropHelper={dragDropHelper}
@@ -312,14 +311,13 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       this._list.current.forceUpdate();
 
       for (let i = 0; i < groupCount; i++) {
-        const group = this._list.current.refs['group_' + String(i)] as GroupedListSection;
+        const group = this._list.current.PageRefs['group_' + String(i)] as GroupedListSection;
         if (group) {
           group.forceListUpdate();
         }
       }
     } else {
-      // eslint-disable-next-line react/no-string-refs
-      const group = this.refs['group_' + String(0)] as GroupedListSection;
+      const group = this._groupRefs['group_' + String(0)];
       if (group) {
         group.forceListUpdate();
       }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -311,7 +311,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       this._list.current.forceUpdate();
 
       for (let i = 0; i < groupCount; i++) {
-        const group = this._list.current.PageRefs['group_' + String(i)] as GroupedListSection;
+        const group = this._list.current.pageRefs['group_' + String(i)] as GroupedListSection;
         if (group) {
           group.forceListUpdate();
         }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -115,6 +115,7 @@ const DEFAULT_DROPPING_CSS_CLASS = 'is-dropping';
 export class GroupedListSection extends React.Component<IGroupedListSectionProps, IGroupedListSectionState> {
   private _root = React.createRef<HTMLDivElement>();
   private _list = React.createRef<List>();
+  private _subGroupRefs: Record<string, GroupedListSection | null> = {};
   private _id: string;
   private _events: EventGroup;
 
@@ -286,7 +287,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         const subGroupCount = group.children.length;
 
         for (let i = 0; i < subGroupCount; i++) {
-          const subGroup = this._list.current.refs['subGroup_' + String(i)] as GroupedListSection;
+          const subGroup = this._list.current.PageRefs['subGroup_' + String(i)] as GroupedListSection;
 
           if (subGroup) {
             subGroup.forceListUpdate();
@@ -294,8 +295,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         }
       }
     } else {
-      // eslint-disable-next-line deprecation/deprecation, react/no-string-refs
-      const subGroup = this.refs['subGroup_' + String(0)] as GroupedListSection;
+      const subGroup = this._subGroupRefs['subGroup_' + String(0)];
 
       if (subGroup) {
         subGroup.forceListUpdate();
@@ -384,7 +384,8 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
     return !subGroup || subGroup.count > 0 || (groupProps && groupProps.showEmptyGroups) ? (
       <GroupedListSection
-        ref={'subGroup_' + subGroupIndex}
+        // eslint-disable-next-line react/jsx-no-bind
+        ref={ref => (this._subGroupRefs['subGroup_' + subGroupIndex] = ref)}
         key={this._getGroupKey(subGroup, subGroupIndex)}
         dragDropEvents={dragDropEvents}
         dragDropHelper={dragDropHelper}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -287,7 +287,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         const subGroupCount = group.children.length;
 
         for (let i = 0; i < subGroupCount; i++) {
-          const subGroup = this._list.current.PageRefs['subGroup_' + String(i)] as GroupedListSection;
+          const subGroup = this._list.current.pageRefs['subGroup_' + String(i)] as GroupedListSection;
 
           if (subGroup) {
             subGroup.forceListUpdate();

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -183,7 +183,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     this._pageCache = {};
   }
 
-  public get PageRefs(): Readonly<Record<string, unknown>> {
+  public get pageRefs(): Readonly<Record<string, unknown>> {
     return this._pageRefs;
   }
 

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -99,12 +99,9 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     renderedWindowsBehind: DEFAULT_RENDERED_WINDOWS_BEHIND,
   };
 
-  public refs: {
-    [key: string]: React.ReactInstance;
-  };
-
   private _root = React.createRef<HTMLDivElement>();
   private _surface = React.createRef<HTMLDivElement>();
+  private _pageRefs: Record<string, unknown> = {};
   private _async: Async;
   private _events: EventGroup;
   private _estimatedPageHeight: number;
@@ -184,6 +181,10 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     this._estimatedPageHeight = 0;
     this._focusedIndex = -1;
     this._pageCache = {};
+  }
+
+  public get PageRefs(): Readonly<Record<string, unknown>> {
+    return this._pageRefs;
   }
 
   /**
@@ -469,13 +470,16 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     const pageStyle = this._getPageStyle(page);
 
     const { onRenderPage = this._onRenderPage } = this.props;
+    const self = this;
 
     const pageElement = onRenderPage(
       {
         page: page,
         className: 'ms-List-page',
         key: page.key,
-        ref: page.key,
+        ref(newRef: unknown) {
+          self._pageRefs[this.page.key] = newRef;
+        },
         style: pageStyle,
         role: 'presentation',
       },
@@ -765,8 +769,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
    */
   private _measurePage(page: IPage<T>): boolean {
     let hasChangedHeight = false;
-    // eslint-disable-next-line react/no-string-refs
-    const pageElement = this.refs[page.key] as HTMLElement;
+    const pageElement = this._pageRefs[page.key] as HTMLElement;
     const cachedHeight = this._cachedPageHeights[page.startIndex];
 
     // console.log('   * measure attempt', page.startIndex, cachedHeight);

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -470,15 +470,14 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     const pageStyle = this._getPageStyle(page);
 
     const { onRenderPage = this._onRenderPage } = this.props;
-    const self = this;
 
     const pageElement = onRenderPage(
       {
         page: page,
         className: 'ms-List-page',
         key: page.key,
-        ref(newRef: unknown) {
-          self._pageRefs[this.page.key] = newRef;
+        ref: (newRef: unknown) => {
+          this._pageRefs[page.key] = newRef;
         },
         style: pageStyle,
         role: 'presentation',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14290 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Towards the goal of making all of OUFR compliant with React StrictMode, this change replaces all usage of string-based `refs` in OUFR with compliant alternatives.

#### Focus areas to test

(optional)
