### PR TITLE
Allow pr-deploy-site to operate with scoped builds

### DIFF
--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -7,98 +7,11 @@
       rel="stylesheet"
       href="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-core/10.0.0/css/fabric.min.css"
     />
-    <style>
-      html {
-        box-sizing: border-box;
-      }
-
-      *,
-      *:before,
-      *:after {
-        box-sizing: inherit;
-      }
-
-      body {
-        align-items: center;
-        background-color: #f3f2f1;
-        background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/PjxzdmcgIHdpZHRoPSI2MDAiICBoZWlnaHQ9IjYwMCIgIHZpZXdCb3g9IjAgMCA2MDAgNjAwIiAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4gIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMwMCwzMDApIj4gICAgPHBhdGggZD0iTTEyMi42LC0xMTQuOEMxNzAuMywtNzUsMjI4LjEsLTM3LjUsMjM0LjQsNi4yQzI0MC42LDUwLDE5NS4zLDk5LjksMTQ3LjYsMTI5LjZDOTkuOSwxNTkuMyw1MCwxNjguNiw0LjcsMTYzLjlDLTQwLjUsMTU5LjIsLTgxLjEsMTQwLjQsLTExNS43LDExMC43Qy0xNTAuNCw4MS4xLC0xNzkuMiw0MC41LC0xOTMuOCwtMTQuNkMtMjA4LjQsLTY5LjgsLTIwOC45LC0xMzkuNSwtMTc0LjIsLTE3OS40Qy0xMzkuNSwtMjE5LjIsLTY5LjgsLTIyOS4xLC0xNi4xLC0yMTNDMzcuNSwtMTk2LjgsNzUsLTE1NC42LDEyMi42LC0xMTQuOFoiIGZpbGw9IiMzZDk3ZTMiIC8+ICA8L2c+PC9zdmc+);
-        background-position: 50% 50%;
-        background-repeat: no-repeat;
-        background-size: 900px 740px;
-        display: flex;
-        height: 100vh;
-        justify-content: center;
-        padding: 20px;
-      }
-
-      .Tiles {
-        display: flex;
-        flex-wrap: wrap;
-        list-style-type: none;
-        margin: 0;
-        max-width: 800px;
-        padding: 0;
-      }
-
-      .Tile {
-        background-color: white;
-        border-radius: 2px;
-        box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
-        margin: 0 12px 12px 0;
-        opacity: 0.96;
-        transition: all 0.15s linear;
-      }
-
-      .Tile:not(.Tile--intro):hover {
-        box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
-        opacity: 1;
-      }
-
-      .Tile-link {
-        align-items: center;
-        color: #323130;
-        display: flex;
-        flex-direction: column;
-        height: 148px;
-        justify-content: center;
-        padding: 20px;
-        text-decoration: none;
-        width: 148px;
-      }
-
-      .Tile-link i {
-        font-size: 32px;
-        margin-bottom: 12px;
-        color: #605e5c;
-      }
-
-      .Tile--intro {
-        max-width: 468px;
-        padding: 20px;
-        width: 100%;
-      }
-
-      .Tile--intro h1 {
-        font-size: 24px;
-        font-weight: 300;
-        margin: 8px 0;
-        padding: 0;
-      }
-
-      .Tile--intro p {
-        font-size: 14px;
-        margin: 0;
-      }
-
-      .Tile--intro a,
-      .Tile--intro a:visited {
-        color: #0078d4;
-      }
-    </style>
+    <link rel="stylesheet" href="./pr-deploy-site.css" />
   </head>
 
   <body class="ms-Fabric">
-    <ul class="Tiles">
+    <ul class="Tiles" id="site-list">
       <li class="Tile Tile--intro">
         <h1>Deployed sites for PR <a href="#" class="prLink"></a></h1>
         <p>
@@ -106,70 +19,10 @@
           introduce any new issues.
         </p>
       </li>
