### PR TITLE
Add back UHF link style overrides via Customizer

### DIFF
--- a/change/@uifabric-example-app-base-2020-08-14-14-42-53-website-links.json
+++ b/change/@uifabric-example-app-base-2020-08-14-14-42-53-website-links.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add back UHF link style overrides via Customizer",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-14T21:42:53.217Z"
+}

--- a/packages/example-app-base/src/components/Page/Page.tsx
+++ b/packages/example-app-base/src/components/Page/Page.tsx
@@ -19,6 +19,7 @@ import {
 } from './sections/index';
 import { IPageProps, IPageSectionProps } from './Page.types';
 import * as styles from './Page.module.scss';
+import { getLinkColors } from '../../utilities/getLinkColors';
 
 const SECTION_STAGGER_INTERVAL = 0.05;
 /** Section key/id prefix for sections which don't have a title */
@@ -32,22 +33,7 @@ const linkCustomizations: Partial<ILinkProps> = {
   styles: props => {
     const { semanticColors } = props.theme;
     return {
-      root: {
-        selectors: {
-          // Be specific to override UHF styles
-          '& a.ms-Link': {
-            color: semanticColors.link,
-            selectors: {
-              '&:link': {
-                color: semanticColors.link,
-              },
-              '&:active, &:hover, &:active:hover': {
-                color: semanticColors.linkHovered,
-              },
-            },
-          },
-        },
-      },
+      root: getLinkColors(semanticColors.link, semanticColors.linkHovered),
     };
   },
 };

--- a/packages/example-app-base/src/components/Page/Page.tsx
+++ b/packages/example-app-base/src/components/Page/Page.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Async, css } from 'office-ui-fabric-react';
+import { Async, css, Customizer, ICustomizations, ILinkProps } from 'office-ui-fabric-react';
 import { slugify } from '../../utilities/index2';
 import { PageHeader } from '../PageHeader/index';
 import { Markdown } from '../Markdown/index';
@@ -27,6 +27,34 @@ const GENERIC_SECTION = 'genericsection';
 export interface IPageState {
   isMountedOffset?: boolean;
 }
+
+const linkCustomizations: Partial<ILinkProps> = {
+  styles: props => {
+    const { semanticColors } = props.theme;
+    return {
+      root: {
+        selectors: {
+          // Be specific to override UHF styles
+          '& a.ms-Link': {
+            color: semanticColors.link,
+            selectors: {
+              '&:link': {
+                color: semanticColors.link,
+              },
+              '&:active, &:hover, &:active:hover': {
+                color: semanticColors.linkHovered,
+              },
+            },
+          },
+        },
+      },
+    };
+  },
+};
+
+const scopedSettings: ICustomizations['scopedSettings'] = {
+  Link: linkCustomizations,
+};
 
 // TODO: I think this component should be templated to forward the TPlatform type to props.
 //        It can then be used in JSX like this:
@@ -65,13 +93,15 @@ export class Page extends React.Component<IPageProps, IPageState> {
 
     const sections = this._getPageSections();
     return (
-      <div className={css(styles.Page, className)}>
-        {this._getPageHeader()}
-        <div className={styles.main}>
-          {this._pageContent(sections)}
-          {this._getSideRail(sections)}
+      <Customizer scopedSettings={scopedSettings}>
+        <div className={css(styles.Page, className)}>
+          {this._getPageHeader()}
+          <div className={styles.main}>
+            {this._pageContent(sections)}
+            {this._getSideRail(sections)}
+          </div>
         </div>
-      </div>
+      </Customizer>
     );
   }
 

--- a/packages/example-app-base/src/components/SideRail/SideRail.styles.ts
+++ b/packages/example-app-base/src/components/SideRail/SideRail.styles.ts
@@ -1,6 +1,7 @@
 import { FontWeights, getFocusOutlineStyle, IStyleFunction } from 'office-ui-fabric-react/lib/index';
 import { appPaddingSm } from '../../styles/constants';
 import { ISideRailStyleProps, ISideRailStyles } from './SideRail.types';
+import { getLinkColors } from '../../utilities/getLinkColors';
 
 export const sideRailClassNames = {
   isActive: 'SideRail-isActive',
@@ -63,16 +64,15 @@ export const getStyles: IStyleFunction<ISideRailStyleProps, ISideRailStyles> = p
     jumpLinkWrapper: {
       position: 'relative',
     },
-    jumpLink: {
-      color: theme.palette.neutralPrimary,
-      borderLeft: '2px solid transparent',
-      paddingLeft: 6, // 8px - 2px border
-      selectors: {
-        '&:focus': {
-          color: theme.palette.neutralPrimary,
-        },
+    jumpLink: [
+      {
+        borderLeft: '2px solid transparent',
+        paddingLeft: 6, // 8px - 2px border
       },
-    },
+      // Courtesty of UHF global styles and overrides of them in Page, we have to be very specific
+      // when overriding the colors. This utility helps.
+      getLinkColors(theme.palette.neutralPrimary, theme.semanticColors.linkHovered, theme.palette.neutralPrimary),
+    ],
     jumpLinkActive: {
       borderLeftColor: theme!.palette.themePrimary,
     },

--- a/packages/example-app-base/src/utilities/getLinkColors.ts
+++ b/packages/example-app-base/src/utilities/getLinkColors.ts
@@ -1,0 +1,30 @@
+import { IRawStyle } from 'office-ui-fabric-react';
+
+/**
+ * Gets a style which should be specific enough to override the UHF link styles.
+ * This should be applied to the root of a Link.
+ * @param rest - Color to use in default/rest state
+ * @param hover - Color to use in hover/active state
+ * @param focus - Color to use in focus state (defaults to `rest`)
+ */
+export function getLinkColors(rest: string, hover: string, focus?: string): IRawStyle {
+  return {
+    selectors: {
+      // Be specific to override UHF styles
+      '& a.ms-Link': {
+        color: rest,
+        selectors: {
+          '&:link': {
+            color: rest,
+          },
+          '&:active, &:hover, &:active:hover': {
+            color: hover,
+          },
+          '&:focus': {
+            color: focus || rest,
+          },
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

#14270 removed some global link style overrides because they were messing up examples in dark mode, but thanks to the horrible UHF global styles, this caused links to be rendered as text color (not blue). Adding back the overrides in Page but doing it via Customizer will hopefully fix this.