### PR TITLE
Lint: update jsx-no-bind settings to ignore native elements

### DIFF
--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
@@ -335,7 +335,6 @@ export class ColorsPage extends React.Component<{}, IColorsPageState> {
         key={slotRule.name}
         className="ms-themer-swatch"
         style={{ backgroundColor: slotRule.color!.str }}
-        // eslint-disable-next-line react/jsx-no-bind
         onClick={this._onSwatchClick.bind(this, slotRule)}
       />
     );

--- a/apps/fabric-website-resources/src/components/pages/ThemePage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ThemePage.tsx
@@ -84,7 +84,6 @@ export class ThemePage extends React.Component<IThemePageProps, IThemePageState>
                 <div
                   className={classNames.colorSwatch}
                   data-is-focusable="true"
-                  // eslint-disable-next-line react/jsx-no-bind
                   onClick={this._onSwatchClicked.bind(this, item, index, list)}
                 >
                   <span className={classNames.swatch} style={{ backgroundColor: item.value }} />

--- a/apps/todo-app/src/components/TodoItem.tsx
+++ b/apps/todo-app/src/components/TodoItem.tsx
@@ -45,7 +45,6 @@ export default class TodoItem extends React.Component<ITodoItemProps, {}> {
     return (
       <div
         role="row"
-        // eslint-disable-next-line react/jsx-no-bind
         ref={(ref: HTMLDivElement) => (this._rowItem = ref)}
         className={className}
         aria-label={this._ariaLabel}

--- a/change/@fluentui-eslint-plugin-2020-08-07-15-55-48-eslint-bind.json
+++ b/change/@fluentui-eslint-plugin-2020-08-07-15-55-48-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-07T22:55:48.328Z"
+}

--- a/change/@fluentui-react-next-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@fluentui-react-next-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:16.868Z"
+}

--- a/change/@uifabric-charting-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@uifabric-charting-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:06.397Z"
+}

--- a/change/@uifabric-date-time-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@uifabric-date-time-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:07.372Z"
+}

--- a/change/@uifabric-example-app-base-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@uifabric-example-app-base-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:09.188Z"
+}

--- a/change/@uifabric-experiments-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@uifabric-experiments-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:10.174Z"
+}

--- a/change/@uifabric-fabric-website-resources-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/@uifabric-fabric-website-resources-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:05.136Z"
+}

--- a/change/office-ui-fabric-react-2020-08-07-15-55-16-eslint-bind.json
+++ b/change/office-ui-fabric-react-2020-08-07-15-55-16-eslint-bind.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Lint: update jsx-no-bind settings to ignore native elements",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-07T22:55:11.645Z"
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack",
     "generate-version-files": "yarn workspace @uifabric/build just generate-version-files",
     "lint": "lerna run lint --stream",
+    "lint:log": "FORCE_COLOR=0 lerna run lint --stream --no-bail > lint.log 2>&1",
     "sync:beachball": "beachball sync --scope \"!packages/fluentui/*\"",
     "publish:beachball": "beachball publish --scope \"!packages/fluentui/*\"",
     "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",

--- a/packages/charting/src/components/CommonComponents/ChartHelper.base.tsx
+++ b/packages/charting/src/components/CommonComponents/ChartHelper.base.tsx
@@ -124,13 +124,11 @@ export class ChartHelperBaseComponent extends React.Component<IChartHelperProps,
         id={this.idForGraph}
         className={this._classNames.root}
         role={'presentation'}
-        // eslint-disable-next-line react/jsx-no-bind
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
       >
         <FocusZone direction={FocusZoneDirection.horizontal}>
           <svg width={svgDimensions.width} height={svgDimensions.height}>
             <g
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(e: SVGElement | null) => {
                 this.xAxisElement = e;
               }}
@@ -139,7 +137,6 @@ export class ChartHelperBaseComponent extends React.Component<IChartHelperProps,
               className={this._classNames.xAxis}
             />
             <g
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(e: SVGElement | null) => {
                 this.yAxisElement = e;
               }}
@@ -150,11 +147,7 @@ export class ChartHelperBaseComponent extends React.Component<IChartHelperProps,
             {children}
           </svg>
         </FocusZone>
