### PR TITLE
Fixing issue #12592-  StackItem does not use its `padding` token

### DIFF
--- a/change/office-ui-fabric-react-2020-08-17-14-01-50-StackItemPaddingFix.json
+++ b/change/office-ui-fabric-react-2020-08-17-14-01-50-StackItemPaddingFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "StackItem: Fixing issue #12592 - StackItem does not use its `padding` token",
+  "packageName": "office-ui-fabric-react",
+  "email": "pavanpadavala@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T08:31:50.541Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
@@ -21,6 +21,7 @@ export const StackItemStyles: IStackItemComponent['styles'] = (props, theme, tok
       classNames.root,
       {
         margin: tokens.margin,
+        padding: tokens.padding,
         height: verticalFill ? '100%' : 'auto',
         width: 'auto',
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12592
- [x] Include a change request file using `$ yarn change`

#### Description of changes

StackItem styles has a 'padding' token but it is not used in the code. so adding that to fix and function as designed.

#### Focus areas to test

(optional)
