### PR TITLE
Change question issue template to a link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 --- 
 contact_links: 
   - 
-    about: "Please ask and answer usage questions on Stack Overflow."
+    about: "Please ask and answer usage questions on Stack Overflow. (If you are a Microsoft employee you can also join the \"Fluent UI Community\" Teams channel.)"
     name: Question
     url: "https://stackoverflow.com/questions/tagged/fluentui"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 --- 
 contact_links: 
   - 
-    about: "Please ask and answer usage questions on Stack Overflow. (If you are a Microsoft employee you can also join the \"Fluent UI Community\" Teams channel.)"
+    about: 'Please ask and answer usage questions on Stack Overflow. (If you are a Microsoft employee you can also join the "Fluent UI Community" Teams channel.)'
     name: Question
     url: "https://stackoverflow.com/questions/tagged/fluentui"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,4 +3,4 @@ contact_links:
   - 
     about: 'Please ask and answer usage questions on Stack Overflow. (If you are a Microsoft employee you can also join the "Fluent UI Community" Teams channel.)'
     name: Question
-    url: "https://stackoverflow.com/questions/tagged/fluentui"
+    url: "https://stackoverflow.com/questions/tagged/fluent-ui"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,6 @@
+--- 
+contact_links: 
+  - 
+    about: "Please ask and answer usage questions on Stack Overflow."
+    name: Question
+    url: "https://stackoverflow.com/questions/tagged/fluentui"

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,8 +1,0 @@
----
-name: Question
-about: 'Please use Stack Overflow for questions #office-ui-fabric, #fluentui-react, #fluentui'
----
-
-For _how-to_ questions and other non-bugs, please use StackOverflow instead of Github issues. You can tag your questions with [office-ui-fabric][fluentui-react] [fluentui](https://stackoverflow.com/questions/tagged/office-ui-fabric).
-
-If you are a Microsoft employee you can also join the "Fluent UI Community" Teams channel.


### PR DESCRIPTION
This creates an 'issue template' that is simply a link 

![image](https://user-images.githubusercontent.com/1434956/89834219-3f3e4e00-db17-11ea-9d51-1a7a075f83dc.png)
