### PR TITLE
Codemods: Add support for repath mod from json

### DIFF
--- a/change/@fluentui-codemods-2020-08-14-16-43-25-t-dama-Codemods_add_repath.json
+++ b/change/@fluentui-codemods-2020-08-14-16-43-25-t-dama-Codemods_add_repath.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add support for repathing and function dictionary",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T20:43:25.769Z"
+}

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.ts
@@ -66,7 +66,15 @@ const codeModMap: CodeModMapType = {
   },
   repathImport: function(file: SourceFile, mod: RepathImportModType) {
     return function() {
-      const imports = getImportsByPath(file, mod.options.from.searchString);
+      /* If the json indicates our search string is a regex, convert it. */
+      const searchString = mod.options.from.isRegex
+        ? new RegExp(
+            (mod.options.from.searchString as string)
+              .substring(1)
+              .substring(0, (mod.options.from.searchString as string).length - 2),
+          )
+        : mod.options.from.searchString;
+      const imports = getImportsByPath(file, searchString);
       imports.forEach(val => {
         repathImport(val, mod.options.to.replacementValue);
       });

--- a/packages/codemods/src/codeMods/mods/upgrades.json
+++ b/packages/codemods/src/codeMods/mods/upgrades.json
@@ -28,6 +28,18 @@
           "replacementName": "checked"
         }
       }
+    },
+    {
+      "name": "Repathing imports from office to fluent",
+      "type": "repathImport",
+      "options": {
+        "from": {
+          "searchString": "/^office\\-ui\\-fabric\\-react/"
+        },
+        "to": {
+          "replacementValue": "@fluentui/react"
+        }
+      }
     }
   ]
 }

