### PR TITLE
Adding createMergedRef for class-based components to merge refs

### DIFF
--- a/change/@uifabric-utilities-2020-08-13-15-11-09-feat-createMergedRefs.json
+++ b/change/@uifabric-utilities-2020-08-13-15-11-09-feat-createMergedRefs.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding `createMergedRef` utility for merging refs in a class component.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-13T22:11:09.460Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -134,6 +134,9 @@ export function createArray<T>(size: number, getItem: (index: number) => T): T[]
 // @public
 export function createMemoizer<F extends (input: any) => any>(getValue: F): F;
 
+// @public
+export const createMergedRef: <TType, TValue = null>(value?: TValue | undefined) => (...newRefs: (((instance: TType | TValue | null) => void) | React.RefObject<TType | TValue | null> | null | undefined)[]) => (newValue: TType | TValue | null) => void;
+
 // Warning: (ae-incompatible-release-tags) The symbol "css" is marked as @public, but its signature references "ICssInput" which is marked as @internal
 //
 // @public

--- a/packages/utilities/src/createMergedRef.test.tsx
+++ b/packages/utilities/src/createMergedRef.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { createMergedRef } from './createMergedRef';
+import { mount } from 'enzyme';
+
+describe('createMergedRef', () => {
+  it('can merge refs', () => {
+    const ref1 = React.createRef<HTMLDivElement>();
+    class Foo extends React.Component<{ domRef?: React.Ref<HTMLDivElement> }> {
+      private mergedRef = createMergedRef<HTMLDivElement>();
+
+      public render() {
+        return <div ref={this.mergedRef(this.props.domRef, ref1)} />;
+      }
+    }
+    const ref2 = React.createRef<HTMLDivElement>();
+    const wrapper = mount(<Foo domRef={ref2} />);
+
+    expect(ref1.current).toBeTruthy();
+    expect(ref2.current).toBeTruthy();
+
+    wrapper.unmount();
+
+    expect(ref1.current).toBeNull();
+    expect(ref2.current).toBeNull();
+  });
+
+  it('returns the same ref object with the same input twice', () => {
+    const mergedRef = createMergedRef();
+
+    expect(mergedRef()).toBe(mergedRef());
+  });
+
+  it('should return a new resolver if the refs change', () => {
+    const mergedRef = createMergedRef();
+
+    expect(mergedRef(null)).not.toBe(mergedRef(React.createRef()));
+  });
+});

--- a/packages/utilities/src/createMergedRef.ts
+++ b/packages/utilities/src/createMergedRef.ts
@@ -30,7 +30,6 @@ const createResolver = <TType, TValue>(local: LocalState<TType, TValue>) => (new
 export const createMergedRef = <TType, TValue = null>(value?: TValue) => {
   const local: LocalState<TType, TValue> = ({
     refs: [],
-    resolver: undefined,
   } as unknown) as LocalState<TType, TValue>;
 
   return (

--- a/packages/utilities/src/createMergedRef.ts
+++ b/packages/utilities/src/createMergedRef.ts
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { arraysEqual } from './array';
+
+/**
+ * Internal state type for the ref.
+ */
+type LocalState<TType, TValue> = {
+  refs: (React.Ref<TType | null | TValue> | undefined)[];
+  resolver: (newValue: TType | TValue | null) => void;
+};
+
+/**
+ * Set up a ref resolver function given internal state managed for the ref.
+ * @param local Set
+ */
+const createResolver = <TType, TValue>(local: LocalState<TType, TValue>) => (newValue: TType | TValue | null) => {
+  for (const ref of local.refs) {
+    if (typeof ref === 'function') {
+      ref(newValue);
+    } else if (ref) {
+      // work around the immutability of the React.Ref type
+      ((ref as unknown) as React.MutableRefObject<TType | TValue | null | undefined>).current = newValue;
+    }
+  }
+};
+
+/**
+ * Helper to merge refs from within class components.
+ */
+export const createMergedRef = <TType, TValue = null>(value?: TValue) => {
+  const local: LocalState<TType, TValue> = ({
+    refs: [],
+    resolver: undefined,
+  } as unknown) as LocalState<TType, TValue>;
+
+  return (
+    ...newRefs: (React.Ref<TType | null | TValue> | undefined)[]
+  ): ((newValue: TType | TValue | null) => void) => {
+    if (!local.resolver || !arraysEqual(local.refs, newRefs)) {
+      local.resolver = createResolver<TType, TValue>(local);
+    }
+
+    local.refs = newRefs;
+
+    return local.resolver;
+  };
+};

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -72,4 +72,6 @@ export * from './getPropsWithDefaults';
 export { IStyleFunctionOrObject, Omit } from '@uifabric/merge-styles';
 export { setFocusVisibility, IsFocusVisibleClassName } from './setFocusVisibility';
 export { setSSR } from './dom/setSSR';
+export { createMergedRef } from './createMergedRef';
+
 import './version';


### PR DESCRIPTION
We have a number of cases which require merging refs, but we can't use `useMergedRefs` in a class component.

Adding a utility to help with this scenario to unblock function component conversion edge cases.