-      <li class="Tile">
-        <a href="./fabric-website-resources/dist/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--FavoriteStar"></i>Demo Site</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./office-ui-fabric-react/dist-storybook/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--FavoriteStar"></i>Fabric Storybook Site</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./fabric-website/dist/index.html?devhost" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--Website"></i>Website</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./react-northstar" class="Tile-link"><i class="ms-Icon ms-Icon--FavoriteStar"></i>react-northstar</a>
-      </li>
-      <li class="Tile">
-        <a href="./react-button/dist-storybook/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--LikeSolid"></i>Button</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./react-tabs/dist-storybook/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--BrowserTab"></i>Tabs</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./react-next/dist-storybook/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--DoubleChevronRight12"></i>Next</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./experiments/dist/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--TestBeaker"></i>Experiments</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./charting/dist/index.html" class="Tile-link"><i class="ms-Icon ms-Icon--BarChart4"></i>Charting</a>
-      </li>
-      <li class="Tile">
-        <a href="./date-time/dist/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--PrimaryCalendar"></i>Date/Time</a
-        >
-      </li>
-      <!--
-        TODO: temporarily disabling this for now until a new pipeline is created for PR Deploy Site builds
-      <li class="Tile">
-        <a href="./test-bundles/test-bundles.stats.html" class="Tile-link"><i class="ms-Icon ms-Icon--SpeedHigh"></i>Bundle Analyzer</a>
-      </li>
-      -->
-      <li class="Tile">
-        <a href="./todo-app/index.html" class="Tile-link"><i class="ms-Icon ms-Icon--CheckMark"></i>Todo Example</a>
-      </li>
-      <li class="Tile">
-        <a href="./theming-designer/index.html" class="Tile-link"
-          ><i class="ms-Icon ms-Icon--CheckMark"></i>Theme Designer Example</a
-        >
-      </li>
-      <li class="Tile">
-        <a href="./perf-test/index.html" class="Tile-link"><i class="ms-Icon ms-Icon--SpeedHigh"></i>Perf Tests</a>
-      </li>
     </ul>
+
+    <script src="./pr-deploy-site.js"></script>
+
     <script>
       const pathParts = window.location.href.split('/');
       const pullRequestIndex = pathParts.indexOf('pull') + 1;
@@ -180,6 +33,10 @@
         link.innerHTML = `#${number}`;
         link.href = `https://github.com/microsoft/fluentui/pull/${number}`;
       }
+    </script>
+
+    <script>
+      renderSiteLinks(/* insert packages here */);
     </script>
   </body>
 </html>

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -5,27 +5,10 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
-    "test": "just-scripts test",
+    "generate:site": "just-scripts generate:site",
     "just": "just-scripts"
   },
   "license": "MIT",
-  "dependencies": {
-    "@fluentui/docs": "^0.51.0",
-    "@fluentui/react-button": "^0.9.3",
-    "@fluentui/react-next": "^8.0.0-alpha.86",
-    "@fluentui/react-tabs": "^0.2.13",
-    "@uifabric/charting": "^3.0.9",
-    "@uifabric/date-time": "^7.14.3",
-    "@uifabric/experiments": "^7.28.2",
-    "@uifabric/fabric-website": "^7.13.24",
-    "@uifabric/fabric-website-resources": "^7.6.121",
-    "office-ui-fabric-react": "^7.128.1",
-    "perf-test": "^7.0.0",
-    "theming-designer": "^7.0.0",
-    "todo-app": "^7.0.0"
-  },
   "devDependencies": {
     "@uifabric/build": "^7.0.0"
   }

