### PR TITLE
Improve query params for enabling strict/dev mode

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -115,7 +115,7 @@
 <script type="text/javascript">
   // @ts-check
   var isProduction = location.hostname === 'developer.microsoft.com';
-  var isDev = getParameterByName('isDev') === '1';
+  var isDev = getParameterByName('dev') === '1' || !!getParameterByName('strict');
   var devhost = getParameterByName('devhost');
   var entryPointFilename = 'fabric-sitev5';
   var appPath = '';

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -156,7 +156,7 @@
     <script type="text/javascript">
       // @ts-check
       var isLocal = location.hostname === 'localhost' || location.hostname.indexOf('ngrok.io') > -1;
-      var isDev = isLocal || getParameterByName('isDev') === '1';
+      var isDev = isLocal || getParameterByName('dev') === '1' || !!getParameterByName('strict');
       var isProduction = location.hostname === 'developer.microsoft.com' || getParameterByName('isProduction') === '1';
       var devhost = getParameterByName('devhost');
       var entryPointFilename = 'fabric-sitev5';

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -245,12 +245,12 @@
 
       function loadAppScripts() {
         // Load app scripts (we don't need to load React because it's bundled)
-        loadScripts([appPath + entryPointFilename + '.js']);
+        loadScripts([appPath + entryPointFilename + (isDev ? '.js' : '.min.js')]);
 
         // Required configuration to make our Monaco wrapper work
         window.MonacoConfig = {
           baseUrl: appPath,
-          useMinified: isProduction,
+          useMinified: !isDev,
         };
       }
 

--- a/change/@uifabric-example-app-base-2020-08-04-14-07-42-strict-params.json
+++ b/change/@uifabric-example-app-base-2020-08-04-14-07-42-strict-params.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Simplify query params for dev and strict mode testing",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T21:07:42.903Z"
+}

--- a/change/@uifabric-fabric-website-2020-08-04-14-07-42-strict-params.json
+++ b/change/@uifabric-fabric-website-2020-08-04-14-07-42-strict-params.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Simplify query params for dev and strict mode testing",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T21:07:41.842Z"
+}

--- a/packages/example-app-base/index.html
+++ b/packages/example-app-base/index.html
@@ -22,7 +22,7 @@
       var url = document.location.href;
       var isLocalHost = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
 
-      var isDev = getParameterByName('isDev') === '1';
+      var isDev = getParameterByName('dev') === '1' || !!getParameterByName('strict');
       var minParam = getParameterByName('min');
       var useMinified =
         !isDev && minParam !== '0' && (minParam === '1' || location.pathname === '/fabric-react/master/');


### PR DESCRIPTION
Quick follow-up for #14327: right after merging that, I realized it doesn't make sense to require people to type *both* `?strict=all&isDev=1`, and the inconsistent naming was annoying. So...
- Rename `isDev` to `dev`
- Make `strict` imply `dev` (`React.StrictMode` only works in React dev builds)