### PR TITLE
react-conformance: share ts.Program to improve test performance

### DIFF
--- a/packages/react-conformance/package.json
+++ b/packages/react-conformance/package.json
@@ -35,7 +35,8 @@
     "jest": "~24.9.0",
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "typescript": "3.7.2"
   },
   "dependencies": {
     "doctrine": "^2.0.0",
@@ -51,6 +52,7 @@
     "enzyme-adapter-react-16": "^1.0.0",
     "jest": "^24.0.0",
     "react": ">=16.8.0 <17.0.0",
-    "react-dom": ">=16.8.0 <17.0.0"
+    "react-dom": ">=16.8.0 <17.0.0",
+    "typescript": "^3.5.0"
   }
 }

--- a/packages/react-conformance/src/isConformant.ts
+++ b/packages/react-conformance/src/isConformant.ts
@@ -1,26 +1,18 @@
-import * as path from 'path';
 import * as fs from 'fs';
 
 import { IsConformantOptions } from './types';
-import { withCustomConfig } from 'react-docgen-typescript';
 import { defaultTests } from './defaultTests';
 import { merge } from './utils/merge';
+import { getComponentDoc } from './utils/getComponentDoc';
 
 export function isConformant(...testInfo: Partial<IsConformantOptions>[]) {
   const mergedOptions = merge<IsConformantOptions>(...testInfo);
   const { componentPath, displayName, disabledTests = [], extraTests, isInternal } = mergedOptions;
-  const tsconfigPath = path.join(process.cwd(), 'tsconfig.json');
-
   if (!fs.existsSync(componentPath)) {
     throw new Error(`Path ${componentPath} does not exist`);
   }
 
-  // Props need to be filtered since react-docgen shows all the props including props
-  // inherited native props or React built-in props.
-  const parser = withCustomConfig(tsconfigPath, {
-    propFilter: prop => !/@types[\\/]react[\\/]/.test(prop.parent?.fileName || ''),
-  });
-  const components = parser.parse(componentPath);
+  const components = getComponentDoc(componentPath);
   const mainComponents = components.filter(comp => comp.displayName === displayName);
 
   if (mainComponents.length === 1) {
@@ -40,14 +32,12 @@ export function isConformant(...testInfo: Partial<IsConformantOptions>[]) {
         extraTests[test](componentInfo, mergedOptions);
       }
     }
+  } else if (components.length === 0) {
+    throw new Error('No exported components in path: ' + componentPath);
   } else {
-    if (components.length === 0) {
-      throw new Error('No exported components in path: ' + componentPath);
-    } else {
-      throw new Error(
-        `No component with name '${displayName}' was found at ${componentPath}. ` +
-          `These are the exported component names: ${components.map(component => component.displayName).join(', ')}`,
-      );
-    }
+    throw new Error(
+      `No component with name '${displayName}' was found at ${componentPath}. ` +
+        `These are the exported component names: ${components.map(component => component.displayName).join(', ')}`,
+    );
   }
 }

--- a/packages/react-conformance/src/utils/getComponentDoc.ts
+++ b/packages/react-conformance/src/utils/getComponentDoc.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as ts from 'typescript';
+
+import { ComponentDoc, FileParser, withCompilerOptions } from 'react-docgen-typescript';
+
+let program: ts.Program;
+let parser: FileParser;
+
+/**
+ * Run `react-docgen-typescript` on a component file to get info about its props.
+ */
+export function getComponentDoc(componentPath: string): ComponentDoc[] {
+  if (!program) {
+    // Calling parse() from react-docgen-typescript would create a new ts.Program for every component,
+    // which can take multiple seconds in a large project. For better performance, we create a single
+    // ts.Program per package and pass it to parseWithProgramProvider().
+
+    const tsconfigPath = ts.findConfigFile(process.cwd(), fs.existsSync);
+    if (!tsconfigPath) {
+      throw new Error('Cannot find tsconfig.json');
+    }
+
+    const compilerOptions = getCompilerOptions(tsconfigPath);
+
+    // To reduce the number of files parsed, only list the index file as the entry point.
+    // This should work okay because it would be strange if a component being conformance tested
+    // was not also referenced from some file eventually imported by the index file.
+    const rootFile = path.join(path.basename(tsconfigPath), 'src', 'index.ts');
+    if (!fs.existsSync(rootFile)) {
+      throw new Error(`Index file does not exist at expected path ${rootFile}`);
+    }
+
+    program = ts.createProgram([rootFile], compilerOptions);
+
+    parser = withCompilerOptions(compilerOptions, {
+      // Props need to be filtered since react-docgen shows all the props including
+      // inherited native props or React built-in props.
+      propFilter: prop => !/@types[\\/]react[\\/]/.test(prop.parent?.fileName || ''),
+    });
+  }
+
+  if (!program.getSourceFile(componentPath)) {
+    // See earlier comment for why it's handled this way (can reconsider if it becomes a problem)
+    throw new Error(`Component file "${componentPath}" does not appear to be referenced from the project index file`);
+  }
+
+  return parser.parseWithProgramProvider(componentPath, () => program);
+}
+
+function getCompilerOptions(tsconfigPath: string) {
+  const basePath = path.dirname(tsconfigPath);
+  const { config, error } = ts.readConfigFile(tsconfigPath, filename => fs.readFileSync(filename, 'utf8'));
+
+  if (error !== undefined) {
+    const errorText =
+      `Cannot load custom tsconfig.json from provided path: ${tsconfigPath}, ` +
+      `with error code: ${error.code}, message: ${error.messageText}`;
+    throw new Error(errorText);
+  }
+
+  const { options, errors } = ts.parseJsonConfigFileContent(config, ts.sys, basePath, {}, tsconfigPath);
+
+  if (errors && errors.length) {
+    throw errors[0];
+  }
+
+  return options;
+}

--- a/packages/react-conformance/src/utils/getComponentDoc.ts
+++ b/packages/react-conformance/src/utils/getComponentDoc.ts
@@ -26,7 +26,7 @@ export function getComponentDoc(componentPath: string): ComponentDoc[] {
     // To reduce the number of files parsed, only list the index file as the entry point.
     // This should work okay because it would be strange if a component being conformance tested
     // was not also referenced from some file eventually imported by the index file.
-    const rootFile = path.join(path.basename(tsconfigPath), 'src', 'index.ts');
+    const rootFile = path.join(path.dirname(tsconfigPath), 'src', 'index.ts');
     if (!fs.existsSync(rootFile)) {
       throw new Error(`Index file does not exist at expected path ${rootFile}`);
     }


### PR DESCRIPTION
Previously, `isConformant` was creating a new `ts.Program` object for every component conformance tested, under the hood in `react-docgen-typescript`. Creating a `ts.Program` is expensive (multiple seconds) since it requires parsing and type checking all files referenced from the entry point file: **~2-3sec per file** based on some previous experiments I did in v0. (This is also the reason v0 component info generation is slow.)

This PR adds the performance optimization of sharing the same program object for all components from a particular package. The initial creation will take longer since it's parsing the whole package (not just the parts included by the current file) but the overall time will be much faster due to reduced duplication of work.