### PR TITLE
[Date-time] weekly day picker first day of week

### DIFF
--- a/change/@uifabric-date-time-2020-08-11-10-37-38-lorejoh12-WeeklyDayPickerFirstDayOfWeek.json
+++ b/change/@uifabric-date-time-2020-08-11-10-37-38-lorejoh12-WeeklyDayPickerFirstDayOfWeek.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding fix for first day of week changing away from Sunday that I broke with previous PR",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T17:37:38.307Z"
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarMonthHeaderRow.tsx
@@ -11,19 +11,20 @@ export interface ICalendarDayMonthHeaderRowProps extends ICalendarDayGridProps {
 }
 
 export const CalendarMonthHeaderRow = (props: ICalendarDayMonthHeaderRowProps) => {
-  const { showWeekNumbers, strings, allFocusable, weeksToShow, weeks, classNames } = props;
+  const { showWeekNumbers, strings, firstDayOfWeek, allFocusable, weeksToShow, weeks, classNames } = props;
   const dayLabels = strings.shortDays.slice();
   const firstOfMonthIndex = findIndex(weeks![1], (day: IDayInfo) => day.originalDate.getDate() === 1);
   if (weeksToShow === 1 && firstOfMonthIndex >= 0) {
     // if we only show one week, replace the header with short month name
-    dayLabels[firstOfMonthIndex] = strings.shortMonths[weeks![1][firstOfMonthIndex].originalDate.getMonth()];
+    const firstOfMonthIndexOffset = (firstOfMonthIndex + firstDayOfWeek) % DAYS_IN_WEEK;
+    dayLabels[firstOfMonthIndexOffset] = strings.shortMonths[weeks![1][firstOfMonthIndex].originalDate.getMonth()];
   }
 
   return (
     <tr>
       {showWeekNumbers && <th className={classNames.dayCell} />}
       {dayLabels.map((val: string, index: number) => {
-        const i = index % DAYS_IN_WEEK;
+        const i = (index + firstDayOfWeek) % DAYS_IN_WEEK;
         const label = index === firstOfMonthIndex ? strings.days[i] + ' ' + dayLabels[i] : strings.days[i];
         return (
           <th

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -184,7 +184,6 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
       >
         {this._renderPreviousWeekNavigationButton(classNames)}
         <CalendarDayGrid
-          {...calendarDayGridProps}
           styles={styles}
           componentRef={this._dayGrid}
           strings={strings}
@@ -203,6 +202,7 @@ export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, 
           today={today}
           lightenDaysOutsideNavigatedMonth={showFullMonth}
           animationDirection={this.state.animationDirection}
+          {...calendarDayGridProps}
         />
         {this._renderNextWeekNavigationButton(classNames)}
       </div>

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.test.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { WeeklyDayPicker } from './WeeklyDayPicker';
+import { resetIds } from '@uifabric/utilities';
+import { safeCreate } from '@uifabric/test-utilities';
+import { DayOfWeek } from '@fluentui/date-time-utilities';
+import { WeeklyDayPickerStrings } from './defaults';
+
+describe('WeeklyDayPicker', () => {
+  beforeEach(() => {
+    resetIds();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useFakeTimers();
+  });
+
+  it('renders default WeeklyDayPicker correctly', () => {
+    safeCreate(<WeeklyDayPicker strings={WeeklyDayPickerStrings} today={new Date('Jan 1 2019')} />, component => {
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+  });
+
+  it('renders WeeklyDayPicker with FirstDayOfWeek=Wednesday correctly', () => {
+    safeCreate(
+      <WeeklyDayPicker
+        strings={WeeklyDayPickerStrings}
+        firstDayOfWeek={DayOfWeek.Friday}
+        today={new Date('Jan 1 2019')}
+      />,
+      component => {
+        const tree = component.toJSON();
+        expect(tree).toMatchSnapshot();
+      },
+    );
+  });
+});

--- a/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -1,0 +1,6259 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday correctly 1`] = `
+<div
+  className=
+      ms-WeeklyDayPicker-root
+      {
+        align-items: center;
+        box-shadow: none;
+        box-sizing: content-box;
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 12px;
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 12px;
+        width: 220px;
+      }
+  onKeyDown={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+>
+  <button
+    aria-disabled={false}
+    className=
+
+        {
+          align-items: center;
+          background-color: #f3f2f1;
+          border: none;
+          display: flex;
+          font-size: 12px;
+          height: 0px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 12px;
+          outline: transparent;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          width: 12px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        .ms-WeeklyDayPicker-root:hover & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible &:focus {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus-within & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        &:hover {
+          background-color: #edebe9;
+          cursor: pointer;
+        }
+        &:active {
+          background-color: #a19f9d;
+        }
+    disabled={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    title="Previous week December 21, 2018 - December 27, 2018"
+    type="button"
+  >
+    <i
+      aria-hidden={true}
+      className=
+
+          {
+            display: inline-block;
+          }
+      data-icon-name="ChevronLeft"
+    />
+  </button>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+        {
+          padding-bottom: 10px;
+        }
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+  >
+    <table
+      aria-activedescendant="id__0"
+      aria-multiselectable="false"
+      aria-readonly="true"
+      className=
+
+          {
+            border-collapse: collapse;
+            border-spacing: 0;
+            font-size: inherit;
+            margin-top: 4px;
+            padding-bottom: 10px;
+            position: relative;
+            table-layout: fixed;
+            text-align: center;
+            width: 196px;
+          }
+      role="grid"
+    >
+      <tbody>
+        <tr>
+          <th
+            aria-label="Friday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Friday"
+          >
+            F
+          </th>
+          <th
+            aria-label="Saturday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Saturday"
+          >
+            S
+          </th>
+          <th
+            aria-label="Sunday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Sunday"
+          >
+            S
+          </th>
+          <th
+            aria-label="Monday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Monday"
+          >
+            M
+          </th>
+          <th
+            aria-label="Tuesday Jan"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Tuesday Jan"
+          >
+            Jan
+          </th>
+          <th
+            aria-label="Wednesday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Wednesday"
+          >
+            W
+          </th>
+          <th
+            aria-label="Thursday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Thursday"
+          >
+            T
+          </th>
+        </tr>
+        <tr
+          className=
+
+              {
+                animation-name: undefined keyframes 100%{width:0px;height:0px;overflow:hidden;}99.9%{width:100%;height:28px;overflow:visible;}0%{width:100%;height:28px;overflow:visible;};
+                height: 0px;
+                opacity: 0;
+                overflow: hidden;
+                position: absolute;
+                width: 0px;
+              }
+          role="presentation"
+        >
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 21, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                21
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 22, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                22
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 23, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                23
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 24, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                24
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 25, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                25
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 26, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                26
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 27, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                27
+              </span>
+            </button>
+          </td>
+        </tr>
+        <tr
+          className=
+
+
+        >
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 28, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                28
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 29, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                29
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 30, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                30
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 31, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                31
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                ms-CalendarDay-daySelected
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  background-color: #edebe9!important;
+                }
+                &:hover {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background: Highlight!important;
+                  border-color: Highlight!important;
+                  color: HighlightText!important;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 1, 2019"
+              aria-readonly={true}
+              aria-selected={true}
+              className=
+                  ms-CalendarDay-dayIsToday
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+                  {
+                    background-color: #0078d4!important;
+                    border-radius: 100%;
+                    color: #ffffff!important;
+                    font-weight: 600!important;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background: WindowText!important;
+                    border-color: WindowText!important;
+                    color: Window!important;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              id="id__0"
+              onKeyDown={[Function]}
+              role="gridcell"
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                1
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 2, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                2
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 3, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                3
+              </span>
+            </button>
+          </td>
+        </tr>
+        <tr
+          className=
+
+              {
+                animation-name: undefined keyframes 100%{width:0px;height:0px;overflow:hidden;}99.9%{width:100%;height:28px;overflow:visible;}0%{width:100%;height:28px;overflow:visible;};
+                height: 0px;
+                margin-top: -28px;
+                opacity: 0;
+                overflow: hidden;
+                position: absolute;
+                width: 0px;
+              }
+          role="presentation"
+        >
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 4, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                4
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 5, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                5
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 6, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                6
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 7, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                7
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 8, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                8
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 9, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                9
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 10, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                10
+              </span>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <button
+    aria-disabled={false}
+    className=
+
+        {
+          align-items: center;
+          background-color: #f3f2f1;
+          border: none;
+          display: flex;
+          font-size: 12px;
+          height: 0px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 12px;
+          outline: transparent;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          width: 12px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        .ms-WeeklyDayPicker-root:hover & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible &:focus {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus-within & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        &:hover {
+          background-color: #edebe9;
+          cursor: pointer;
+        }
+        &:active {
+          background-color: #a19f9d;
+        }
+    disabled={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    title="Next week January 4, 2019 - January 10, 2019"
+    type="button"
+  >
+    <i
+      aria-hidden={true}
+      className=
+
+          {
+            display: inline-block;
+          }
+      data-icon-name="ChevronRight"
+    />
+  </button>
+</div>
+`;
+
+exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
+<div
+  className=
+      ms-WeeklyDayPicker-root
+      {
+        align-items: center;
+        box-shadow: none;
+        box-sizing: content-box;
+        display: flex;
+        flex-direction: row;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 12px;
+        padding-left: 12px;
+        padding-right: 12px;
+        padding-top: 12px;
+        width: 220px;
+      }
+  onKeyDown={[Function]}
+  onTouchMove={[Function]}
+  onTouchStart={[Function]}
+>
+  <button
+    aria-disabled={false}
+    className=
+
+        {
+          align-items: center;
+          background-color: #f3f2f1;
+          border: none;
+          display: flex;
+          font-size: 12px;
+          height: 0px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 12px;
+          outline: transparent;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          width: 12px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        .ms-WeeklyDayPicker-root:hover & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible &:focus {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus-within & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        &:hover {
+          background-color: #edebe9;
+          cursor: pointer;
+        }
+        &:active {
+          background-color: #a19f9d;
+        }
+    disabled={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    title="Previous week December 23, 2018 - December 29, 2018"
+    type="button"
+  >
+    <i
+      aria-hidden={true}
+      className=
+
+          {
+            display: inline-block;
+          }
+      data-icon-name="ChevronLeft"
+    />
+  </button>
+  <div
+    className=
+        ms-FocusZone
+        &:focus {
+          outline: none;
+        }
+        {
+          padding-bottom: 10px;
+        }
+    data-focuszone-id="FocusZone1"
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onMouseDownCapture={[Function]}
+  >
+    <table
+      aria-activedescendant="id__0"
+      aria-multiselectable="false"
+      aria-readonly="true"
+      className=
+
+          {
+            border-collapse: collapse;
+            border-spacing: 0;
+            font-size: inherit;
+            margin-top: 4px;
+            padding-bottom: 10px;
+            position: relative;
+            table-layout: fixed;
+            text-align: center;
+            width: 196px;
+          }
+      role="grid"
+    >
+      <tbody>
+        <tr>
+          <th
+            aria-label="Sunday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Sunday"
+          >
+            S
+          </th>
+          <th
+            aria-label="Monday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Monday"
+          >
+            M
+          </th>
+          <th
+            aria-label="Tuesday Jan"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Tuesday Jan"
+          >
+            Jan
+          </th>
+          <th
+            aria-label="Wednesday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Wednesday"
+          >
+            W
+          </th>
+          <th
+            aria-label="Thursday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Thursday"
+          >
+            T
+          </th>
+          <th
+            aria-label="Friday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Friday"
+          >
+            F
+          </th>
+          <th
+            aria-label="Saturday"
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  animation-duration: 0.267s;
+                  animation-fill-mode: both;
+                  animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                  animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                }
+            scope="col"
+            title="Saturday"
+          >
+            S
+          </th>
+        </tr>
+        <tr
+          className=
+
+              {
+                animation-name: undefined keyframes 100%{width:0px;height:0px;overflow:hidden;}99.9%{width:100%;height:28px;overflow:visible;}0%{width:100%;height:28px;overflow:visible;};
+                height: 0px;
+                opacity: 0;
+                overflow: hidden;
+                position: absolute;
+                width: 0px;
+              }
+          role="presentation"
+        >
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 23, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                23
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 24, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                24
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 25, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                25
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 26, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                26
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 27, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                27
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 28, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                28
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="December 29, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                29
+              </span>
+            </button>
+          </td>
+        </tr>
+        <tr
+          className=
+
+
+        >
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 30, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                30
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  color: #605e5c;
+                  font-weight: 400;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="December 31, 2018"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                31
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                ms-CalendarDay-daySelected
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+                {
+                  background-color: #edebe9!important;
+                }
+                &:hover {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9!important;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background: Highlight!important;
+                  color: HighlightText!important;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background: Highlight!important;
+                  border-color: Highlight!important;
+                  color: HighlightText!important;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 1, 2019"
+              aria-readonly={true}
+              aria-selected={true}
+              className=
+                  ms-CalendarDay-dayIsToday
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+                  {
+                    background-color: #0078d4!important;
+                    border-radius: 100%;
+                    color: #ffffff!important;
+                    font-weight: 600!important;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background: WindowText!important;
+                    border-color: WindowText!important;
+                    color: Window!important;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              id="id__0"
+              onKeyDown={[Function]}
+              role="gridcell"
+              tabIndex={0}
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                1
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 2, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                2
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 3, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                3
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 4, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                4
+              </span>
+            </button>
+          </td>
+          <td
+            className=
+                
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+                {
+                  border-top-left-radius: 2px;
+                }
+                {
+                  border-top-right-radius: 2px;
+                }
+                {
+                  border-bottom-left-radius: 2px;
+                }
+                {
+                  border-bottom-right-radius: 2px;
+                }
+            onClick={[Function]}
+            onMouseDown={[Function]}
+            onMouseOut={[Function]}
+            onMouseOver={[Function]}
+            onMouseUp={[Function]}
+          >
+            <button
+              aria-disabled={false}
+              aria-label="January 5, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={true}
+              disabled={false}
+              onKeyDown={[Function]}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                5
+              </span>
+            </button>
+          </td>
+        </tr>
+        <tr
+          className=
+
+              {
+                animation-name: undefined keyframes 100%{width:0px;height:0px;overflow:hidden;}99.9%{width:100%;height:28px;overflow:visible;}0%{width:100%;height:28px;overflow:visible;};
+                height: 0px;
+                margin-top: -28px;
+                opacity: 0;
+                overflow: hidden;
+                position: absolute;
+                width: 0px;
+              }
+          role="presentation"
+        >
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 6, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                6
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 7, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                7
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 8, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                8
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 9, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                9
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 10, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                10
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 11, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                11
+              </span>
+            </button>
+          </td>
+          <td
+            aria-hidden={true}
+            className=
+
+                {
+                  border-radius: 100%!important;
+                  color: #323130;
+                  cursor: pointer;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 28px;
+                  line-height: 28px;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  width: 28px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: Window;
+                  color: WindowText;
+                  z-index: 0;
+                }
+                &.ms-CalendarDay-hoverStyle {
+                  background-color: #f3f2f1;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                  z-index: 3;
+                }
+                &.ms-CalendarDay-pressedStyle {
+                  background-color: #edebe9;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle {
+                  background-color: Window;
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active){&.ms-CalendarDay-pressedStyle.ms-CalendarDay-hoverStyle {
+                  background-color: Window;
+                  outline: 1px solid Highlight;
+                }
+          >
+            <button
+              aria-disabled={false}
+              aria-hidden={true}
+              aria-label="January 12, 2019"
+              aria-readonly={true}
+              aria-selected={false}
+              className=
+
+                  {
+                    background-color: transparent;
+                    border-radius: 100%;
+                    border: none;
+                    color: inherit;
+                    cursor: pointer;
+                    font-size: 12px;
+                    font-weight: inherit;
+                    height: 24px;
+                    line-height: 24px;
+                    outline: transparent;
+                    overflow: visible;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    width: 24px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: -1px;
+                    content: "";
+                    left: -1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: -1px;
+                    top: -1px;
+                    z-index: 1;
+                  }
+                  & span {
+                    height: inherit;
+                    line-height: inherit;
+                  }
+              data-is-focusable={false}
+              disabled={false}
+              role="gridcell"
+              type="button"
+            >
+              <span
+                aria-hidden="true"
+              >
+                12
+              </span>
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <button
+    aria-disabled={false}
+    className=
+
+        {
+          align-items: center;
+          background-color: #f3f2f1;
+          border: none;
+          display: flex;
+          font-size: 12px;
+          height: 0px;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          min-width: 12px;
+          outline: transparent;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: relative;
+          width: 12px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid #ffffff;
+          bottom: 1px;
+          content: "";
+          left: 1px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 1px;
+          top: 1px;
+          z-index: 1;
+        }
+        .ms-WeeklyDayPicker-root:hover & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible &:focus {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        .ms-Fabric--isFocusVisible .ms-WeeklyDayPicker-root:focus-within & {
+          height: 53px;
+          min-height: 12px;
+          overflow: initial;
+        }
+        &:hover {
+          background-color: #edebe9;
+          cursor: pointer;
+        }
+        &:active {
+          background-color: #a19f9d;
+        }
+    disabled={false}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    title="Next week January 6, 2019 - January 12, 2019"
+    type="button"
+  >
+    <i
+      aria-hidden={true}
+      className=
+
+          {
+            display: inline-block;
+          }
+      data-icon-name="ChevronRight"
+    />
+  </button>
+</div>
+`;

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
@@ -26,7 +26,7 @@ export class WeeklyDayPickerInlineExample extends React.Component<{}, IWeeklyDay
         </div>
         <WeeklyDayPicker
           onSelectDate={this._onSelectDate}
-          firstDayOfWeek={DayOfWeek.Sunday}
+          firstDayOfWeek={DayOfWeek.Wednesday}
           strings={defaultWeeklyDayPickerStrings}
           initialDate={this.state.selectedDate}
         />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Back in https://github.com/lorejoh12/fluentui/commit/b0ad85aef3e82623a7146c33a696f215ccbd26ee, checked in a change to fix the first day of the month showing up on the wrong day if the FirstDayOfWeek was not Sunday. My fix did that... by removing the FirstDayOfWeek functionality entirely. Undoing that change, fixing the initial issue by fixing the offset calculation in the correct place, and changing the example to have the firstDayOfWeek set to something other than Sunday (so we can see problems like this in the future).

Also moving the props for CalendarDayGrid to the bottom to allow consumer to override props if they want to (right now, passing other props like firstWeekOfYear are completely ignored).

#### Focus areas to test

(optional)
