### PR TITLE
[Date-time] IWeeklyDayPickerProps extends ICalendarDayGridProps

### DIFF
--- a/change/@uifabric-date-time-2020-08-06-10-58-22-lorejoh12-weeklyDayPickerDayGridProps.json
+++ b/change/@uifabric-date-time-2020-08-06-10-58-22-lorejoh12-weeklyDayPickerDayGridProps.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding dayGridProps to weeklyDayPicker so it can pass them through to the underlying day grid. Adding example of marking days to show usage",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T17:58:22.931Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -315,7 +315,7 @@ export interface IWeeklyDayPicker {
 }
 
 // @public (undocumented)
-export interface IWeeklyDayPickerProps extends IBaseProps<IWeeklyDayPicker> {
+export interface IWeeklyDayPickerProps extends IBaseProps<IWeeklyDayPicker>, Partial<ICalendarDayGridProps> {
     animationDirection?: AnimationDirection;
     className?: string;
     componentRef?: IRefObject<IWeeklyDayPicker>;

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -166,6 +166,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
       className,
       showFullMonth,
       weeksToShow,
+      ...calendarDayGridProps
     } = this.props;
 
     const classNames = getClassNames(styles, {
@@ -183,6 +184,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
       >
         {this._renderPreviousWeekNavigationButton(classNames)}
         <CalendarDayGrid
+          {...calendarDayGridProps}
           styles={styles}
           componentRef={this._dayGrid}
           strings={strings}

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.types.ts
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.types.ts
@@ -7,13 +7,17 @@ import {
   AnimationDirection,
 } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '@uifabric/styling';
-import { ICalendarDayGridStyleProps, ICalendarDayGridStyles } from '../CalendarDayGrid/CalendarDayGrid.types';
+import {
+  ICalendarDayGridProps,
+  ICalendarDayGridStyleProps,
+  ICalendarDayGridStyles,
+} from '../CalendarDayGrid/CalendarDayGrid.types';
 
 export interface IWeeklyDayPicker {
   focus(): void;
 }
 
-export interface IWeeklyDayPickerProps extends IBaseProps<IWeeklyDayPicker> {
+export interface IWeeklyDayPickerProps extends IBaseProps<IWeeklyDayPicker>, Partial<ICalendarDayGridProps> {
   /**
    * Optional callback to access the IWeeklyDayPicker interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.MarkedDays.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.MarkedDays.Example.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { WeeklyDayPicker, DayOfWeek, addDays, defaultWeeklyDayPickerStrings } from '@uifabric/date-time';
+import { mergeStyleSets } from '@uifabric/styling';
+
+const styles = mergeStyleSets({
+  wrapper: { height: 340 },
+  button: { margin: '17px 10px 0 0' },
+});
+
+export const WeeklyDayPickerInlineMarkedDaysExample = () => {
+  const [selectedDate, setSelectedDate] = React.useState<Date>(new Date());
+
+  return (
+    <div className={styles.wrapper}>
+      <div>
+        Selected date(s): <span>{!selectedDate ? 'Not set' : selectedDate.toLocaleString()}</span>
+      </div>
+      <WeeklyDayPicker
+        onSelectDate={setSelectedDate}
+        firstDayOfWeek={DayOfWeek.Sunday}
+        strings={defaultWeeklyDayPickerStrings}
+        initialDate={selectedDate}
+        getMarkedDays={getMarkedDays}
+      />
+    </div>
+  );
+};
+
+function getMarkedDays(startingDate: Date, endingDate: Date): Date[] {
+  return [addDays(startingDate, 3), addDays(startingDate, 4)];
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changing IWeeklyDayPickerProps to extend ICalendarDayGridProps. The WeeklyDayPicker wraps a CalendarDayGrid, so we should be able to pass through custom props, this means for future props added to CalendarDayGrid the WeeklyDayPicker will get them for free. Adding an example to show usage of marking days to demonstrate.

#### Focus areas to test

(optional)
