### PR TITLE
fix: apply badge styles to control rather than host element

### DIFF
--- a/change/@fluentui-web-components-2020-08-14-14-13-52-users-chhol-fix-badge-styling.json
+++ b/change/@fluentui-web-components-2020-08-14-14-13-52-users-chhol-fix-badge-styling.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: apply badge appearance styling to control not host element",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T21:13:52.358Z"
+}

--- a/packages/web-components/src/badge/badge.styles.ts
+++ b/packages/web-components/src/badge/badge.styles.ts
@@ -20,18 +20,18 @@ export const BadgeStyles = css`
     padding: calc(var(--design-unit) * 0.5px) calc(var(--design-unit) * 1px);
   }
 
-  :host(.lightweight) {
+  :host(.lightweight) .control {
     background: transparent;
     color: ${neutralForegroundRestBehavior.var};
     font-weight: 600;
   }
 
-  :host(.accent) {
+  :host(.accent) .control {
     background: ${accentFillRestBehavior.var};
     color: ${accentForegroundCutRestBehavior.var};
   }
 
-  :host(.neutral) {
+  :host(.neutral) .control {
     background: ${neutralFillRestBehavior.var};
     color: ${neutralForegroundRestBehavior.var};
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14397
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The styling of badges with an appearance attribute was being applied to the host element rather than the control. This was leading to incorrect/broken appearances (no corner radius, padding).

#### Focus areas to test

(optional)
