### PR TITLE
Update brand icon usage example on website

### DIFF
--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -1,6 +1,6 @@
 To use the Microsoft 365 multicolor brand icons, select the format and size that best meets your needs. Fluent UI includes a media query that automatically selects the right image file for the pixel density of the screen you’re targeting.
 
-The following code shows you how to specify a 96px product icon by brand using the office-ui-fabric-core css and a `<div>` element:
+The following code shows you how to specify a 96px product icon by brand using the office-ui-fabric-core CSS and a `<div>` element:
 
 ```jsx
 // Sample code for using office-ui-fabric-core version 11.0.0 to display an Word 96x96px Icon

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -12,7 +12,7 @@ The following code shows you how to specify a 96px product icon by brand using t
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
 ```
 
-This following code shows you how to specify a 48px product icon by brand using the office-ui-fabric-core svg and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
+This following code shows you how to specify a 48px product icon by brand using the office-ui-fabric-core SVG and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
 
 ```jsx
 import { Image } from '@fluentui/react';

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -1,8 +1,26 @@
 To use the Microsoft 365 multicolor brand icons, select the format and size that best meets your needs. Fluent UI includes a media query that automatically selects the right image file for the pixel density of the screen you’re targeting.
 
-The following code shows you how to specify a product icon by extension, item type, icon size, and image type using Fluent UI's `<Icon>` component:
+The following code shows you how to specify a 96px product icon by brand using the office-ui-fabric-core css and a `<div>` element:
 
 ```jsx
-// Sample code for displaying an Word 96x96px Icon
+// Sample code for using office-ui-fabric-core version 11.0.0 to display an Word 96x96px Icon
+<link
+  rel="stylesheet"
+  href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"
+/>
+
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word" />
+```
+
+This following code shows you how to specify a 48px product icon by brand using the office-ui-fabric-core svg and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
+
+```jsx
+import { Image } from '@fluentui/react';
+
+<Image 
+  src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/svg/word_48x1.svg" 
+  width={48}
+  height={48}
+  alt="Word product icon" 
+/>
 ```

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -12,7 +12,7 @@ The following code shows you how to specify a 96px product icon by brand using t
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
 ```
 
-This following code shows you how to specify a 48px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) SVG and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
+This following code shows you how to specify a 48px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) SVG and an `<img>` element: 
 
 ```jsx
 <img

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -9,7 +9,7 @@ The following code shows you how to specify a 96px product icon by brand using t
   href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/11.0.0/css/fabric.min.css"
 />
 
-<div class="ms-BrandIcon--icon96 ms-BrandIcon--word" />
+<div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
 ```
 
 This following code shows you how to specify a 48px product icon by brand using the office-ui-fabric-core svg and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):

--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -1,6 +1,6 @@
 To use the Microsoft 365 multicolor brand icons, select the format and size that best meets your needs. Fluent UI includes a media query that automatically selects the right image file for the pixel density of the screen you’re targeting.
 
-The following code shows you how to specify a 96px product icon by brand using the office-ui-fabric-core CSS and a `<div>` element:
+The following code shows you how to specify a 96px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) CSS and a `<div>` element:
 
 ```jsx
 // Sample code for using office-ui-fabric-core version 11.0.0 to display an Word 96x96px Icon
@@ -12,15 +12,13 @@ The following code shows you how to specify a 96px product icon by brand using t
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
 ```
 
-This following code shows you how to specify a 48px product icon by brand using the office-ui-fabric-core SVG and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
+This following code shows you how to specify a 48px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) SVG and a Fluent UI `<Image>` component (a regular `<img>` element can be used too):
 
 ```jsx
-import { Image } from '@fluentui/react';
-
-<Image 
+<img
   src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/svg/word_48x1.svg" 
-  width={48}
-  height={48}
+  width="48"
+  height="48"
   alt="Word product icon" 
 />
 ```

--- a/change/@uifabric-fabric-website-2020-08-04-22-16-52-JustSlone-website-brandIcon.json
+++ b/change/@uifabric-fabric-website-2020-08-04-22-16-52-JustSlone-website-brandIcon.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update brand icon usage example on website",
+  "packageName": "@uifabric/fabric-website",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-05T05:16:52.419Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes a comment raised within #13922
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The current brand icon implementation example doesn't contain enough information to succeed in using the brand icons. In particular, without including the office-ui-fabric-core CSS the example on the page does not work. 

This change updates the CSS based example and adds another example using SVG from the same CDN.

#### Focus areas to test

The website, the brand icon page in particular (/styles/web/office-brand-icons)
