### PR TITLE
ProgressIndicator: Fix HC styling to properly show progress bar 

### DIFF
--- a/change/office-ui-fabric-react-2020-08-07-10-11-27-a11y-progress-indicator.json
+++ b/change/office-ui-fabric-react-2020-08-07-10-11-27-a11y-progress-indicator.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add HC styling to fix ProgressIndicator progress bar",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T17:11:27.719Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -1,4 +1,11 @@
-import { HighContrastSelector, keyframes, noWrap, getGlobalClassNames, IRawStyle } from '../../Styling';
+import {
+  HighContrastSelector,
+  keyframes,
+  noWrap,
+  getGlobalClassNames,
+  IRawStyle,
+  getEdgeChromiumNoHighContrastAdjustSelector,
+} from '../../Styling';
 import { getRTL, memoizeFunction } from '../../Utilities';
 import { IProgressIndicatorStyleProps, IProgressIndicatorStyles } from './ProgressIndicator.types';
 
@@ -104,6 +111,7 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
           [HighContrastSelector]: {
             backgroundColor: 'highlight',
           },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -68,6 +68,9 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             background-color: highlight;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       role="progressbar"
       style={
         Object {
@@ -161,6 +164,9 @@ exports[`ProgressIndicator renders React content 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             background-color: highlight;
             background: highlight;
+          }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       role="progressbar"
       style={
@@ -256,6 +262,9 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
             background-color: highlight;
             background: highlight;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       role="progressbar"
       style={
         Object {
@@ -333,6 +342,9 @@ exports[`ProgressIndicator renders with no label or description 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             background-color: highlight;
             background: highlight;
+          }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       role="progressbar"
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -221,6 +221,9 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
             @media screen and (-ms-high-contrast: active){& {
               background-color: highlight;
             }
+            @media screen and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         role="progressbar"
         style={
           Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
@@ -68,6 +68,9 @@ exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctl
           @media screen and (-ms-high-contrast: active){& {
             background-color: highlight;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       role="progressbar"
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
@@ -69,6 +69,9 @@ exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx 
             background-color: highlight;
             background: highlight;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       role="progressbar"
       style={
         Object {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In HC mode, there is a black overlay to show progress, which is hard to see. This PR changes styling to make it Highlight.

**Before**
![image](https://user-images.githubusercontent.com/66456876/89676038-c8e3e680-d89f-11ea-9604-df42a923a34e.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89676075-db5e2000-d89f-11ea-80d4-28560cc88c90.png)

Part of mega issue #13012 

#### Focus areas to test

(optional)
