### PR TITLE
FocusTrapZone: Adding aria-hidden to bumper elements so that they are not read by screen readers

### DIFF
--- a/change/@fluentui-react-next-2020-08-05-17-51-12-focusTrapZoneAriaHidden.json
+++ b/change/@fluentui-react-next-2020-08-05-17-51-12-focusTrapZoneAriaHidden.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "FocusTrapZone: Adding aria-hidden to bumper elements so that they are not read by screen readers.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T00:51:12.447Z"
+}

--- a/change/office-ui-fabric-react-2020-08-05-17-51-12-focusTrapZoneAriaHidden.json
+++ b/change/office-ui-fabric-react-2020-08-05-17-51-12-focusTrapZoneAriaHidden.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusTrapZone: Adding aria-hidden to bumper elements so that they are not read by screen readers.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T00:51:10.340Z"
+}

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -26,6 +26,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Fix bidirectional `FocusZone` to land focus correctly on DOWN key press after series of UP arrow keys @sophieH29 ([#1794](https://github.com/stardust-ui/react/pull/1794))
 - Use always `getDocument` to correctly define current document object @sophieH29 ([#1820](https://github.com/stardust-ui/react/pull/1820))
 - Fix element reference memory leaks - Fabric PR 11618 @jurokapsiar ([#2270](https://github.com/microsoft/fluent-ui-react/pull/2270))
+- Adding aria-hidden to bumper elements so that they are not read by screen readers @khmakoto ([#14376](https://github.com/microsoft/fluentui/pull/14376))
 
 ### Features
 - Add embed mode for FocusZone and new Chat behavior ([#233](https://github.com/stardust-ui/react/pull/233))

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.tsx
@@ -126,6 +126,7 @@ export class FocusTrapZone extends React.Component<FocusTrapZoneProps, {}> {
     const ElementType = getElementType(this.props);
 
     const bumperProps = {
+      'aria-hidden': true,
       style: {
         pointerEvents: 'none',
         position: 'fixed', // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.deprecated.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -293,6 +294,7 @@ exports[`Dialog deprecated props renders Dialog with className 1`] = `
             </div>
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -447,6 +449,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -603,6 +606,7 @@ exports[`Dialog deprecated props renders Dialog with containerClassName 1`] = `
             </div>
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -757,6 +761,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -1045,6 +1050,7 @@ exports[`Dialog deprecated props renders Dialog with isBlocking set to true 1`] 
             </div>
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -1199,6 +1205,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -1355,6 +1362,7 @@ exports[`Dialog deprecated props renders Dialog with isDarkOverlay set to true 1
             </div>
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -111,6 +111,7 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     const bumperProps = {
+      'aria-hidden': true,
       style: {
         pointerEvents: 'none',
         position: 'fixed', // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -149,6 +150,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -289,6 +291,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -314,6 +317,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
           }
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -151,6 +152,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -305,6 +307,7 @@ exports[`Modal renders Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -331,6 +334,7 @@ exports[`Modal renders Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -463,6 +467,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -489,6 +494,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -153,6 +153,7 @@ exports[`Panel renders Panel correctly 1`] = `
           style={Object {}}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -380,6 +381,7 @@ exports[`Panel renders Panel correctly 1`] = `
             </div>
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -580,6 +581,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
       </button>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -141,6 +142,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -184,6 +186,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -254,6 +257,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -293,6 +297,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -848,6 +853,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
       </button>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -887,6 +893,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -932,6 +939,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -971,6 +979,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1045,6 +1054,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1084,6 +1094,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1192,6 +1203,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1268,6 +1280,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1338,6 +1351,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1377,6 +1391,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1453,6 +1468,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -832,6 +832,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 onFocusCapture={[Function]}
                               >
                                 <div
+                                  aria-hidden={true}
                                   data-is-visible={true}
                                   onFocus={[Function]}
                                   style={
@@ -884,6 +885,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                         onFocusCapture={[Function]}
                                       >
                                         <div
+                                          aria-hidden={true}
                                           data-is-visible={true}
                                           onFocus={[Function]}
                                           style={
@@ -1100,6 +1102,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                           </button>
                                         </div>
                                         <div
+                                          aria-hidden={true}
                                           data-is-visible={true}
                                           onFocus={[Function]}
                                           style={
@@ -1115,6 +1118,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                   </div>
                                 </div>
                                 <div
+                                  aria-hidden={true}
                                   data-is-visible={true}
                                   onFocus={[Function]}
                                   style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -7,6 +7,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
   onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={
@@ -444,6 +445,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
     </a>
   </div>
   <div
+    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -189,6 +189,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -626,6 +627,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
       </a>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -189,6 +189,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -627,6 +628,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
       </a>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -7,6 +7,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
   onFocusCapture={[Function]}
 >
   <div
+    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={
@@ -1101,6 +1102,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
     </div>
   </div>
   <div
+    aria-hidden={true}
     data-is-visible={true}
     onFocus={[Function]}
     style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -8,6 +8,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -336,6 +337,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         onFocusCapture={[Function]}
       >
         <div
+          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -665,6 +667,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -990,6 +993,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               </button>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1007,6 +1011,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1332,6 +1337,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               </button>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -1345,6 +1351,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </div>
         </div>
         <div
+          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1362,6 +1369,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         onFocusCapture={[Function]}
       >
         <div
+          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1686,6 +1694,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
           </button>
         </div>
         <div
+          aria-hidden={true}
           data-is-visible={true}
           onFocus={[Function]}
           style={
@@ -1699,6 +1708,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/react-next/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -95,6 +95,7 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     const bumperProps = {
+      'aria-hidden': true,
       style: {
         pointerEvents: 'none',
         position: 'fixed', // 'fixed' prevents browsers from scrolling to bumpers when viewport does not contain them

--- a/packages/react-next/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/react-next/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
           }
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -151,6 +152,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -304,6 +306,7 @@ exports[`Modal renders Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -330,6 +333,7 @@ exports[`Modal renders Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -462,6 +466,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
           onFocusCapture={[Function]}
         >
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={
@@ -488,6 +493,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
             Test Content
           </div>
           <div
+            aria-hidden={true}
             data-is-visible={true}
             onFocus={[Function]}
             style={

--- a/packages/react-next/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/react-next/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -25,6 +25,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -580,6 +581,7 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
       </button>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={

--- a/packages/react-next/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/react-next/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -96,6 +96,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
             onFocusCapture={[Function]}
           >
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -141,6 +142,7 @@ exports[`TeachingBubble renders TeachingBubble correctly 1`] = `
               </div>
             </div>
             <div
+              aria-hidden={true}
               data-is-visible={true}
               onFocus={[Function]}
               style={
@@ -184,6 +186,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -254,6 +257,7 @@ exports[`TeachingBubble renders TeachingBubbleContent correctly 1`] = `
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -293,6 +297,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -848,6 +853,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
       </button>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -887,6 +893,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -932,6 +939,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with calloutProps that dea
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -971,6 +979,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1045,6 +1054,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1084,6 +1094,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1192,6 +1203,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1268,6 +1280,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1338,6 +1351,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with image correctly 1`] =
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1377,6 +1391,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
     onFocusCapture={[Function]}
   >
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={
@@ -1453,6 +1468,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
       </div>
     </div>
     <div
+      aria-hidden={true}
       data-is-visible={true}
       onFocus={[Function]}
       style={


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14241
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `aria-hidden='true'` to bumper elements in the `FocusTrapZone` component so they are not read by screen readers, as they are just there for functionality purposes and could confuse the users if read.

#### Focus areas to test

(optional)
