### PR TITLE
Fix min-width to be equals to thumb size

### DIFF
--- a/change/@fluentui-web-components-2020-08-06-21-47-11-fix_min-width_to_be_equals_to_thumb_size.json
+++ b/change/@fluentui-web-components-2020-08-06-21-47-11-fix_min-width_to_be_equals_to_thumb_size.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix min-width to be equals to thumb size",
+  "packageName": "@fluentui/web-components",
+  "email": "barahonajm@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T01:47:11.657Z"
+}

--- a/packages/web-components/src/slider/slider.styles.ts
+++ b/packages/web-components/src/slider/slider.styles.ts
@@ -69,7 +69,7 @@ export const SliderStyles = css`
         transform: translateY(calc(var(--thumb-translate) * 1px));
     }
     :host(.horizontal) {
-        min-width: calc(var(--design-unit) * 60px);
+        min-width: calc(var(--thumb-size) * 1px);
     }
     :host(.horizontal) .track {
         right: calc(var(--track-overhang) * 1px);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: https://github.com/microsoft/fast/issues/3634

#### Description of changes

Changes the `min-width` to be equals to the size of the thumb, this is a change to keep consistency with the already merged PR https://github.com/microsoft/fast/pull/3640

