### PR TITLE
ComboBox: Fix HC styling for ComboBox header to differentiate between clickable and nonclickable items

### DIFF
--- a/change/@fluentui-react-next-2020-08-07-12-38-31-combobox-header.json
+++ b/change/@fluentui-react-next-2020-08-07-12-38-31-combobox-header.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update Dropdown HC styling",
+  "packageName": "@fluentui/react-next",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T19:38:31.789Z"
+}

--- a/change/office-ui-fabric-react-2020-08-07-12-02-02-combobox-header.json
+++ b/change/office-ui-fabric-react-2020-08-07-12-02-02-combobox-header.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add HC styling to make clickable and nonclickable items differentiable",
+  "packageName": "office-ui-fabric-react",
+  "email": "ololubek@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T19:02:02.893Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -9,6 +9,7 @@ import {
   getPlaceholderStyles,
   hiddenContentStyle,
   getInputFocusStyle,
+  getEdgeChromiumNoHighContrastAdjustSelector,
 } from '../../Styling';
 import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
@@ -488,6 +489,12 @@ export const getStyles = memoizeFunction(
           padding: '0 8px',
           userSelect: 'none',
           textAlign: 'left',
+          selectors: {
+            [HighContrastSelector]: {
+              color: 'GrayText',
+            },
+            ...getEdgeChromiumNoHighContrastAdjustSelector(),
+          },
         },
       ],
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -387,6 +387,12 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         padding: '0 8px',
         userSelect: 'none',
         textAlign: 'left',
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'GrayText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
     ],
     subComponentStyles: {

--- a/packages/react-next/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/react-next/src/components/Dropdown/Dropdown.styles.ts
@@ -387,6 +387,12 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         padding: '0 8px',
         userSelect: 'none',
         textAlign: 'left',
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'GrayText',
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
+        },
       },
     ],
     subComponentStyles: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13771 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Clickable and non clickable items, in ComboBox and Dropdown are not differentiable on high contrast mode. This fix will change the header element for ComboBox and Dropdown to 'GrayText' to differentiate.

**ComboBox**
**Before**
![image](https://user-images.githubusercontent.com/66456876/89680609-1ebc8c80-d8a8-11ea-9af7-2178748fd002.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89680647-34ca4d00-d8a8-11ea-8352-6e9123e3685f.png)


**Dropdown**
**Before**
![image](https://user-images.githubusercontent.com/66456876/89685258-d786c980-d8b0-11ea-8a2c-14af58228ef5.png)

**After**
![image](https://user-images.githubusercontent.com/66456876/89685307-ec635d00-d8b0-11ea-8273-905b94900ce5.png)


#### Focus areas to test

(optional)
