### PR TITLE
feat(Icon): factory patch for supporting jsx icons in the shorthands

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
@@ -192,7 +192,9 @@ function isFluentJSXIcon(value: ShorthandValue<IconProps>): value is React.React
 }
 
 function toIconNameFromDisplayName(displayName: string) {
-  return inconsistentIconNames[displayName] ? inconsistentIconNames : _.kebabCase(displayName.replace('Icon', ''));
+  return inconsistentIconNames[displayName]
+    ? inconsistentIconNames[displayName]
+    : _.kebabCase(displayName.replace('Icon', ''));
 }
 
 const iconOriginalShorthandFactory = createShorthandFactory({

--- a/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
@@ -4,11 +4,25 @@ import { getElementType, getUnhandledProps, useAccessibility, useStyles, useTele
 import { callable } from '@fluentui/styles';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
+import * as _ from 'lodash';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-import { createShorthandFactory, UIComponentProps, commonPropTypes, ColorComponentProps, SizeValue } from '../../utils';
-import { FluentComponentStaticProps, ProviderContextPrepared, WithAsProp, withSafeTypeForAs } from '../../types';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  commonPropTypes,
+  ColorComponentProps,
+  SizeValue,
+  ShorthandFactory,
+} from '../../utils';
+import {
+  FluentComponentStaticProps,
+  ProviderContextPrepared,
+  ShorthandValue,
+  WithAsProp,
+  withSafeTypeForAs,
+} from '../../types';
 
 export type IconXSpacing = 'none' | 'before' | 'after' | 'both';
 
@@ -178,7 +192,7 @@ function isFluentJSXIcon(value: ShorthandValue<IconProps>): value is React.React
 }
 
 function toIconNameFromDisplayName(displayName: string) {
-  return inconsistentIconNames[displayName] ? inconsistentIconNames : kebabCase(displayName.replace('Icon', ''));
+  return inconsistentIconNames[displayName] ? inconsistentIconNames : _.kebabCase(displayName.replace('Icon', ''));
 }
 
 const iconOriginalShorthandFactory = createShorthandFactory({
@@ -195,7 +209,7 @@ const iconPatchedShorthandFactory: ShorthandFactory<IconProps> = (value, options
       );
     }
 
-    if (isPlainObject(value)) {
+    if (_.isPlainObject(value)) {
       if ((value as IconProps).name) {
         console.warn(
           `Fluent UI: Deprecation notice, please use JSX icon as a value instead of an object, for example replace <Button icon={{ name: 'bell', outline: true }} /> with <Button icon={<BellIcon outline />} />.`,

--- a/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
@@ -219,7 +219,7 @@ const iconPatchedShorthandFactory: ShorthandFactory<IconProps> = (value, options
   }
 
   if (isFluentJSXIcon(value)) {
-    const iconName = toIconNameFromDisplayName(value.type.displayName.replace('Icon', ''));
+    const iconName = toIconNameFromDisplayName(value.type.displayName);
 
     return iconOriginalShorthandFactory({ ...value.props, name: iconName }, options);
   }


### PR DESCRIPTION
This PR augments the Icon's create factory to be able to convert new jsx icons to the current icon shorthand format.

![image](https://user-images.githubusercontent.com/4512430/89646305-d4dda180-d8bb-11ea-84bc-869d740a9d69.png)