-        <div
-          // eslint-disable-next-line react/jsx-no-bind
-          ref={(e: HTMLDivElement) => (this.legendContainer = e)}
-          className={this._classNames.legendContainer}
-        >
+        <div ref={(e: HTMLDivElement) => (this.legendContainer = e)} className={this._classNames.legendContainer}>
           {this.props.legendBars}
         </div>
         {!this.props.hideTooltip && calloutProps!.isCalloutVisible && (

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -40,18 +40,14 @@ export class Arc extends React.Component<IArcProps, IArcState> {
         <path
           id={id}
           d={arc(this.props.data)}
-          // eslint-disable-next-line react/jsx-no-bind
           onFocus={this._onFocus.bind(this, this.props.data!.data, id)}
           className={classNames.root}
           data-is-focusable={true}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={this._hoverOn.bind(this, this.props.data!.data)}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseMove={this._hoverOn.bind(this, this.props.data!.data)}
           onMouseLeave={this._hoverOff}
           onBlur={this._onBlur}
           opacity={opacity}
-          // eslint-disable-next-line react/jsx-no-bind
           onClick={this._redirectToUrl.bind(this, href)}
           aria-labelledby={this.props.calloutId}
         />

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -103,18 +103,10 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
     const outerRadius = radius;
     const chartData = data && data.chartData;
     return (
-      <div
-        className={this._classNames.root}
-        // eslint-disable-next-line react/jsx-no-bind
-        ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}
-      >
+      <div className={this._classNames.root} ref={(rootElem: HTMLElement | null) => (this._rootElem = rootElem)}>
         <FocusZone direction={FocusZoneDirection.horizontal} isCircularNavigation={true}>
           <div>
-            <svg
-              className={this._classNames.chart}
-              // eslint-disable-next-line react/jsx-no-bind
-              ref={(node: SVGElement | null) => this._setViewBox(node)}
-            >
+            <svg className={this._classNames.chart} ref={(node: SVGElement | null) => this._setViewBox(node)}>
               <Pie
                 width={_width!}
                 height={_height!}

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -161,7 +161,6 @@ export class GroupedVerticalBarChartBase extends React.Component<
     return (
       <div
         id={`d3GroupedChart_${this._uniqLineText}`}
-        // eslint-disable-next-line react/jsx-no-bind
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
         className={this._classNames.root}
       >
@@ -169,14 +168,12 @@ export class GroupedVerticalBarChartBase extends React.Component<
           <svg width={svgDimensions.width} height={svgDimensions.height} id={this._uniqLineText}>
             <g
               id="xAxisGElement"
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setXAxis(node, x0Axis)}
               className={this._classNames.xAxis}
               transform={`translate(0, ${svgDimensions.height - 35})`}
             />
             <g
               id="yAxisGElement"
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setYAxis(node, yAxis)}
               className={this._classNames.yAxis}
               transform={`translate(40, 0)`}
@@ -185,7 +182,6 @@ export class GroupedVerticalBarChartBase extends React.Component<
           </svg>
         </FocusZone>
         <div
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(e: HTMLDivElement) => (this.legendContainer = e)}
           id={this._uniqLineText}
           className={this._classNames.legendContainer}

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.base.tsx
@@ -98,12 +98,10 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                     <g
                       id={keyVal}
                       key={keyVal}
-                      // eslint-disable-next-line react/jsx-no-bind
                       ref={(e: SVGGElement) => {
                         this._refCallback(e, points!.chartData![0].legend);
                       }}
                       className={this._classNames.barWrapper}
-                      // eslint-disable-next-line react/jsx-no-bind
                       onMouseOver={this._hoverOn.bind(
                         this,
                         points!
@@ -114,7 +112,6 @@ export class HorizontalBarChartBase extends React.Component<IHorizontalBarChartP
                         points!.chartData![0].xAxisCalloutData!,
                         points!.chartData![0].yAxisCalloutData!,
                       )}
-                      // eslint-disable-next-line react/jsx-no-bind
                       onFocus={this._hoverOn.bind(
                         this,
                         points!

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -245,7 +245,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       >
         <div
           className={classNames.overflowIndicationTextStyle}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           data-is-focusable={false}
         >
@@ -309,14 +308,12 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       <button
         key={index}
         className={classNames.legend}
-        /* eslint-disable react/jsx-no-bind */
         onClick={onClickHandler}
         onMouseOver={onHoverHandler}
         onMouseOut={onMouseOut}
         onFocus={onHoverHandler}
         onBlur={onMouseOut}
         data-is-focusable={false}
-        /* eslint-enable react/jsx-no-bind */
       >
         <div className={this._getShapeClass(classNames, legend)} />
         <div className={classNames.text}>{legend.title}</div>

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -226,7 +226,6 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         const y2 = this._points[i].data[j].y;
         const xAxisCalloutData = this._points[i].data[j - 1].xAxisCalloutData;
         if (this.state.activeLegend === legendVal || this.state.activeLegend === '') {
-          /* eslint-disable react/jsx-no-bind */
           lines.push(
             <line
               id={lineId}
@@ -300,7 +299,6 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
                 strokeWidth={3}
               />,
             );
-            /* eslint-enable react/jsx-no-bind */
           }
         } else {
           lines.push(

--- a/packages/charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
+++ b/packages/charting/src/components/LineChart/eventAnnotation/LabelLink.tsx
@@ -67,13 +67,7 @@ export const LabelLink: React.FunctionComponent<ILabelLinkProps> = props => {
 
   return (
     <>
-      <g
-        ref={gRef}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={onClick}
-        data-is-focusable={true}
-        style={{ cursor: 'pointer' }}
-      >
+      <g ref={gRef} onClick={onClick} data-is-focusable={true} style={{ cursor: 'pointer' }}>
         <Textbox
           text={text}
           x={props.labelDef.x}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -11,7 +11,7 @@ import {
 } from './index';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard } from '@uifabric/charting';
+import { ChartHoverCard } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>();
 
@@ -150,13 +150,11 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         <g
           key={index}
           className={point.placeHolder ? this._classNames.placeHolderOnHover : this._classNames.opacityChangeOnHover}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(e: SVGGElement) => {
             this._refCallback(e, point.legend!);
           }}
           data-is-focusable={true}
           focusable={'true'}
-          // eslint-disable-next-line react/jsx-no-bind
           onFocus={this._onBarFocus.bind(
             this,
             point.legend!,
@@ -167,7 +165,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
           )}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={
             point.placeHolder
               ? undefined
@@ -180,7 +177,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
                   point.yAxisCalloutData!,
                 )
           }
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseMove={
             point.placeHolder
               ? undefined
@@ -194,7 +190,6 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
                 )
           }
           onMouseLeave={point.placeHolder ? undefined : this._onBarLeave}
-          // eslint-disable-next-line react/jsx-no-bind
           onClick={point.placeHolder ? undefined : this._redirectToUrl.bind(this, href)}
         >
           <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={barHeight} fill={color} />
@@ -203,24 +198,14 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     });
     if (data.chartData!.length === 0) {
       bars.push(
-        <g
-          key={0}
-          className={this._classNames.noData}
-          // eslint-disable-next-line react/jsx-no-bind
-          onClick={this._redirectToUrl.bind(this, href)}
-        >
+        <g key={0} className={this._classNames.noData} onClick={this._redirectToUrl.bind(this, href)}>
           <rect key={0} x={'0%'} y={0} width={'100%'} height={barHeight} fill={palette.neutralTertiaryAlt} />
         </g>,
       );
     }
     if (total === 0) {
       bars.push(
-        <g
-          key={'empty'}
-          className={this._classNames.noData}
-          // eslint-disable-next-line react/jsx-no-bind
-          onClick={this._redirectToUrl.bind(this, href)}
-        >
+        <g key={'empty'} className={this._classNames.noData} onClick={this._redirectToUrl.bind(this, href)}>
           <rect key={0} x={'0%'} y={0} width={'100%'} height={barHeight} fill={palette.neutralTertiaryAlt} />
         </g>,
       );

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -6,7 +6,7 @@ import { IChartDataPoint, IChartProps } from './index';
 import { IStackedBarChartProps, IStackedBarChartStyleProps, IStackedBarChartStyles } from './StackedBarChart.types';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { FocusZone, FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartHoverCard } from '@uifabric/charting';
+import { ChartHoverCard } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IStackedBarChartStyleProps, IStackedBarChartStyles>();
 
@@ -260,13 +260,11 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
         <g
           key={index}
           className={this._classNames.opacityChangeOnHover}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(e: SVGGElement) => {
             this._refCallback(e, legend.title);
           }}
           data-is-focusable={true}
           focusable={'true'}
