### PR TITLE
Fix nohoist settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,15 +79,20 @@
       "packages/*",
       "scripts",
       "packages/fluentui/*"
+    ],
+    "nohoist": [
+      "packages/web-components/typescript",
+      "packages/web-components/typescript/**",
+      "packages/web-components/ts-loader",
+      "packages/web-components/ts-loader/**",
+      "packages/web-components/ts-node",
+      "packages/web-components/ts-node/**",
+      "packages/web-components/mocha",
+      "packages/web-components/mocha/**",
+      "packages/web-components/webpack",
+      "packages/web-components/webpack/**"
     ]
   },
-  "nohoist": [
-    "packages/web-components/typescript",
-    "packages/web-components/tsconfig-path",
-    "packages/web-components/ts-loader",
-    "packages/web-components/ts-node",
-    "packages/web-components/mocha/*"
-  ],
   "resolutions": {
     "eslint": "^7.1.0",
     "webpack": "^4.35.0",


### PR DESCRIPTION
People were intermittently hitting typescript build issues in `react-northstar` which @dzearing and I figured out were due to the additional TS version introduced by web-components getting installed at the repo root. That was supposed to be prevented by `nohoist` settings, but it wasn't configured quite correctly (probably thanks to [unclear documentation](https://classic.yarnpkg.com/blog/2018/02/15/nohoist/)). So this PR fixes the settings.