### PR TITLE
Fix input and label IDs not respected by choice group option.

### DIFF
--- a/change/office-ui-fabric-react-2020-08-06-21-05-55-master.json
+++ b/change/office-ui-fabric-react-2020-08-06-21-05-55-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix input and label IDs not respected by choice group option.",
+  "packageName": "office-ui-fabric-react",
+  "email": "supsing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T15:35:55.174Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -234,7 +234,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
   }
 
   private _getOptionId(option: IChoiceGroupOption): string {
-    return option.id ? option.id : `${this._id}-${option.key}`;
+    return option.id || `${this._id}-${option.key}`;
   }
 
   private _getOptionLabelId(option: IChoiceGroupOption): string {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -238,7 +238,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
   }
 
   private _getOptionLabelId(option: IChoiceGroupOption): string {
-    return option.labelId ? option.labelId : `${this._labelId}-${option.key}`; 
+    return option.labelId || `${this._labelId}-${option.key}`; 
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -137,7 +137,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
                 checked: option.key === keyChecked,
                 disabled: option.disabled || disabled,
                 id: this._getOptionId(option),
-                labelId: `${this._labelId}-${option.key}`,
+                labelId: this._getOptionLabelId(option),
                 name: name || this._id,
                 required,
               };
@@ -234,7 +234,11 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
   }
 
   private _getOptionId(option: IChoiceGroupOption): string {
-    return `${this._id}-${option.key}`;
+    return option.id ? option.id : `${this._id}-${option.key}`;
+  }
+
+  private _getOptionLabelId(option: IChoiceGroupOption): string {
+    return option.labelId ? option.labelId : `${this._labelId}-${option.key}`; 
   }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14386
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Passed the correct input and label id's to ChoiceGroupOption.

#### Focus areas to test

Please refer to the issue linked above for more details.