-          // eslint-disable-next-line react/jsx-no-bind
           onFocus={this._onBarFocus.bind(
             this,
             point.legend!,
@@ -277,7 +275,6 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           )}
           onBlur={this._onBarLeave}
           aria-labelledby={this._calloutId}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={this._onBarHover.bind(
             this,
             point.legend!,
@@ -286,7 +283,6 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
             point.xAxisCalloutData!,
             point.yAxisCalloutData!,
           )}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseMove={this._onBarHover.bind(
             this,
             point.legend!,
@@ -297,7 +293,6 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
           )}
           onMouseLeave={this._onBarLeave}
           pointerEvents="all"
-          // eslint-disable-next-line react/jsx-no-bind
           onClick={this._redirectToUrl.bind(this, href)}
         >
           <rect key={index} x={startingPoint[index] + '%'} y={0} width={value + '%'} height={barHeight} fill={color} />

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -125,7 +125,6 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     return (
       <div
         id="VerticalBarChart"
-        // eslint-disable-next-line react/jsx-no-bind
         ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
         className={this._classNames.root}
       >
@@ -133,14 +132,12 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           <svg width={svgDimensions.width} height={svgDimensions.height}>
             <g
               id="xAxisGElement"
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setXAxis(node, xAxis)}
               className={this._classNames.xAxis}
               transform={`translate(0, ${svgDimensions.height - this.margins.bottom})`}
             />
             <g
               id="yAxisGElement"
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setYAxis(node, yAxis)}
               className={this._classNames.yAxis}
               transform={`translate(40, 0)`}
