### PR TITLE
Add GitHub action to send Teams messages for PRs and Issues

### DIFF
--- a/.github/workflows/actions-mention-to-teams.yml
+++ b/.github/workflows/actions-mention-to-teams.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Run
         continue-on-error: true
-        uses: JustSlone/actions-mention-to-teams@v0.4-beta
+        uses: JustSlone/actions-mention-to-teams@v0.4.1-beta
         with:
           teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
           run-id: ${{ github.run_id }}

--- a/.github/workflows/actions-mention-to-teams.yml
+++ b/.github/workflows/actions-mention-to-teams.yml
@@ -1,0 +1,26 @@
+name: Route mentions to Teams
+
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request:
+    types: [opened, edited, review_requested]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created, edited]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  mention-to-teams:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Run
+        continue-on-error: true
+        uses: JustSlone/actions-mention-to-teams@v0.4-beta
+        with:
+          teams-webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          run-id: ${{ github.run_id }}


### PR DESCRIPTION
This PR is intended to propose and start the discussion on adding this functionality to our repo. Feedback is welcome!!

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 - N/A
- [ ] Include a change request file using `$ yarn change` - N/A

### Description of changes

Add GitHub action to send Teams messages for PRs and Issues.
 **Note**: this will add a new check to all PRs that is currently configured to always pass. 

#### Problem
It's difficult to stay on top of Pull Requests and Issues in our GitHub repository when the notifications are either buried in our GitHub notifications or come in via e-mail along with a huge pile of noise from GitHub. It makes it hard to filter the signal from the noise. 

#### Solution
We spend a lot of time using Teams, we communicate there, we have meetings there, that's where our attention is by default. 
I originally proposed in our PR request review expectations that we should check GitHub notifications more often, however, @pompomon had a great counterpoint that maybe we should just route GitHub mentions and PRs to Teams. 

So I did that during the hackathon last week. This is the in-repo part of that implementation. 

#### Details
There are two parts here
1. A GitHub action that triggers on Issues and PRs
2. A Power Automate Flow that responds to HTTP requests

This PR is just to add the the GitHub action, which is released from here: https://github.com/JustSlone/actions-mention-to-teams/

An important note with this PR: because this responds to Pull Request events, this action **will** show up as a "check" in all PRs. I've configured the check to always pass by using `continue-on-error` in the workflow config. I did some research to see if we could show it as optional in the checks so we know if the workflow is working or not, but I couldn't find a way to accomplish that. 

How this works:
- On changes to Issues, PRs, or comments
- Look at PR review requests and @mentions, extract GH usernames mentioned or requested
- Send information to Flow via HTTP (URL stored in `TEAMS_WEBHOOK_URL` repo secret)
- Flow loads a GH username -> Teams e-mail mapping table (stored as an Excel file in our PR Teams channel)
- If there exists a mapping for a GH username, "Flow Bot" will send that user a message
- User then comes to GitHub and quickly replies to issue or PR
- Happy customers!

#### Focus areas to test

If you want to test this out, add your GH username and MS/Teams e-mail to the github-username-mapping.xlsx file in our Pull Requests channel in Teams. Then visit my repo: https://github.com/JustSlone/fluentui and mention yourself in an issue.

