### PR TITLE
T dama/Codemods - check in renameProp

### DIFF
--- a/change/@fluentui-codemods-2020-08-07-22-21-20-t-dama-codeMods_new_button.json
+++ b/change/@fluentui-codemods-2020-08-07-22-21-20-t-dama-codeMods_new_button.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "polish renameProp",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-08T02:21:20.753Z"
+}

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -6,8 +6,7 @@ const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
       const tags = findJsxTag(file, 'CompoundButton');
-      renameProp(tags, 'description', 'description', 'newDesc!');
-      //renameProp(tags, 'toggled', 'checked');
+      renameProp(tags, 'toggled', 'checked');
     } catch (e) {
       return { success: false };
     }

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -1,6 +1,6 @@
 import { SourceFile } from 'ts-morph';
 import { CodeMod } from '../../types';
-import { renameImport, renameProp, findJsxTag } from '../../utilities';
+import { renameProp, findJsxTag } from '../../utilities';
 
 //const buttonPath = 'office-ui-fabric-react/lib/Button';
 

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -1,0 +1,23 @@
+import { SourceFile } from 'ts-morph';
+import { CodeMod } from 'src/codeMods/types';
+import { renameImport, renameProp, findJsxTag } from 'src/codeMods/utilities';
+
+//const buttonPath = 'office-ui-fabric-react/lib/Button';
+
+const oldToNewButton: CodeMod = {
+  run: (file: SourceFile) => {
+    try {
+      renameImport(file, 'toggled', 'checked');
+      const tags = findJsxTag(file, 'Button');
+      renameProp(tags, 'toggled', 'checked');
+    } catch (e) {
+      return { success: false };
+    }
+    return { success: true };
+  },
+  version: '100000',
+  name: 'oldToNewButton',
+  enabled: true,
+};
+
+export default oldToNewButton;

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -7,7 +7,6 @@ import { renameImport, renameProp, findJsxTag } from '../../utilities';
 const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
-      renameImport(file, 'toggled', 'checked');
       const tags = findJsxTag(file, 'Button');
       renameProp(tags, 'toggled', 'checked');
     } catch (e) {

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -2,13 +2,12 @@ import { SourceFile } from 'ts-morph';
 import { CodeMod } from '../../types';
 import { renameProp, findJsxTag } from '../../utilities';
 
-//const buttonPath = 'office-ui-fabric-react/lib/Button';
-
 const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
-      const tags = findJsxTag(file, 'Button');
-      renameProp(tags, 'toggled', 'checked');
+      const tags = findJsxTag(file, 'DefaultButton');
+      renameProp(tags, 'actionBarOverflowButtonAriaLabel', 'actionBarOverflowButtonAriaLabel', 'newLabel!');
+      //renameProp(tags, 'toggled', 'checked');
     } catch (e) {
       return { success: false };
     }

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -5,8 +5,8 @@ import { renameProp, findJsxTag } from '../../utilities';
 const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
-      const tags = findJsxTag(file, 'CompoundButton');
-      renameProp(tags, 'toggled', 'checked');
+      const tags = findJsxTag(file, 'DefaultButton');
+      renameProp(tags, 'ariaLabel', 'ariaLabel', 'newwwww label!');
     } catch (e) {
       return { success: false };
     }

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -6,7 +6,7 @@ const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
       const tags = findJsxTag(file, 'DefaultButton');
-      renameProp(tags, 'ariaLabel', 'ariaLabel', 'newwwww label!');
+      renameProp(tags, 'ariaLabel', 'splitButtonAriaLabel', `'${'text'}'`);
     } catch (e) {
       return { success: false };
     }

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -1,6 +1,6 @@
 import { SourceFile } from 'ts-morph';
-import { CodeMod } from 'src/codeMods/types';
-import { renameImport, renameProp, findJsxTag } from 'src/codeMods/utilities';
+import { CodeMod } from '../../types';
+import { renameImport, renameProp, findJsxTag } from '../../utilities';
 
 //const buttonPath = 'office-ui-fabric-react/lib/Button';
 

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -5,8 +5,8 @@ import { renameProp, findJsxTag } from '../../utilities';
 const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
