### PR TITLE
Update outdated URLs for controls in ToDo example

### DIFF
--- a/apps/todo-app/src/components/Todo.tsx
+++ b/apps/todo-app/src/components/Todo.tsx
@@ -13,7 +13,7 @@ import strings from '../strings';
  * Todo component is the top level react component of this web part.
  * It uses fabric-react component <Spinner>
  *
- * Link of Spinner: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/spinner
+ * Link of Spinner: https://developer.microsoft.com/en-us/fluentui#/controls/web/spinner
  */
 export default class Todo extends React.Component<ITodoProps, ITodoState> {
   constructor(props: ITodoProps) {

--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -38,8 +38,8 @@ export interface ITodoFormState {
  * The form component used for adding new item to the list. It uses fabric-react components
  * TextField and PrimaryButton.
  *
- * TextField: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/textfield
- * Button: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/button
+ * Link of <TextField>: https://developer.microsoft.com/en-us/fluentui#/controls/web/textfield
+ * Link of <Button>: https://developer.microsoft.com/en-us/fluentui#/controls/web/button
  */
 export default class TodoForm extends React.Component<ITodoFormProps, ITodoFormState> {
   private _textField = React.createRef<ITextField>();

--- a/apps/todo-app/src/components/TodoItem.tsx
+++ b/apps/todo-app/src/components/TodoItem.tsx
@@ -12,10 +12,10 @@ import strings from './../strings';
 /**
  * TodoItem component using fabric-react component <FocusZone> <Checkbox> <IconButton> <DocumentCardActivity>.
  *
- * Link of FocusZone: https://fabricreact.azurewebsites.net/fabric-react/master/#examples/focuszone
- * Link of Checkbox: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/checkbox
- * Link of Button: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/button
- * Link of DocumentCardActivity: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/documentcard
+ * Link of FocusZone: https://developer.microsoft.com/en-us/fluentui#/controls/web/focuszone
+ * Link of Checkbox: https://developer.microsoft.com/en-us/fluentui#/controls/web/checkbox
+ * Link of Button: https://developer.microsoft.com/en-us/fluentui#/controls/web/button
+ * Link of DocumentCardActivity: https://developer.microsoft.com/en-us/fluentui#/controls/web/documentcard
  */
 export default class TodoItem extends React.Component<ITodoItemProps, {}> {
   private static ANIMATION_TIMEOUT = 200;

--- a/apps/todo-app/src/components/TodoTabs.tsx
+++ b/apps/todo-app/src/components/TodoTabs.tsx
@@ -13,9 +13,9 @@ import strings from './../strings';
 /**
  * The TodoTabs component using fabric-react component <Pivot> <List> <FocusZone>.
  *
- * Link of <Pivot>: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/pivot
- * Link of <List>: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/list
- * Link of <FocusZone>: https://fabricreact.azurewebsites.net/fabric-react/master/#examples/focuszone
+ * Link of <Pivot>: https://developer.microsoft.com/en-us/fluentui#/controls/web/pivot
+ * Link of <List>: https://developer.microsoft.com/en-us/fluentui#/controls/web/list
+ * Link of <FocusZone>: https://developer.microsoft.com/en-us/fluentui#/controls/web/focuszone
  */
 export default class TodoTabs extends React.Component<ITodoTabsProps, {}> {
   public render(): React.ReactElement<IPivotProps> | null {


### PR DESCRIPTION
This commit updates the outdated URLs to the controls documentation in
the To Do example application.