### PR TITLE
update lage and pipeline to do some caching

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
         displayName: check change
 
       - script: |
-          yarn lage build test lint --verbose --no-cache --grouped
+          yarn lage build test lint --verbose --grouped
         displayName: build, test, lint
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
@@ -85,7 +85,7 @@ jobs:
           DANGER_GITHUB_API_TOKEN: $(DANGER_GITHUB_API_TOKEN)
 
       - script: |
-          yarn lage build --since $(target_branch) --scope @fluentui/* --no-deps --verbose --no-cache --grouped
+          yarn lage build --since $(target_branch) --scope @fluentui/* --no-deps --verbose --grouped
         displayName: build
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
@@ -122,7 +122,7 @@ jobs:
       - template: .devops/templates/pr-target-branch.yml
 
       - script: |
-          yarn lage bundle --since $(target_branch) --no-deps --verbose --no-cache --grouped
+          yarn lage bundle --since $(target_branch) --no-deps --verbose --grouped
         displayName: bundle
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
@@ -177,7 +177,7 @@ jobs:
         displayName: config git user and email
 
       - script: |
-          yarn lage screener --scope vr-tests --debug --verbose --no-deps --no-cache --grouped
+          yarn lage screener --scope vr-tests --debug --verbose --no-deps --grouped
         displayName: run VR Test
         env:
           SCREENER_API_KEY: $(screener.key)

--- a/lage.config.js
+++ b/lage.config.js
@@ -17,22 +17,38 @@ module.exports = {
   // All of these options are sent to `backfill`: https://github.com/microsoft/backfill/blob/master/README.md
   cacheOptions: {
     // These are the subset of files in the package directories that will be saved into the cache
+    // Lots of these are from .gitignore file
     outputGlob: [
+      // dist files
       'dist/**/*',
+      'dist-storybook/**/*',
+      '**/dist.stats.json',
+
+      // generated files in src
+      'coverage/**/*',
+      'src/componentInfo/**/*',
+      'src/componentMenu.json',
+      'src/behaviorMenu.json',
+      'src/bundleStats.json',
+      'src/currentBundleStats.json',
+      'src/exampleMenus/**/*',
+      'src/exampleSources/**/*',
+      'src/schema.ts',
+      'src/**/*.scss.ts',
+      '**/*.source.json',
+      '**/*.info.json',
+      '**/*.tar.gz',
+      '**/*.event.ts',
+      '**/*.resx.ts',
+
+      // lib output
       'lib/**/*',
       'lib-commonjs/**/*',
       'lib-amd/**/*',
+      'lib-es2015/**/*',
       'esm/**/*',
-      '**/*.source.json',
-      '**/*.info.json',
-      '**/dist.stats.json',
-      'dist-storybook/**/*',
-      '**/*.tar.gz',
       '!bower_components',
       '!node_modules',
-      'lib-es2015/**/*',
-      'coverage/**/*',
-      'src/**/*.scss.ts',
     ],
 
     // These are relative to the git root, and affects the hash of the cache


### PR DESCRIPTION
#### Description of changes

This change adds the backfill caching to the PR builds. It relies on the `outputGlob` to do its job finding files to be cached.

#### Focus areas to test

(optional)
