### PR TITLE
Toggle: fix thumb border width style

### DIFF
--- a/change/@fluentui-react-next-2020-08-05-10-59-22-checkbox-border-width.json
+++ b/change/@fluentui-react-next-2020-08-05-10-59-22-checkbox-border-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Toggle: Fix thumb border-width style",
+  "packageName": "@fluentui/react-next",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T17:59:22.409Z"
+}

--- a/change/office-ui-fabric-react-2020-08-05-10-29-45-checkbox-border-width.json
+++ b/change/office-ui-fabric-react-2020-08-05-10-29-45-checkbox-border-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix border width styling for toggle icon image",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T17:29:45.730Z"
+}

--- a/change/office-ui-fabric-react-2020-08-05-10-29-45-checkbox-border-width.json
+++ b/change/office-ui-fabric-react-2020-08-05-10-29-45-checkbox-border-width.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix border width styling for toggle icon image",
+  "comment": "Toggle: fix thumb border width style",
   "packageName": "office-ui-fabric-react",
   "email": "ololubek@microsoft.com",
   "dependentChangeType": "patch",

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -182,7 +182,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
         backgroundColor: thumbBackground,
         /* Border is added to handle high contrast mode for Firefox */
         borderColor: 'transparent',
-        borderWidth: '.28em',
+        borderWidth: DEFAULT_THUMB_SIZE / 2,
         borderStyle: 'solid',
         boxSizing: 'border-box',
       },

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -88,7 +88,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
               border-color: transparent;
               border-radius: 50%;
               border-style: solid;
-              border-width: .28em;
+              border-width: 6px;
               box-sizing: border-box;
               display: block;
               height: 12px;
@@ -218,7 +218,7 @@ exports[`Toggle renders toggle correctly 1`] = `
               border-color: transparent;
               border-radius: 50%;
               border-style: solid;
-              border-width: .28em;
+              border-width: 6px;
               box-sizing: border-box;
               display: block;
               height: 12px;
@@ -354,7 +354,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
               border-color: transparent;
               border-radius: 50%;
               border-style: solid;
-              border-width: .28em;
+              border-width: 6px;
               box-sizing: border-box;
               display: block;
               height: 12px;
@@ -488,7 +488,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
               border-color: transparent;
               border-radius: 50%;
               border-style: solid;
-              border-width: .28em;
+              border-width: 6px;
               box-sizing: border-box;
               display: block;
               height: 12px;
@@ -621,7 +621,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
               border-color: transparent;
               border-radius: 50%;
               border-style: solid;
-              border-width: .28em;
+              border-width: 6px;
               box-sizing: border-box;
               display: block;
               height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1360,7 +1360,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -541,7 +541,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -673,7 +673,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -151,7 +151,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;
@@ -325,7 +325,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -135,7 +135,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -253,7 +253,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;
@@ -388,7 +388,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -119,7 +119,7 @@ Array [
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -119,7 +119,7 @@ Array [
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -126,7 +126,7 @@ Array [
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -140,7 +140,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -161,7 +161,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -343,7 +343,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     border-color: transparent;
                     border-radius: 50%;
                     border-style: solid;
-                    border-width: .28em;
+                    border-width: 6px;
                     box-sizing: border-box;
                     display: block;
                     height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -343,7 +343,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     border-color: transparent;
                     border-radius: 50%;
                     border-style: solid;
-                    border-width: .28em;
+                    border-width: 6px;
                     box-sizing: border-box;
                     display: block;
                     height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -161,7 +161,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -162,7 +162,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     border-color: transparent;
                     border-radius: 50%;
                     border-style: solid;
-                    border-width: .28em;
+                    border-width: 6px;
                     box-sizing: border-box;
                     display: block;
                     height: 12px;
@@ -491,7 +491,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         border-color: transparent;
                         border-radius: 50%;
                         border-style: solid;
-                        border-width: .28em;
+                        border-width: 6px;
                         box-sizing: border-box;
                         display: block;
                         height: 12px;
@@ -820,7 +820,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                             border-color: transparent;
                             border-radius: 50%;
                             border-style: solid;
-                            border-width: .28em;
+                            border-width: 6px;
                             box-sizing: border-box;
                             display: block;
                             height: 12px;
@@ -1162,7 +1162,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                             border-color: transparent;
                             border-radius: 50%;
                             border-style: solid;
-                            border-width: .28em;
+                            border-width: 6px;
                             box-sizing: border-box;
                             display: block;
                             height: 12px;
@@ -1516,7 +1516,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         border-color: transparent;
                         border-radius: 50%;
                         border-style: solid;
-                        border-width: .28em;
+                        border-width: 6px;
                         box-sizing: border-box;
                         display: block;
                         height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/GroupedList.CustomCheckbox.Example.tsx.shot
@@ -277,7 +277,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                       border-color: transparent;
                                       border-radius: 50%;
                                       border-style: solid;
-                                      border-width: .28em;
+                                      border-width: 6px;
                                       box-sizing: border-box;
                                       display: block;
                                       height: 12px;
@@ -2246,7 +2246,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                       border-color: transparent;
                                       border-radius: 50%;
                                       border-style: solid;
-                                      border-width: .28em;
+                                      border-width: 6px;
                                       box-sizing: border-box;
                                       display: block;
                                       height: 12px;
@@ -4215,7 +4215,7 @@ exports[`Component Examples renders GroupedList.CustomCheckbox.Example.tsx corre
                                       border-color: transparent;
                                       border-radius: 50%;
                                       border-style: solid;
