### PR TITLE
Enable eslint-plugin-react-hooks for react-next

### DIFF
--- a/change/@fluentui-eslint-plugin-2020-08-11-18-34-28-eslint-hooks-next.json
+++ b/change/@fluentui-eslint-plugin-2020-08-11-18-34-28-eslint-hooks-next.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add rule to prevent accidental references to globals",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-12T01:34:12.441Z"
+}

--- a/change/@fluentui-react-next-2020-08-11-18-34-28-eslint-hooks-next.json
+++ b/change/@fluentui-react-next-2020-08-11-18-34-28-eslint-hooks-next.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Enable eslint-plugin-react-hooks in react-next and fix a few bugs",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-12T01:34:16.311Z"
+}

--- a/change/@uifabric-monaco-editor-2020-08-11-19-02-22-eslint-hooks-next.json
+++ b/change/@uifabric-monaco-editor-2020-08-11-19-02-22-eslint-hooks-next.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix violation of newly added lint rule",
+  "packageName": "@uifabric/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-12T02:02:22.263Z"
+}

--- a/change/@uifabric-test-utilities-2020-08-11-18-34-28-eslint-hooks-next.json
+++ b/change/@uifabric-test-utilities-2020-08-11-18-34-28-eslint-hooks-next.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix misleading docs for safeMount",
+  "packageName": "@uifabric/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-12T01:34:27.992Z"
+}

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -87,6 +87,13 @@ const config = {
     'no-empty': 'error',
     'no-eval': 'error',
     'no-new-wrappers': 'error',
+    'no-restricted-globals': [
+      'error',
+      ...['blur', 'close', 'focus', 'length', 'name', 'parent', 'self', 'stop'].map(name => ({
+        name,
+        message: `"${name}" refers to a DOM global. Did you mean to reference a local value instead?`,
+      })),
+    ],
     'no-restricted-properties': [
       'error',
       { object: 'describe', property: 'only', message: 'describe.only should only be used during test development' },
@@ -204,7 +211,6 @@ const config = {
     // permanently disable because we disagree with these rules
     'import/prefer-default-export': 'off',
     'no-await-in-loop': 'off', // contrary to rule docs, awaited things often are NOT parallelizable
-    'no-restricted-globals': 'off', // airbnb bans isNaN in favor of Number.isNaN which is unavailable in IE 11
     'react/jsx-props-no-spreading': 'off',
     'react/prop-types': 'off',
 

--- a/packages/monaco-editor/src/configureEnvironment.ts
+++ b/packages/monaco-editor/src/configureEnvironment.ts
@@ -10,6 +10,7 @@ export interface IMonacoConfig {
   crossDomain?: boolean;
 }
 
+// eslint-disable-next-line no-restricted-globals
 const globalObj = (typeof self !== 'undefined' ? self : typeof window !== 'undefined' ? window : {}) as Window & {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   MonacoEnvironment?: any;

--- a/packages/react-next/.eslintrc.json
+++ b/packages/react-next/.eslintrc.json
@@ -3,9 +3,6 @@
   "extends": ["../office-ui-fabric-react/.eslintrc"],
   "root": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "error",
-    // Disable until issues are dealt with
-    "react-hooks/exhaustive-deps": "off",
-    "react-hooks/rules-of-hooks": "off"
+    "@typescript-eslint/no-explicit-any": "error"
   }
 }

--- a/packages/react-next/RELEASE_NOTES.md
+++ b/packages/react-next/RELEASE_NOTES.md
@@ -2,17 +2,9 @@
 
 ## Breaking changes
 
-### Beak
+### Calendar
 
-- Removed empty `IBeak` interface
-- Removed `componentRef` prop
-
-### SpinButton
-
-- Simplified props to `ISpinButtonStyles` to include only the parts of the component to bring inline with
-  other components.
-- Replaced `getClassNames` legacy prop with `styles` prop to bring component consistent to other components
-  and improve cachability of internal styles.
+TODO: Diff of OUFR vs date-time Calendar
 
 ### Checkbox
 
@@ -24,10 +16,27 @@
 ### Coachmark
 
 - Removed `isBeaconAnimating` and `isMeasured` style props
+- Beak:
+  - Removed empty `IBeak` interface
+  - Removed `componentRef` prop
+
+### DatePicker
+
+TODO: Diff of OUFR vs date-time DatePicker
 
 ### Pivot
 
 - Removed deprecated and redundant props from v7, including: `initialSelectedKey` and `defaultSelectedIndex`. Use `selectedKey` or `defaultSelectedKey` to define the selected tab, and provide `itemKey` on pivot item children.
+  - TODO: enumerate all removed props
+
+### Slider
+
+TODO: document any API or functionality changes
+
+### SpinButton
+
+- Simplified props to `ISpinButtonStyles` to include only the parts of the component to bring inline with other components.
+- Replaced `getClassNames` legacy prop with `styles` prop to bring component consistent to other components and improve cachability of internal styles.
 
 ### Others
 
@@ -45,7 +54,7 @@
 
 - Updated enums to string union type: `PivotLinkFormat`, `PivotLinkSize`. (#13370)
 
-## Changes worth callout
+## Other notable changes
 
 - `styles` prop backward compat solution.
 - css variables and IE 11 solution.

--- a/packages/react-next/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react-next/src/components/Callout/CalloutContent.base.tsx
@@ -28,7 +28,7 @@ import {
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
 import { AnimationClassNames } from '../../Styling';
-import { useMergedRefs, useAsync } from '@uifabric/react-hooks';
+import { useMergedRefs, useAsync, useConst } from '@uifabric/react-hooks';
 
 const ANIMATIONS: { [key: number]: string | undefined } = {
   [RectangleEdge.top]: AnimationClassNames.slideUpIn10,
@@ -142,7 +142,7 @@ function useBounds(
       cachedBounds.current = currentBounds;
     }
     return cachedBounds.current;
-  }, [bounds, minPagePadding, target]);
+  }, [bounds, minPagePadding, target, targetRef, targetWindowRef]);
 
   return getBounds;
 }
@@ -174,6 +174,12 @@ function useMaxHeight(
     } else if (hidden) {
       setMaxHeight(undefined);
     }
