### PR TITLE
Link: Fixing High Contrast styling of links rendered as buttons

### DIFF
--- a/change/office-ui-fabric-react-2020-08-12-15-56-03-linkAsButtonHC.json
+++ b/change/office-ui-fabric-react-2020-08-12-15-56-03-linkAsButtonHC.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Link: Fixing High Contrast styling of links rendered as buttons.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-12T22:56:03.220Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -1,4 +1,5 @@
 import {
+  getEdgeChromiumNoHighContrastAdjustSelector,
   getGlobalClassNames,
   HighContrastSelectorWhite,
   HighContrastSelectorBlack,
@@ -73,6 +74,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           [HighContrastSelectorWhite]: {
             color: '#00009F',
           },
+          ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
       },
       !isButton && {
@@ -103,6 +105,15 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           '&:active, &:hover, &:active:hover': {
             color: linkInteractedColor,
             textDecoration: 'underline',
+
+            selectors: {
+              [HighContrastSelectorBlack]: {
+                color: '#FFFF00',
+              },
+              [HighContrastSelectorWhite]: {
+                color: '#00009F',
+              },
+            },
           },
           '&:focus': {
             color: linkColor,

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -29,13 +29,31 @@ exports[`Link renders Link correctly 1`] = `
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:active {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active {
+        color: #00009F;
+      }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+        color: #00009F;
+      }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+        color: #00009F;
       }
       &:focus {
         color: #0078d4;
@@ -96,17 +114,38 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
       }
+      @media screen and (forced-colors: active){& {
+        forced-color-adjust: none;
+      }
       &:active {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active {
+        color: #00009F;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+        color: #00009F;
+      }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+        color: #00009F;
       }
       &:focus {
         color: #0078d4;
@@ -147,13 +186,31 @@ exports[`Link renders Link with a custom class name 1`] = `
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:active {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active {
+        color: #00009F;
+      }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+        color: #00009F;
+      }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+        color: #00009F;
       }
       &:focus {
         color: #0078d4;
@@ -213,17 +270,38 @@ exports[`Link renders Link with no href as a button 1`] = `
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
       }
+      @media screen and (forced-colors: active){& {
+        forced-color-adjust: none;
+      }
       &:active {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active {
+        color: #00009F;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+        color: #00009F;
+      }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+        color: #00009F;
       }
       &:focus {
         color: #0078d4;
@@ -325,6 +403,9 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
       }
+      @media screen and (forced-colors: active){& {
+        forced-color-adjust: none;
+      }
       &:link {
         pointer-events: none;
       }
@@ -389,17 +470,38 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       @media screen and (-ms-high-contrast: black-on-white){& {
         color: #00009F;
       }
+      @media screen and (forced-colors: active){& {
+        forced-color-adjust: none;
+      }
       &:active {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active {
+        color: #00009F;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
+      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+        color: #00009F;
+      }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
+      }
+      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+        color: #FFFF00;
+      }
+      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+        color: #00009F;
       }
       &:focus {
         color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -111,17 +111,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -192,17 +213,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -341,17 +383,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -499,17 +562,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -569,17 +653,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -639,17 +744,38 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -187,17 +187,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -493,17 +514,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -563,17 +605,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -633,17 +696,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -993,17 +1077,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -1063,17 +1168,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -1483,17 +1609,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -1553,17 +1700,38 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               @media screen and (-ms-high-contrast: black-on-white){& {
                 color: #00009F;
               }
+              @media screen and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &:active {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -364,10 +364,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -375,10 +384,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -525,10 +546,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -536,10 +566,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -774,10 +816,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -785,10 +836,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -935,10 +998,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -946,10 +1018,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1096,10 +1180,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1107,10 +1200,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1257,10 +1362,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1268,10 +1382,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1418,10 +1544,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1429,10 +1564,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1579,10 +1726,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1590,10 +1746,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1741,10 +1909,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1752,10 +1929,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2152,16 +2341,34 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
+                      }
                       &:hover {
                         background-color: #f3f2f1;
                         color: #323130;
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2385,16 +2592,34 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
+                      }
                       &:hover {
                         background-color: #f3f2f1;
                         color: #323130;
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2610,10 +2835,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2621,10 +2855,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2771,10 +3017,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2782,10 +3037,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -3089,10 +3356,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -3100,10 +3376,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -3245,10 +3533,19 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -3256,10 +3553,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -171,10 +171,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -182,10 +191,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -332,10 +353,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -343,10 +373,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -493,10 +535,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -504,10 +555,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -654,10 +717,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -665,10 +737,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -904,10 +988,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -915,10 +1008,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1327,10 +1432,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1338,10 +1452,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1577,10 +1703,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1588,10 +1723,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1807,10 +1954,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1818,10 +1974,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2162,10 +2330,19 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2173,10 +2350,22 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -340,10 +340,19 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -351,10 +360,22 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;
@@ -590,10 +611,19 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       @media screen and (-ms-high-contrast: black-on-white){& {
                         color: #00009F;
                       }
+                      @media screen and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                       &:active {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active {
+                        color: #00009F;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -601,10 +631,22 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         cursor: pointer;
                         text-decoration: none;
                       }
+                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                        color: #00009F;
+                      }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                        color: #00009F;
                       }
                       &:focus {
                         color: #201f1e;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -354,13 +354,31 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
+          }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -683,13 +683,31 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -798,17 +798,38 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -865,17 +886,38 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1099,17 +1099,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -1627,17 +1648,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -2155,17 +2197,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -2683,17 +2746,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -3211,17 +3295,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -3739,17 +3844,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -4267,17 +4393,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -4795,17 +4942,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -5323,17 +5491,38 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 @media screen and (-ms-high-contrast: black-on-white){& {
                                   color: #00009F;
                                 }
+                                @media screen and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                                 &:active {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                                  color: #00009F;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
+                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                                  color: #00009F;
+                                }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
+                                }
+                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                                  color: #FFFF00;
+                                }
+                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                                  color: #00009F;
                                 }
                                 &:focus {
                                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -571,13 +571,31 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active {
+                    color: #00009F;
+                  }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                    color: #00009F;
+                  }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
+                  }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                    color: #00009F;
                   }
                   &:focus {
                     color: #0078d4;
@@ -681,13 +699,31 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active {
+                    color: #00009F;
+                  }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                    color: #00009F;
+                  }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
+                  }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                    color: #00009F;
                   }
                   &:focus {
                     color: #0078d4;
@@ -791,13 +827,31 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active {
+                    color: #00009F;
+                  }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                    color: #00009F;
+                  }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
+                  }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                    color: #00009F;
                   }
                   &:focus {
                     color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -152,13 +152,31 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                  color: #00009F;
+                }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                  color: #00009F;
+                }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
+                }
+                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                  color: #00009F;
                 }
                 &:focus {
                   color: #0078d4;
@@ -262,13 +280,31 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                  color: #00009F;
+                }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                  color: #00009F;
+                }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
+                }
+                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                  color: #00009F;
                 }
                 &:focus {
                   color: #0078d4;
@@ -372,13 +408,31 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:active {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active {
+                  color: #00009F;
+                }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
+                @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                  color: #00009F;
+                }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
+                }
+                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                  color: #FFFF00;
+                }
+                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                  color: #00009F;
                 }
                 &:focus {
                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -426,13 +426,31 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
+          }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -608,13 +608,31 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               color: #004578;
               text-decoration: underline;
             }
+            @media screen and (-ms-high-contrast: white-on-black){&:active {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:active {
+              color: #00009F;
+            }
             &:hover {
               color: #004578;
               text-decoration: underline;
             }
+            @media screen and (-ms-high-contrast: white-on-black){&:hover {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:hover {
+              color: #00009F;
+            }
             &:active:hover {
               color: #004578;
               text-decoration: underline;
+            }
+            @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+              color: #00009F;
             }
             &:focus {
               color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -609,13 +609,31 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               color: #004578;
               text-decoration: underline;
             }
+            @media screen and (-ms-high-contrast: white-on-black){&:active {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:active {
+              color: #00009F;
+            }
             &:hover {
               color: #004578;
               text-decoration: underline;
             }
+            @media screen and (-ms-high-contrast: white-on-black){&:hover {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:hover {
+              color: #00009F;
+            }
             &:active:hover {
               color: #004578;
               text-decoration: underline;
+            }
+            @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+              color: #FFFF00;
+            }
+            @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+              color: #00009F;
             }
             &:focus {
               color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -245,13 +245,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -928,13 +946,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -1611,13 +1647,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -2294,13 +2348,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -2977,13 +3049,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -3660,13 +3750,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -4343,13 +4451,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -5026,13 +5152,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -5709,13 +5853,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;
@@ -6392,13 +6554,31 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:active {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active {
+                color: #00009F;
+              }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
+              @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                color: #00009F;
+              }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
+              }
+              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                color: #FFFF00;
+              }
+              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                color: #00009F;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1181,13 +1181,31 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                     color: #004578;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active {
+                    color: #00009F;
+                  }
                   &:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
+                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
+                    color: #00009F;
+                  }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
+                  }
+                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+                    color: #FFFF00;
+                  }
+                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+                    color: #00009F;
                   }
                   &:focus {
                     color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -46,13 +46,31 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
+          }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;
@@ -111,17 +129,38 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -76,17 +76,38 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;
@@ -153,17 +174,38 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;
@@ -230,17 +272,38 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -220,17 +220,38 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;
@@ -297,17 +318,38 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;
@@ -374,17 +416,38 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           @media screen and (-ms-high-contrast: black-on-white){& {
             color: #00009F;
           }
+          @media screen and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &:active {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active {
+            color: #00009F;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
+          @media screen and (-ms-high-contrast: white-on-black){&:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:hover {
+            color: #00009F;
+          }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
+          }
+          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
+            color: #FFFF00;
+          }
+          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
+            color: #00009F;
           }
           &:focus {
             color: #0078d4;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14482
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes the High Contrast styling of `Links` rendered as buttons.

__Before:__
![image](https://user-images.githubusercontent.com/7798177/90076412-78f88b80-dcb4-11ea-9d71-5ad9ba0281c7.png)

__After:__
![image](https://user-images.githubusercontent.com/7798177/90076449-8ca3f200-dcb4-11ea-9d5b-f661fcdc0bd8.png)

#### Focus areas to test

(optional)