@@ -149,11 +146,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           </svg>
         </FocusZone>
         {!hideLegend && (
-          <div
-            // eslint-disable-next-line react/jsx-no-bind
-            ref={(e: HTMLDivElement) => (this.legendContainer = e)}
-            className={this._classNames.legendContainer}
-          >
+          <div ref={(e: HTMLDivElement) => (this.legendContainer = e)} className={this._classNames.legendContainer}>
             {legends!}
           </div>
         )}
@@ -376,11 +369,9 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           width={this._barWidth}
           data-is-focusable={true}
           height={yBarScale(point.y) > 0 ? yBarScale(point.y) : 0}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend!, refArrayIndexNumber);
           }}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={this._onBarHover.bind(
             this,
             point.legend,
@@ -392,7 +383,6 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           )}
           aria-labelledby={this._calloutId}
           onMouseLeave={this._onBarLeave}
-          // eslint-disable-next-line react/jsx-no-bind
           onFocus={this._onBarFocus.bind(
             this,
             point.legend,
@@ -438,7 +428,6 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
           width={this._barWidth}
           height={yBarScale(point.y) > 0 ? yBarScale(point.y) : 0}
           aria-labelledby={this._calloutId}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={this._onBarHover.bind(
             this,
             point.legend!,

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -124,21 +124,15 @@ export class VerticalStackedBarChartBase extends React.Component<
       height: this.state.containerHeight,
     };
     return (
-      <div
-        className={this._classNames.root}
-        // eslint-disable-next-line react/jsx-no-bind
-        ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}
-      >
+      <div className={this._classNames.root} ref={(rootElem: HTMLDivElement) => (this.chartContainer = rootElem)}>
         <FocusZone direction={FocusZoneDirection.vertical}>
           <svg width={svgDimensions.width} height={svgDimensions.height}>
             <g
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setXAxis(node, xAxis)}
               transform={`translate(0, ${svgDimensions.height - this.margins.bottom})`}
               className={this._classNames.xAxis}
             />
             <g
-              // eslint-disable-next-line react/jsx-no-bind
               ref={(node: SVGGElement | null) => this._setYAxis(node, yAxis)}
               transform={`translate(${this.margins.left}, 0)`}
               className={this._classNames.yAxis}
@@ -147,11 +141,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           </svg>
         </FocusZone>
         {
-          <div
-            // eslint-disable-next-line react/jsx-no-bind
-            ref={(e: HTMLDivElement) => (this.legendContainer = e)}
-            className={this._classNames.legendContainer}
-          >
+          <div ref={(e: HTMLDivElement) => (this.legendContainer = e)} className={this._classNames.legendContainer}>
             {legends}
           </div>
         }
@@ -461,13 +451,11 @@ export class VerticalStackedBarChartBase extends React.Component<
           width={this._barWidth}
           height={yBarScale(point.data) > 0 ? yBarScale(point.data) : 0}
           fill={color}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(e: SVGRectElement) => {
             this._refCallback(e, point.legend, refArrayIndexNumber);
           }}
           data-is-focusable={true}
           focusable={'true'}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseOver={this._onBarHover.bind(
             this,
             point.legend,
@@ -477,7 +465,6 @@ export class VerticalStackedBarChartBase extends React.Component<
             point.xAxisCalloutData!,
             point.yAxisCalloutData!,
           )}
-          // eslint-disable-next-line react/jsx-no-bind
           onMouseMove={this._onBarHover.bind(
             this,
             point.legend,
@@ -489,7 +476,6 @@ export class VerticalStackedBarChartBase extends React.Component<
           )}
           aria-labelledby={this._calloutId}
           onMouseLeave={this._onBarLeave}
-          // eslint-disable-next-line react/jsx-no-bind
           onFocus={this._onBarFocus.bind(
             this,
             point.legend,
@@ -501,7 +487,6 @@ export class VerticalStackedBarChartBase extends React.Component<
             point.yAxisCalloutData!,
           )}
           onBlur={this._onBarLeave}
-          // eslint-disable-next-line react/jsx-no-bind
           onClick={this._redirectToUrl.bind(this, href)}
         />
       );

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -345,7 +345,6 @@ export const CalendarBase = React.forwardRef(
         ref={forwardedRef}
         aria-label={selectionAndTodayString}
         className={css(rootClass, classes.root, className, 'ms-slideDownIn10')}
-        // eslint-disable-next-line react/jsx-no-bind
         onKeyDown={onDatePickerPopupKeyDown}
       >
         <div className={classes.liveRegion} aria-live="polite" aria-atomic="true">

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -210,7 +210,6 @@ export const CalendarMonthBase = React.forwardRef(
         <div className={classNames.headerContainer}>
           <button
             className={classNames.currentItemButton}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={onHeaderSelect}
             onKeyDown={onButtonKeyDown(onHeaderSelect)}
             aria-label={headerAriaLabel}

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -346,9 +346,7 @@ const CalendarYearTitle = React.forwardRef(
         <button
           ref={forwardedRef as React.Ref<HTMLButtonElement>}
           className={classNames.currentItemButton}
-          // eslint-disable-next-line react/jsx-no-bind
           onClick={onHeaderSelect}
-          // eslint-disable-next-line react/jsx-no-bind
           onKeyDown={onHeaderKeyDown}
           aria-label={ariaLabel}
           role="button"

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -40,7 +40,6 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
   public render(): JSX.Element {
     return (
       <div>
-        {/* eslint-disable-next-line react/jsx-no-bind */}
         <div ref={(calendarBtn: HTMLDivElement) => (this._calendarButtonElement = calendarBtn!)}>
           <DefaultButton
             onClick={this._onClick}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -216,7 +216,6 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
         !day.isInBounds && classNames.dayOutsideBounds,
         !day.isInMonth && classNames.dayOutsideNavigatedMonth,
       )}
-      // eslint-disable-next-line react/jsx-no-bind
       ref={(element: HTMLTableCellElement) => {
         customDayCellRef?.(element, day.originalDate, classNames);
         day.setRef(element);

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -104,6 +104,8 @@ const config = {
         allowArrowFunctions: false, // tslint: jsx-no-lambda
         allowFunctions: false,
         allowBind: false,
+        ignoreDOMComponents: true,
+        ignoreRefs: true,
       },
     ],
     'react/no-string-refs': 'error',

--- a/packages/example-app-base/src/components/ColorPalette/ColorPalette.tsx
+++ b/packages/example-app-base/src/components/ColorPalette/ColorPalette.tsx
@@ -94,9 +94,7 @@ class ColorPaletteBase extends React.Component<IColorPaletteProps, IColorPalette
       <li
         key={name}
         className={css(classNames.swatch, isSelected && classNames.swatchSelected)}
-        // eslint-disable-next-line react/jsx-no-bind
         onClick={() => this._selectColor(color)}
-        // eslint-disable-next-line react/jsx-no-bind
         onFocusCapture={() => this._selectColor(color)}
         style={{ backgroundColor: color.hex }}
         data-is-focusable={true}

--- a/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
@@ -31,7 +31,6 @@ export const ActionableView: IActionableComponent['view'] = (props, slots) => {
     <slots.root
       type={htmlType}
       role="button"
-      // eslint-disable-next-line react/jsx-no-bind
       onClick={_onClick}
       {...buttonProps}
       {...keytipAttributes}

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -44,7 +44,6 @@ export const ButtonView: IButtonComponent['view'] = (props, slots) => {
     <slots.root
       type={htmlType}
       role="button"
-      // eslint-disable-next-line react/jsx-no-bind
       onClick={_onClick}
       {...buttonProps}
       {...keytipAttributes}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -220,10 +220,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     <div
       ref={rootRef}
       className={css('ms-BasePicker ms-BaseExtendedPicker', className ? className : '')}
-      /* eslint-disable react/jsx-no-bind */
       onKeyDown={_onBackspace}
       onCopy={_onCopy}
-      /* eslint-enable react/jsx-no-bind */
     >
       <FocusZone direction={FocusZoneDirection.bidirectional} {...focusZoneProps}>
         <MarqueeSelection selection={selection} isEnabled={true}>

--- a/packages/experiments/src/slots/examples/Slots.Recomposition.Example.tsx
+++ b/packages/experiments/src/slots/examples/Slots.Recomposition.Example.tsx
@@ -46,7 +46,6 @@ const IconAtEndButtonView: IButtonComponent['view'] = (props, slots) => {
     <slots.root
       type="button"
       role="button"
-      // eslint-disable-next-line react/jsx-no-bind
       onClick={_onClick}
       {...buttonProps}
       disabled={disabled && !allowDisabledFocus}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -676,7 +676,6 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
       const onClick = (ev: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
         ev.stopPropagation();
       };
-      // eslint-disable-next-line react/jsx-no-bind
       return <span className={classNames.divider} aria-hidden={true} onClick={onClick} />;
     }
     return null;

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -327,7 +327,6 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                             [styles.monthSelection]: dateRangeType === DateRangeType.Month,
                           },
                         )}
-                        // eslint-disable-next-line react/jsx-no-bind
                         ref={element => this._setDayCellRef(element, day, isNavigatedDate)}
                         onMouseOver={
                           dateRangeType !== DateRangeType.Day && day.isInBounds
@@ -364,7 +363,6 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                           aria-readonly={true}
                           aria-selected={day.isInBounds ? day.isSelected : undefined}
                           data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
-                          // eslint-disable-next-line react/jsx-no-bind
                           ref={element => this._setDayRef(element, day, isNavigatedDate)}
                           disabled={!allFocusable && !day.isInBounds}
                           aria-disabled={!day.isInBounds}

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -68,10 +68,7 @@ export const CalendarButtonExample: React.FunctionComponent<ICalendarButtonExamp
 
   return (
     <div>
-      <div
-        // eslint-disable-next-line react/jsx-no-bind
-        ref={calendarBtn => (calendarButtonElement = calendarBtn!)}
-      >
+      <div ref={calendarBtn => (calendarButtonElement = calendarBtn!)}>
         <DefaultButton
           onClick={toggleShowCalendar}
           text={!selectedDate ? buttonString : selectedDate.toLocaleDateString()}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -361,7 +361,6 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
             aria-label={ariaLabel}
             aria-labelledby={labelElementId}
             style={contextMenuStyle}
-            // eslint-disable-next-line react/jsx-no-bind
             ref={(host: HTMLDivElement) => (this._host = host)}
             id={id}
             className={this._classNames.container}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -80,7 +80,6 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
         {(keytipAttributes: any): JSX.Element => (
           <div
             data-ktp-target={keytipAttributes['data-ktp-target']}
-            // eslint-disable-next-line react/jsx-no-bind
             ref={(splitButton: HTMLDivElement) => (this._splitButton = splitButton)}
             role={getMenuItemAriaRole(item)}
             aria-label={item.ariaLabel}
@@ -93,7 +92,6 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
             aria-posinset={focusableElementIndex + 1}
             aria-setsize={totalItemCount}
             onMouseEnter={this._onItemMouseEnterPrimary}
-            // eslint-disable-next-line react/jsx-no-bind
             onMouseLeave={
               onItemMouseLeave ? onItemMouseLeave.bind(this, { ...item, subMenuProps: null, items: null }) : undefined
             }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -645,7 +645,6 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
             [classNames.cellIsResizing]: columnResizeDetails && columnResizeDetails.columnIndex === columnIndex,
           },
         )}
-        // eslint-disable-next-line react/jsx-no-bind
         onDoubleClick={this._onSizerDoubleClick.bind(this, columnIndex)}
       />
     ) : null;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -205,7 +205,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     return (
       <GroupedListSection
-        // eslint-disable-next-line react/jsx-no-bind
         ref={ref => (this._groupRefs['group_' + groupIndex] = ref)}
         key={this._getGroupKey(group, groupIndex)}
         dragDropEvents={dragDropEvents}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -384,7 +384,6 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
     return !subGroup || subGroup.count > 0 || (groupProps && groupProps.showEmptyGroups) ? (
       <GroupedListSection
-        // eslint-disable-next-line react/jsx-no-bind
         ref={ref => (this._subGroupRefs['subGroup_' + subGroupIndex] = ref)}
         key={this._getGroupKey(subGroup, subGroupIndex)}
         dragDropEvents={dragDropEvents}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -172,7 +172,6 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
         {link.links && link.links.length > 0 ? (
           <button
             className={classNames.chevronButton}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={this._onLinkExpandClicked.bind(this, link)}
             aria-label={finalExpandBtnAriaLabel}
             aria-expanded={link.isExpanded ? 'true' : 'false'}
@@ -272,13 +271,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
       : undefined;
 
     return (
-      <button
-        className={classNames.chevronButton}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={onClick}
-        aria-label={label}
-        aria-expanded={isExpanded}
-      >
+      <button className={classNames.chevronButton} onClick={onClick} aria-label={label} aria-expanded={isExpanded}>
         <Icon className={classNames.chevronIcon} iconName="ChevronDown" />
         {group.name}
       </button>

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -121,9 +121,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             id={starIds[i - 1]}
             key={i}
             {...(i === Math.ceil(rating) ? { 'data-is-current': true } : {})}
-            // eslint-disable-next-line react/jsx-no-bind
             onFocus={this._onFocus.bind(this, i)}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={this._onFocus.bind(this, i)} // For Safari & Firefox on OSX
             disabled={disabled || readOnly ? true : false}
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ThemeGenerator/ThemeGenerator.doc.tsx
@@ -308,7 +308,6 @@ export class ThemeGeneratorPage extends React.Component<{}, IThemeGeneratorPageS
         key={slotRule.name}
         className="ms-themer-swatch"
         style={{ backgroundColor: slotRule.color!.str }}
-        // eslint-disable-next-line react/jsx-no-bind
         onClick={this._onSwatchClick.bind(this, slotRule)}
       />
     );

--- a/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
@@ -151,19 +151,8 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
   useComponentRef(props.componentRef, inputElementRef, hasFocus);
 
   return (
-    <div
-      role="search"
-      ref={mergedRootRef}
-      className={classNames.root}
-      // eslint-disable-next-line react/jsx-no-bind
-      onFocusCapture={onFocusCapture}
-    >
-      <div
-        className={classNames.iconContainer}
-        // eslint-disable-next-line react/jsx-no-bind
-        onClick={onClickFocus}
-        aria-hidden
-      >
+    <div role="search" ref={mergedRootRef} className={classNames.root} onFocusCapture={onFocusCapture}>
+      <div className={classNames.iconContainer} onClick={onClickFocus} aria-hidden>
         <Icon iconName="Search" {...iconProps} className={classNames.icon} />
       </div>
       <input
@@ -171,13 +160,9 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
         id={id}
         className={classNames.field}
         placeholder={placeholderValue}
-        // eslint-disable-next-line react/jsx-no-bind
         onChange={onInputChange}
-        // eslint-disable-next-line react/jsx-no-bind
         onInput={onInputChange}
-        // eslint-disable-next-line react/jsx-no-bind
         onBlur={onBlur}
-        // eslint-disable-next-line react/jsx-no-bind
         onKeyDown={onKeyDown}
         value={value}
         disabled={disabled}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The [`react/jsx-no-bind`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) ESLint rule warns when `bind()` **or arrow functions** are used in JSX props, since this creates a new function every render and can potentially cause performance problems.

However, practically speaking, we're pretty sure that the main concern (in modern browsers) is not the function creation itself, but the fact that it could cause extra re-renders of custom components which might do equality checks on that prop. That issue isn't a concern for native elements (or for `ref` which is handled by React). So I updated the rule settings to enable `ignoreDOMComponents` and `ignoreRefs`.

Unfortunately this also removes any way to prevent use of `bind()` in native element props (which we still don't want because it's a discouraged older pattern), but overall it seems like an okay tradeoff.