### PR TITLE
Add onRenderLayout for Reorganizing Rendered Contents in ContextualMenuItem

### DIFF
--- a/change/office-ui-fabric-react-2020-08-14-23-22-14-master.json
+++ b/change/office-ui-fabric-react-2020-08-14-23-22-14-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Custom Layout for Contextual Menu",
+  "packageName": "office-ui-fabric-react",
+  "email": "michael.mao99@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-15T03:22:14.968Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2925,8 +2925,8 @@ export interface IContextualMenuItem {
     onClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
     onMouseDown?: (item: IContextualMenuItem, event: React.MouseEvent<HTMLElement>) => void;
     onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
+    onRenderContent?: (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => React.ReactNode;
     onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
-    onRenderLayout?: (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => React.ReactNode;
     primaryDisabled?: boolean;
     rel?: string;
     role?: string;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -753,7 +753,7 @@ export class ContextualMenuItemBase extends React.Component<IContextualMenuItemP
     openSubMenu: () => void;
     // (undocumented)
     render(): JSX.Element;
-}
+    }
 
 // @public (undocumented)
 export enum ContextualMenuItemType {
@@ -2926,6 +2926,7 @@ export interface IContextualMenuItem {
     onMouseDown?: (item: IContextualMenuItem, event: React.MouseEvent<HTMLElement>) => void;
     onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
     onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
+    onRenderLayout?: (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => React.ReactNode;
     primaryDisabled?: boolean;
     rel?: string;
     role?: string;
@@ -2958,6 +2959,15 @@ export interface IContextualMenuItemProps extends React.HTMLAttributes<IContextu
     openSubMenu?: (item: any, target: HTMLElement) => void;
     styles?: IStyleFunctionOrObject<IContextualMenuItemStyleProps, IContextualMenuItemStyles>;
     theme?: ITheme;
+}
+
+// @public (undocumented)
+export interface IContextualMenuItemRenderFunctions {
+    renderCheckMarkIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+    renderItemIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+    renderItemName: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+    renderSecondaryText: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+    renderSubMenuIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -495,13 +495,12 @@ export interface IContextualMenuItem {
   onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
 
   /**
-   * Method to reorganize sub-components of this menu item.
+   * Method to customize sub-components rendering of this menu item.
    *
    * @param props - Props used to pass into render functions
    * @param defaultRenders - Default render functions that renders default sub-components
-   * @param customClasses - Custom classes to add to renders of default render functions
    */
-  onRenderLayout?: (
+  onRenderContent?: (
     props: IContextualMenuItemProps,
     defaultRenders: IContextualMenuItemRenderFunctions,
   ) => React.ReactNode;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -14,6 +14,7 @@ import {
   IContextualMenuItemProps,
   IContextualMenuRenderItem,
   IContextualMenuItemStyleProps,
+  IContextualMenuItemRenderFunctions,
 } from './ContextualMenuItem.types';
 import { IKeytipProps } from '../../Keytip';
 
@@ -492,6 +493,18 @@ export interface IContextualMenuItem {
    * item click dismisses the menu. (Will be undefined if rendering a command bar item.)
    */
   onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
+
+  /**
+   * Method to reorganize sub-components of this menu item.
+   *
+   * @param props - Props used to pass into render functions
+   * @param defaultRenders - Default render functions that renders default sub-components
+   * @param customClasses - Custom classes to add to renders of default render functions
+   */
+  onRenderLayout?: (
+    props: IContextualMenuItemProps,
+    defaultRenders: IContextualMenuItemRenderFunctions,
+  ) => React.ReactNode;
 
   /**
    * A function to be executed on mouse down. This is executed before an `onClick` event and can

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -76,11 +76,11 @@ export class ContextualMenuItemBase extends React.Component<IContextualMenuItemP
 
   public render() {
     const { item, classNames } = this.props;
-    const RenderLayout = item.onRenderLayout ? item.onRenderLayout : this._renderLayout;
+    const RenderContent = item.onRenderContent ? item.onRenderContent : this._renderLayout;
 
     return (
       <div className={item.split ? classNames.linkContentMenu : classNames.linkContent}>
-        {RenderLayout(this.props, {
+        {RenderContent(this.props, {
           renderCheckMarkIcon,
           renderItemIcon,
           renderItemName,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { hasSubmenu, getIsChecked } from '../../utilities/contextualMenu/index';
 import { getRTL, initializeComponentRef } from '../../Utilities';
 import { Icon } from '../../Icon';
-import { IContextualMenuItemProps } from './ContextualMenuItem.types';
+import { IContextualMenuItemProps, IContextualMenuItemRenderFunctions } from './ContextualMenuItem.types';
 
 const renderItemIcon = (props: IContextualMenuItemProps) => {
   const { item, hasIcons, classNames } = props;
@@ -76,14 +76,17 @@ export class ContextualMenuItemBase extends React.Component<IContextualMenuItemP
 
   public render() {
     const { item, classNames } = this.props;
+    const RenderLayout = item.onRenderLayout ? item.onRenderLayout : this._renderLayout;
 
     return (
       <div className={item.split ? classNames.linkContentMenu : classNames.linkContent}>
-        {renderCheckMarkIcon(this.props)}
-        {renderItemIcon(this.props)}
-        {renderItemName(this.props)}
-        {renderSecondaryText(this.props)}
-        {renderSubMenuIcon(this.props)}
+        {RenderLayout(this.props, {
+          renderCheckMarkIcon,
+          renderItemIcon,
+          renderItemName,
+          renderSecondaryText,
+          renderSubMenuIcon,
+        })}
       </div>
     );
   }
@@ -111,4 +114,16 @@ export class ContextualMenuItemBase extends React.Component<IContextualMenuItemP
       dismissMenu(undefined /* ev */, dismissAll);
     }
   };
+
+  private _renderLayout(props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) {
+    return (
+      <>
+        {defaultRenders.renderCheckMarkIcon(props)}
+        {defaultRenders.renderItemIcon(props)}
+        {defaultRenders.renderItemName(props)}
+        {defaultRenders.renderSecondaryText(props)}
+        {defaultRenders.renderSubMenuIcon(props)}
+      </>
+    );
+  }
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
@@ -244,3 +244,30 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
    */
   linkContentMenu: IStyle;
 }
+
+export interface IContextualMenuItemRenderFunctions {
+  /**
+   * Rendering function for check mark icon
+   */
+  renderCheckMarkIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+
+  /**
+   * Rendering function for item icon
+   */
+  renderItemIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+
+  /**
+   * Rendering function for item label
+   */
+  renderItemName: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+
+  /**
+   * Rendering function for secondary text label
+   */
+  renderSecondaryText: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+
+  /**
+   * Rendering function for submenu icon
+   */
+  renderSubMenuIcon: (props: IContextualMenuItemProps, customClassNames?: string[]) => React.ReactNode;
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
@@ -1,0 +1,96 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { IContextualMenuProps, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItemProps, IContextualMenuItemRenderFunctions } from '../ContextualMenuItem.types';
+
+export const ContextualMenuIconCustomLayoutExample: React.FunctionComponent = () => {
+  return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
+};
+
+const renderLayout = (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => {
+  return (
+    <>
+      {defaultRenders.renderCheckMarkIcon(props)}
+      {defaultRenders.renderItemIcon(props)}
+      <div className={'ms-ContextualMenu-renderContentCustomizationExample-textWrapper'}>
+        {defaultRenders.renderItemName(props)}
+        {defaultRenders.renderSecondaryText(props)}
+      </div>
+      {defaultRenders.renderSubMenuIcon(props)}
+    </>
+  );
+};
+
+const menuItems: IContextualMenuItem[] = [
+  {
+    key: 'Later Today',
+    iconProps: {
+      iconName: 'Clock',
+    },
+    text: 'Later Today',
+    secondaryText: '7:00 PM',
+    onRenderLayout: renderLayout,
+  },
+  {
+    key: 'Tomorrow',
+    iconProps: {
+      iconName: 'Coffeescript',
+    },
+    text: 'Tomorrow',
+    secondaryText: 'Thu. 8:00 AM',
+    onRenderLayout: renderLayout,
+  },
+  {
+    key: 'This Weekend',
+    iconProps: {
+      iconName: 'Vacation',
+    },
+    text: 'This Weekend',
+    secondaryText: 'Sat. 10:00 AM',
+    onRenderLayout: renderLayout,
+  },
+  {
+    key: 'Next Week',
+    iconProps: {
+      iconName: 'Suitcase',
+    },
+    text: 'Next Week',
+    secondaryText: 'Mon. 8:00 AM',
+    onRenderLayout: renderLayout,
+  },
+];
+
+const menuProps: IContextualMenuProps = {
+  shouldFocusOnMount: true,
+  items: menuItems,
+  styles: {
+    subComponentStyles: {
+      menuItem: {
+        root: {
+          height: 'unset',
+        },
+        label: {
+          margin: '0',
+          fontSize: '14px',
+          lineHeight: '18px',
+        },
+        secondaryText: {
+          paddingLeft: '0',
+          textAlign: 'left',
+          fontSize: '10px',
+          lineHeight: '14px',
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Included CSS:
+ *
+ * .ms-ContextualMenu-renderContentCustomizationExample-textWrapper {
+ *   display: flex;
+ *   flex-direction: column;
+ *   margin: 8px 4px;
+ * }
+ */

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
@@ -11,7 +11,7 @@ export const ContextualMenuIconCustomLayoutExample: React.FunctionComponent = ()
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;
 };
 
-const renderLayout = (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => {
+const renderContent = (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => {
   return (
     <>
       {defaultRenders.renderCheckMarkIcon(props)}
@@ -33,7 +33,7 @@ const menuItems: IContextualMenuItem[] = [
     },
     text: 'Later Today',
     secondaryText: '7:00 PM',
-    onRenderLayout: renderLayout,
+    onRenderContent: renderContent,
   },
   {
     key: 'Tomorrow',
@@ -42,7 +42,7 @@ const menuItems: IContextualMenuItem[] = [
     },
     text: 'Tomorrow',
     secondaryText: 'Thu. 8:00 AM',
-    onRenderLayout: renderLayout,
+    onRenderContent: renderContent,
   },
   {
     key: 'This Weekend',
@@ -51,7 +51,7 @@ const menuItems: IContextualMenuItem[] = [
     },
     text: 'This Weekend',
     secondaryText: 'Sat. 10:00 AM',
-    onRenderLayout: renderLayout,
+    onRenderContent: renderContent,
   },
   {
     key: 'Next Week',
@@ -60,7 +60,7 @@ const menuItems: IContextualMenuItem[] = [
     },
     text: 'Next Week',
     secondaryText: 'Mon. 8:00 AM',
-    onRenderLayout: renderLayout,
+    onRenderContent: renderContent,
   },
 ];
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.CustomLayout.Example.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { IContextualMenuProps, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { IContextualMenuItemProps, IContextualMenuItemRenderFunctions } from '../ContextualMenuItem.types';
+import {
+  IContextualMenuProps,
+  IContextualMenuItem,
+  IContextualMenuItemProps,
+  IContextualMenuItemRenderFunctions,
+} from 'office-ui-fabric-react/lib/ContextualMenu';
 
 export const ContextualMenuIconCustomLayoutExample: React.FunctionComponent = () => {
   return <DefaultButton text="Click for ContextualMenu" menuProps={menuProps} />;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenuExample.scss
@@ -72,6 +72,12 @@
     width: 40%;
     margin: 2%;
   }
+
+  .ms-ContextualMenu-renderContentCustomizationExample-textWrapper {
+    display: flex;
+    flex-direction: column;
+    margin: 8px 4px;
+  }
 }
 
 .iconContainer {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.CustomLayout.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.CustomLayout.Example.tsx.shot
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders ContextualMenu.Icon.CustomLayout.Example.tsx correctly 1`] = `
+<button
+  aria-expanded={false}
+  aria-haspopup={true}
+  aria-owns={null}
+  className=
+      ms-Button
+      ms-Button--default
+      ms-Button--hasMenu
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background-color: #ffffff;
+        border-radius: 2px;
+        border: 1px solid #8a8886;
+        box-sizing: border-box;
+        color: #323130;
+        cursor: pointer;
+        display: inline-block;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 32px;
+        min-width: 80px;
+        outline: transparent;
+        padding-bottom: 0;
+        padding-left: 16px;
+        padding-right: 16px;
+        padding-top: 0;
+        position: relative;
+        text-align: center;
+        text-decoration: none;
+        user-select: none;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid transparent;
+        bottom: 2px;
+        content: "";
+        left: 2px;
+        outline: 1px solid #605e5c;
+        position: absolute;
+        right: 2px;
+        top: 2px;
+        z-index: 1;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        bottom: -2px;
+        left: -2px;
+        outline-color: ButtonText;
+        right: -2px;
+        top: -2px;
+      }
+      &:active > * {
+        left: 0px;
+        position: relative;
+        top: 0px;
+      }
+      &:hover {
+        background-color: #f3f2f1;
+        color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:hover {
+        border-color: Highlight;
+        color: Highlight;
+      }
+      &:active {
+        background-color: #edebe9;
+        color: #201f1e;
+      }
+  data-is-focusable={true}
+  onClick={[Function]}
+  onKeyDown={[Function]}
+  onKeyPress={[Function]}
+  onKeyUp={[Function]}
+  onMouseDown={[Function]}
+  onMouseUp={[Function]}
+  type="button"
+>
+  <span
+    className=
+        ms-Button-flexContainer
+        {
+          align-items: center;
+          display: flex;
+          flex-wrap: nowrap;
+          height: 100%;
+          justify-content: center;
+        }
+    data-automationid="splitbuttonprimary"
+  >
+    <span
+      className=
+          ms-Button-textContainer
+          {
+            display: block;
+            flex-grow: 1;
+          }
+    >
+      <span
+        className=
+            ms-Button-label
+            {
+              display: block;
+              font-weight: 600;
+              line-height: 100%;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+            }
+        id="id__0"
+      >
+        Click for ContextualMenu
+      </span>
+    </span>
+    <i
+      aria-hidden={true}
+      className=
+          ms-Icon
+          ms-Button-menuIcon
+          {
+            display: inline-block;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: "FabricMDL2Icons";
+            font-style: normal;
+            font-weight: normal;
+            speak: none;
+          }
+          {
+            flex-shrink: 0;
+            font-size: 12px;
+            height: 16px;
+            line-height: 16px;
+            margin-bottom: 0;
+            margin-left: 4px;
+            margin-right: 4px;
+            margin-top: 0;
+            text-align: center;
+          }
+      data-icon-name="ChevronDown"
+      role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
+    >
+      
+    </i>
+  </span>
+</button>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14457
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding an optional prop `onRenderLayout?: (props: IContextualMenuItemProps, defaultRenders: IContextualMenuItemRenderFunctions) => React.ReactNode` for reorganizing layout of rendered subcomponents. 

#### Focus areas to test

(optional)
