### PR TITLE
fix modal getting visible shortly when re-rendering while closing

### DIFF
--- a/change/office-ui-fabric-react-2020-08-13-14-40-59-dialog-flicker-bug.json
+++ b/change/office-ui-fabric-react-2020-08-13-14-40-59-dialog-flicker-bug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix modal getting visible shortly when re-rendering while closing",
+  "packageName": "office-ui-fabric-react",
+  "email": "mail@lenzw.de",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T12:40:59.832Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.FlickerBug.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.FlickerBug.Example.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Dialog, DialogType, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
+import { PrimaryButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { hiddenContentStyle, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { useId, useBoolean } from '@uifabric/react-hooks';
+
+const dialogStyles = { main: { maxWidth: 450 } };
+const dragOptions = {
+  moveMenuItemText: 'Move',
+  closeMenuItemText: 'Close',
+  menu: ContextualMenu,
+};
+const screenReaderOnly = mergeStyles(hiddenContentStyle);
+const dialogContentProps = {
+  type: DialogType.normal,
+  title: 'Missing Subject',
+  closeButtonAriaLabel: 'Close',
+  subText: 'Do you want to send this message without a subject?',
+};
+
+export const DialogFlickerBugExample: React.FunctionComponent = () => {
+  const [hideDialog, { toggle: toggleHideDialog }] = useBoolean(true);
+  const [, setSomethingElse] = React.useState(0);
+
+  function toggleFlickering() {
+    toggleHideDialog();
+    setTimeout(() => setSomethingElse(x => x + 1), 10);
+  }
+
+  const [isDraggable, { toggle: toggleIsDraggable }] = useBoolean(false);
+  const labelId: string = useId('dialogLabel');
+  const subTextId: string = useId('subTextLabel');
+
+  const modalProps = React.useMemo(
+    () => ({
+      titleAriaId: labelId,
+      subtitleAriaId: subTextId,
+      isBlocking: false,
+      styles: dialogStyles,
+      dragOptions: isDraggable ? dragOptions : undefined,
+    }),
+    [isDraggable, labelId, subTextId],
+  );
+
+  return (
+    <>
+      <Toggle label="Is draggable" onChange={toggleIsDraggable} checked={isDraggable} />
+      <DefaultButton secondaryText="Opens the Sample Dialog" onClick={toggleHideDialog} text="Open Dialog" />
+      <label id={labelId} className={screenReaderOnly}>
+        My sample label
+      </label>
+      <label id={subTextId} className={screenReaderOnly}>
+        My sample description
+      </label>
+
+      <Dialog
+        hidden={hideDialog}
+        onDismiss={toggleHideDialog}
+        dialogContentProps={dialogContentProps}
+        modalProps={modalProps}
+      >
+        <DialogFooter>
+          <PrimaryButton onClick={toggleHideDialog} text="Close without Flicker" />
+          <DefaultButton onClick={toggleFlickering} text="Close and Flicker" />
+        </DialogFooter>
+      </Dialog>
+    </>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -146,7 +146,7 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
   }
 
   public componentDidUpdate(prevProps: IModalProps, prevState: IDialogState) {
-    if (!prevProps.isOpen && !prevState.isVisible) {
+    if (!prevProps.isOpen && !prevState.isVisible && this.props.isOpen) {
       this.setState({
         isVisible: true,
       });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

If the parent component triggers a re-render while a Dialog or Modal is in the process of closing, the Modal resets it's internal state to `isVisible: true` in `componentDidUpdate`, which leads to the Dialog getting visible again before finally disappearing (flickering).

This should prevent this behavior.

#### Focus areas to test

This PR includes a storybook story that demonstrates this behavior. Once you have validated the bug & the fix, please ping me and I will remove that story.
