### PR TITLE
[Date-time-utilities] fix date time utilities tests

### DIFF
--- a/change/@fluentui-date-time-utilities-2020-08-06-17-09-29-lorejoh12-fixDateTimeUtilitiesTests.json
+++ b/change/@fluentui-date-time-utilities-2020-08-06-17-09-29-lorejoh12-fixDateTimeUtilitiesTests.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "date time utilities unit tests were timezone dependent, because the start date was right on the border between two months and when getting run locally the dates convert to local time zone. changing initial date fixes it",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T00:09:29.892Z"
+}

--- a/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
@@ -5,7 +5,7 @@ import * as DateGrid from './getDayGrid';
 import { IDay } from './dateGrid.types';
 
 describe('getDayGrid', () => {
-  const defaultDate = new Date('2016-04-02T00:00:00.000Z');
+  const defaultDate = new Date('Apr 1 2016');
   const defaultOptions: IDayGridOptions = {
     selectedDate: defaultDate,
     navigatedDate: defaultDate,

--- a/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
+++ b/packages/date-time-utilities/src/dateGrid/getDayGrid.test.ts
@@ -5,7 +5,7 @@ import * as DateGrid from './getDayGrid';
 import { IDay } from './dateGrid.types';
 
 describe('getDayGrid', () => {
-  const defaultDate = new Date('2016-04-01T00:00:00.000Z');
+  const defaultDate = new Date('2016-04-02T00:00:00.000Z');
   const defaultOptions: IDayGridOptions = {
     selectedDate: defaultDate,
     navigatedDate: defaultDate,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Date time grid is on a per-month basis. The initial selected date for the tests is Apr 1st at 00:00. When running the tests in any timezone earlier than GMT (for example, PST is GMT-07:00), the date gets converted to Mar 31 at 17:00, which means the dates get generated for month of March instead of April as test expects.

Most simple fix is to just adjust starting date to some date in Apr that will remain in the month of Apr no matter what time zone you're in.

#### Focus areas to test

(optional)