--- a/packages/codemods/src/codeMods/mods/upgrades.json
+++ b/packages/codemods/src/codeMods/mods/upgrades.json
@@ -34,7 +34,8 @@
       "type": "repathImport",
       "options": {
         "from": {
-          "searchString": "/^office\\-ui\\-fabric\\-react/"
+          "searchString": "/^office\\-ui\\-fabric\\-react/",
+          "isRegex": true
         },
         "to": {
           "replacementValue": "@fluentui/react"

--- a/packages/codemods/src/codeMods/tests/configMod/__snapshots__/configMod.test.ts.snap
+++ b/packages/codemods/src/codeMods/tests/configMod/__snapshots__/configMod.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tests a simple data-driven codeMod can rename props in CompoundButton and Dropdown 1`] = `
+exports[`Tests a simple data-driven codeMod can run all mods in upgrades.json successfully 1`] = `
 "import * as React from 'react';
-import { CompoundButton } from 'office-ui-fabric-react/lib/Button';
+import { CompoundButton } from '@fluentui/react';
 
 export class RenderButton extends React.Component<LocalButtonProps> {
   public render(): JSX.Element {
@@ -26,9 +26,9 @@ export interface LocalButtonProps {
 "
 `;
 
-exports[`Tests a simple data-driven codeMod can rename props in CompoundButton and Dropdown 2`] = `
+exports[`Tests a simple data-driven codeMod can run all mods in upgrades.json successfully 2`] = `
 "import * as React from 'react';
-import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
+import { Dropdown } from '@fluentui/react';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const RenderDropdown = (props: any) => {

--- a/packages/codemods/src/codeMods/tests/configMod/configMod.test.ts
+++ b/packages/codemods/src/codeMods/tests/configMod/configMod.test.ts
@@ -6,6 +6,9 @@ import { runMods } from '../../../modRunner/runnerUtilities';
 const buttonPath = '/**/tests/mock/**/button/**/*.tsx';
 const dropDownPath = '/**/tests/mock/**/dropdown/**/*.tsx';
 
+const basicFileName = 'mockImports.tsx';
+const oldRoot = 'office-ui-fabric-react';
+
 describe('Tests a simple data-driven codeMod', () => {
   let project: Project;
 
@@ -13,12 +16,10 @@ describe('Tests a simple data-driven codeMod', () => {
     project = new Project();
     project.addSourceFilesAtPaths(`${process.cwd()}${buttonPath}`);
     project.addSourceFilesAtPaths(`${process.cwd()}${dropDownPath}`);
+    project.addSourceFilesAtPaths(`${process.cwd()}/**/tests/mock/utils/*.tsx`);
   });
 
-  // TODO: Can you raise more errors in renameProp for better mod logging?
-  // TODO: Add value change examples && more mods in a later, larger PR.
-
-  it('can rename props in CompoundButton and Dropdown', () => {
+  it('can run all mods in upgrades.json successfully', () => {
     const mod = Maybe(createCodeModFromJson());
     if (mod.something) {
       const mods = [];
@@ -31,7 +32,14 @@ describe('Tests a simple data-driven codeMod', () => {
         }
       });
     }
+    /* Test for renameProp. */
     expect(project.getSourceFile('mCompoundButtonProps.tsx')?.getFullText()).toMatchSnapshot();
     expect(project.getSourceFile('mDropdownProps.tsx')?.getFullText()).toMatchSnapshot();
+    /* Test for repathImport. */
+    const file = project.getSourceFileOrThrow(basicFileName);
+    file.getImportStringLiterals().forEach(val => {
+      const impPath = val.getLiteralValue();
+      expect(impPath.indexOf(oldRoot)).not.toEqual(0);
+    });
   });
 });

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -97,6 +97,7 @@ export type RepathImportModType = {
   options: {
     from: {
       searchString: string | RegExp;
+      isRegex: boolean;
     };
     to: {
       replacementValue: string;

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -65,3 +65,50 @@ export enum SpreadPropInStatement {
   PropRight,
   NotFound,
 }
+
+/* Type definition for the mod type - mod function dictionary used
+   in configMod.ts. */
+export type CodeModMapType = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: (file: SourceFile, mod: any) => () => void;
+};
+
+/* Type definition for a CodeMod object representing a renameProp mod. */
+export type RenamePropModType = {
+  name: string;
+  type: 'renameProp';
+  options: {
+    from: {
+      importName: string;
+      toRename: string;
+      paths?: string[];
+    };
+    to: {
+      replacementName: string;
+      replacementValue?: string;
+    };
+  };
+};
+
+/* Type definition for a CodeMod object representing a repathImport mod. */
+export type RepathImportModType = {
+  name: string;
+  type: 'repathImport';
+  options: {
+    from: {
+      searchString: string | RegExp;
+    };
+    to: {
+      replacementValue: string;
+    };
+  };
+};
+
+/* upgrades.json internal mods are of this type: a union of supported types. */
+export type ModTypes = RenamePropModType | RepathImportModType;
+
+/* Type of the upgrades.json object */
+export type UpgradeJSONType = {
+  name: string;
+  upgrades: ModTypes[];
+};

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -183,8 +183,6 @@ export function renamePropInSpread(
         } else {
           throw 'Could not find prop in component specified.';
         }
-      } else {
-        throw 'Could not ID any spread object to be destructured.';
       }
     }
   });

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-throw-literal */
 import {
   ts,
   Node,
@@ -29,7 +30,7 @@ export function renamePropInSpread(
         const firstIdentifier = attribute.getFirstChildByKind(SyntaxKind.Identifier);
         const propertyAccess = attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
         if (!attribute || (!firstIdentifier && !propertyAccess)) {
-          return;
+          throw 'Invalid spread prop. Could access internal identifiers successfully.';
         }
         const spreadIsIdentifier = firstIdentifier !== undefined;
         /* Verify this attribute contains the name of our desired prop. */
@@ -53,7 +54,6 @@ export function renamePropInSpread(
               blockContainer = containerMaybe.value;
               newJSXFlag = true;
             } else {
-              // eslint-disable-next-line no-throw-literal
               throw 'attempt to create a new block around prop failed.';
             }
           }
@@ -61,14 +61,12 @@ export function renamePropInSpread(
           /* Step 5: Get the parent of BLOCKCONTAINER so that we can insert our own variable statements. */
           const parentContainer = blockContainer!.getParentIfKind(SyntaxKind.Block);
           if (parentContainer === undefined) {
-            // eslint-disable-next-line no-throw-literal
             throw 'unable to get parent container from block';
           }
 
           /* Step 6: Get the index of BLOCKCONTAINER within PARENTCONTAINER that we'll use to insert our variables. */
           const insertIndex = blockContainer!.getChildIndex();
           if (insertIndex === undefined) {
-            // eslint-disable-next-line no-throw-literal
             throw 'unable to find child index';
           }
 
@@ -182,7 +180,11 @@ export function renamePropInSpread(
               ? `{${replacementValue}}`
               : `{${toRename}}`,
           }); // Add the updated prop name and set its value.
+        } else {
+          throw 'Could not find prop in component specified.';
         }
+      } else {
+        throw 'Could not ID any spread object to be destructured.';
       }
     }
   });