+    // TODO: check with Michael
+    // - Missing dependencies: coverTarget, directionalHintFixed, isBeakVisible, maxHeight
+    //   (and immutable values async, targetRef)
+    // - "Mutable values like 'targetRef.current' aren't valid dependencies because mutating them
+    //   doesn't re-render the component"
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [targetRef.current, gapSpace, beakWidth, directionalHint, getBounds, hidden]);
 
   return maxHeight;
@@ -215,6 +221,9 @@ function useHeightOffset({ finalHeight, hidden }: ICalloutProps, calloutElement:
     if (!hidden) {
       setHeightOffsetEveryFrame();
     }
+    // TODO: check with Michael
+    // (missing dep on setHeightOffsetEveryFrame)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [finalHeight, hidden]);
 
   return heightOffset;
@@ -275,6 +284,10 @@ function usePositions(
 
       return () => async.cancelAnimationFrame(timerId);
     }
+    // TODO: check with Michael
+    // missing deps finalHeight, getBounds, onPositioned, positions, props, target
+    // (and immutable values async, calloutElement, hostElement, targetRef)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hidden, directionalHint]);
 
   return positions;
@@ -289,8 +302,9 @@ function useAutoFocus(
   calloutElement: React.RefObject<HTMLDivElement>,
 ) {
   const async = useAsync();
+  const hasPositions = !!positions;
   React.useEffect(() => {
-    if (!hidden && setInitialFocus && positions && calloutElement.current) {
+    if (!hidden && setInitialFocus && hasPositions && calloutElement.current) {
       const timerId = async.requestAnimationFrame(
         () => focusFirstChild(calloutElement.current!),
         calloutElement.current,
@@ -298,7 +312,11 @@ function useAutoFocus(
 
       return () => async.cancelAnimationFrame(timerId);
     }
-  }, [hidden, !!positions]);
+    // TODO: check with Michael
+    // missing dep on setInitialFocus
+    // (and immutable values async, calloutElement)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hidden, hasPositions]);
 }
 
 /**
@@ -314,55 +332,56 @@ function useDismissHandlers(
   const isMouseDownOnPopup = React.useRef(false);
   const async = useAsync();
 
-  const mouseDownOnPopup = () => {
-    isMouseDownOnPopup.current = true;
-  };
-
-  const mouseUpOnPopup = () => {
-    isMouseDownOnPopup.current = false;
-  };
-
-  const dismissOnScroll = (ev: Event) => {
-    if (positions && !preventDismissOnScroll) {
-      dismissOnClickOrScroll(ev);
-    }
-  };
-
-  const dismissOnResize = (ev: Event) => {
-    if (!preventDismissOnResize) {
-      onDismiss?.(ev);
-    }
-  };
-
-  const dismissOnLostFocus = (ev: Event) => {
-    if (!preventDismissOnLostFocus) {
-      dismissOnClickOrScroll(ev);
-    }
-  };
-
-  const dismissOnClickOrScroll = (ev: Event) => {
-    const target = ev.target as HTMLElement;
-    const isEventTargetOutsideCallout = hostElement.current && !elementContains(hostElement.current, target);
-
-    // If mouse is pressed down on callout but moved outside then released, don't dismiss the callout.
-    if (isEventTargetOutsideCallout && isMouseDownOnPopup.current) {
+  const mouseDownHandlers = useConst([
+    () => {
+      isMouseDownOnPopup.current = true;
+    },
+    () => {
       isMouseDownOnPopup.current = false;
-      return;
-    }
-
-    if (
-      (!targetRef.current && isEventTargetOutsideCallout) ||
-      (ev.target !== targetWindowRef.current &&
-        isEventTargetOutsideCallout &&
-        (!targetRef.current ||
-          'stopPropagation' in targetRef.current ||
-          (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
-    ) {
-      onDismiss?.(ev);
-    }
-  };
+    },
+  ] as const);
 
   React.useEffect(() => {
+    const dismissOnScroll = (ev: Event) => {
+      if (positions && !preventDismissOnScroll) {
+        dismissOnClickOrScroll(ev);
+      }
+    };
+
+    const dismissOnResize = (ev: Event) => {
+      if (!preventDismissOnResize) {
+        onDismiss?.(ev);
+      }
+    };
+
+    const dismissOnLostFocus = (ev: Event) => {
+      if (!preventDismissOnLostFocus) {
+        dismissOnClickOrScroll(ev);
+      }
+    };
+
+    const dismissOnClickOrScroll = (ev: Event) => {
+      const target = ev.target as HTMLElement;
+      const isEventTargetOutsideCallout = hostElement.current && !elementContains(hostElement.current, target);
+
+      // If mouse is pressed down on callout but moved outside then released, don't dismiss the callout.
+      if (isEventTargetOutsideCallout && isMouseDownOnPopup.current) {
+        isMouseDownOnPopup.current = false;
+        return;
+      }
+
+      if (
+        (!targetRef.current && isEventTargetOutsideCallout) ||
+        (ev.target !== targetWindowRef.current &&
+          isEventTargetOutsideCallout &&
+          (!targetRef.current ||
+            'stopPropagation' in targetRef.current ||
+            (target !== targetRef.current && !elementContains(targetRef.current as HTMLElement, target))))
+      ) {
+        onDismiss?.(ev);
+      }
+    };
+
     // This is added so the callout will dismiss when the window is scrolled
     // but not when something inside the callout is scrolled. The delay seems
     // to be required to avoid React firing an async focus event in IE from
@@ -381,14 +400,42 @@ function useDismissHandlers(
         };
       }
     }, 0);
+    // TODO: check with Michael
+    // missing deps on onDismiss, positions, preventDismissOnLostFocus, preventDismissOnResize, preventDismissOnScroll
+    // (and immutable values async, hostElement, targetRef, targetWindowRef
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hidden]);
 
-  return [mouseDownOnPopup, mouseUpOnPopup] as const;
+  return mouseDownHandlers;
 }
 
 export const CalloutContentBase = React.memo(
   React.forwardRef((propsWithoutDefaults: ICalloutProps, forwardedRef: React.Ref<HTMLDivElement>) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+
+    const {
+      styles,
+      style,
+      ariaLabel,
+      ariaDescribedBy,
+      ariaLabelledBy,
+      className,
+      isBeakVisible,
+      children,
+      beakWidth,
+      calloutWidth,
+      calloutMaxWidth,
+      finalHeight,
+      hideOverflow = !!finalHeight,
+      backgroundColor,
+      calloutMaxHeight,
+      onScroll,
+      // eslint-disable-next-line deprecation/deprecation
+      shouldRestoreFocus = true,
+      target,
+      hidden,
+      onLayerMounted,
+    } = props;
 
     const hostElement = React.useRef<HTMLDivElement>(null);
     const calloutElement = React.useRef<HTMLDivElement>(null);
@@ -410,35 +457,16 @@ export const CalloutContentBase = React.memo(
     useAutoFocus(props, positions, calloutElement);
 
     React.useEffect(() => {
-      if (!props.hidden) {
-        props.onLayerMounted?.();
+      if (!hidden) {
+        onLayerMounted?.();
       }
-    }, [props.hidden]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run if hidden changes
+    }, [hidden]);
+
     // If there is no target window then we are likely in server side rendering and we should not render anything.
     if (!targetWindowRef.current) {
       return null;
     }
-    const {
-      styles,
-      style,
-      ariaLabel,
-      ariaDescribedBy,
-      ariaLabelledBy,
-      className,
-      isBeakVisible,
-      children,
-      beakWidth,
-      calloutWidth,
-      calloutMaxWidth,
-      finalHeight,
-      hideOverflow = !!finalHeight,
-      backgroundColor,
-      calloutMaxHeight,
-      onScroll,
-      // eslint-disable-next-line deprecation/deprecation
-      shouldRestoreFocus = true,
-      target,
-    } = props;
 
     const getContentMaxHeight: number | undefined = maxHeight ? maxHeight + heightOffset : undefined;
     const contentMaxHeight: number | undefined =

--- a/packages/react-next/src/components/Checkbox/useCheckbox.ts
+++ b/packages/react-next/src/components/Checkbox/useCheckbox.ts
@@ -84,6 +84,7 @@ export const useCheckbox = (props: ICheckboxProps, forwardedRef: React.Ref<HTMLD
 
 function useDebugWarning(props: ICheckboxProps) {
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: 'Checkbox',
       props,
@@ -116,6 +117,6 @@ function useComponentRef(
         }
       },
     }),
-    [isChecked, isIndeterminate],
+    [checkBoxRef, isChecked, isIndeterminate],
   );
 }

--- a/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
@@ -118,7 +118,7 @@ function useBeakPosition(
   targetAlignment: RectangleEdge | undefined,
   targetPosition: RectangleEdge | undefined,
 ) {
-  const { theme } = props;
+  const isRTL = getRTL(props.theme);
 
   return React.useMemo(() => {
     const beakDirection = targetPosition === undefined ? RectangleEdge.bottom : getOppositeEdge(targetPosition);
@@ -178,14 +178,14 @@ function useBeakPosition(
         }
 
         if (beakDirection === RectangleEdge.left) {
-          if (getRTL(theme)) {
+          if (isRTL) {
             beakPosition.right = distanceAdjustment;
           } else {
             beakPosition.left = distanceAdjustment;
           }
           transformOriginX = 'left';
         } else {
-          if (getRTL(theme)) {
+          if (isRTL) {
             beakPosition.left = distanceAdjustment;
           } else {
             beakPosition.right = distanceAdjustment;
@@ -196,7 +196,7 @@ function useBeakPosition(
     }
 
     return [beakPosition as Readonly<BeakPosition>, `${transformOriginX} ${transformOriginY}`] as const;
-  }, [targetAlignment, targetPosition, theme]);
+  }, [targetAlignment, targetPosition, isRTL]);
 }
 
 function useListeners(

--- a/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
@@ -8,7 +8,6 @@ import {
   IRectangle,
   KeyCodes,
   getRTL,
-  warnDeprecations,
   EventGroup,
   getPropsWithDefaults,
 } from '../../Utilities';
@@ -23,7 +22,8 @@ import { DirectionalHint } from '../../common/DirectionalHint';
 import { ICoachmarkProps, ICoachmarkStyles, ICoachmarkStyleProps } from './Coachmark.types';
 import { COACHMARK_HEIGHT, COACHMARK_WIDTH } from './Coachmark.styles';
 import { FocusTrapZone } from '../../FocusTrapZone';
-import { useAsync, useOnEvent } from '@uifabric/react-hooks';
+import { useAsync, useOnEvent, useSetTimeout, useWarnings } from '@uifabric/react-hooks';
+import { IBeakProps } from './Beak/Beak.types';
 
 const getClassNames = classNamesFunction<ICoachmarkStyleProps, ICoachmarkStyles>();
 
@@ -37,6 +37,8 @@ export interface IEntityRect {
   height?: number;
 }
 
+type BeakPosition = Pick<IBeakProps, 'left' | 'top' | 'right' | 'bottom' | 'direction'>;
+
 const DEFAULT_PROPS: Partial<ICoachmarkProps> = {
   isCollapsed: true,
   mouseProximityOffset: 10,
@@ -49,43 +51,43 @@ const DEFAULT_PROPS: Partial<ICoachmarkProps> = {
 };
 
 function useCollapsedState(props: ICoachmarkProps, entityInnerHostElementRef: React.RefObject<HTMLDivElement>) {
-  /**
-   * Is the Coachmark currently collapsed into
-   * a tear drop shape
-   */
-  const [isCollapsed, setIsCollapsed] = React.useState<boolean>(!!props.isCollapsed);
-  const async = useAsync();
+  const { isCollapsed: propsIsCollapsed, onAnimationOpenStart, onAnimationOpenEnd } = props;
+
+  /** Is the Coachmark currently collapsed into a tear drop shape */
+  const [isCollapsed, setIsCollapsed] = React.useState<boolean>(!!propsIsCollapsed);
+  const { setTimeout } = useSetTimeout();
 
   // Rather than pushing out logic elsewhere to prevent openCoachmark from being called repeatedly,
   // we'll track it here and only invoke the logic once. We do this with a ref, rather than just the state,
   // because the openCoachmark callback can be captured in scope for an effect
   const hasCoachmarkBeenOpened = React.useRef(!isCollapsed);
 
-  const openCoachmark = () => {
+  const openCoachmark = React.useCallback(() => {
     if (!hasCoachmarkBeenOpened.current) {
       setIsCollapsed(false);
 
-      props.onAnimationOpenStart?.();
+      onAnimationOpenStart?.();
 
       entityInnerHostElementRef.current?.addEventListener?.('transitionend', (): void => {
         // Need setTimeout to trigger narrator
-        async.setTimeout(() => {
+        setTimeout(() => {
           if (entityInnerHostElementRef.current) {
             focusFirstChild(entityInnerHostElementRef.current);
           }
         }, 1000);
 
-        props.onAnimationOpenEnd?.();
+        onAnimationOpenEnd?.();
       });
       hasCoachmarkBeenOpened.current = true;
     }
-  };
+  }, [entityInnerHostElementRef, onAnimationOpenEnd, onAnimationOpenStart, setTimeout]);
 
   React.useEffect(() => {
-    if (!props.isCollapsed) {
+    if (!propsIsCollapsed) {
       openCoachmark();
     }
-  }, [props.isCollapsed]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run if isCollapsed changes
+  }, [propsIsCollapsed]);
 
   return [isCollapsed, openCoachmark] as const;
 }
@@ -116,36 +118,15 @@ function useBeakPosition(
   targetAlignment: RectangleEdge | undefined,
   targetPosition: RectangleEdge | undefined,
 ) {
-  const beakDirection = targetPosition === undefined ? RectangleEdge.bottom : getOppositeEdge(targetPosition);
+  const { theme } = props;
 
-  /**
-   * The left position of the beak
-   */
-  const [beakLeft, setBeakLeft] = React.useState<string>();
+  return React.useMemo(() => {
+    const beakDirection = targetPosition === undefined ? RectangleEdge.bottom : getOppositeEdge(targetPosition);
 
-  /**
-   * The right position of the beak
-   */
-  const [beakTop, setBeakTop] = React.useState<string>();
+    const beakPosition: BeakPosition = { direction: beakDirection };
 
-  /**
-   * The right position of the beak
-   */
-  const [beakRight, setBeakRight] = React.useState<string>();
-
-  /**
-   * The bottom position of the beak
-   */
-  const [beakBottom, setBeakBottom] = React.useState<string>();
-
-  /**
-   * Transform origin of teaching bubble callout
-   */
-  const [transformOrigin, setTransformOrigin] = React.useState<string>();
-
-  React.useEffect(() => {
-    let transformOriginX;
-    let transformOriginY;
+    let transformOriginX: string;
+    let transformOriginY: string;
 
     const distanceAdjustment = '3px'; // Adjustment distance for Beak to shift towards Coachmark bubble.
 
@@ -155,25 +136,25 @@ function useBeakPosition(
       case RectangleEdge.bottom:
         // If there is no target alignment, then beak is X-axis centered in callout
         if (!targetAlignment) {
-          setBeakLeft(`calc(50% - ${BEAK_WIDTH / 2}px)`);
+          beakPosition.left = `calc(50% - ${BEAK_WIDTH / 2}px)`;
           transformOriginX = 'center';
         } else {
           // Beak is aligned to the left of target
           if (targetAlignment === RectangleEdge.left) {
-            setBeakLeft(`${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`);
+            beakPosition.left = `${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`;
             transformOriginX = 'left';
           } else {
             // Beak is aligned to the right of target
-            setBeakRight(`${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`);
+            beakPosition.right = `${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`;
             transformOriginX = 'right';
           }
         }
 
         if (beakDirection === RectangleEdge.top) {
-          setBeakTop(distanceAdjustment);
+          beakPosition.top = distanceAdjustment;
           transformOriginY = 'top';
         } else {
-          setBeakBottom(distanceAdjustment);
+          beakPosition.bottom = distanceAdjustment;
           transformOriginY = 'bottom';
         }
         break;
@@ -182,45 +163,40 @@ function useBeakPosition(
       case RectangleEdge.right:
         // If there is no target alignment, then beak is Y-axis centered in callout
         if (!targetAlignment) {
-          setBeakTop(`calc(50% - ${BEAK_WIDTH / 2}px)`);
+          beakPosition.top = `calc(50% - ${BEAK_WIDTH / 2}px)`;
           transformOriginY = `center`;
         } else {
           // Beak is aligned to the top of target
           if (targetAlignment === RectangleEdge.top) {
-            setBeakTop(`${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`);
+            beakPosition.top = `${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`;
             transformOriginY = `top`;
           } else {
             // Beak is aligned to the bottom of target
-            setBeakBottom(`${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`);
+            beakPosition.bottom = `${COACHMARK_WIDTH / 2 - BEAK_WIDTH / 2}px`;
             transformOriginY = `bottom`;
           }
         }
 
         if (beakDirection === RectangleEdge.left) {
-          if (getRTL(props.theme)) {
-            setBeakRight(distanceAdjustment);
+          if (getRTL(theme)) {
+            beakPosition.right = distanceAdjustment;
           } else {
-            setBeakLeft(distanceAdjustment);
+            beakPosition.left = distanceAdjustment;
           }
           transformOriginX = 'left';
         } else {
-          if (getRTL(props.theme)) {
-            setBeakLeft(distanceAdjustment);
+          if (getRTL(theme)) {
+            beakPosition.left = distanceAdjustment;
           } else {
-            setBeakRight(distanceAdjustment);
+            beakPosition.right = distanceAdjustment;
           }
           transformOriginX = 'right';
         }
         break;
     }
 
-    setTransformOrigin(`${transformOriginX} ${transformOriginY}`);
-  }, [targetAlignment, targetPosition]);
-
-  return [
-    { direction: beakDirection, top: beakTop, bottom: beakBottom, left: beakLeft, right: beakRight } as const,
-    transformOrigin,
-  ] as const;
+    return [beakPosition as Readonly<BeakPosition>, `${transformOriginX} ${transformOriginY}`] as const;
+  }, [targetAlignment, targetPosition, theme]);
 }
 
 function useListeners(
@@ -270,58 +246,50 @@ function useProximityHandlers(
   translateAnimationContainer: React.RefObject<HTMLDivElement>,
   openCoachmark: () => void,
 ) {
-  const async = useAsync();
+  const { setTimeout, clearTimeout } = useSetTimeout();
 
-  /**
-   * The target element the mouse would be in
-   * proximity to
-   */
+  /** The target element the mouse would be in proximity to */
   const targetElementRect = React.useRef<DOMRect>();
 
-  const setTargetElementRect = (): void => {
-    if (translateAnimationContainer?.current) {
-      targetElementRect.current = translateAnimationContainer.current.getBoundingClientRect();
-    }
-  };
-
   React.useEffect(() => {
+    const setTargetElementRect = (): void => {
+      if (translateAnimationContainer.current) {
+        targetElementRect.current = translateAnimationContainer.current.getBoundingClientRect();
+      }
+    };
+
     const events = new EventGroup({});
 
-    // We don't want to the user to immediately trigger the Coachmark when it's opened
-    async.setTimeout(() => {
+    // We don't want the user to immediately trigger the Coachmark when it's opened
+    setTimeout(() => {
       const { mouseProximityOffset = 0 } = props;
-      /**
-       * An array of cached ids returned when setTimeout runs during
-       * the window resize event trigger.
-       */
+
+      /** Cached ids returned when setTimeout runs during the window resize event trigger. */
       const timeoutIds: number[] = [];
 
-      // Take the initial measure out of the initial render to prevent
-      // an unnecessary render.
-      async.setTimeout(() => {
+      // Take the initial measure out of the initial render to prevent an unnecessary render.
+      setTimeout(() => {
         setTargetElementRect();
 
-        // When the window resizes we want to async
-        // get the bounding client rectangle.
-        // Every time the event is triggered we want to
-        // setTimeout and then clear any previous instances
-        // of setTimeout.
+        // When the window resizes we want to async get the bounding client rectangle.
+        // Every time the event is triggered we want to setTimeout and then clear any previous
+        // instances of setTimeout.
         events.on(window, 'resize', (): void => {
           timeoutIds.forEach((value: number): void => {
-            clearInterval(value);
+            clearTimeout(value);
           });
+          timeoutIds.splice(0, timeoutIds.length); // clear array
 
           timeoutIds.push(
-            async.setTimeout((): void => {
+            setTimeout((): void => {
               setTargetElementRect();
             }, 100),
           );
         });
       }, 10);
 
-      // Every time the document's mouse move is triggered
-      // we want to check if inside of an element and
-      // set the state with the result.
+      // Every time the document's mouse move is triggered, we want to check if inside of an element
+      // and set the state with the result.
       events.on(document, 'mousemove', (e: MouseEvent) => {
         const mouseY = e.clientY;
         const mouseX = e.clientX;
@@ -336,27 +304,27 @@ function useProximityHandlers(
     }, props.delayBeforeMouseOpen!);
 
     return () => events.dispose();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
   }, []);
 }
 
 function useComponentRef(props: ICoachmarkProps) {
+  const { onDismiss } = props;
   React.useImperativeHandle(
     props.componentRef,
     (ev?: Event | React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => ({
       dismiss() {
-        props.onDismiss?.(ev);
+        onDismiss?.(ev);
       },
     }),
-    [props.onDismiss],
+    [onDismiss],
   );
 }
 
 function useAriaAlert({ ariaAlertText }: ICoachmarkProps) {
   const async = useAsync();
 
-  /**
-   * ARIA alert text to read aloud with Narrator once the Coachmark is mounted
-   */
+  /** ARIA alert text to read aloud with Narrator once the Coachmark is mounted */
   const [alertText, setAlertText] = React.useState<string | undefined>();
 
   React.useEffect(() => {
@@ -364,13 +332,14 @@ function useAriaAlert({ ariaAlertText }: ICoachmarkProps) {
     async.requestAnimationFrame(() => {
       setAlertText(ariaAlertText);
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
   }, []);
 
   return alertText;
 }
 
 function useAutoFocus({ preventFocusOnMount }: ICoachmarkProps) {
-  const async = useAsync();
+  const { setTimeout } = useSetTimeout();
 
   /**
    * The cached HTMLElement reference to the Entity Inner Host
@@ -380,22 +349,18 @@ function useAutoFocus({ preventFocusOnMount }: ICoachmarkProps) {
 
   React.useEffect(() => {
     if (!preventFocusOnMount) {
-      async.setTimeout(() => entityHost.current?.focus(), 1000);
+      setTimeout(() => entityHost.current?.focus(), 1000);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
   }, []);
 
   return entityHost;
 }
 
 function useEntityHostMeasurements(props: ICoachmarkProps, entityInnerHostElementRef: React.RefObject<HTMLDivElement>) {
-  /**
-   * Is the teaching bubble currently retreiving the
-   * original dimensions of the hosted entity.
-   */
+  /** Is the teaching bubble currently retrieving the original dimensions of the hosted entity. */
   const [isMeasuring, setIsMeasuring] = React.useState<boolean>(!!props.isCollapsed);
-  /**
-   * Cached width and height of _entityInnerHostElement
-   */
+  /** Cached width and height of _entityInnerHostElement */
   const [entityInnerHostRect, setEntityInnerHostRect] = React.useState<IEntityRect>(
     props.isCollapsed ? { width: 0, height: 0 } : {},
   );
@@ -411,22 +376,28 @@ function useEntityHostMeasurements(props: ICoachmarkProps, entityInnerHostElemen
         setIsMeasuring(false);
       }
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
   }, []);
 
   return [isMeasuring, entityInnerHostRect] as const;
 }
 
 function useDeprecationWarning(props: ICoachmarkProps) {
-  React.useEffect(() => {
-    warnDeprecations(COMPONENT_NAME, props, {
-      teachingBubbleRef: undefined,
-      collapsed: 'isCollapsed',
-      beakWidth: undefined,
-      beakHeight: undefined,
-      width: undefined,
-      height: undefined,
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
+    useWarnings({
+      name: COMPONENT_NAME,
+      props,
+      deprecations: {
+        teachingBubbleRef: undefined,
+        collapsed: 'isCollapsed',
+        beakWidth: undefined,
+        beakHeight: undefined,
+        width: undefined,
+        height: undefined,
+      },
     });
-  }, []);
+  }
 }
 
 const COMPONENT_NAME = 'CoachmarkBase';

--- a/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -31,8 +31,7 @@ import { useMergedRefs, useAsync } from '@uifabric/react-hooks';
 
 const OFF_SCREEN_STYLE = { opacity: 0 };
 
-// In order for some of the max height logic to work
-// properly we need to set the border.
+// In order for some of the max height logic to work properly we need to set the border.
 // The value is abitrary.
 const BORDER_WIDTH = 1;
 const SLIDE_ANIMATIONS = {
@@ -53,15 +52,11 @@ function useTargets({ target }: IPositioningContainerProps, positionedHost: Reac
   const previousTargetProp = React.useRef<HTMLElement | string | MouseEvent | Point | null | undefined>();
 
   const targetRef = React.useRef<HTMLElement | MouseEvent | Point | null>(null);
-  /**
-   * Stores an instance of Window, used to check
-   * for server side rendering and if focus was lost.
-   */
+  /** Stores an instance of Window, used to check for server side rendering and if focus was lost. */
   const targetWindowRef = React.useRef<Window>();
 
-  // If the target element changed, find the new one. If we are tracking
-  // target with class name, always find element because we do not know if
-  // fabric has rendered a new element and disposed the old element.
+  // If the target element changed, find the new one. If we are tracking target with class name,
+  // always find element because the element may have been disposed and re-rendered.
   if (target !== previousTargetProp.current || typeof target === 'string') {
     const currentElement = positionedHost.current;
 
@@ -96,10 +91,7 @@ function useTargets({ target }: IPositioningContainerProps, positionedHost: Reac
 }
 
 function useCachedBounds(props: IPositioningContainerProps, targetWindowRef: React.RefObject<Window | undefined>) {
-  /**
-   * The bounds used when determing if and where the
-   * PositioningContainer should be placed.
-   */
+  /** The bounds used when determining if and where the PositioningContainer should be placed. */
   const positioningBounds = React.useRef<IRectangle>();
 
   const getCachedBounds = (): IRectangle => {
@@ -289,6 +281,7 @@ function useAutoDismissEvents(
     }, 0);
 
     return () => events.dispose();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on mount
   }, []);
 }
 
@@ -304,9 +297,7 @@ export function useHeightOffset(
   const async = useAsync();
   const setHeightOffsetTimer = React.useRef<number>(0);
 
-  /**
-   * Animates the height if finalHeight was given.
-   */
+  /** Animates the height if finalHeight was given. */
   const setHeightOffsetEveryFrame = (): void => {
     if (contentHost && finalHeight) {
       setHeightOffsetTimer.current = async.requestAnimationFrame(() => {
@@ -330,6 +321,7 @@ export function useHeightOffset(
     }
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- should only re-run if finalHeight changes
   React.useEffect(setHeightOffsetEveryFrame, [finalHeight]);
 
   return heightOffset;
@@ -362,6 +354,7 @@ export const PositioningContainer = React.forwardRef(
     useSetInitialFocus(props, contentHost, positions);
     useAutoDismissEvents(props, positionedHost, targetWindowRef, targetRef, positions, updateAsyncPosition);
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on initial render
     React.useEffect(() => props.onLayerMounted?.(), []);
 
     // If there is no target window then we are likely in server side rendering and we should not render anything.

--- a/packages/react-next/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react-next/src/components/Fabric/Fabric.base.tsx
@@ -89,7 +89,8 @@ function useApplyThemeToBody(
         };
       }
     }
-  }, [bodyThemed]);
+    // TODO: verify with Michael
+  }, [bodyThemed, applyThemeToBody, rootElement]);
 
   return rootElement;
 }

--- a/packages/react-next/src/components/Link/useLink.ts
+++ b/packages/react-next/src/components/Link/useLink.ts
@@ -60,7 +60,7 @@ const useComponentRef = (props: ILinkProps, link: React.RefObject<ILink>) => {
         }
       },
     }),
-    [],
+    [link],
   );
 };
 

--- a/packages/react-next/src/components/Persona/Persona.base.tsx
+++ b/packages/react-next/src/components/Persona/Persona.base.tsx
@@ -28,6 +28,7 @@ const DEFAULT_PROPS = {
 
 function useDebugWarnings(props: IPersonaProps) {
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: 'Persona',
       props,

--- a/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -37,6 +37,7 @@ const DEFAULT_PROPS = {
 
 function useDebugWarnings(props: IPersonaCoinProps) {
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: 'PersonaCoin',
       props,

--- a/packages/react-next/src/components/Popup/Popup.tsx
+++ b/packages/react-next/src/components/Popup/Popup.tsx
@@ -64,12 +64,14 @@ function useRestoreFocus(props: IPopupProps, root: React.RefObject<HTMLDivElemen
       // De-reference DOM Node to avoid retainment via transpiled closure of _onKeyDown
       originalFocusedElement.current = undefined;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
   }, []);
 
   React.useEffect(() => {
     if (doesElementContainFocus(root.current!)) {
       containsFocus.current = true;
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
   }, []);
 
   useOnEvent(
@@ -96,6 +98,7 @@ function useRestoreFocus(props: IPopupProps, root: React.RefObject<HTMLDivElemen
       if (root.current && ev.relatedTarget && !root.current.contains(ev.relatedTarget as HTMLElement)) {
         containsFocus.current = false;
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on first render
     }, []),
     true,
   );
@@ -114,7 +117,7 @@ export const Popup = React.forwardRef((props: IPopupProps, forwardedRef: React.R
 
   useRestoreFocus(props, root);
 
-  const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style, children } = props;
+  const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style, children, onDismiss } = props;
   const needsVerticalScrollBar = useScrollbarAsync(props, root);
 
   const onKeyDown = React.useCallback(
@@ -122,8 +125,8 @@ export const Popup = React.forwardRef((props: IPopupProps, forwardedRef: React.R
       // eslint-disable-next-line deprecation/deprecation
       switch (ev.which) {
         case KeyCodes.escape:
-          if (props.onDismiss) {
-            props.onDismiss(ev);
+          if (onDismiss) {
+            onDismiss(ev);
 
             ev.preventDefault();
             ev.stopPropagation();
@@ -132,7 +135,7 @@ export const Popup = React.forwardRef((props: IPopupProps, forwardedRef: React.R
           break;
       }
     },
-    [props.onDismiss],
+    [onDismiss],
   );
 
   useOnEvent(getWindow(root.current), 'keydown', onKeyDown as (ev: Event) => void);

--- a/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -455,6 +455,7 @@ function useResizingBehavior(props: IResizeGroupProps, rootRef: React.RefObject<
 
 function useDebugWarnings(props: IResizeGroupProps) {
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: COMPONENT_NAME,
       props,

--- a/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
@@ -1,15 +1,17 @@
 import * as React from 'react';
 import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles, ISearchBox } from './SearchBox.types';
 import { KeyCodes, classNamesFunction, getNativeProps, inputProperties } from '../../Utilities';
-import { useBoolean, useControllableValue, useId, useMergedRefs, useWarnings } from '@uifabric/react-hooks';
-import { IconButton } from '../../compat/Button';
-import { Icon } from '../../Icon';
+import { useControllableValue, useId, useMergedRefs, useWarnings } from '@uifabric/react-hooks';
+import { IconButton, IButtonProps, IButtonStyles } from '../../compat/Button';
+import { Icon, IIconProps } from '../../Icon';
 
 const COMPONENT_NAME = 'SearchBox';
-const iconButtonStyles = { root: { height: 'auto' }, icon: { fontSize: '12px' } };
-const iconButtonProps = { iconName: 'Clear' };
+const iconButtonStyles: Partial<IButtonStyles> = { root: { height: 'auto' }, icon: { fontSize: '12px' } };
+const iconButtonProps: IIconProps = { iconName: 'Clear' };
+const defaultClearButtonProps: IButtonProps = { ariaLabel: 'Clear text' };
 
 const getClassNames = classNamesFunction<ISearchBoxStyleProps, ISearchBoxStyles>();
+
 const useComponentRef = (
   componentRef: React.Ref<ISearchBox> | undefined,
   inputElementRef: React.RefObject<HTMLInputElement>,
@@ -26,27 +28,29 @@ const useComponentRef = (
 };
 
 export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-  const [hasFocus, { setTrue: setHasFocusTrue, setFalse: setHasFocusFalse }] = useBoolean(false);
+  const [hasFocus, setHasFocus] = React.useState(false);
   const [value = '', setValue] = useControllableValue(props.value, props.defaultValue, props.onChange);
   const rootElementRef = React.useRef<HTMLDivElement>(null);
   const inputElementRef = React.useRef<HTMLInputElement>(null);
   const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
-  const fallbackId = useId(COMPONENT_NAME);
+  const id = useId(COMPONENT_NAME, props.id);
 
   const {
     ariaLabel,
-    placeholder,
     className,
     disabled,
     underlined,
     styles,
     // eslint-disable-next-line deprecation/deprecation
     labelText,
+    // eslint-disable-next-line deprecation/deprecation
+    placeholder = labelText,
     theme,
-    clearButtonProps = { ariaLabel: 'Clear text' },
+    clearButtonProps = defaultClearButtonProps,
     disableAnimation = false,
+    onClear: customOnClear,
+    onBlur: customOnBlur,
     iconProps,
-    id = fallbackId,
   } = props;
 
   const classNames = getClassNames(styles!, {
@@ -55,7 +59,7 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
     underlined,
     hasFocus,
     disabled,
-    hasInput: value!.length > 0,
+    hasInput: value.length > 0,
     disableAnimation,
   });
 
@@ -67,47 +71,48 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
     'value',
   ]);
 
-  const placeholderValue = placeholder !== undefined ? placeholder : labelText;
+  const onClear = React.useCallback(
+    (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => {
+      customOnClear?.(ev);
+      if (!ev.defaultPrevented) {
+        setValue('');
+        inputElementRef.current?.focus();
+        ev.stopPropagation();
+        ev.preventDefault();
+      }
+    },
+    [customOnClear, setValue],
+  );
 
-  const onClear = (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement> | React.KeyboardEvent<HTMLElement>) => {
-    props.onClear && props.onClear(ev);
-    if (!ev.defaultPrevented) {
-      setValue('');
-      inputElementRef.current?.focus();
-      ev.stopPropagation();
-      ev.preventDefault();
-    }
-  };
-
-  const onClearClick = (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
-    if (clearButtonProps && clearButtonProps.onClick) {
-      clearButtonProps.onClick(ev);
-    }
-    if (!ev.defaultPrevented) {
-      onClear(ev);
-    }
-  };
+  const onClearClick = React.useCallback(
+    (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+      clearButtonProps?.onClick?.(ev);
+      if (!ev.defaultPrevented) {
+        onClear(ev);
+      }
+    },
+    [clearButtonProps, onClear],
+  );
 
   const onFocusCapture = (ev: React.FocusEvent<HTMLElement>) => {
-    setHasFocusTrue();
-    if (props.onFocus) {
-      props.onFocus(ev as React.FocusEvent<HTMLInputElement>);
-    }
+    setHasFocus(true);
+    props.onFocus?.(ev as React.FocusEvent<HTMLInputElement>);
   };
 
   const onClickFocus = () => {
     if (inputElementRef.current) {
-      focus();
+      inputElementRef.current.focus();
       inputElementRef.current.selectionStart = inputElementRef.current.selectionEnd = 0;
     }
   };
 
-  const onBlur = (ev: React.FocusEvent<HTMLInputElement>): void => {
-    setHasFocusFalse();
-    if (props.onBlur) {
-      props.onBlur(ev);
-    }
-  };
+  const onBlur = React.useCallback(
+    (ev: React.FocusEvent<HTMLInputElement>): void => {
+      setHasFocus(false);
+      customOnBlur?.(ev);
+    },
+    [customOnBlur],
+  );
 
   const onInputChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
     setValue(ev.target.value);
@@ -116,7 +121,7 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
   const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
     switch (ev.which) {
       case KeyCodes.escape:
-        props.onEscape && props.onEscape(ev);
+        props.onEscape?.(ev);
         if (!ev.defaultPrevented) {
           onClear(ev);
         }
@@ -129,7 +134,7 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
         // if we don't handle the enter press then we shouldn't prevent default
         return;
       default:
-        onKeyDown && onKeyDown(ev);
+        onKeyDown?.(ev);
         if (!ev.defaultPrevented) {
           return;
         }
@@ -141,6 +146,7 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
   };
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: COMPONENT_NAME,
       props,
@@ -159,7 +165,7 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
         {...nativeProps}
         id={id}
         className={classNames.field}
-        placeholder={placeholderValue}
+        placeholder={placeholder}
         onChange={onInputChange}
         onInput={onInputChange}
         onBlur={onBlur}
@@ -173,12 +179,10 @@ export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwarded
       {value!.length > 0 && (
         <div className={classNames.clearButton}>
           <IconButton
-            // eslint-disable-next-line react/jsx-no-bind
             onBlur={onBlur}
             styles={iconButtonStyles}
             iconProps={iconButtonProps}
             {...clearButtonProps}
-            // eslint-disable-next-line react/jsx-no-bind
             onClick={onClearClick}
           />
         </div>

--- a/packages/react-next/src/components/Slider/Slider.base.tsx
+++ b/packages/react-next/src/components/Slider/Slider.base.tsx
@@ -14,6 +14,7 @@ export const SliderBase = React.forwardRef((props: ISliderProps, ref: React.Ref<
   const slotProps = useSlider(props, ref);
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: COMPONENT_NAME,
       props,

--- a/packages/react-next/src/components/Slider/useSlider.ts
+++ b/packages/react-next/src/components/Slider/useSlider.ts
@@ -50,7 +50,7 @@ const useComponentRef = (props: ISliderProps, thumb: React.RefObject<HTMLSpanEle
         }
       },
     }),
-    [value],
+    [thumb, value],
   );
 };
 

--- a/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps -- will come back and fix separately */
 import * as React from 'react';
 import { IconButton } from '../../compat/Button';
 import { Label } from '../../Label';
@@ -94,6 +95,7 @@ export const SpinButtonBase = (props: ISpinButtonProps) => {
   );
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: COMPONENT_NAME,
       props,

--- a/packages/react-next/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react-next/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Toggle renders hidden toggle correctly 1`] = `
       data-is-focusable={true}
       data-ktp-target={true}
       hidden={true}
-      id="id__0"
+      id="Toggle0"
       onClick={[Function]}
       role="switch"
       type="button"
@@ -56,8 +56,8 @@ exports[`Toggle renders toggle correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
-    htmlFor="id__0"
-    id="id__0-label"
+    htmlFor="Toggle0"
+    id="Toggle0-label"
   >
     Label
   </label>
@@ -66,11 +66,11 @@ exports[`Toggle renders toggle correctly 1`] = `
   >
     <button
       aria-checked={false}
-      aria-labelledby="id__0-label"
+      aria-labelledby="Toggle0-label"
       className="ms-Toggle-background"
       data-is-focusable={true}
       data-ktp-target={true}
-      id="id__0"
+      id="Toggle0"
       onClick={[Function]}
       role="switch"
       type="button"
@@ -112,8 +112,8 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
-    htmlFor="id__0"
-    id="id__0-label"
+    htmlFor="Toggle0"
+    id="Toggle0-label"
   >
     <p>
       Label
@@ -124,11 +124,11 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
   >
     <button
       aria-checked={false}
-      aria-labelledby="id__0-label"
+      aria-labelledby="Toggle0-label"
       className="ms-Toggle-background"
       data-is-focusable={true}
       data-ktp-target={true}
-      id="id__0"
+      id="Toggle0"
       onClick={[Function]}
       role="switch"
       type="button"
@@ -170,8 +170,8 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
-    htmlFor="id__0"
-    id="id__0-label"
+    htmlFor="Toggle0"
+    id="Toggle0-label"
   >
     Label
   </label>
@@ -180,11 +180,11 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
   >
     <button
       aria-checked={false}
-      aria-labelledby="id__0-label"
+      aria-labelledby="Toggle0-label"
       className="ms-Toggle-background"
       data-is-focusable={true}
       data-ktp-target={true}
-      id="id__0"
+      id="Toggle0"
       onClick={[Function]}
       role="switch"
       type="button"
@@ -226,8 +226,8 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           padding-top: 5px;
           word-wrap: break-word;
         }
-    htmlFor="id__0"
-    id="id__0-label"
+    htmlFor="Toggle0"
+    id="Toggle0-label"
   >
     Label
   </label>
@@ -236,11 +236,11 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
   >
     <button
       aria-checked={false}
-      aria-labelledby="id__0-label id__0-stateText"
+      aria-labelledby="Toggle0-label Toggle0-stateText"
       className="ms-Toggle-background"
       data-is-focusable={true}
       data-ktp-target={true}
-      id="id__0"
+      id="Toggle0"
       onClick={[Function]}
       role="switch"
       type="button"
@@ -274,8 +274,8 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="id__0"
-      id="id__0-stateText"
+      htmlFor="Toggle0"
+      id="Toggle0-stateText"
     >
       Off
     </label>

--- a/packages/react-next/src/components/Toggle/useToggle.ts
+++ b/packages/react-next/src/components/Toggle/useToggle.ts
@@ -20,7 +20,6 @@ export const useToggle = (
     className,
     defaultChecked = false,
     disabled,
-    id: toggleId,
     inlineLabel,
     label,
     // eslint-disable-next-line deprecation/deprecation
@@ -46,7 +45,7 @@ export const useToggle = (
     onOffMissing: !onText && !offText,
   });
   const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
-  const id = toggleId || useId();
+  const id = useId(COMPONENT_NAME, props.id);
   const labelId = `${id}-label`;
   const stateTextId = `${id}-stateText`;
   const stateText = checked ? onText : offText;
@@ -74,6 +73,7 @@ export const useToggle = (
   useComponentRef(props, checked, toggleButton);
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
     useWarnings({
       name: COMPONENT_NAME,
       props,
@@ -166,6 +166,6 @@ const useComponentRef = (
         }
       },
     }),
-    [isChecked],
+    [isChecked, toggleButtonRef],
   );
 };

--- a/packages/test-utilities/src/safeMount.ts
+++ b/packages/test-utilities/src/safeMount.ts
@@ -2,9 +2,8 @@ import * as React from 'react';
 import { mount, ReactWrapper } from 'enzyme';
 
 /**
- * Calls renderer.create from react-test-renderer, then calls the callback,
- * then unmounts. This prevents mounted components from sitting around doing
- * unfathomable things in the background while other tests start executing.
+ * Calls `mount` from enzyme, calls the callback, and unmounts. This prevents mounted components
+ * from sitting around doing unfathomable things in the background while other tests execute.
  *
  * @param content - JSX content to test.
  * @param callback - Function callback which receives the component to use.


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Enable `eslint-plugin-react-hooks` for react-next to help catch hook-related mistakes, and fix existing issues. Also add a rule to our eslint config to help catch accidental usage of DOM globals (such as `focus()` which was accidentally used in SearchBox).

In the interest of getting this merged more quickly, I temporarily disabled the rule in a bunch of places for CalloutContent and SpinButton and will make follow-up issues to fix this.

Also started making some updates to the release notes breaking changes to alphabetize components and add a couple missing things (or notes about components to look over later).