-                                      border-width: .28em;
+                                      border-width: 6px;
                                       box-sizing: border-box;
                                       display: block;
                                       height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1096,7 +1096,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                         border-color: transparent;
                         border-radius: 50%;
                         border-style: solid;
-                        border-width: .28em;
+                        border-width: 6px;
                         box-sizing: border-box;
                         display: block;
                         height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1126,7 +1126,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -123,7 +123,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -138,7 +138,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -270,7 +270,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -134,7 +134,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -298,7 +298,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -473,7 +473,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -123,7 +123,7 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -125,7 +125,7 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
@@ -123,7 +123,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3710,7 +3710,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;
@@ -3838,7 +3838,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;
@@ -3966,7 +3966,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                   border-color: transparent;
                   border-radius: 50%;
                   border-style: solid;
-                  border-width: .28em;
+                  border-width: 6px;
                   box-sizing: border-box;
                   display: block;
                   height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -125,7 +125,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -104,7 +104,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -468,7 +468,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -144,7 +144,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -143,7 +143,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -316,7 +316,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -482,7 +482,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -649,7 +649,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -825,7 +825,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -991,7 +991,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -1168,7 +1168,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -1293,7 +1293,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -1425,7 +1425,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -171,7 +171,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;
@@ -376,7 +376,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
@@ -123,7 +123,7 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
                 border-color: transparent;
                 border-radius: 50%;
                 border-style: solid;
-                border-width: .28em;
+                border-width: 6px;
                 box-sizing: border-box;
                 display: block;
                 height: 12px;

--- a/packages/react-next/src/components/Toggle/Toggle.scss
+++ b/packages/react-next/src/components/Toggle/Toggle.scss
@@ -119,7 +119,7 @@ $DEFAULT_THUMB_SIZE: 12px;
   // Border is added to handle high contrast mode for Firefox.
   border-color: transparent;
   border-style: solid;
-  border-width: 0.28em;
+  border-width: $DEFAULT_THUMB_SIZE / 2;
 
   &.checked {
     background-color: var($semanticColorsInputForegroundChecked);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There is a tiny dot in the thumb of the Toggle which doesn't need to be there. This PR removes the tiny dot.

**Before**
![image](https://user-images.githubusercontent.com/66456876/89445666-51c81a00-d708-11ea-8196-a29e8c3e7082.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89445739-69070780-d708-11ea-8c2a-fb4f65e1414b.png)


#### Focus areas to test

(optional)
