### PR TITLE
Dropdown: Fixing multiselect scenarios not reading out aria-setsize and aria-posinset due to incorrect placement of role=option in Checkbox

### DIFF
--- a/change/office-ui-fabric-react-2020-08-05-13-56-49-multiSelectDropdownAria.json
+++ b/change/office-ui-fabric-react-2020-08-05-13-56-49-multiSelectDropdownAria.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Fixing multiselect scenarios not reading out aria-setsize and aria-posinset due to incorrect placement of role=option in Checkbox.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T20:56:49.492Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -747,17 +747,17 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
         disabled={item.disabled}
         onChange={this._onItemClick(item)}
         inputProps={{
+          'aria-selected': isItemSelected,
           onMouseEnter: this._onItemMouseEnter.bind(this, item),
           onMouseLeave: this._onMouseItemLeave.bind(this, item),
           onMouseMove: this._onItemMouseMove.bind(this, item),
+          role: 'option',
         }}
         label={item.text}
         title={title}
         // eslint-disable-next-line react/jsx-no-bind
         onRenderLabel={this._onRenderItemLabel.bind(this, item)}
         className={itemClassName}
-        role="option"
-        aria-selected={isItemSelected ? 'true' : 'false'}
         checked={isItemSelected}
         styles={multiSelectItemStyles}
         ariaPositionInSet={this._sizePosCache.positionInSet(item.index)}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14300
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was an issue with multiselect `Dropdowns` where, when expanded, screen readers weren't reading `aria-posinset` and `aria-setsize` information. This was happening due to the `role='option'` being applied incorrectly. This PR places it correctly to fix this issue.

In testing it was also noticed that a similar thing was happening with all options reading as `non-selected` by screen readers given an incorrect placement of `aria-selected`. This PR similarly fixes that issue by moving `aria-selected` to the correct place.

#### Focus areas to test

(optional)
