### PR TITLE
split out lage build and test and lint steps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,20 +27,18 @@ jobs:
           yarn checkchange
         displayName: check change
 
-      ## only do scoped builds with PRs
+      ## TODO: clean up the @fluentui/docs build and @fluentui/react-northstar test WRT component-info generation
+      ## the dependency order cannot be expressed with lage configuration currently
       - script: |
-          yarn lage build test lint --verbose --no-cache --grouped --since $(target_branch)
-        displayName: build, test, lint (pr, scoped)
-        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
+          yarn lage build --only --verbose --no-cache --grouped
+        displayName: build
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
 
-      ## duplicated build step, but without --since flag for master CI builds
       - script: |
-          yarn lage build test lint --verbose --no-cache --grouped
-        displayName: build, test, lint (master)
-        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+          yarn lage test lint --only --verbose --no-cache --grouped
+        displayName: test, lint
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

There is a subtle race condition in component-info generation between @fluentui/docs BUILD and @fluentui/react-northstar TEST. The dependency order cannot be expressed with lage's configuration currently since these both write to the same files and are run potentially in parallel. This will cause the builds to SOMETIMES fail and sometimes succeed randomly. I am splitting these out to two separate build steps to mitigate.

#### Focus areas to test

(optional)
