### PR TITLE
Optimizing PR builds with new feature from lage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,18 +27,20 @@ jobs:
           yarn checkchange
         displayName: check change
 
-      ## TODO: clean up the @fluentui/docs build and @fluentui/react-northstar test WRT component-info generation
-      ## the dependency order cannot be expressed with lage configuration currently
+      ## only do scoped builds with PRs
       - script: |
-          yarn lage build --only --verbose --no-cache --grouped
-        displayName: build
+          yarn lage build test lint --verbose --no-cache --grouped --since $(target_branch)
+        displayName: build, test, lint (pr, scoped)
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
 
+      ## duplicated build step, but without --since flag for master CI builds
       - script: |
-          yarn lage test lint --only --verbose --no-cache --grouped
-        displayName: test, lint
+          yarn lage build test lint --verbose --no-cache --grouped
+        displayName: build, test, lint (master)
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'

--- a/lage.config.js
+++ b/lage.config.js
@@ -9,6 +9,7 @@ module.exports = {
     test: ['build'],
     'code-style': [],
     'update-snapshots': ['^update-snapshots'],
+    '@fluentui/docs:build': ['@fluentui/react-northstar:test'],
   },
 
   // Ignores these minimatch patterns when considers what packages have changed for the --since flag

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "danger": "^6.0.5",
     "gulp": "^4.0.2",
     "lerna": "^3.15.0",
-    "lage": "^0.17.5",
+    "lage": "^0.19.0",
     "lint-staged": "^10.2.9",
     "sass-loader": "^6.0.6",
     "satisfied": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2468,10 +2468,10 @@
   resolved "https://registry.yarnpkg.com/@microsoft/package-deps-hash/-/package-deps-hash-2.2.158.tgz#57a02d6ee62fd95390a477120ab24186767cb0fe"
   integrity sha512-gN0vkVrF38flbxbPJlEEGJi72Hxqn9JFYILCs0rOSL+LZOGuKUzaZYm3B7XbX7GF6LzPs2R3T5gmWx1EHxxQAQ==
 
-"@microsoft/task-scheduler@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.4.0.tgz#f53ca144036c5089ef1806834b1686ed4b6fc535"
-  integrity sha512-mHEYP45l1CJ6TKNkQqzJPM8UAVQcZkWJybIXIy4QfPAyt77/XvEkrxlYiuvaO4uLkW0a/E3juFYwcbgsZ9Xtww==
+"@microsoft/task-scheduler@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/task-scheduler/-/task-scheduler-2.6.0.tgz#6108b2264711299d1d0350c4def6f038b73ea504"
+  integrity sha512-KeMyrw5c9IAQxKYn/QrnqT9BNfLC7UUY2OwyXNaMKOcSRKMscPzYilPir0LzwHwSzg9uAmNX9rJ87sKKJ7mOVw==
 
 "@microsoft/ts-command-line@4.3.6":
   version "4.3.6"
@@ -15191,12 +15191,12 @@ kleur@^3.0.2, kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-lage@^0.17.5:
-  version "0.17.5"
-  resolved "https://registry.yarnpkg.com/lage/-/lage-0.17.5.tgz#30cc3b1cb2c054b6e524aabd02f6a6c34b493fd3"
-  integrity sha512-A+fDTtwW6Z2pxC7sUP35vbF5RwkM4nieZBrF156nfFYGlUGHXTtPj6U+4R9dhY5vcoBTEOozwww8sxQtT1/xEw==
+lage@^0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/lage/-/lage-0.19.0.tgz#b95f59a80b784ff3e2391adc497b165e18c15963"
+  integrity sha512-PFyOWebV+Za5n5e4uuk66TZQNiFD4OG3UUnrM3JoqOPAxFPogMDr+PuYDj01R0U6ENMaOrH0pC0EypcH+P9HrQ==
   dependencies:
-    "@microsoft/task-scheduler" "^2.4.0"
+    "@microsoft/task-scheduler" "^2.6.0"
     abort-controller "^3.0.0"
     backfill "^6.0.1"
     backfill-config "^6.0.0"


### PR DESCRIPTION
#### Description of changes

Previously, we had to roll back scoped changes as well as splitting back out build from test / lint. This was due to the lack of ability for `lage` to specify an order for @fluentui/docs:build and @fluentui/react-northstar:test. Now that this has been added in lage, we can combine those steps again to optimize the build better.

#### Focus areas to test

(optional)