--- a/packages/codemods/src/codeMods/utilities/imports.ts
+++ b/packages/codemods/src/codeMods/utilities/imports.ts
@@ -22,20 +22,15 @@ export function renameImport(file: SourceFile, originalImport: string, renamedIm
  */
 export function getImportsByPath(file: SourceFile, pathOrRegex: string | RegExp): ImportDeclaration[] {
   let imps: ImportDeclaration[] = [];
-  if (typeof pathOrRegex === 'string' && !stringIsRegex(pathOrRegex)) {
+  if (typeof pathOrRegex === 'string') {
     imps = file.getImportDeclarations().filter(cond => {
       return cond.getModuleSpecifierValue() === pathOrRegex;
     });
   } else {
-    if (typeof pathOrRegex === 'string' && stringIsRegex(pathOrRegex)) {
-      const newRegex = pathOrRegex.substring(1).substring(0, pathOrRegex.length - 2);
-      pathOrRegex = new RegExp(newRegex);
-    }
     imps = file.getImportDeclarations().filter(cond => {
-      return (pathOrRegex as RegExp).test(cond.getModuleSpecifierValue());
+      return pathOrRegex.test(cond.getModuleSpecifierValue());
     });
   }
-
   return imps;
 }
 
@@ -70,16 +65,5 @@ export function repathImport(imp: ImportDeclaration, replacementString: string, 
     imp.setModuleSpecifier(current.replace(regex, replacementString));
   } else {
     imp.setModuleSpecifier(replacementString);
-  }
-}
-
-/* Helper function used to determine whether a string is actually
-   a regular expression, needed to support upgrades.json because
-   regexes are stored as strings. */
-function stringIsRegex(exp: string): boolean {
-  if (exp.length < 2) {
-    return false;
-  } else {
-    return exp.charAt(0) === '/' && exp.charAt(exp.length - 1) === '/';
   }
 }

--- a/packages/codemods/src/codeMods/utilities/imports.ts
+++ b/packages/codemods/src/codeMods/utilities/imports.ts
@@ -22,13 +22,17 @@ export function renameImport(file: SourceFile, originalImport: string, renamedIm
  */
 export function getImportsByPath(file: SourceFile, pathOrRegex: string | RegExp): ImportDeclaration[] {
   let imps: ImportDeclaration[] = [];
-  if (typeof pathOrRegex === 'string') {
+  if (typeof pathOrRegex === 'string' && !stringIsRegex(pathOrRegex)) {
     imps = file.getImportDeclarations().filter(cond => {
       return cond.getModuleSpecifierValue() === pathOrRegex;
     });
   } else {
+    if (typeof pathOrRegex === 'string' && stringIsRegex(pathOrRegex)) {
+      const newRegex = pathOrRegex.substring(1).substring(0, pathOrRegex.length - 2);
+      pathOrRegex = new RegExp(newRegex);
+    }
     imps = file.getImportDeclarations().filter(cond => {
-      return pathOrRegex.test(cond.getModuleSpecifierValue());
+      return (pathOrRegex as RegExp).test(cond.getModuleSpecifierValue());
     });
   }
 
@@ -66,5 +70,16 @@ export function repathImport(imp: ImportDeclaration, replacementString: string, 
     imp.setModuleSpecifier(current.replace(regex, replacementString));
   } else {
     imp.setModuleSpecifier(replacementString);
+  }
+}
+
+/* Helper function used to determine whether a string is actually
+   a regular expression, needed to support upgrades.json because
+   regexes are stored as strings. */
+function stringIsRegex(exp: string): boolean {
+  if (exp.length < 2) {
+    return false;
+  } else {
+    return exp.charAt(0) === '/' && exp.charAt(exp.length - 1) === '/';
   }
 }


### PR DESCRIPTION
Added a simple repath mod to the json general config codemod.

This brought about a few other changes:

-Introduced total typing into the json object to remove those pesky `any` types floating around.
-Instead of using `if` casing to determine what mod to run, I created a dictionary that maps codemod types to functions.
-Changed the repathImport utility _very slightly_ to support regexes that could come from json (because strings aren't very flexible).
-Added some more error throwing in propHelpers because codemods can and should be able to throw detailed errors when mods fail instead of silently doing nothing.