### PR TITLE
docs: Update web-components README npm badge

### DIFF
--- a/packages/web-components/README.md
+++ b/packages/web-components/README.md
@@ -1,7 +1,7 @@
 # Fluent UI Web Components
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![npm version](https://badge.fury.io/js/%40microsoft%2Fweb-components.svg)](https://badge.fury.io/js/%40microsoft%2Fweb-components)
+[![npm version](https://badge.fury.io/js/%40fluentui%2Fweb-components.svg)](https://badge.fury.io/js/%40fluentui%2Fweb-components)
 
 `@fluentui/web-components` is a library of Web Components that _composes_ `@microsoft/fast-foundation` and supports Microsoft's Fluent design language.
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`web-components` package's README npm badge updated with `fluentui` namespace,
still had `microsoft` as a leftover after #14345.