--- a/apps/pr-deploy-site/pr-deploy-site.css
+++ b/apps/pr-deploy-site/pr-deploy-site.css
@@ -1,0 +1,86 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+body {
+  align-items: center;
+  background-color: #f3f2f1;
+  background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBzdGFuZGFsb25lPSJubyI/PjxzdmcgIHdpZHRoPSI2MDAiICBoZWlnaHQ9IjYwMCIgIHZpZXdCb3g9IjAgMCA2MDAgNjAwIiAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4gIDxnIHRyYW5zZm9ybT0idHJhbnNsYXRlKDMwMCwzMDApIj4gICAgPHBhdGggZD0iTTEyMi42LC0xMTQuOEMxNzAuMywtNzUsMjI4LjEsLTM3LjUsMjM0LjQsNi4yQzI0MC42LDUwLDE5NS4zLDk5LjksMTQ3LjYsMTI5LjZDOTkuOSwxNTkuMyw1MCwxNjguNiw0LjcsMTYzLjlDLTQwLjUsMTU5LjIsLTgxLjEsMTQwLjQsLTExNS43LDExMC43Qy0xNTAuNCw4MS4xLC0xNzkuMiw0MC41LC0xOTMuOCwtMTQuNkMtMjA4LjQsLTY5LjgsLTIwOC45LC0xMzkuNSwtMTc0LjIsLTE3OS40Qy0xMzkuNSwtMjE5LjIsLTY5LjgsLTIyOS4xLC0xNi4xLC0yMTNDMzcuNSwtMTk2LjgsNzUsLTE1NC42LDEyMi42LC0xMTQuOFoiIGZpbGw9IiMzZDk3ZTMiIC8+ICA8L2c+PC9zdmc+);
+  background-position: 50% 50%;
+  background-repeat: no-repeat;
+  background-size: 900px 740px;
+  display: flex;
+  height: 100vh;
+  justify-content: center;
+  padding: 20px;
+}
+
+.Tiles {
+  display: flex;
+  flex-wrap: wrap;
+  list-style-type: none;
+  margin: 0;
+  max-width: 800px;
+  padding: 0;
+}
+
+.Tile {
+  background-color: white;
+  border-radius: 2px;
+  box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+  margin: 0 12px 12px 0;
+  opacity: 0.96;
+  transition: all 0.15s linear;
+}
+
+.Tile:not(.Tile--intro):hover {
+  box-shadow: 0 6.4px 14.4px 0 rgba(0, 0, 0, 0.132), 0 1.2px 3.6px 0 rgba(0, 0, 0, 0.108);
+  opacity: 1;
+}
+
+.Tile-link {
+  align-items: center;
+  color: #323130;
+  display: flex;
+  flex-direction: column;
+  height: 148px;
+  justify-content: center;
+  padding: 20px;
+  text-decoration: none;
+  width: 148px;
+}
+
+.Tile-link i {
+  font-size: 32px;
+  margin-bottom: 12px;
+  color: #605e5c;
+}
+
+.Tile--intro {
+  max-width: 468px;
+  padding: 20px;
+  width: 100%;
+}
+
+.Tile--intro h1 {
+  font-size: 24px;
+  font-weight: 300;
+  margin: 8px 0;
+  padding: 0;
+}
+
+.Tile--intro p {
+  font-size: 14px;
+  margin: 0;
+}
+
+.Tile--intro a,
+.Tile--intro a:visited {
+  color: #0078d4;
+}

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -19,7 +19,7 @@ const siteInfo = [
     icon: 'Website',
     title: 'Website',
   },
