### PR TITLE
useCustomizationSettings: fix bug on reading from context, use it in styled

### DIFF
--- a/change/@uifabric-utilities-2020-08-06-15-07-54-xgao-useCustomizationsettings.json
+++ b/change/@uifabric-utilities-2020-08-06-15-07-54-xgao-useCustomizationsettings.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "useCustomizationSettings: fix not getting correct settings from context when context updates, use it in styled",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-06T22:07:54.056Z"
+}

--- a/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
+++ b/packages/utilities/src/customizations/useCustomizationSettings.test.tsx
@@ -85,5 +85,37 @@ describe('useCustomizatioSettings', () => {
     );
     expect(settingsStates.length).toBe(1);
     expect(settingsStates[0]).toEqual({ theme: { color: 'red' } });
+
+    const updatedContext = { customizations: { settings: { theme: { color: 'green' } }, scopedSettings: {} } };
+    wrapper.setProps({ value: updatedContext });
+
+    expect(settingsStates.length).toBe(2);
+    expect(settingsStates[1]).toEqual({ theme: { color: 'green' } });
+  });
+
+  it('does not re-render if global settings update but within context', () => {
+    Customizations.applySettings({ a: 'a' });
+    const settingsStates: ISettings[] = [];
+
+    const TestComponent: React.FunctionComponent = () => {
+      const settings = useCustomizationSettings(['a']);
+
+      settingsStates.push(settings);
+      return null;
+    };
+
+    const newContext = { customizations: { settings: { a: 'aa' }, scopedSettings: {}, inCustomizerContext: true } };
+    wrapper = mount(
+      <CustomizerContext.Provider value={newContext}>
+        <TestComponent />
+      </CustomizerContext.Provider>,
+    );
+
+    ReactTestUtils.act(() => {
+      Customizations.applySettings({ a: 'aaa' });
+    });
+
+    expect(settingsStates.length).toBe(1);
+    expect(settingsStates[0]).toEqual({ a: 'aa' });
   });
 });

--- a/packages/utilities/src/customizations/useCustomizationSettings.ts
+++ b/packages/utilities/src/customizations/useCustomizationSettings.ts
@@ -8,25 +8,24 @@ import { CustomizerContext } from './CustomizerContext';
  */
 export function useCustomizationSettings(properties: string[], scopeName?: string): ISettings {
   const forceUpdate = useForceUpdate();
-  const customizerContext = React.useContext(CustomizerContext);
-  const localSettings = customizerContext.customizations;
-
+  const { customizations } = React.useContext(CustomizerContext);
+  const { inCustomizerContext } = customizations;
   React.useEffect(() => {
-    if (!localSettings.inCustomizerContext) {
+    if (!inCustomizerContext) {
       Customizations.observe(forceUpdate);
     }
     return () => {
-      if (!localSettings.inCustomizerContext) {
+      if (!inCustomizerContext) {
         Customizations.unobserve(forceUpdate);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- exclude forceUpdate
-  }, [localSettings.inCustomizerContext]);
+  }, [inCustomizerContext]);
 
-  return Customizations.getSettings(properties, scopeName, localSettings);
+  return Customizations.getSettings(properties, scopeName, customizations);
 }
 
 function useForceUpdate() {
-  const [, reducer] = React.useReducer((state: number) => state + 1, 0);
-  return () => reducer(null);
+  const [, setValue] = React.useState(0);
+  return () => setValue(value => ++value);
 }

--- a/packages/utilities/src/customizations/useCustomizationSettings.ts
+++ b/packages/utilities/src/customizations/useCustomizationSettings.ts
@@ -14,8 +14,12 @@ export function useCustomizationSettings(properties: string[], scopeName?: strin
   React.useEffect(() => {
     if (!localSettings.inCustomizerContext) {
       Customizations.observe(forceUpdate);
-      return () => Customizations.unobserve(forceUpdate);
     }
+    return () => {
+      if (!localSettings.inCustomizerContext) {
+        Customizations.unobserve(forceUpdate);
+      }
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- exclude forceUpdate
   }, [localSettings.inCustomizerContext]);
 

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { IStyleSet, IStyleFunctionOrObject, concatStyleSetsWithProps } from '@uifabric/merge-styles';
-import { Customizations } from './customizations/Customizations';
-import { CustomizerContext } from './customizations/CustomizerContext';
+import { useCustomizationSettings } from './customizations/useCustomizationSettings';
 
 export interface IPropsWithStyles<TStyleProps, TStyleSet extends IStyleSet<TStyleSet>> {
   styles?: IStyleFunctionOrObject<TStyleProps, TStyleSet>;
@@ -29,11 +28,6 @@ export type StyleFunction<TStyleProps, TStyleSet> = IStyleFunctionOrObject<TStyl
   /** True if no styles prop or styles from Customizer is passed to wrapped component. */
   __noStyleOverride__: boolean;
 };
-
-function useForceUpdate() {
-  const [, reducer] = React.useReducer((state: number) => state + 1, 0);
-  return () => reducer(null);
-}
 
 /**
  * The styled HOC wrapper allows you to create a functional wrapper around a given component which will resolve
@@ -96,19 +90,7 @@ export function styled<
   const Wrapped = React.forwardRef((props: TComponentProps, forwardedRef: React.Ref<TRef>) => {
     const styles = React.useRef<StyleFunction<TStyleProps, TStyleSet>>();
 
-    const forceUpdate = useForceUpdate();
-    const context = React.useContext(CustomizerContext);
-
-    React.useEffect((): void | (() => void) => {
-      if (!context.customizations.inCustomizerContext) {
-        Customizations.observe(forceUpdate);
-
-        return () => Customizations.unobserve(forceUpdate);
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
-    }, []);
-
-    const settings = Customizations.getSettings(fields, scope, context.customizations);
+    const settings = useCustomizationSettings(fields, scope);
     const { styles: customizedStyles, dir, ...rest } = settings;
     const additionalProps = getProps ? getProps(props) : undefined;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
1. fix not getting the correct settings from context when context value updates
2. added more test coverage
3. use `useCustomizationSettings` in `styled`

#### Focus areas to test

(optional)
