### PR TITLE
Tooltip: Stopping propagation when clicking Esc on tooltip host

### DIFF
--- a/change/office-ui-fabric-react-2020-08-11-13-37-55-tooltipEsc.json
+++ b/change/office-ui-fabric-react-2020-08-11-13-37-55-tooltipEsc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tooltip: Stopping propagation when clicking Esc on tooltip host.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-11T20:37:55.359Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -225,6 +225,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
     if (ev.which === KeyCodes.escape) {
       this._hideTooltip();
+      ev.stopPropagation();
     }
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14465
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Pressing `Escape` dismisses the `Tooltip` but propagation does not stop there, which leads to unexpected results such as dismissing `Dialogs` when `Tooltips` are hosted inside. This PR fixes this by stopping propagation of the `onKeyDown` event in `TooltipHost`.

#### Focus areas to test

(optional)