-  { package: '@fluentui/react-northstar', link: './react-northstar', icon: 'FavoriteStar', title: 'react-northstar' },
+  { package: '@fluentui/docs', link: './react-northstar', icon: 'FavoriteStar', title: 'react-northstar' },
   {
     package: '@fluentui/react-button',
     link: './react-button/dist-storybook/index.html',

--- a/apps/pr-deploy-site/pr-deploy-site.js
+++ b/apps/pr-deploy-site/pr-deploy-site.js
@@ -1,0 +1,68 @@
+// If you are adding a new tile into this site, place make sure it is also being copied from `just.config.ts`
+
+const siteInfo = [
+  {
+    package: '@uifabric/fabric-website-resources',
+    link: './fabric-website-resources/dist/index.html',
+    icon: 'FavoriteStar',
+    title: 'Demo Site',
+  },
+  {
+    package: '@uifabric/fabric-website-resources',
+    link: './office-ui-fabric-react/dist-storybook/index.html',
+    icon: 'FavoriteStar',
+    title: 'Fabric Storybook Site',
+  },
+  {
+    package: '@uifabric/fabric-website',
+    link: './fabric-website/dist/index.html?devhost',
+    icon: 'Website',
+    title: 'Website',
+  },
+  { package: '@fluentui/react-northstar', link: './react-northstar', icon: 'FavoriteStar', title: 'react-northstar' },
+  {
+    package: '@fluentui/react-button',
+    link: './react-button/dist-storybook/index.html',
+    icon: 'LikeSolid',
+    title: 'Button',
+  },
+  {
+    package: '@fluentui/react-tabs',
+    link: './react-tabs/dist-storybook/index.html',
+    icon: 'BrowserTab',
+    title: 'Tabs',
+  },
+  {
+    package: '@fluentui/react-next',
+    link: './react-next/dist-storybook/index.html',
+    icon: 'DoubleChevronRight12',
+    title: 'Next',
+  },
+  { package: '@uifabric/experiments', link: './experiments/dist/index.html', icon: 'TestBeaker', title: 'Experiments' },
+  { package: '@uifabric/charting', link: './charting/dist/index.html', icon: 'BarChart4', title: 'Charting' },
+  { package: '@uifabric/date-time', link: './date-time/dist/index.html', icon: 'PrimaryCalendar', title: 'Date/Time' },
+  { package: 'todo-app', link: './todo-app/index.html', icon: 'CheckMark', title: 'Todo Example' },
+  {
+    package: 'theming-designer',
+    link: './theming-designer/index.html',
+    icon: 'CheckMark',
+    title: 'Theme Designer Example',
+  },
+  { package: 'perf-test', link: './perf-test/index.html', icon: 'SpeedHigh', title: 'Perf Tests' },
+];
+
+var siteLink = document.getElementById('site-list');
+
+window.renderSiteLinks = function(packages) {
+  siteInfo.forEach(function(info) {
+    if (packages.indexOf(info.package) > -1) {
+      var li = document.createElement('LI');
+      li.className = 'Tile';
+      li.innerHTML = `<a href="${info.link}" class="Tile-link">
+        <i class="ms-Icon ms-Icon--${info.icon}"></i>${info.title}
+      </a>`;
+
+      siteLink.appendChild(li);
+    }
+  });
+};

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -19,7 +19,7 @@ steps:
   # @fluentui/perf-test needs build and bundle steps
   - script: |
       yarn lage build --scope @fluentui/perf-test --scope perf-test --no-deps --verbose --no-cache --grouped
-    displayName: build, bundle @fluentui v0
+    displayName: build  @fluentui v0
     env:
       BACKFILL_CACHE_PROVIDER: 'azure-blob'
       BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,12 +57,30 @@ jobs:
           yarn
         displayName: yarn
 
+      - template: .devops/templates/pr-target-branch.yml
+
+      ## only do scoped bundle with PRs
       - script: |
-          yarn lage bundle --scope @uifabric/pr-deploy-site --no-deps --verbose --no-cache --grouped
-        displayName: bundle
+          yarn lage bundle --verbose --no-cache --grouped --since $(target_branch)
+        displayName: bundle (pr, scoped)
+        condition: ne(variables['Build.SourceBranch'], 'refs/heads/master')
         env:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
+
+      ## duplicated for  master CI builds
+      - script: |
+          yarn lage bundle --verbose --no-cache --grouped
+        displayName: bundle (master)
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        env:
+          BACKFILL_CACHE_PROVIDER: 'azure-blob'
+          BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
+
+      ## This runs regardless of scope, the app will adapt to the scope as well
+      - script: |
+          yarn workspace @uifabric/pr-deploy-site generate-site
+        displayName: generate PR Deploy Site
 
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: Build-PR-$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
 
       ## This runs regardless of scope, the app will adapt to the scope as well
       - script: |
-          yarn workspace @uifabric/pr-deploy-site generate-site
+          yarn workspace @uifabric/pr-deploy-site generate:site
         displayName: generate PR Deploy Site
 
       - publish: $(Build.ArtifactStagingDirectory)

--- a/scripts/storybook/webpack.config.js
+++ b/scripts/storybook/webpack.config.js
@@ -93,6 +93,11 @@ module.exports = ({ config }) => {
     new IgnoreNotFoundExportWebpackPlugin({ include: [/\.tsx?$/] }),
   );
 
+  // Disable ProgressPlugin which logs verbose webpack build progress. Warnings and Errors are still logged.
+  if (process.env.TF_BUILD) {
+    config.plugins = config.plugins.filter(({ constructor }) => constructor.name !== 'ProgressPlugin');
+  }
+
   config.optimization.minimize = false;
 
   return config;


### PR DESCRIPTION
#### Description of changes

With this change, the deploy step can also participate in scoped builds as well. This way, PR deployed site itself will be smart enough to build out an index.html that can handle detected built packages.

This is needed so that as we scale out the number of packages, the PR deployed site will only need to display the sites that are actually affected the change. This makes it so that the scopes are respected even in the "Deploy" job of the PR pipeline.

#### Future
Make sure perf-test and bundle-size auditor are also aware of scopes so that we do not over build when it is not necessary.

#### Focus areas to test

(optional)
