### PR TITLE
Spinner: Fix HC styling for spinner to show spinner color

### DIFF
--- a/change/office-ui-fabric-react-2020-08-05-15-38-44-a11y-spinner.json
+++ b/change/office-ui-fabric-react-2020-08-05-15-38-44-a11y-spinner.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Spinner: Fix HC styling of spinner componet to show highlight color",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-05T22:38:43.868Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.styles.tsx
@@ -1,5 +1,11 @@
 import { ISpinnerStyleProps, ISpinnerStyles, SpinnerSize } from './Spinner.types';
-import { hiddenContentStyle, keyframes, HighContrastSelector, getGlobalClassNames } from '../../Styling';
+import {
+  hiddenContentStyle,
+  keyframes,
+  HighContrastSelector,
+  getGlobalClassNames,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+} from '../../Styling';
 import { memoizeFunction } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -61,6 +67,7 @@ export const getStyles = (props: ISpinnerStyleProps): ISpinnerStyles => {
           [HighContrastSelector]: {
             borderTopColor: 'Highlight',
           },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       size === SpinnerSize.xSmall && [

--- a/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Spinner/__snapshots__/Spinner.test.tsx.snap
@@ -30,6 +30,9 @@ exports[`Spinner renders Spinner correctly 1`] = `
         @media screen and (-ms-high-contrast: active){& {
           border-top-color: Highlight;
         }
+        @media screen and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   />
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
@@ -100,6 +100,9 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       />
     </div>
   </div>
@@ -180,6 +183,9 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       />
     </div>
@@ -262,6 +268,9 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       />
     </div>
   </div>
@@ -342,6 +351,9 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             }
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       />
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
@@ -80,6 +80,9 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       />
       <div
         className=
@@ -158,6 +161,9 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             }
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       />
       <div
@@ -238,6 +244,9 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       />
       <div
         className=
@@ -316,6 +325,9 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             }
             @media screen and (-ms-high-contrast: active){& {
               border-top-color: Highlight;
+            }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       />
       <div


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Before in Edge chromium Spinner component shows as white in HC, making it hard to see. This fix shows the Spinner component with a highlight color to improve visibility.

**Before**
![image](https://user-images.githubusercontent.com/66456876/89471291-9cf72280-d732-11ea-92f5-b59208c9d895.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89471305-ab453e80-d732-11ea-9c6a-b880473ba6ea.png)

Part of #13012 mega issue list

#### Focus areas to test

(optional)
