### PR TITLE
fix: tab should have pointer as cursor

### DIFF
--- a/change/@fluentui-web-components-2020-08-08-12-50-31-users-chhol-fix-tab-pointer-cursor.json
+++ b/change/@fluentui-web-components-2020-08-08-12-50-31-users-chhol-fix-tab-pointer-cursor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: tab should have pointer as cursor",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-08T19:50:31.375Z"
+}

--- a/packages/web-components/src/tabs/tab/tab.styles.ts
+++ b/packages/web-components/src/tabs/tab/tab.styles.ts
@@ -14,7 +14,7 @@ export const TabStyles = css`
         box-sizing: border-box;
         font-family: var(--body-font);
         ${
-          /* Font size, weight, and line height are temporary - 
+          /* Font size, weight, and line height are temporary -
             replace when adaptive typography is figured out */ ''
         } font-size: 12px;
         font-weight: 400;
@@ -27,6 +27,7 @@ export const TabStyles = css`
         align-items: center;
         justify-content: center;
         grid-row: 1;
+        cursor: pointer;
     }
 
     :host([aria-selected="true"]) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14418 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fixes an issue where the tab cursor is incorrect.

#### Focus areas to test

Boot storybook, navigate to tabs - hover over the tab.
