### PR TITLE
ContextualMenu: Modifying examples so that screen readers read the different ways to open a submenu

### DIFF
--- a/change/office-ui-fabric-react-2020-08-06-18-45-44-contextualMenuSubMenuExamples.json
+++ b/change/office-ui-fabric-react-2020-08-06-18-45-44-contextualMenuSubMenuExamples.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Modifying examples so that screen readers read the different ways to open a submenu.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T01:45:44.000Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -109,6 +109,7 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
         isChecked: selection[keys[5]],
         split: true,
         onClick: onToggleSelect,
+        ariaLabel: 'Split Button. Click to check/uncheck. Press right arrow key to open submenu.',
       },
       {
         key: keys[8],
@@ -139,6 +140,7 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
         split: true,
         onClick: onToggleSelect,
         disabled: true,
+        ariaLabel: 'Split Button. Click to check/uncheck. Press right arrow key to open submenu.',
       },
       {
         key: keys[11],
@@ -169,6 +171,7 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
         isChecked: selection[keys[11]],
         split: true,
         onClick: onToggleSelect,
+        ariaLabel: 'Split Button Left Menu. Click to check/uncheck. Press right arrow key to open submenu.',
       },
       {
         key: keys[12],
@@ -189,6 +192,7 @@ export const ContextualMenuCheckmarksExample: React.FunctionComponent = () => {
         name: 'Split Button Disabled Primary',
         split: true,
         primaryDisabled: true,
+        ariaLabel: 'Split Button Disabled Primary. Click to check/uncheck. Press right arrow key to open submenu.',
       },
       {
         key: keys[13],

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Customization.Example.tsx
@@ -70,6 +70,7 @@ const menuItems: IContextualMenuItem[] = [
     key: 'charm',
     text: 'Charm',
     className: 'Charm-List',
+    ariaLabel: 'Charm. Press enter, space or right arrow keys to open submenu.',
     subMenuProps: {
       focusZoneProps: { direction: FocusZoneDirection.bidirectional },
       items: [
@@ -167,6 +168,7 @@ const menuItems: IContextualMenuItem[] = [
   {
     key: 'categories',
     text: 'Categorize',
+    ariaLabel: 'Categorize. Press enter, space or right arrow keys to open submenu.',
     subMenuProps: {
       items: [
         {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -72,6 +72,7 @@ const menuItems: IContextualMenuItem[] = [
     key: 'charm',
     text: 'Charm',
     className: 'Charm-List',
+    ariaLabel: 'Charm. Press enter, space or right arrow keys to open submenu.',
     subMenuProps: {
       focusZoneProps: {
         direction: FocusZoneDirection.bidirectional,
@@ -178,6 +179,7 @@ const menuItems: IContextualMenuItem[] = [
   {
     key: 'categories',
     text: 'Categorize',
+    ariaLabel: 'Categorize. Press enter, space or right arrow keys to open submenu.',
     subMenuProps: {
       items: [
         {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Header.Example.tsx
@@ -62,6 +62,7 @@ const menuItems: IContextualMenuItem[] = [
       ],
     },
     text: 'Sharing',
+    ariaLabel: 'Sharing. Press enter, space or right arrow keys to open submenu.',
   },
   {
     key: 'navigation',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -68,6 +68,7 @@ const menuItems: IContextualMenuItem[] = [
     href: 'https://bing.com',
     text: 'New',
     target: '_blank',
+    ariaLabel: 'New. Press enter or right arrow keys to open submenu.',
   },
   {
     key: 'share',
@@ -102,6 +103,7 @@ const menuItems: IContextualMenuItem[] = [
       ],
     },
     text: 'Share',
+    ariaLabel: 'Share. Press enter, space or right arrow keys to open submenu.',
   },
   {
     key: 'shareSplit',
@@ -138,5 +140,6 @@ const menuItems: IContextualMenuItem[] = [
       ],
     },
     text: 'Share w/ Split',
+    ariaLabel: 'Share w/ Split. Press enter or space keys to trigger action. Press right arrow key to open submenu.',
   },
 ];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14306
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds an `aria-label` to menu items that open submenus indicating the different ways one can open them via the keyboard since we support some non-standard ways of doing this such as using the right arrow key.

#### Focus areas to test

(optional)
