### PR TITLE
chore: add typescript as explicit dev dependency to react-northstar

### DIFF
--- a/packages/fluentui/ability-attributes/package.json
+++ b/packages/fluentui/ability-attributes/package.json
@@ -8,7 +8,8 @@
     "ability-attributes": "^0.0.8"
   },
   "devDependencies": {
-    "ability-attributes-generator": "^0.0.8"
+    "ability-attributes-generator": "^0.0.8",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -15,7 +15,8 @@
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "gulp": "^4.0.2",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/code-sandbox/package.json
+++ b/packages/fluentui/code-sandbox/package.json
@@ -12,7 +12,8 @@
     "@fluentui/eslint-plugin": "^0.53.2",
     "@fluentui/react-northstar": "^0.51.0",
     "@uifabric/build": "^7.0.0",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/digest/package.json
+++ b/packages/fluentui/digest/package.json
@@ -24,7 +24,8 @@
   },
   "devDependencies": {
     "@types/node": "^10.3.2",
-    "@types/webpack": "4.4.0"
+    "@types/webpack": "4.4.0",
+    "typescript": "3.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/docs-components/package.json
+++ b/packages/fluentui/docs-components/package.json
@@ -21,7 +21,8 @@
     "@uifabric/build": "^7.0.0",
     "gulp": "^4.0.2",
     "prettier": "~1.19.1",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/docs/package.json
+++ b/packages/fluentui/docs/package.json
@@ -59,7 +59,8 @@
     "@types/react-virtualized": "^9.21.8",
     "@types/webpack-env": "1.15.1",
     "@uifabric/build": "^7.0.0",
-    "gulp": "^4.0.2"
+    "gulp": "^4.0.2",
+    "typescript": "3.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/e2e/package.json
+++ b/packages/fluentui/e2e/package.json
@@ -21,6 +21,9 @@
     "react-dom": "16.8.6",
     "react-router-dom": "^5.2.0"
   },
+  "devDependencies": {
+    "typescript": "3.7.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -25,7 +25,8 @@
     "just-scripts": "0.43.1",
     "node-fetch": "^2.6.0",
     "react": "16.8.6",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "typescript": "3.7.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fluentui/perf/package.json
+++ b/packages/fluentui/perf/package.json
@@ -17,6 +17,9 @@
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },
+  "devDependencies": {
+    "typescript": "3.7.2"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -28,7 +28,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -22,7 +22,8 @@
     "@fluentui/eslint-plugin": "^0.53.2",
     "@types/react-frame-component": "^4.1.1",
     "@uifabric/build": "^7.0.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "typescript": "3.7.2"
   },
   "peerDependencies": {
     "@babel/standalone": "^7.8.3"

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -14,7 +14,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "simulant": "^0.2.2"
+    "simulant": "^0.2.2",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -13,7 +13,8 @@
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -16,7 +16,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-context-selector/package.json
+++ b/packages/fluentui/react-context-selector/package.json
@@ -14,7 +14,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "react-is": "^16.6.3"
+    "react-is": "^16.6.3",
+    "typescript": "3.7.2"
   },
   "peerDependencies": {
     "react": "^16.8.0"

--- a/packages/fluentui/react-icons-northstar/package.json
+++ b/packages/fluentui/react-icons-northstar/package.json
@@ -19,7 +19,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "react-is": "^16.6.3"
+    "react-is": "^16.6.3",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-northstar-emotion-renderer/package.json
+++ b/packages/fluentui/react-northstar-emotion-renderer/package.json
@@ -19,7 +19,8 @@
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-northstar-fela-renderer/package.json
+++ b/packages/fluentui/react-northstar-fela-renderer/package.json
@@ -24,7 +24,8 @@
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-northstar-styles-renderer/package.json
+++ b/packages/fluentui/react-northstar-styles-renderer/package.json
@@ -12,7 +12,8 @@
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
-    "react": "16.8.6"
+    "react": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-northstar/package.json
+++ b/packages/fluentui/react-northstar/package.json
@@ -51,7 +51,8 @@
     "qs": "^6.8.0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
-    "simulant": "^0.2.2"
+    "simulant": "^0.2.2",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -13,7 +13,8 @@
     "@fluentui/eslint-plugin": "^0.53.2",
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/react-telemetry/package.json
+++ b/packages/fluentui/react-telemetry/package.json
@@ -19,7 +19,8 @@
     "@uifabric/build": "^7.0.0",
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
-    "react-dom": "16.8.6"
+    "react-dom": "16.8.6",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.53.2",
     "@uifabric/build": "^7.0.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -13,7 +13,8 @@
     "@fluentui/eslint-plugin": "^0.53.2",
     "@types/react": "16.8.25",
     "@uifabric/build": "^7.0.0",
-    "lerna-alias": "^3.0.3-0"
+    "lerna-alias": "^3.0.3-0",
+    "typescript": "3.7.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
This PR adds typescript as an explicit dev dependency for react-northstar. For some reason, it was building with TS version of ^3.9.x. My working assumption is that it defaulted to an installed version as one was not explicitly defined in the package.json.

#### Focus areas to test
The build passes 😄 
