### PR TITLE
Remove trailing whitespace from BrandIcon markdown file

### DIFF
--- a/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/OfficeBrandIconsPage/docs/web/OfficeBrandIconsImplementation.md
@@ -12,13 +12,13 @@ The following code shows you how to specify a 96px product icon by brand using t
 <div class="ms-BrandIcon--icon96 ms-BrandIcon--word"></div>
 ```
 
-This following code shows you how to specify a 48px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) SVG and an `<img>` element: 
+This following code shows you how to specify a 48px product icon by brand using the [office-ui-fabric-core](https://github.com/OfficeDev/office-ui-fabric-core) SVG and an `<img>` element:
 
 ```jsx
 <img
-  src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/svg/word_48x1.svg" 
+  src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/product/svg/word_48x1.svg"
   width="48"
   height="48"
-  alt="Word product icon" 
+  alt="Word product icon"
 />
 ```

--- a/change/@uifabric-fabric-website-2020-08-06-08-35-34-JustSlone-BrandIcon-whitespace.json
+++ b/change/@uifabric-fabric-website-2020-08-06-08-35-34-JustSlone-BrandIcon-whitespace.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Remove trailing whitespace from markdown file",
+  "comment": "Remove trailing whitespace from OfficeBrandIconsImplementation.md",
   "packageName": "@uifabric/fabric-website",
   "email": "jslone@microsoft.com",
   "dependentChangeType": "none",

--- a/change/@uifabric-fabric-website-2020-08-06-08-35-34-JustSlone-BrandIcon-whitespace.json
+++ b/change/@uifabric-fabric-website-2020-08-06-08-35-34-JustSlone-BrandIcon-whitespace.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove trailing whitespace from markdown file",
+  "packageName": "@uifabric/fabric-website",
+  "email": "jslone@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-06T15:35:34.817Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Editing OfficeBrandIconsImplementation.md in the GitHub markdown editor seems to have left trailing whitespace, which is getting normalized by our pre-commit hook, resulting in unwanted additional changes for folks working in the repo.

This commit runs prettier on the file 

#### Focus areas to test

Website brand icon page