-      const tags = findJsxTag(file, 'DefaultButton');
-      renameProp(tags, 'actionBarOverflowButtonAriaLabel', 'actionBarOverflowButtonAriaLabel', 'newLabel!');
+      const tags = findJsxTag(file, 'CompoundButton');
+      renameProp(tags, 'description', 'description', 'newDesc!');
       //renameProp(tags, 'toggled', 'checked');
     } catch (e) {
       return { success: false };

--- a/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
+++ b/packages/codemods/src/codeMods/mods/oldToNewButton/oldToNewButton.mod.ts
@@ -6,7 +6,7 @@ const oldToNewButton: CodeMod = {
   run: (file: SourceFile) => {
     try {
       const tags = findJsxTag(file, 'DefaultButton');
-      renameProp(tags, 'ariaLabel', 'splitButtonAriaLabel', `'${'text'}'`);
+      renameProp(tags, 'toggled', 'checked');
     } catch (e) {
       return { success: false };
     }

--- a/packages/codemods/src/codeMods/tests/mock/button/mButtonProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mButtonProps.tsx
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as React from 'react';
+import { Button } from 'office-ui-fabric-react/lib/Button';
+
+export const RenderButton = (props: any) => {
+  return (
+    <div>
+      <Button toggled={true} />
+      <Button> toggled={false} </Button>
+    </div>
+  );
+};

--- a/packages/codemods/src/codeMods/tests/mock/button/mButtonStyles.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mButtonStyles.tsx
@@ -1,5 +1,3 @@
-//import { ITheme, IButtonProps } from 'office-ui-fabric-react';
-
 export interface ButtonProps {
   id: string;
   description?: string;

--- a/packages/codemods/src/codeMods/tests/mock/button/mButtonStyles.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mButtonStyles.tsx
@@ -1,0 +1,8 @@
+//import { ITheme, IButtonProps } from 'office-ui-fabric-react';
+
+export interface ButtonProps {
+  id: string;
+  description?: string;
+  imageSource: string;
+  toggled?: boolean;
+}

--- a/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { CompoundButton } from 'office-ui-fabric-react/lib/Button';
-import { ButtonProps } from './mButtonStyles';
 
-export class RenderButton extends React.Component<ButtonProps> {
+export class RenderButton extends React.Component<LocalButtonProps> {
   public render(): JSX.Element {
     const { id, ...restProps } = this.props;
     return (
@@ -13,4 +12,11 @@ export class RenderButton extends React.Component<ButtonProps> {
       </div>
     );
   }
+}
+
+export interface LocalButtonProps {
+  id: string;
+  description?: string;
+  imageSource: string;
+  toggled?: boolean;
 }

--- a/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { CompoundButton } from 'office-ui-fabric-react/lib/Button';
+import { ButtonProps } from './mButtonStyles';
+//import { IButtonProps } from 'office-ui-fabric-react';
+
+export class RenderButton extends React.Component<ButtonProps> {
+  public render(): JSX.Element {
+    const { id, ...restProps } = this.props;
+    return (
+      <div>
+        <CompoundButton {...this.props} />
+        <CompoundButton {...restProps} id={'d2'}>
+          Button!
+        </CompoundButton>
+      </div>
+    );
+  }
+}
+
+export interface SimpleProps {
+  id: string;
+  description?: string;
+  imageSource: string;
+  toggled?: boolean;
+}
+
+// export const RenderButton = (props: ButtonProps) => {
+//   const { id, ...restProps } = props;
+//   return (
+//     <div>
+//       <CompoundButton {...props} />
+//       <CompoundButton {...restProps} id={'d2'}>
+//         Button!
+//       </CompoundButton>
+//     </div>
+//   );
+// };

--- a/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { CompoundButton } from 'office-ui-fabric-react/lib/Button';
 import { ButtonProps } from './mButtonStyles';
-//import { IButtonProps } from 'office-ui-fabric-react';
 
 export class RenderButton extends React.Component<ButtonProps> {
   public render(): JSX.Element {
@@ -16,22 +15,3 @@ export class RenderButton extends React.Component<ButtonProps> {
     );
   }
 }
-
-export interface SimpleProps {
-  id: string;
-  description?: string;
-  imageSource: string;
-  toggled?: boolean;
-}
-
-// export const RenderButton = (props: ButtonProps) => {
-//   const { id, ...restProps } = props;
-//   return (
-//     <div>
-//       <CompoundButton {...props} />
-//       <CompoundButton {...restProps} id={'d2'}>
-//         Button!
-//       </CompoundButton>
-//     </div>
-//   );
-// };

--- a/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/button/mCompoundButtonProps.tsx
@@ -7,8 +7,7 @@ export class RenderButton extends React.Component<ButtonProps> {
     const { id, ...restProps } = this.props;
     return (
       <div>
-        <CompoundButton {...this.props} />
-        <CompoundButton {...restProps} id={'d2'}>
+        <CompoundButton {...this.props} {...restProps} id={'d2'}>
           Button!
         </CompoundButton>
       </div>

--- a/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
@@ -15,26 +15,26 @@ export const RenderDropdown = (props: any) => {
   );
 };
 
-export const RenderLetDropdown = (props: any) => {
-  let propsTest = { options: [], isDisabled: false };
-  return (
-    <div>
-      <Dropdown {...propsTest}>Dropdown!</Dropdown>
-      {/* include self closing Dropdown check */}
-      <Dropdown {...propsTest} />
-    </div>
-  );
-};
+// export const RenderLetDropdown = (props: any) => {
+//   let propsTest = { options: [], isDisabled: false };
+//   return (
+//     <div>
+//       <Dropdown {...propsTest}>Dropdown!</Dropdown>
+//       {/* include self closing Dropdown check */}
+//       <Dropdown {...propsTest} />
+//     </div>
+//   );
+// };
 
-export const RenderDropdownProps = (props: IDropdownProps) => {
-  return (
-    <div>
-      <Dropdown {...props}>Dropdown!</Dropdown>
-      {/* include self closing Dropdown check */}
-      <Dropdown {...props} />
-    </div>
-  );
-};
+// export const RenderDropdownProps = (props: IDropdownProps) => {
+//   return (
+//     <div>
+//       <Dropdown {...props}>Dropdown!</Dropdown>
+//       {/* include self closing Dropdown check */}
+//       <Dropdown {...props} />
+//     </div>
+//   );
+// };
 
 export function RenderDropdownPropsFunc(props: IDropdownProps) {
   return (

--- a/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
@@ -15,27 +15,6 @@ export const RenderDropdown = (props: any) => {
   );
 };
 
-// export const RenderLetDropdown = (props: any) => {
-//   let propsTest = { options: [], isDisabled: false };
-//   return (
-//     <div>
-//       <Dropdown {...propsTest}>Dropdown!</Dropdown>
-//       {/* include self closing Dropdown check */}
-//       <Dropdown {...propsTest} />
-//     </div>
-//   );
-// };
-
-// export const RenderDropdownProps = (props: IDropdownProps) => {
-//   return (
-//     <div>
-//       <Dropdown {...props}>Dropdown!</Dropdown>
-//       {/* include self closing Dropdown check */}
-//       <Dropdown {...props} />
-//     </div>
-//   );
-// };
-
 export function RenderDropdownPropsFunc(props: IDropdownProps) {
   return (
     <div>

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -33,7 +33,8 @@ describe('Persona props mod tests', () => {
   it('can rename a prop in a spread operator with complex spread examples', () => {
     const file = project.getSourceFileOrThrow('mCompoundButtonProps.tsx');
     const tags = findJsxTag(file, 'CompoundButton');
-    renameProp(tags, 'toggled', 'checked');
+    renameProp(tags, 'toggled', 'checked', undefined, undefined);
+
     tags.forEach(val => {
       expect(val.getText().includes('checked={toggled}')).toBeTruthy();
     });

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -1,0 +1,22 @@
+import { Project } from 'ts-morph';
+import { findJsxTag, renameProp } from '../../utilities';
+const buttonPath = '/**/tests/mock/**/button/**/*.tsx';
+
+describe('Persona props mod tests', () => {
+  let project: Project;
+
+  beforeEach(() => {
+    project = new Project();
+    project.addSourceFilesAtPaths(`${process.cwd()}${buttonPath}`);
+  });
+  it('can rename the toggled feature in Button', () => {
+    const file = project.getSourceFileOrThrow('mButtonProps.tsx');
+    //renameImport(file, 'toggled', 'checked');
+    const tags = findJsxTag(file, 'Button');
+    renameProp(tags, 'toggled', 'checked');
+    tags.forEach(val => {
+      expect(val.getAttribute('toggled')).not.toBeTruthy();
+    });
+    console.log(file);
+  });
+});

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -37,6 +37,5 @@ describe('Persona props mod tests', () => {
     tags.forEach(val => {
       expect(val.getText().includes('checked={toggled}')).toBeTruthy();
     });
-    //console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -37,6 +37,6 @@ describe('Persona props mod tests', () => {
     tags.forEach(val => {
       expect(val.getText().includes('checked={toggled}')).toBeTruthy();
     });
-    console.log(file);
+    //console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -1,6 +1,7 @@
 import { Project } from 'ts-morph';
 import { findJsxTag, renameProp } from '../../utilities';
 const buttonPath = '/**/tests/mock/**/button/**/*.tsx';
+const dropDownPath = '/**/tests/mock/**/dropdown/**/*.tsx';
 
 describe('Persona props mod tests', () => {
   let project: Project;
@@ -8,15 +9,38 @@ describe('Persona props mod tests', () => {
   beforeEach(() => {
     project = new Project();
     project.addSourceFilesAtPaths(`${process.cwd()}${buttonPath}`);
+    project.addSourceFilesAtPaths(`${process.cwd()}${dropDownPath}`);
   });
-  it('can rename the toggled feature in Button', () => {
-    const file = project.getSourceFileOrThrow('mButtonProps.tsx');
-    //renameImport(file, 'toggled', 'checked');
-    const tags = findJsxTag(file, 'Button');
+
+  // it('can rename the toggled feature in Button', () => {
+  //   const file = project.getSourceFileOrThrow('mButtonProps.tsx');
+  //   const tags = findJsxTag(file, 'Button');
+  //   renameProp(tags, 'toggled', 'checked');
+  //   tags.forEach(val => {
+  //     expect(val.getAttribute('toggled')).not.toBeTruthy();
+  //   });
+  // });
+
+  // it('can work on the dropdown example', () => {
+  //   const file = project.getSourceFileOrThrow('mDropdownSpreadProps.tsx');
+  //   const tags = findJsxTag(file, 'Dropdown');
+  //   renameProp(tags, 'isDisabled', 'disabled');
+  //   tags.forEach(val => {
+  //     expect(val.getText().includes('isDisabled')).toBeFalsy();
+  //     //console.log(val);
+  //   });
+  // });
+
+  it('can rename a prop in a spread operator with complex spread examples', () => {
+    const file = project.getSourceFileOrThrow('mCompoundButtonProps.tsx');
+    project.getSourceFiles().forEach(f => {
+      console.log(f.getFilePath());
+    });
+    const tags = findJsxTag(file, 'CompoundButton');
     renameProp(tags, 'toggled', 'checked');
     tags.forEach(val => {
-      expect(val.getAttribute('toggled')).not.toBeTruthy();
+      //console.log(val);
+      //expect(val.getText().includes('toggled')).toBeFalsy();
     });
-    console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
+++ b/packages/codemods/src/codeMods/tests/oldToNewButton/oldToNewButton.test.ts
@@ -12,35 +12,31 @@ describe('Persona props mod tests', () => {
     project.addSourceFilesAtPaths(`${process.cwd()}${dropDownPath}`);
   });
 
-  // it('can rename the toggled feature in Button', () => {
-  //   const file = project.getSourceFileOrThrow('mButtonProps.tsx');
-  //   const tags = findJsxTag(file, 'Button');
-  //   renameProp(tags, 'toggled', 'checked');
-  //   tags.forEach(val => {
-  //     expect(val.getAttribute('toggled')).not.toBeTruthy();
-  //   });
-  // });
+  it('can rename the toggled feature in Button', () => {
+    const file = project.getSourceFileOrThrow('mButtonProps.tsx');
+    const tags = findJsxTag(file, 'Button');
+    renameProp(tags, 'toggled', 'checked');
+    tags.forEach(val => {
+      expect(val.getAttribute('toggled')).not.toBeTruthy();
+    });
+  });
 
-  // it('can work on the dropdown example', () => {
-  //   const file = project.getSourceFileOrThrow('mDropdownSpreadProps.tsx');
-  //   const tags = findJsxTag(file, 'Dropdown');
-  //   renameProp(tags, 'isDisabled', 'disabled');
-  //   tags.forEach(val => {
-  //     expect(val.getText().includes('isDisabled')).toBeFalsy();
-  //     //console.log(val);
-  //   });
-  // });
+  it('can work on the dropdown example', () => {
+    const file = project.getSourceFileOrThrow('mDropdownSpreadProps.tsx');
+    const tags = findJsxTag(file, 'Dropdown');
+    renameProp(tags, 'isDisabled', 'disabled');
+    tags.forEach(val => {
+      expect(val.getText().includes('disabled={isDisabled}')).toBeTruthy();
+    });
+  });
 
   it('can rename a prop in a spread operator with complex spread examples', () => {
     const file = project.getSourceFileOrThrow('mCompoundButtonProps.tsx');
-    project.getSourceFiles().forEach(f => {
-      console.log(f.getFilePath());
-    });
     const tags = findJsxTag(file, 'CompoundButton');
     renameProp(tags, 'toggled', 'checked');
     tags.forEach(val => {
-      //console.log(val);
-      //expect(val.getText().includes('toggled')).toBeFalsy();
+      expect(val.getText().includes('checked={toggled}')).toBeTruthy();
     });
+    console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -48,210 +48,171 @@ describe('Props Utilities Test', () => {
       renameProp(tags, 'primaryText', 'Text', undefined);
       tags.forEach(val => {
         val.getAttributes().forEach(att => {
-          if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-            att
-              .getFirstChildByKind(SyntaxKind.Identifier)
-              ?.getType()
-              .getProperties()
-              .forEach(prop => {
-                expect(prop.getName()).not.toEqual('primaryText');
-              });
-          }
+          expect(val.getText().includes('Text={primaryText}')).toBeTruthy();
         });
       });
     });
-  });
 
-  describe('Edge Case Tests (changes in value)', () => {
-    it('[SANITY] can ID the correct file and get the JSX elements', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      expect(tags.length).toEqual(2);
-    });
-    it('can rename and replace the values of props (primitives)', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      renameProp(tags, 'isDisabled', 'disabled', 'false');
-      tags.forEach(tag => {
-        expect(tag.getAttribute('isDisabled')).toBeFalsy();
-        const valMaybe = Maybe(tag.getAttribute('disabled'));
-        const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-        expect(val.something).toBeTruthy();
-        const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-        expect(propValueText.something).toBeTruthy();
-        if (propValueText.something) {
-          expect(propValueText.value).toEqual('false');
-        }
+    describe('Edge Case Tests (changes in value)', () => {
+      it('[SANITY] can ID the correct file and get the JSX elements', () => {
+        const file = project.getSourceFileOrThrow(DropdownPropsFile);
+        const tags = findJsxTag(file, 'Dropdown');
+        expect(tags.length).toEqual(2);
       });
-    });
-
-    it('can replace props with changed values in a spread attribute', () => {
-      const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      renameProp(tags, 'isDisabled', 'disabled', 'false');
-      tags.forEach(val => {
-        val.getAttributes().forEach(att => {
-          if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-            att
-              .getFirstChildByKind(SyntaxKind.Identifier)
-              ?.getType()
-              .getProperties()
-              .forEach(prop => {
-                expect(prop.getName()).not.toEqual('isDisabled');
-              });
+      it('can rename and replace the values of props (primitives)', () => {
+        const file = project.getSourceFileOrThrow(DropdownPropsFile);
+        const tags = findJsxTag(file, 'Dropdown');
+        renameProp(tags, 'isDisabled', 'disabled', 'false');
+        tags.forEach(tag => {
+          expect(tag.getAttribute('isDisabled')).toBeFalsy();
+          const valMaybe = Maybe(tag.getAttribute('disabled'));
+          const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
+          expect(val.something).toBeTruthy();
+          const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
+          expect(propValueText.something).toBeTruthy();
+          if (propValueText.something) {
+            expect(propValueText.value).toEqual('false');
           }
         });
       });
-    });
-  });
 
-  describe('Edge Case Tests (transform functions)', () => {
-    it('can replace only the values of a given prop (number)', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      const func = numberTransform(100);
-      renameProp(tags, 'dropdownWidth', 'dropdownWidth', undefined, func);
-      tags.forEach(tag => {
-        expect(tag.getAttribute('dropdownWidth')).toBeTruthy();
-        const valMaybe = Maybe(tag.getAttribute('dropdownWidth'));
-        const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-        expect(val.something).toBeTruthy();
-        const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-        expect(propValueText.something).toBeTruthy();
-        if (propValueText.something) {
-          expect(propValueText.value).toEqual('100');
-        }
+      it('can replace props with changed values in a spread attribute', () => {
+        const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
+        const tags = findJsxTag(file, 'Dropdown');
+        renameProp(tags, 'isDisabled', 'disabled', 'false');
+        tags.forEach(val => {
+          expect(val.getText().includes('disabled={false}')).toBeTruthy();
+        });
       });
-    });
 
-    it('can rename and replace the values of props with a default value', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      const func = boolTransform(); // No args => assign to old value.
-      renameProp(tags, 'isDisabled', 'disabled', undefined, func);
-      tags.forEach(tag => {
-        expect(tag.getAttribute('isDisabled')).toBeFalsy();
-        const valMaybe = Maybe(tag.getAttribute('disabled'));
-        const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-        expect(val.something).toBeTruthy();
-        const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-        expect(propValueText.something).toBeTruthy();
-        if (propValueText.something) {
-          expect(propValueText.value).toEqual('isDisabled');
-        }
-      });
-    });
-
-    it('can replace props with changed enum values in Spinner (spread)', () => {
-      const file = project.getSourceFileOrThrow(spinnerPropsFile);
-      const tags = findJsxTag(file, 'Spinner');
-      const oldEnumValues: string[] = ['SpinnerType.large', 'SpinnerType.normal'];
-      const enumFn = enumTransform(spinnerMap);
-      renameProp(tags, 'type', 'size', undefined, enumFn);
-      tags.forEach(tag => {
-        expect(tag.getAttribute('type')).toBeFalsy();
-        const currentEnumValue = Maybe(oldEnumValues.pop());
-        const innerMaybe = Maybe(
-          (tag.getAttribute('size') as JsxAttribute).getFirstChildByKind(SyntaxKind.JsxExpression),
-        );
-        if (innerMaybe.something && currentEnumValue.something) {
-          const inner = innerMaybe.then(value => {
-            return value.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
+      describe('Edge Case Tests (transform functions)', () => {
+        it('can replace only the values of a given prop (number)', () => {
+          const file = project.getSourceFileOrThrow(DropdownPropsFile);
+          const tags = findJsxTag(file, 'Dropdown');
+          const func = numberTransform(100);
+          renameProp(tags, 'dropdownWidth', 'dropdownWidth', undefined, func);
+          tags.forEach(tag => {
+            expect(tag.getAttribute('dropdownWidth')).toBeTruthy();
+            const valMaybe = Maybe(tag.getAttribute('dropdownWidth'));
+            const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
+            expect(val.something).toBeTruthy();
+            const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
+            expect(propValueText.something).toBeTruthy();
+            if (propValueText.something) {
+              expect(propValueText.value).toEqual('100');
+            }
           });
+        });
 
-          expect(inner.something).toBeTruthy();
-          expect(currentEnumValue.something).toBeTruthy();
-          const newVal = spinnerMap[currentEnumValue.value];
-          const firstInnerChild = inner.then(value => value.getFirstChildByKind(SyntaxKind.Identifier));
-          const LastInnerChild = inner.then(value => value.getLastChildByKind(SyntaxKind.Identifier));
-          expect(firstInnerChild.something).toBeTruthy();
-          expect(LastInnerChild.something).toBeTruthy();
-          if (firstInnerChild.something && LastInnerChild.something) {
-            /* Need this if statement to clear value on the next line. */
-            expect(firstInnerChild.value.getText()).toEqual('SpinnerSize');
-            expect(LastInnerChild.value.getText()).toEqual(newVal.substring(newVal.indexOf('.') + 1));
-          }
-        }
-      });
-    });
+        it('can rename and replace the values of props with a default value', () => {
+          const file = project.getSourceFileOrThrow(DropdownPropsFile);
+          const tags = findJsxTag(file, 'Dropdown');
+          const func = boolTransform(); // No args => assign to old value.
+          renameProp(tags, 'isDisabled', 'disabled', undefined, func);
+          tags.forEach(tag => {
+            expect(tag.getAttribute('isDisabled')).toBeFalsy();
+            const valMaybe = Maybe(tag.getAttribute('disabled'));
+            const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
+            expect(val.something).toBeTruthy();
+            const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
+            expect(propValueText.something).toBeTruthy();
+            if (propValueText.something) {
+              expect(propValueText.value).toEqual('isDisabled');
+            }
+          });
+        });
 
-    it('can replace props with changed  values in Dropdown (spread)', () => {
-      const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      const transform: PropTransform = boolTransform(true, undefined);
-      renameProp(tags, 'isDisabled', 'disabled', undefined, transform);
-      tags.forEach(val => {
-        val.getAttributes().forEach(att => {
-          if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-            att
-              .getFirstChildByKind(SyntaxKind.Identifier)
-              ?.getType()
-              .getProperties()
-              .forEach(prop => {
-                expect(prop.getName()).not.toEqual('isDisabled');
+        it('can replace props with changed enum values in Spinner (spread)', () => {
+          const file = project.getSourceFileOrThrow(spinnerPropsFile);
+          const tags = findJsxTag(file, 'Spinner');
+          const oldEnumValues: string[] = ['SpinnerType.large', 'SpinnerType.normal'];
+          const enumFn = enumTransform(spinnerMap);
+          renameProp(tags, 'type', 'size', undefined, enumFn);
+          tags.forEach(tag => {
+            expect(tag.getAttribute('type')).toBeFalsy();
+            const currentEnumValue = Maybe(oldEnumValues.pop());
+            const innerMaybe = Maybe(
+              (tag.getAttribute('size') as JsxAttribute).getFirstChildByKind(SyntaxKind.JsxExpression),
+            );
+            if (innerMaybe.something && currentEnumValue.something) {
+              const inner = innerMaybe.then(value => {
+                return value.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
               });
-          }
-          /* Want to see these substrings somewhere in the Jsx element. */
-          expect(
-            val.getText().includes('{...__migProps}') || val.getText().includes('{...__migPropsTest}'),
-          ).toBeTruthy();
-          expect(val.getText().includes('disabled={true}')).toBeTruthy();
+
+              expect(inner.something).toBeTruthy();
+              expect(currentEnumValue.something).toBeTruthy();
+              const newVal = spinnerMap[currentEnumValue.value];
+              const firstInnerChild = inner.then(value => value.getFirstChildByKind(SyntaxKind.Identifier));
+              const LastInnerChild = inner.then(value => value.getLastChildByKind(SyntaxKind.Identifier));
+              expect(firstInnerChild.something).toBeTruthy();
+              expect(LastInnerChild.something).toBeTruthy();
+              if (firstInnerChild.something && LastInnerChild.something) {
+                /* Need this if statement to clear value on the next line. */
+                expect(firstInnerChild.value.getText()).toEqual('SpinnerSize');
+                expect(LastInnerChild.value.getText()).toEqual(newVal.substring(newVal.indexOf('.') + 1));
+              }
+            }
+          });
+        });
+
+        it('can replace props with changed  values in Dropdown (spread)', () => {
+          const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
+          const tags = findJsxTag(file, 'Dropdown');
+          const transform: PropTransform = boolTransform(true, undefined);
+          renameProp(tags, 'isDisabled', 'disabled', undefined, transform);
+          tags.forEach(val => {
+            expect(val.getText().includes('disabled={true}')).toBeTruthy();
+          });
+        });
+
+        it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
+          const file = project.getSourceFileOrThrow(spinnerSpreadPropsFile);
+          let tags = findJsxTag(file, 'Spinner');
+          const transform = enumTransform(spinnerMap);
+          renameProp(tags, 'type', 'size', undefined, transform);
+          tags = findJsxTag(file, 'Spinner');
+          /* Need to reacquire tags because the tags have been modified since then! */
+          tags.forEach(val => {
+            // val.getAttributes().forEach(att => {
+            //   if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
+            //     att
+            //       .getFirstChildByKind(SyntaxKind.Identifier)
+            //       ?.getType()
+            //       .getProperties()
+            //       .forEach(prop => {
+            //         expect(prop.getName()).not.toEqual('SpinnerType');
+            //       });
+            //   }
+            //   /* Want to see these substrings somewhere in the Jsx element. */
+            // });
+            expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
+          });
         });
       });
-      //console.log(file);
-    });
 
-    it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
-      const file = project.getSourceFileOrThrow(spinnerSpreadPropsFile);
-      let tags = findJsxTag(file, 'Spinner');
-      const transform = enumTransform(spinnerMap);
-      renameProp(tags, 'type', 'size', undefined, transform);
-      tags = findJsxTag(file, 'Spinner');
-      /* Need to reacquire tags because the tags have been modified since then! */
-      tags.forEach(val => {
-        val.getAttributes().forEach(att => {
-          if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-            att
-              .getFirstChildByKind(SyntaxKind.Identifier)
-              ?.getType()
-              .getProperties()
-              .forEach(prop => {
-                expect(prop.getName()).not.toEqual('SpinnerType');
-              });
-          }
-          /* Want to see these substrings somewhere in the Jsx element. */
-          expect(
-            val.getText().includes('{...__migProps}') || val.getText().includes('{...__migPropsTest}'),
-          ).toBeTruthy();
+      it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
+        const file = project.getSourceFileOrThrow(spinnerSpreadPropsFile);
+        let tags = findJsxTag(file, 'Spinner');
+        const transform = enumTransform(spinnerMap);
+        renameProp(tags, 'type', 'size', undefined, transform);
+        tags = findJsxTag(file, 'Spinner');
+        /* Need to reacquire tags because the tags have been modified since then! */
+        tags.forEach(val => {
+          // val.getAttributes().forEach(att => {
+          //   if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
+          //     att
+          //       .getFirstChildByKind(SyntaxKind.Identifier)
+          //       ?.getType()
+          //       .getProperties()
+          //       .forEach(prop => {
+          //         expect(prop.getName()).not.toEqual('SpinnerType');
+          //       });
+          //   }
+          //   /* Want to see these substrings somewhere in the Jsx element. */
+          // });
           expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
         });
       });
     });
-  });
-
-  it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
-    const file = project.getSourceFileOrThrow(spinnerSpreadPropsFile);
-    let tags = findJsxTag(file, 'Spinner');
-    const transform = enumTransform(spinnerMap);
-    renameProp(tags, 'type', 'size', undefined, transform);
-    tags = findJsxTag(file, 'Spinner');
-    /* Need to reacquire tags because the tags have been modified since then! */
-    tags.forEach(val => {
-      val.getAttributes().forEach(att => {
-        if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-          att
-            .getFirstChildByKind(SyntaxKind.Identifier)
-            ?.getType()
-            .getProperties()
-            .forEach(prop => {
-              expect(prop.getName()).not.toEqual('SpinnerType');
-            });
-        }
-        /* Want to see these substrings somewhere in the Jsx element. */
-        expect(val.getText().includes('{...__migProps}') || val.getText().includes('{...__migPropsTest}')).toBeTruthy();
-        expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
-      });
-    });
-    console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -173,18 +173,6 @@ describe('Props Utilities Test', () => {
           tags = findJsxTag(file, 'Spinner');
           /* Need to reacquire tags because the tags have been modified since then! */
           tags.forEach(val => {
-            // val.getAttributes().forEach(att => {
-            //   if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-            //     att
-            //       .getFirstChildByKind(SyntaxKind.Identifier)
-            //       ?.getType()
-            //       .getProperties()
-            //       .forEach(prop => {
-            //         expect(prop.getName()).not.toEqual('SpinnerType');
-            //       });
-            //   }
-            //   /* Want to see these substrings somewhere in the Jsx element. */
-            // });
             expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
           });
         });
@@ -198,20 +186,9 @@ describe('Props Utilities Test', () => {
         tags = findJsxTag(file, 'Spinner');
         /* Need to reacquire tags because the tags have been modified since then! */
         tags.forEach(val => {
-          // val.getAttributes().forEach(att => {
-          //   if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-          //     att
-          //       .getFirstChildByKind(SyntaxKind.Identifier)
-          //       ?.getType()
-          //       .getProperties()
-          //       .forEach(prop => {
-          //         expect(prop.getName()).not.toEqual('SpinnerType');
-          //       });
-          //   }
-          //   /* Want to see these substrings somewhere in the Jsx element. */
-          // });
           expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
         });
+        console.log(file);
       });
     });
   });

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -1,11 +1,4 @@
-import {
-  renameProp,
-  findJsxTag,
-  boolTransform,
-  enumTransform,
-  stringTransform,
-  numberTransform,
-} from '../../utilities';
+import { renameProp, findJsxTag, boolTransform, enumTransform, numberTransform } from '../../utilities';
 import { Project, SyntaxKind, JsxAttribute } from 'ts-morph';
 import { ValueMap, PropTransform } from '../../types';
 import { Maybe } from '../../../helpers/maybe';
@@ -259,5 +252,6 @@ describe('Props Utilities Test', () => {
         expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
       });
     });
+    console.log(file);
   });
 });

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -131,24 +131,6 @@ describe('Props Utilities Test', () => {
       });
     });
 
-    it('can rename and replace the values of props with a specified value', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      const func = boolTransform(false);
-      renameProp(tags, 'isDisabled', 'disabled', undefined, func);
-      tags.forEach(tag => {
-        expect(tag.getAttribute('isDisabled')).toBeFalsy();
-        const valMaybe = Maybe(tag.getAttribute('disabled'));
-        const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-        expect(val.something).toBeTruthy();
-        const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-        expect(propValueText.something).toBeTruthy();
-        if (propValueText.something) {
-          expect(propValueText.value).toEqual('false');
-        }
-      });
-    });
-
     it('can rename and replace the values of props with a default value', () => {
       const file = project.getSourceFileOrThrow(DropdownPropsFile);
       const tags = findJsxTag(file, 'Dropdown');
@@ -200,7 +182,7 @@ describe('Props Utilities Test', () => {
       });
     });
 
-    it('can replace props with changed enum values in Dropdown (spread)', () => {
+    it('can replace props with changed  values in Dropdown (spread)', () => {
       const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
       const tags = findJsxTag(file, 'Dropdown');
       const transform: PropTransform = boolTransform(true, undefined);
@@ -223,6 +205,7 @@ describe('Props Utilities Test', () => {
           expect(val.getText().includes('disabled={true}')).toBeTruthy();
         });
       });
+      //console.log(file);
     });
 
     it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
@@ -251,47 +234,6 @@ describe('Props Utilities Test', () => {
         });
       });
     });
-
-    it('can replace props with changed string values in dropdown', () => {
-      const file = project.getSourceFileOrThrow(DropdownPropsFile);
-      const tags = findJsxTag(file, 'Dropdown');
-      const transform = stringTransform('newPlaceholder');
-      renameProp(tags, 'placeHolder', 'placeholder', undefined, transform);
-      tags.forEach(tag => {
-        expect(tag.getAttribute('placeHolder')).toBeFalsy();
-        const valMaybe = Maybe(tag.getAttribute('placeholder'));
-        const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-        expect(val.something).toBeTruthy();
-        const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-        expect(propValueText.something).toBeTruthy();
-        if (propValueText.something) {
-          expect(propValueText.value).toEqual('newPlaceholder');
-        }
-      });
-    });
-  });
-
-  it('can replace props with changed enum values in Dropdown (spread)', () => {
-    const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
-    const tags = findJsxTag(file, 'Dropdown');
-    const transform: PropTransform = boolTransform(true, undefined);
-    renameProp(tags, 'isDisabled', 'disabled', undefined, transform);
-    tags.forEach(val => {
-      val.getAttributes().forEach(att => {
-        if (att.getKind() === SyntaxKind.JsxSpreadAttribute) {
-          att
-            .getFirstChildByKind(SyntaxKind.Identifier)
-            ?.getType()
-            .getProperties()
-            .forEach(prop => {
-              expect(prop.getName()).not.toEqual('isDisabled');
-            });
-        }
-        /* Want to see these substrings somewhere in the Jsx element. */
-        expect(val.getText().includes('{...__migProps}') || val.getText().includes('{...__migPropsTest}')).toBeTruthy();
-        expect(val.getText().includes('disabled={true}')).toBeTruthy();
-      });
-    });
   });
 
   it('can replace props with changed enum values in a spread attribute where the body is missing', () => {
@@ -316,24 +258,6 @@ describe('Props Utilities Test', () => {
         expect(val.getText().includes('{...__migProps}') || val.getText().includes('{...__migPropsTest}')).toBeTruthy();
         expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
       });
-    });
-  });
-
-  it('can replace props with changed string values in dropdown', () => {
-    const file = project.getSourceFileOrThrow(DropdownPropsFile);
-    const tags = findJsxTag(file, 'Dropdown');
-    const transform = stringTransform('newPlaceholder');
-    renameProp(tags, 'placeHolder', 'placeholder', undefined, transform);
-    tags.forEach(tag => {
-      expect(tag.getAttribute('placeHolder')).toBeFalsy();
-      const valMaybe = Maybe(tag.getAttribute('placeholder'));
-      const val = valMaybe.then(value => value.getFirstChildByKind(SyntaxKind.JsxExpression));
-      expect(val.something).toBeTruthy();
-      const propValueText = val.then(value => value.getText().substring(1, value.getText().length - 1));
-      expect(propValueText.something).toBeTruthy();
-      if (propValueText.something) {
-        expect(propValueText.value).toEqual('newPlaceholder');
-      }
     });
   });
 });

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -188,7 +188,6 @@ describe('Props Utilities Test', () => {
         tags.forEach(val => {
           expect(val.getText().includes('size={__migEnumMap[type]}')).toBeTruthy();
         });
-        console.log(file);
       });
     });
   });

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -48,3 +48,20 @@ export type PropTransform = (
   toRename: string,
   replacementName: string,
 ) => void;
+
+/**
+ * Enum that defines the cases by which this codemod can
+ * handle a prop in a spread operator. Called on a variable
+ * statement that contains the identified spread prop.
+ * Cases are
+ * SpreadPropLeft: if the desired spread prop exists on the left side of the deconstruction with '...' before it.
+ * PropLeft: if the desired prop exists on the left side of the deconstruction with no '...'.
+ * PropRight: if the desired prop exists on the right side of the variable statement.
+ * NotFound: if the variable statement does not match one of these cases, mark it as incompatible with the mod.
+ */
+export enum SpreadPropInStatement {
+  SpreadPropLeft,
+  PropLeft,
+  PropRight,
+  NotFound,
+}

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -23,13 +23,21 @@ export function renamePropInSpread(
   /* Step 1: Figure out which attribute contains the spread prop. */
   const allAttributes = element.getAttributes();
   allAttributes.forEach(attribute => {
+    console.log('trying it');
     if (attribute.getKind() === SyntaxKind.JsxSpreadAttribute) {
-      const spreadProp = attribute.getFirstChildByKind(SyntaxKind.Identifier);
+      console.log(attribute.getText());
+      //const p = attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
+      //console.log(p?.getType().getProperties().length);
+      const spreadProp = attribute.getFirstDescendantByKind(SyntaxKind.Identifier);
       /* Verify this attribute contains the name of our desired prop. */
       if (spreadContains(toRename, spreadProp)) {
+        console.log('spread contains!');
+
         /* Step 2: Verify that the spread prop is legitimately defined as a variable.  */
         const propDefinitions = spreadProp!.getDefinitions();
         if (verifyVariableDefinition(propDefinitions)) {
+          console.log('definition works!');
+
           /* Step 3: Create names for your new potential objects. */
           const propSpreadName = propDefinitions[0].getName();
           const newSpreadName = '__mig' + propSpreadName[0].toUpperCase() + propSpreadName.substring(1);
@@ -111,6 +119,7 @@ export function renamePropInSpread(
               : `{${toRename}}`,
           }); // Add the updated prop name and set its value.
         }
+        console.log(element.getText()); // first case doesn't get this far :0
       }
     }
   });
@@ -148,13 +157,26 @@ function createDeconstructedProp(newSpreadPropName: string, toRename: string, ol
 /* Helper function that returns TRUE if the supplied spread object
    contains the prop we're looking for. Else returns FALSE. */
 function spreadContains(oldPropName: string, spreadProp?: Identifier): boolean {
-  return (
-    spreadProp !== undefined &&
-    spreadProp
-      .getType()
-      .getProperties()
-      .some(name => name.getName() === oldPropName)
-  );
+  console.log(spreadProp?.getType().getText()); // should not print "any"
+  // const classDec = spreadProp?.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+  // //console.log(classDec?.getText());
+  // const heritage = classDec?.getFirstChildByKind(SyntaxKind.HeritageClause);
+  //console.log(heritage?.getText());
+  // // const propName = heritage?.getFirstDescendantByKind(SyntaxKind.TypeReference);
+  // const p = propName?.getFirstChildByKind(SyntaxKind.Identifier);
+  // console.log(p?.getText());
+
+  return false;
+  // return (
+  //   spreadProp !== undefined &&
+  //   spreadProp
+  //     .getType()
+  //     .getProperties()
+  //     .some(name => {
+  //       console.log(name.getName());
+  //       return name.getName() === oldPropName;
+  //     })
+  // );
 }
 
 /* Verifies that the spread object supplied is a variable

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -38,7 +38,7 @@ export function renamePropInSpread(
         const elemmm = spreadIsIdentifier
           ? attribute.getFirstChildByKind(SyntaxKind.Identifier)
           : attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
-        console.log(elemmm?.getContextualType());
+        console.log(elemmm?.getContextualType()?.getText());
         /* Step 3: Create names for your new potential objects. */
         const propSpreadName = spreadIsIdentifier ? firstIdentifier!.getText() : propertyAccess!.getText();
         let newSpreadName = '__migProps';

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -90,11 +90,14 @@ export function renamePropInSpread(
           if (variableStatementWithSpreadProp) {
             switch (locateSpreadPropInStatement(variableStatementWithSpreadProp, propSpreadName, newSpreadName)) {
               case SpreadPropInStatement.PropLeft: {
-                console.log('propleft found');
-                parentContainer.insertVariableStatement(
-                  insertIndex,
-                  createDeconstructedProp(newSpreadName, toRename, propSpreadName),
-                );
+                if (!propAlreadyExists(parentContainer, toRename)) {
+                  parentContainer.insertVariableStatement(
+                    insertIndex,
+                    createDeconstructedProp(newSpreadName, toRename, propSpreadName),
+                  );
+                } else {
+                  newSpreadName = propSpreadName;
+                }
                 break;
               }
               case SpreadPropInStatement.SpreadPropLeft: {
@@ -116,6 +119,8 @@ export function renamePropInSpread(
                 newSpreadName = propSpreadName;
                 if (!propAlreadyExists(parentContainer, toRename)) {
                   tryInsertExistingDecomposedProp(toRename, variableStatementWithSpreadProp);
+                } else {
+                  newSpreadName = propSpreadName;
                 }
                 break;
               }
@@ -127,10 +132,14 @@ export function renamePropInSpread(
               }
             }
           } else {
-            parentContainer.insertVariableStatement(
-              insertIndex,
-              createDeconstructedProp(newSpreadName, toRename, propSpreadName),
-            );
+            if (!propAlreadyExists(parentContainer, toRename)) {
+              parentContainer.insertVariableStatement(
+                insertIndex,
+                createDeconstructedProp(newSpreadName, toRename, propSpreadName),
+              );
+            } else {
+              newSpreadName = propSpreadName;
+            }
           }
 
           /* Step 8: Declare other auxiliary objects if necessary (i.e. value mapping case). */
@@ -176,7 +185,6 @@ export function renamePropInSpread(
             // don't replace unless you know you added it
             attrToRename.replaceWithText(`{...${newSpreadName}}`); // Replace old spread name.
           }
-          console.log('adding attribute');
           element.addAttribute({
             name: replacementName,
             initializer: changeValueMap

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -91,7 +91,6 @@ export function renamePropInSpread(
             /* Depending on where this spread prop was in the statement, there are different things we need to do. */
             switch (locateSpreadPropInStatement(variableStatementWithSpreadProp, propSpreadName, newSpreadName)) {
               case SpreadPropInStatement.PropLeft: {
-                console.log(variableStatementWithSpreadProp.getText());
                 /* If the spread prop was on the left with no '...' in front of it, try and create a new variable
                    statement, deconstructing this spread prop. */
                 if (!propAlreadyExists(parentContainer, toRename)) {

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -6,11 +6,13 @@ import {
   JsxSelfClosingElement,
   VariableDeclarationKind,
   CodeBlockWriter,
-  Identifier,
-  DefinitionInfo,
+  JsxAttributeLike,
+  Block,
+  VariableStatement,
 } from 'ts-morph';
 import { ValueMap } from 'src/codeMods/types';
 import { Maybe } from '../../../helpers/maybe';
+import { getParent } from 'office-ui-fabric-react/lib/Utilities';
 
 /* Helper function to rename a prop if in a spread operator.  */
 export function renamePropInSpread(
@@ -23,106 +25,150 @@ export function renamePropInSpread(
   /* Step 1: Figure out which attribute contains the spread prop. */
   const allAttributes = element.getAttributes();
   allAttributes.forEach(attribute => {
-    console.log('trying it');
     if (attribute.getKind() === SyntaxKind.JsxSpreadAttribute) {
-      console.log(attribute.getText());
-      //const p = attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
-      //console.log(p?.getType().getProperties().length);
-      const spreadProp = attribute.getFirstDescendantByKind(SyntaxKind.Identifier);
+      const firstIdentifier = attribute.getFirstChildByKind(SyntaxKind.Identifier);
+      const propertyAccess = attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
+      if (!attribute || (!firstIdentifier && !propertyAccess)) {
+        return;
+      }
+      const spreadIsIdentifier = firstIdentifier !== undefined;
       /* Verify this attribute contains the name of our desired prop. */
-      if (spreadContains(toRename, spreadProp)) {
-        console.log('spread contains!');
+      if (spreadContains(toRename, spreadIsIdentifier, attribute)) {
+        /* Step 3: Create names for your new potential objects. */
 
-        /* Step 2: Verify that the spread prop is legitimately defined as a variable.  */
-        const propDefinitions = spreadProp!.getDefinitions();
-        if (verifyVariableDefinition(propDefinitions)) {
-          console.log('definition works!');
+        const propSpreadName = spreadIsIdentifier ? firstIdentifier!.getText() : propertyAccess!.getText();
+        let newSpreadName = '__mig' + propSpreadName[0].toUpperCase() + propSpreadName.substring(1);
+        const newMapName = '__migEnumMap';
+        /* Metadata in case we need to reacquire the current element (AST modification). */
+        let newJSXFlag = false;
+        const elementType = element.getKind();
 
-          /* Step 3: Create names for your new potential objects. */
-          const propSpreadName = propDefinitions[0].getName();
-          const newSpreadName = '__mig' + propSpreadName[0].toUpperCase() + propSpreadName.substring(1);
-          const newMapName = '__migEnumMap';
-          /* Metadata in case we need to reacquire the current element (AST modification). */
-          let newJSXFlag = false;
-          const elementType = element.getKind();
-
-          /* Step 4: Get the container node who is the direct child of the closest SyntaxKind.Block.
+        /* Step 4: Get the container node who is the direct child of the closest SyntaxKind.Block.
              If we need to insert auxiliary variables, we'll insert them before this node. */
-          let blockContainer = getBlockContainer(element);
-          if (blockContainer === undefined) {
-            /* In the case there was NO code block, the following function will create one for you.
+        let blockContainer = getBlockContainer(element);
+        if (blockContainer === undefined) {
+          /* In the case there was NO code block, the following function will create one for you.
                If successful, initialize the newJSXFlag because you'll need to reaquire the spread element. */
-            const containerMaybe = createBlockContainer(element);
-            if (containerMaybe.something) {
-              blockContainer = containerMaybe.value;
-              newJSXFlag = true;
-            } else {
-              // eslint-disable-next-line no-throw-literal
-              throw 'attempt to create a new block around prop failed.';
-            }
-          }
-
-          /* Step 5: Get the parent of BLOCKCONTAINER so that we can insert our own variable statements. */
-          const parentContainer = blockContainer!.getParentIfKind(SyntaxKind.Block);
-          if (parentContainer === undefined) {
+          const containerMaybe = createBlockContainer(element);
+          if (containerMaybe.something) {
+            blockContainer = containerMaybe.value;
+            newJSXFlag = true;
+          } else {
             // eslint-disable-next-line no-throw-literal
-            throw 'unable to get parent container from block';
+            throw 'attempt to create a new block around prop failed.';
           }
-
-          /* Step 6: Get the index of BLOCKCONTAINER within PARENTCONTAINER that we'll use to insert our variables. */
-          const insertIndex = blockContainer!.getChildIndex();
-          if (insertIndex === undefined) {
-            // eslint-disable-next-line no-throw-literal
-            throw 'unable to find child index';
-          }
-
-          /* Step 7: Insert new variable statement deconstructing the spread prop, isolating the prop to be renamed. */
-          if (!parentContainer.getVariableStatement(newSpreadName)) {
-            parentContainer.insertVariableStatement(
-              insertIndex,
-              createDeconstructedProp(newSpreadName, toRename, propSpreadName),
-            );
-          }
-
-          /* Step 8: Declare other auxiliary objects if necessary (i.e. value mapping case). */
-          if (changeValueMap && !parentContainer.getVariableStatement(newMapName)) {
-            parentContainer.insertVariableStatement(
-              insertIndex,
-              createAuxiliaryVariable(VariableDeclarationKind.Const, newMapName, JSON.stringify(changeValueMap)),
-            );
-          }
-
-          /* Step 9: Handle any last auxiliary cases (i.e. component rendered with no body). */
-          let attrToRename = attribute;
-          /* attribute is an iterator variable in the forEach function. */
-          if (newJSXFlag) {
-            const newSpreadProp = Maybe(blockContainer!.getFirstDescendantByKind(SyntaxKind.JsxSpreadAttribute));
-            const newJSXElem = Maybe(
-              blockContainer!.getFirstDescendantByKind(
-                elementType as SyntaxKind.JsxOpeningElement | SyntaxKind.JsxSelfClosingElement,
-              ),
-            );
-            if (newSpreadProp.something && newJSXElem.something) {
-              attrToRename = newSpreadProp.value;
-              element = newJSXElem.value;
-            }
-          }
-
-          /* Step 10: Replace the props in the component with your new ones! */
-          attrToRename.replaceWithText(`{...${newSpreadName}}`); // Replace old spread name.
-          element.addAttribute({
-            name: replacementName,
-            initializer: changeValueMap
-              ? `{${newMapName}[${toRename}]}`
-              : replacementValue
-              ? `{${replacementValue}}`
-              : `{${toRename}}`,
-          }); // Add the updated prop name and set its value.
         }
-        console.log(element.getText()); // first case doesn't get this far :0
+
+        /* Step 5: Get the parent of BLOCKCONTAINER so that we can insert our own variable statements. */
+        const parentContainer = blockContainer!.getParentIfKind(SyntaxKind.Block);
+        if (parentContainer === undefined) {
+          // eslint-disable-next-line no-throw-literal
+          throw 'unable to get parent container from block';
+        }
+
+        /* Step 6: Get the index of BLOCKCONTAINER within PARENTCONTAINER that we'll use to insert our variables. */
+        const insertIndex = blockContainer!.getChildIndex();
+        if (insertIndex === undefined) {
+          // eslint-disable-next-line no-throw-literal
+          throw 'unable to find child index';
+        }
+
+        /* Step 7: Look to see if the prop we're looking for exists already. Manually
+           deconstruct it from the spread prop if not. */
+        const variableStatementWithSpreadProp = parentContainer.getVariableStatement(
+          (declaration: VariableStatement) => {
+            const elem = declaration.getFirstDescendantByKind(SyntaxKind.VariableDeclaration);
+            return (
+              elem !== undefined &&
+              (elem.getText().includes(`...${propSpreadName}`) || elem.getText().includes(`...${newSpreadName}`))
+            );
+          },
+        );
+        /* If a variable statement with the spread prop in question exists, try and use it.  */
+        if (variableStatementWithSpreadProp) {
+          /* Get the name of the deconstructed object, becuase we'll try and reuse it. */
+          const existingDecomposedPropName = Maybe(
+            variableStatementWithSpreadProp.getFirstDescendantByKind(SyntaxKind.DotDotDotToken),
+          )
+            .then(val => val.getParent())
+            .then(val => val.getFirstChildByKind(SyntaxKind.Identifier))
+            .then(val => val.getText());
+          if (existingDecomposedPropName.something) {
+            newSpreadName = existingDecomposedPropName.value;
+          }
+          if (!propAlreadyExists(parentContainer, toRename)) {
+            tryInsertExistingDecomposedProp(toRename, variableStatementWithSpreadProp);
+          }
+        } else {
+          /* If we could not find a variable statement with our spread prop in it, make one. */
+          parentContainer.insertVariableStatement(
+            insertIndex,
+            createDeconstructedProp(newSpreadName, toRename, propSpreadName),
+          );
+        }
+
+        /* Step 8: Declare other auxiliary objects if necessary (i.e. value mapping case). */
+        if (changeValueMap && !parentContainer.getVariableStatement(newMapName)) {
+          parentContainer.insertVariableStatement(
+            insertIndex,
+            createAuxiliaryVariable(VariableDeclarationKind.Const, newMapName, JSON.stringify(changeValueMap)),
+          );
+        }
+
+        /* Step 9: Handle any last auxiliary cases (i.e. component rendered with no body). */
+        let attrToRename = attribute;
+        /* attribute is an iterator variable in the forEach function. */
+        if (newJSXFlag) {
+          const newSpreadProp = Maybe(blockContainer!.getFirstDescendantByKind(SyntaxKind.JsxSpreadAttribute));
+          const newJSXElem = Maybe(
+            blockContainer!.getFirstDescendantByKind(
+              elementType as SyntaxKind.JsxOpeningElement | SyntaxKind.JsxSelfClosingElement,
+            ),
+          );
+          if (newSpreadProp.something && newJSXElem.something) {
+            attrToRename = newSpreadProp.value;
+            element = newJSXElem.value;
+          }
+        }
+
+        /* Step 10: Replace the props in the component with your new ones! */
+        attrToRename.replaceWithText(`{...${newSpreadName}}`); // Replace old spread name.
+        element.addAttribute({
+          name: replacementName,
+          initializer: changeValueMap
+            ? `{${newMapName}[${toRename}]}`
+            : replacementValue
+            ? `{${replacementValue}}`
+            : `{${toRename}}`,
+        }); // Add the updated prop name and set its value.
       }
     }
   });
+}
+
+/* Helper that identifies whether the prop TORENAME exists in a variable
+   declaration. If it does, the caller may not need to create a new variable
+   declatation statement. */
+function propAlreadyExists(parentContainer: Block, toRename: string): boolean {
+  if (parentContainer.getVariableStatement(toRename)) {
+    return true;
+  } else {
+    const statements = parentContainer.getVariableStatements();
+    return statements.some(statement => {
+      const declaration = statement.getFirstDescendantByKind(SyntaxKind.VariableDeclaration);
+      return declaration && declaration.getText().includes(toRename);
+    });
+  }
+}
+
+/* Attempts to insert the desired prop into the provided spread prop decomposition. */
+function tryInsertExistingDecomposedProp(oldProp: string, statement: VariableStatement) {
+  const decompObject = statement.getFirstDescendantByKind(SyntaxKind.ObjectBindingPattern);
+  if (decompObject) {
+    let objectText = decompObject.getText();
+    objectText = objectText.substr(0, 1) + ` ${oldProp},` + objectText.substr(1);
+    decompObject.replaceWithText(objectText);
+  }
 }
 
 /* Creates and returns a variable statement to the user's specification. KIND determines how
@@ -156,42 +202,18 @@ function createDeconstructedProp(newSpreadPropName: string, toRename: string, ol
 
 /* Helper function that returns TRUE if the supplied spread object
    contains the prop we're looking for. Else returns FALSE. */
-function spreadContains(oldPropName: string, spreadProp?: Identifier): boolean {
-  console.log(spreadProp?.getType().getText()); // should not print "any"
-  // const classDec = spreadProp?.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
-  // //console.log(classDec?.getText());
-  // const heritage = classDec?.getFirstChildByKind(SyntaxKind.HeritageClause);
-  //console.log(heritage?.getText());
-  // // const propName = heritage?.getFirstDescendantByKind(SyntaxKind.TypeReference);
-  // const p = propName?.getFirstChildByKind(SyntaxKind.Identifier);
-  // console.log(p?.getText());
-
-  return false;
-  // return (
-  //   spreadProp !== undefined &&
-  //   spreadProp
-  //     .getType()
-  //     .getProperties()
-  //     .some(name => {
-  //       console.log(name.getName());
-  //       return name.getName() === oldPropName;
-  //     })
-  // );
-}
-
-/* Verifies that the spread object supplied is a variable
-  defined by CONST or LET, or that it exists as a parameter or variable.
-  Although an array is passed in, there should be only a single entry. */
-function verifyVariableDefinition(propDefinitions: DefinitionInfo[]): boolean {
-  if (propDefinitions.length !== 1) {
-    return false;
-  }
-  const kind = propDefinitions[0].getKind();
+function spreadContains(oldPropName: string, spreadIsIdentifier: boolean, spreadProp: JsxAttributeLike): boolean {
+  const element = spreadIsIdentifier
+    ? spreadProp.getFirstChildByKind(SyntaxKind.Identifier)
+    : spreadProp.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
   return (
-    kind === ts.ScriptElementKind.constElement ||
-    kind === ts.ScriptElementKind.letElement ||
-    kind === ts.ScriptElementKind.variableElement ||
-    kind === ts.ScriptElementKind.parameterElement
+    element !== undefined &&
+    element
+      .getContextualType()!
+      .getProperties()
+      .some(name => {
+        return name.getName() === oldPropName;
+      })
   );
 }
 

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -90,6 +90,7 @@ export function renamePropInSpread(
           if (variableStatementWithSpreadProp) {
             switch (locateSpreadPropInStatement(variableStatementWithSpreadProp, propSpreadName, newSpreadName)) {
               case SpreadPropInStatement.PropLeft: {
+                console.log('propleft found');
                 parentContainer.insertVariableStatement(
                   insertIndex,
                   createDeconstructedProp(newSpreadName, toRename, propSpreadName),
@@ -106,7 +107,7 @@ export function renamePropInSpread(
                 if (existingDecomposedPropName.something) {
                   newSpreadName = existingDecomposedPropName.value;
                 }
-                if (!propAlreadyExists(parentContainer, toRename)) {
+                if (replacementValue === undefined && !propAlreadyExists(parentContainer, toRename)) {
                   tryInsertExistingDecomposedProp(toRename, variableStatementWithSpreadProp);
                 }
                 break;
@@ -125,30 +126,6 @@ export function renamePropInSpread(
                 break;
               }
             }
-            /* Get the name of the deconstructed object, becuase we'll try and reuse it. */
-            //   const existingDecomposedPropName = Maybe(
-            //     variableStatementWithSpreadProp.getFirstDescendantByKind(SyntaxKind.DotDotDotToken),
-            //   )
-            //     .then(val => val.getParent())
-            //     .then(val => val.getFirstChildByKind(SyntaxKind.Identifier))
-            //     .then(val => val.getText());
-            //   if (existingDecomposedPropName.something) {
-            //     newSpreadName = existingDecomposedPropName.value;
-            //   } else {
-            //     /* If there is no spread prop on the left side, use the right-side prop name. */
-            //     /* well it might not be on the left side at all */
-            //     newSpreadName = propSpreadName;
-            //   }
-            //   if (!propAlreadyExists(parentContainer, toRename)) {
-            //     tryInsertExistingDecomposedProp(toRename, variableStatementWithSpreadProp);
-            //   }
-            // } else {
-            //   /* If we could not find a variable statement with our spread prop in it, make one. */
-            //   parentContainer.insertVariableStatement(
-            //     insertIndex,
-            //     createDeconstructedProp(newSpreadName, toRename, propSpreadName),
-            //   );
-            // }
           } else {
             parentContainer.insertVariableStatement(
               insertIndex,
@@ -199,6 +176,7 @@ export function renamePropInSpread(
             // don't replace unless you know you added it
             attrToRename.replaceWithText(`{...${newSpreadName}}`); // Replace old spread name.
           }
+          console.log('adding attribute');
           element.addAttribute({
             name: replacementName,
             initializer: changeValueMap
@@ -237,7 +215,7 @@ function locateSpreadPropInStatement(
         if (leftSideObject.getText().includes('...')) {
           return SpreadPropInStatement.SpreadPropLeft;
         } else {
-          return SpreadPropInStatement.PropRight;
+          return SpreadPropInStatement.PropLeft;
         }
       }
     }

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -12,7 +12,6 @@ import {
 } from 'ts-morph';
 import { ValueMap } from 'src/codeMods/types';
 import { Maybe } from '../../../helpers/maybe';
-import { getParent } from 'office-ui-fabric-react/lib/Utilities';
 
 /* Helper function to rename a prop if in a spread operator.  */
 export function renamePropInSpread(
@@ -34,10 +33,15 @@ export function renamePropInSpread(
       const spreadIsIdentifier = firstIdentifier !== undefined;
       /* Verify this attribute contains the name of our desired prop. */
       if (spreadContains(toRename, spreadIsIdentifier, attribute)) {
+        console.log('contains, holy cow');
+        console.log(attribute.getText());
+        const elemmm = spreadIsIdentifier
+          ? attribute.getFirstChildByKind(SyntaxKind.Identifier)
+          : attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
+        console.log(elemmm?.getContextualType());
         /* Step 3: Create names for your new potential objects. */
-
         const propSpreadName = spreadIsIdentifier ? firstIdentifier!.getText() : propertyAccess!.getText();
-        let newSpreadName = '__mig' + propSpreadName[0].toUpperCase() + propSpreadName.substring(1);
+        let newSpreadName = '__migProps';
         const newMapName = '__migEnumMap';
         /* Metadata in case we need to reacquire the current element (AST modification). */
         let newJSXFlag = false;
@@ -102,12 +106,6 @@ export function renamePropInSpread(
             tryInsertExistingDecomposedProp(toRename, variableStatementWithSpreadProp);
           }
         } else {
-          console.log(
-            'writing a new container for new spread name: ' +
-              newSpreadName +
-              ', with propSpreadName: ' +
-              propSpreadName,
-          );
           /* If we could not find a variable statement with our spread prop in it, make one. */
           parentContainer.insertVariableStatement(
             insertIndex,
@@ -166,8 +164,6 @@ export function renamePropInSpread(
               ? `{${replacementValue}}`
               : `{${toRename}}`,
           }); // Add the updated prop name and set its value.
-        } else {
-          console.log('caught attempted repeat');
         }
       }
     }

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -18,7 +18,7 @@ export function renameProp(
       /* If found, do a simple name-replacementName. */
       foundProp.value.set({ name: replacementName });
       if (replacementValue) {
-        foundProp.value.set({ initializer: `{${replacementValue}}` });
+        foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression)?.replaceWithText(`{${replacementValue}}`);
       } else {
         const enumInJsx = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
         if (enumInJsx.something) {
@@ -32,7 +32,7 @@ export function renameProp(
       if (transform) {
         transform(val, toRename, replacementName);
       } else {
-        renamePropInSpread(val, toRename, replacementName);
+        renamePropInSpread(val, toRename, replacementName, undefined, replacementValue);
       }
     }
   });

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -18,10 +18,7 @@ export function renameProp(
       /* If found, do a simple name-replacementName. */
       foundProp.value.set({ name: replacementName });
       if (replacementValue) {
-        console.log('replacing text');
-        console.log(foundProp.value.getText());
         foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression)?.replaceWithText(`{${replacementValue}}`);
-        console.log(foundProp.value.getText()); // no print
       } else {
         const enumInJsx = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
         if (enumInJsx.something) {

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -32,6 +32,7 @@ export function renameProp(
       if (transform) {
         transform(val, toRename, replacementName);
       } else {
+        console.log('time for spread!');
         renamePropInSpread(val, toRename, replacementName);
       }
     }

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -18,7 +18,10 @@ export function renameProp(
       /* If found, do a simple name-replacementName. */
       foundProp.value.set({ name: replacementName });
       if (replacementValue) {
+        console.log('replacing text');
+        console.log(foundProp.value.getText());
         foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression)?.replaceWithText(`{${replacementValue}}`);
+        console.log(foundProp.value.getText());
       } else {
         const enumInJsx = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
         if (enumInJsx.something) {

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -32,7 +32,6 @@ export function renameProp(
       if (transform) {
         transform(val, toRename, replacementName);
       } else {
-        console.log('time for spread!');
         renamePropInSpread(val, toRename, replacementName);
       }
     }

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -21,7 +21,7 @@ export function renameProp(
         console.log('replacing text');
         console.log(foundProp.value.getText());
         foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression)?.replaceWithText(`{${replacementValue}}`);
-        console.log(foundProp.value.getText());
+        console.log(foundProp.value.getText()); // no print
       } else {
         const enumInJsx = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
         if (enumInJsx.something) {


### PR DESCRIPTION
Checking-in the renameProp utility. 
-Cleaned up spread prop changes because ts-morph can't detect imported files. 
-Added a new mock and test codemod to rename props in a button, as well as some test prop files.
-Added more casing for various spread cases.