### PR TITLE
Fix Elevation Implementation to use DefaultEffects

### DIFF
--- a/apps/fabric-website/src/pages/Styles/ElevationPage/docs/web/ElevationImplementation.md
+++ b/apps/fabric-website/src/pages/Styles/ElevationPage/docs/web/ElevationImplementation.md
@@ -1,9 +1,9 @@
 ### Fluent UI React (JavaScript variables)
 
 ```jsx
-import { Depths } from '@uifabric/fluent-theme/lib/fluent/FluentDepths';
+import { DefaultEffects } from '@fluentui/react';
 
-<div style={{ boxShadow: Depths.depth8 }} />;
+<div style={{ boxShadow: DefaultEffects.elevation }} />;
 ```
 
 ### Fabric Core (SCSS variables)


### PR DESCRIPTION
The documentation before would reference using a `Depth` class. This is no longer the case, apparently you can access the depths (now referred to as "elevations") in DefaultEffects. So I just put an example and changed the import. Hope this was fine!

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 (doesn't address an issue, but rather this closed issue #9169 ([link](https://github.com/microsoft/fluentui/issues/9169#issuecomment-494903484)) where I was able to learn that I needed to use `DefaultEffects` as opposed to trying to import/find `Depth`)
- [ ] Include a change request file using `$ yarn change` (ran this command but it didn't generate a change file from my fork)

#### Description of changes

Updated the markdown for the documentations page for "Elevation" ([link](https://developer.microsoft.com/en-us/fluentui#/styles/web/elevation)) to use functionality available from `@fluentui/react`.

#### Focus areas to test

None.