### PR TITLE
fix: ensure radio control does not shrink

### DIFF
--- a/change/@fluentui-web-components-2020-08-11-10-24-32-users-chhol-ensure-radios-do-not-shrink.json
+++ b/change/@fluentui-web-components-2020-08-11-10-24-32-users-chhol-ensure-radios-do-not-shrink.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: ensure radio control does not shrink",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T17:24:32.852Z"
+}

--- a/packages/web-components/src/radio/radio.styles.ts
+++ b/packages/web-components/src/radio/radio.styles.ts
@@ -60,6 +60,10 @@ export const RadioStyles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    .control, .checked-indicator {
+      flex-shrink: 0;
+    }
+
     .checked-indicator {
         position: absolute;
         top: 5px;
@@ -68,7 +72,6 @@ export const RadioStyles = css`
         bottom: 5px;
         border-radius: 50%;
         display: inline-block;
-        flex-shrink: 0;
         background: ${neutralForegroundRestBehavior.var};
         fill: ${neutralForegroundRestBehavior.var};
         opacity: 0;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
In rare scenarios the radio button control can end up shrinking slightly due to the use of flexbox. This PR ensures that the radio control itself does not shrink in those scenarios.

#### Focus areas to test

(optional)
