### PR TITLE
Remove usage of `findDOMNode` from dragDropHelper

### DIFF
--- a/change/office-ui-fabric-react-2020-08-04-22-49-31-v8-drag-drop-helper.json
+++ b/change/office-ui-fabric-react-2020-08-04-22-49-31-v8-drag-drop-helper.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove findDOMNode usage from DragDropHelper",
+  "packageName": "office-ui-fabric-react",
+  "email": "miclo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-04T22:49:31.230Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/DragDropHelper.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { EventGroup, getDocument } from '../../Utilities';
 import { IDragDropHelper, IDragDropTarget, IDragDropOptions, IDragDropEvent, IDragDropContext } from './interfaces';
 import { ISelection } from '../../utilities/selection/interfaces';
@@ -379,9 +377,7 @@ export class DragDropHelper implements IDragDropHelper {
   /**
    * determine whether the child target is a descendant of the parent
    */
-  private _isChild(parent: React.ReactInstance, child: React.ReactInstance): boolean {
-    const parentElement = ReactDOM.findDOMNode(parent);
-    let childElement = ReactDOM.findDOMNode(child);
+  private _isChild(parentElement: HTMLElement, childElement: HTMLElement): boolean {
     while (childElement && childElement.parentElement) {
       if (childElement.parentElement === parentElement) {
         return true;

--- a/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dragdrop/interfaces.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { EventGroup } from '../../Utilities';
 
 /**
@@ -95,7 +94,7 @@ export interface IDragDropContext {
 }
 
 export interface IDragDropTarget {
-  root: React.ReactInstance;
+  root: HTMLElement;
   options: IDragDropOptions;
   key: string;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14321
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was no reason at all to use `findDOMNode` in the first place. Fixing up one interface signature obviates the need for it.

#### Focus areas to test

(optional)
