### PR TITLE
react-cards: Importing Stack from lib specific path.

### DIFF
--- a/change/@uifabric-react-cards-2020-08-05-18-19-42-reactCardsImports.json
+++ b/change/@uifabric-react-cards-2020-08-05-18-19-42-reactCardsImports.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "react-cards: Importing Stack from lib specific path.",
+  "packageName": "@uifabric/react-cards",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T01:19:42.185Z"
+}

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { withSlots, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties, warn, KeyCodes } from '@uifabric/utilities';
-import { Stack, IStackComponent } from 'office-ui-fabric-react';
+import { Stack, IStackComponent } from 'office-ui-fabric-react/lib/Stack';
 
 import { ICardComponent, ICardProps, ICardSlots, ICardTokens } from './Card.types';
 import { CardItem } from './CardItem/CardItem';

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.view.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.view.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { withSlots, getSlots } from '@uifabric/foundation';
-import { Stack } from 'office-ui-fabric-react';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { ICardItemComponent, ICardItemProps, ICardItemSlots } from './CardItem.types';
 
 export const CardItemView: ICardItemComponent['view'] = props => {

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.view.tsx
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.view.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { withSlots, getSlots } from '@uifabric/foundation';
-import { Stack } from 'office-ui-fabric-react';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { ICardSectionComponent, ICardSectionProps, ICardSectionSlots } from './CardSection.types';
 
 export const CardSectionView: ICardSectionComponent['view'] = props => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13918
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#13918 indicated that, under some configurations, the imports directly from `office-ui-fabric-react` were causing trouble in the `react-cards` package. This PR fixes this by importing from the `lib` path.

#### Focus areas to test

(optional)
