### PR TITLE
Moving Layer to react-next, in preparation for converting to a function component

### DIFF
--- a/change/@fluentui-react-next-2020-08-17-13-34-33-feat-moving-layer.json
+++ b/change/@fluentui-react-next-2020-08-17-13-34-33-feat-moving-layer.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Moving Layer to react-next, in preparation for converting to a function component.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T20:34:33.473Z"
+}

--- a/change/office-ui-fabric-react-2020-08-17-14-01-50-StackItemPaddingFix.json
+++ b/change/office-ui-fabric-react-2020-08-17-14-01-50-StackItemPaddingFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "StackItem: Fixing issue #12592 - StackItem does not use its `padding` token",
+  "packageName": "office-ui-fabric-react",
+  "email": "pavanpadavala@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T08:31:50.541Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.styles.ts
@@ -21,6 +21,7 @@ export const StackItemStyles: IStackItemComponent['styles'] = (props, theme, tok
       classNames.root,
       {
         margin: tokens.margin,
+        padding: tokens.padding,
         height: verticalFill ? '100%' : 'auto',
         width: 'auto',
       },

--- a/packages/react-next/src/components/Layer/Layer.base.tsx
+++ b/packages/react-next/src/components/Layer/Layer.base.tsx
@@ -1,0 +1,228 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Fabric } from '../../Fabric';
+import { ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer.types';
+import {
+  classNamesFunction,
+  customizable,
+  getDocument,
+  setPortalAttribute,
+  setVirtualParent,
+  warnDeprecations,
+} from '../../Utilities';
+import { registerLayer, getDefaultTarget, unregisterLayer } from './Layer.notification';
+
+export type ILayerBaseState = {
+  hostId?: string;
+  layerElement?: HTMLElement;
+};
+
+const getClassNames = classNamesFunction<ILayerStyleProps, ILayerStyles>();
+
+@customizable('Layer', ['theme', 'hostId'])
+export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
+  public static defaultProps: ILayerProps = {
+    onLayerDidMount: () => undefined,
+    onLayerWillUnmount: () => undefined,
+  };
+
+  private _rootRef = React.createRef<HTMLSpanElement>();
+
+  constructor(props: ILayerProps) {
+    super(props);
+
+    this.state = {};
+
+    if (process.env.NODE_ENV !== 'production') {
+      warnDeprecations('Layer', props, {
+        onLayerMounted: 'onLayerDidMount',
+      });
+    }
+  }
+
+  public componentDidMount(): void {
+    const { hostId } = this.props;
+
+    this._createLayerElement();
+
+    if (hostId) {
+      registerLayer(hostId, this._createLayerElement);
+    }
+  }
+
+  public render(): React.ReactNode {
+    const { layerElement } = this.state;
+    const classNames = this._getClassNames();
+    const { eventBubblingEnabled } = this.props;
+
+    return (
+      <span className="ms-layer" ref={this._rootRef}>
+        {layerElement &&
+          ReactDOM.createPortal(
+            <Fabric {...(!eventBubblingEnabled && _getFilteredEvents())} className={classNames.content}>
+              {this.props.children}
+            </Fabric>,
+            layerElement,
+          )}
+      </span>
+    );
+  }
+
+  public componentDidUpdate(): void {
+    if (this.props.hostId !== this.state.hostId) {
+      this._createLayerElement();
+    }
+  }
+
+  public componentWillUnmount(): void {
+    const { hostId } = this.props;
+
+    this._removeLayerElement();
+    if (hostId) {
+      unregisterLayer(hostId, this._createLayerElement);
+    }
+  }
+
+  private _createLayerElement = () => {
+    const { hostId } = this.props;
+
+    const doc = getDocument(this._rootRef.current);
+    const host = this._getHost();
+
+    if (!doc || !host) {
+      return;
+    }
+
+    // If one was already existing, remove.
+    this._removeLayerElement();
+
+    const layerElement = doc.createElement('div');
+    const classNames = this._getClassNames();
+
+    layerElement.className = classNames.root!;
+    setPortalAttribute(layerElement);
+    setVirtualParent(layerElement, this._rootRef.current!);
+
+    this.props.insertFirst ? host.insertBefore(layerElement, host.firstChild) : host.appendChild(layerElement);
+
+    this.setState(
+      {
+        hostId,
+        layerElement,
+      },
+      () => {
+        // eslint-disable-next-line deprecation/deprecation
+        const { onLayerDidMount, onLayerMounted } = this.props;
+        if (onLayerMounted) {
+          onLayerMounted();
+        }
+
+        if (onLayerDidMount) {
+          onLayerDidMount();
+        }
+      },
+    );
+  };
+
+  private _removeLayerElement(): void {
+    const { onLayerWillUnmount } = this.props;
+    const { layerElement } = this.state;
+
+    if (onLayerWillUnmount) {
+      onLayerWillUnmount();
+    }
+
+    if (layerElement && layerElement.parentNode) {
+      const parentNode = layerElement.parentNode;
+      if (parentNode) {
+        parentNode.removeChild(layerElement);
+      }
+    }
+  }
+
+  private _getClassNames() {
+    const { className, styles, theme } = this.props;
+    const classNames = getClassNames(styles!, {
+      theme: theme!,
+      className,
+      isNotHost: !this.props.hostId,
+    });
+
+    return classNames;
+  }
+
+  private _getHost(): Node | undefined {
+    const { hostId } = this.props;
+    const doc = getDocument(this._rootRef.current);
+    if (!doc) {
+      return undefined;
+    }
+
+    if (hostId) {
+      return doc.getElementById(hostId) as Node;
+    } else {
+      const defaultHostSelector = getDefaultTarget();
+      return defaultHostSelector ? (doc.querySelector(defaultHostSelector) as Node) : doc.body;
+    }
+  }
+}
+
+const _onFilterEvent = (ev: React.SyntheticEvent<HTMLElement>): void => {
+  // We should just be able to check ev.bubble here and only stop events that are bubbling up. However, even though
+  // mouseenter and mouseleave do NOT bubble up, they are showing up as bubbling. Therefore we stop events based on
+  // event name rather than ev.bubble.
+  if (
+    ev.eventPhase === Event.BUBBLING_PHASE &&
+    ev.type !== 'mouseenter' &&
+    ev.type !== 'mouseleave' &&
+    ev.type !== 'touchstart' &&
+    ev.type !== 'touchend'
+  ) {
+    ev.stopPropagation();
+  }
+};
+
+let _filteredEventProps: { [key: string]: (ev: React.SyntheticEvent<HTMLElement, Event>) => void };
+
+function _getFilteredEvents() {
+  if (!_filteredEventProps) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    _filteredEventProps = {} as any;
+
+    [
+      'onClick',
+      'onContextMenu',
+      'onDoubleClick',
+      'onDrag',
+      'onDragEnd',
+      'onDragEnter',
+      'onDragExit',
+      'onDragLeave',
+      'onDragOver',
+      'onDragStart',
+      'onDrop',
+      'onMouseDown',
+      'onMouseEnter',
+      'onMouseLeave',
+      'onMouseMove',
+      'onMouseOver',
+      'onMouseOut',
+      'onMouseUp',
+      'onTouchMove',
+      'onTouchStart',
+      'onTouchCancel',
+      'onTouchEnd',
+      'onKeyDown',
+      'onKeyPress',
+      'onKeyUp',
+      'onFocus',
+      'onBlur',
+      'onChange',
+      'onInput',
+      'onInvalid',
+      'onSubmit',
+    ].forEach(name => (_filteredEventProps[name] = _onFilterEvent));
+  }
+
+  return _filteredEventProps;
+}

--- a/packages/react-next/src/components/Layer/Layer.doc.tsx
+++ b/packages/react-next/src/components/Layer/Layer.doc.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { LayerBasicExample } from './examples/Layer.Basic.Example';
+
+import { IDocPageProps } from '../../common/DocPage.types';
+import { LayerHostedExample } from './examples/Layer.Hosted.Example';
+import { LayerCustomizedExample } from './examples/Layer.Customized.Example';
+import { LayerNestedLayersExample } from './examples/Layer.NestedLayers.Example';
+
+const LayerBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Basic.Example.tsx') as string;
+const LayerHostedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Hosted.Example.tsx') as string;
+const LayerCustomizedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.Customized.Example.tsx') as string;
+const LayerNestedLayersExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Layer/examples/Layer.NestedLayers.Example.tsx') as string;
+
+export const LayerPageProps: IDocPageProps = {
+  title: 'Layer',
+  componentName: 'Layer',
+  componentUrl:
+    'https://github.com/microsoft/fluentui/tree/master/packages/office-ui-fabric-react/src/components/Layer',
+  examples: [
+    {
+      title: 'Basic layered content',
+      code: LayerBasicExampleCode,
+      view: <LayerBasicExample />,
+    },
+    {
+      title: 'Using LayerHost to control projection',
+      code: LayerHostedExampleCode,
+      view: <LayerHostedExample />,
+    },
+    {
+      title: 'Using Customizer to control the default layer behavior',
+      code: LayerCustomizedExampleCode,
+      view: <LayerCustomizedExample />,
+    },
+    {
+      title: 'Nested Layers Example',
+      code: LayerNestedLayersExampleCode,
+      view: <LayerNestedLayersExample />,
+    },
+  ],
+  overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Layer/docs/LayerOverview.md'),
+  bestPractices: require<string>('!raw-loader!office-ui-fabric-react/src/components/Layer/docs/LayerBestPractices.md'),
+  dos: require<string>('!raw-loader!office-ui-fabric-react/src/components/Layer/docs/LayerDos.md'),
+  donts: require<string>('!raw-loader!office-ui-fabric-react/src/components/Layer/docs/LayerDonts.md'),
+  isHeaderVisible: true,
+  isFeedbackVisible: true,
+};

--- a/packages/react-next/src/components/Layer/Layer.notification.ts
+++ b/packages/react-next/src/components/Layer/Layer.notification.ts
@@ -1,0 +1,62 @@
+const _layersByHostId: { [hostId: string]: (() => void)[] } = {};
+
+let _defaultHostSelector: string | undefined;
+
+/**
+ * Register a layer for a given host id
+ * @param hostId Id of the layer host
+ * @param layer Layer instance
+ */
+export function registerLayer(hostId: string, callback: () => void) {
+  if (!_layersByHostId[hostId]) {
+    _layersByHostId[hostId] = [];
+  }
+
+  _layersByHostId[hostId].push(callback);
+}
+
+/**
+ * Unregister a layer for a given host id
+ * @param hostId Id of the layer host
+ * @param layer Layer instance
+ */
+export function unregisterLayer(hostId: string, callback: () => void) {
+  if (_layersByHostId[hostId]) {
+    const idx = _layersByHostId[hostId].indexOf(callback);
+    if (idx >= 0) {
+      _layersByHostId[hostId].splice(idx, 1);
+      if (_layersByHostId[hostId].length === 0) {
+        delete _layersByHostId[hostId];
+      }
+    }
+  }
+}
+
+/**
+ * Used for notifying applicable Layers that a host is available/unavailable and to re-evaluate Layers that
+ * care about the specific host.
+ */
+export function notifyHostChanged(id: string) {
+  if (_layersByHostId[id]) {
+    _layersByHostId[id].forEach(callback => callback());
+  }
+}
+
+/**
+ * Sets the default target selector to use when determining the host in which
+ * Layered content will be injected into. If not provided, an element will be
+ * created at the end of the document body.
+ *
+ * Passing in a falsey value will clear the default target and reset back to
+ * using a created element at the end of document body.
+ */
+export function setDefaultTarget(selector?: string) {
+  _defaultHostSelector = selector;
+}
+
+/**
+ * Get the default target selector when determining a host
+ */
+export function getDefaultTarget(): string | undefined {
+  return _defaultHostSelector;
+}

--- a/packages/react-next/src/components/Layer/Layer.styles.ts
+++ b/packages/react-next/src/components/Layer/Layer.styles.ts
@@ -1,0 +1,40 @@
+import { ILayerStyleProps, ILayerStyles } from './Layer.types';
+import { ZIndexes, getGlobalClassNames } from '../../Styling';
+
+const GlobalClassNames = {
+  root: 'ms-Layer',
+  rootNoHost: 'ms-Layer--fixed',
+  content: 'ms-Layer-content',
+};
+
+export const getStyles = (props: ILayerStyleProps): ILayerStyles => {
+  const { className, isNotHost, theme } = props;
+
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    root: [
+      classNames.root,
+      theme.fonts.medium,
+      isNotHost && [
+        classNames.rootNoHost,
+        {
+          position: 'fixed',
+          zIndex: ZIndexes.Layer,
+          top: 0,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          visibility: 'hidden',
+        },
+      ],
+      className,
+    ],
+    content: [
+      classNames.content,
+      {
+        visibility: 'visible',
+      },
+    ],
+  };
+};

--- a/packages/react-next/src/components/Layer/Layer.test.tsx
+++ b/packages/react-next/src/components/Layer/Layer.test.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { Layer } from './Layer';
+import { LayerHost } from './LayerHost';
+import { mount } from 'enzyme';
+
+const ReactDOM = require('react-dom');
+
+const testEvents: string[] = (
+  'click contextmenu doubleclick drag dragend dragenter dragleave dragover dragstart drop ' +
+  'mousedown mousemove mouseout mouseup keydown keypress keyup focus blur change input submit'
+).split(' ');
+
+describe('Layer', () => {
+  interface IFooContext {
+    foo?: string;
+  }
+  const context = React.createContext<IFooContext>({ foo: undefined });
+
+  it('renders Layer correctly', () => {
+    // Mock createPortal to capture its component hierarchy in snapshot output.
+    const createPortal = ReactDOM.createPortal;
+    ReactDOM.createPortal = jest.fn(element => {
+      return element;
+    });
+
+    const component = renderer.create(<Layer>Content</Layer>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+
+    ReactDOM.createPortal = createPortal;
+  });
+
+  it('can render in a targeted LayerHost and pass context through', () => {
+    class Child extends React.Component<{}, {}> {
+      public render(): JSX.Element {
+        return <context.Consumer>{val => <div id="child">{val.foo}</div>}</context.Consumer>;
+      }
+    }
+
+    class Parent extends React.Component<{}, {}> {
+      public render(): JSX.Element {
+        return (
+          <context.Provider value={{ foo: 'bar' }}>
+            <div id="parent">
+              <Layer hostId="foo">
+                <Child />
+              </Layer>
+            </div>
+          </context.Provider>
+        );
+      }
+    }
+
+    class App extends React.Component<{}, {}> {
+      public render(): JSX.Element {
+        return (
+          <div id="app">
+            <Parent />
+            <LayerHost id="foo" />
+          </div>
+        );
+      }
+    }
+
+    const appElement = document.createElement('div');
+
+    try {
+      document.body.appendChild(appElement);
+      ReactDOM.render(<App />, appElement);
+
+      const parentElement = appElement.querySelector('#parent');
+
+      expect(parentElement).toBeDefined();
+      expect(parentElement!.ownerDocument).toBeDefined();
+
+      const childElement = appElement.querySelector('#child') as Element;
+
+      expect(childElement.textContent).toEqual('bar');
+    } finally {
+      ReactDOM.unmountComponentAtNode(appElement);
+      appElement.remove();
+    }
+  });
+
+  it('stops bubbling events', () => {
+    // Simulate does not propagate events up the hierarchy.
+    // Instead, let's check for calls to stopPropagation.
+    // https://airbnb.io/enzyme/docs/api/ShallowWrapper/simulate.html
+    const targetClassName = 'ms-Layer-content';
+    const expectedStopPropagationCount = testEvents.length;
+    let stopPropagationCount = 0;
+
+    const eventObject = (event: string) => {
+      return {
+        eventPhase: Event.BUBBLING_PHASE,
+        stopPropagation: () => {
+          // Debug code for figuring out which events are firing on test failures:
+          // console.log(event);
+          stopPropagationCount++;
+        },
+      };
+    };
+
+    const wrapper = mount(<Layer />);
+
+    const targetContent = wrapper.find(`.${targetClassName}`).at(0);
+
+    testEvents.forEach(event => {
+      targetContent.simulate(event, eventObject(event));
+    });
+
+    expect(stopPropagationCount).toEqual(expectedStopPropagationCount);
+
+    // These events should never be stopped
+    targetContent.simulate('mouseenter', eventObject('mouseenter'));
+    targetContent.simulate('mouseleave', eventObject('mouseleave'));
+
+    expect(stopPropagationCount).toEqual(expectedStopPropagationCount);
+  });
+
+  it('does not stop non-bubbling events', () => {
+    // Simulate does not propagate events up the hierarchy.
+    // Instead, let's check for calls to stopPropagation.
+    // https://airbnb.io/enzyme/docs/api/ShallowWrapper/simulate.html
+    const targetClassName = 'ms-Layer-content';
+    const expectedStopPropagationCount = 0;
+    let stopPropagationCount = 0;
+
+    const eventObject = (event: string) => {
+      return {
+        eventPhase: Event.CAPTURING_PHASE,
+        stopPropagation: () => {
+          // Debug code for figuring out which events are firing on test failures:
+          // console.log(event);
+          stopPropagationCount++;
+        },
+      };
+    };
+
+    const wrapper = mount(<Layer />);
+
+    const targetContent = wrapper.find(`.${targetClassName}`).at(0);
+
+    testEvents.forEach(event => {
+      targetContent.simulate(event, eventObject(event));
+    });
+
+    expect(stopPropagationCount).toEqual(expectedStopPropagationCount);
+  });
+
+  it('allows events to bubble with eventBubblingEnabled prop', () => {
+    // Simulate does not propagate events up the hierarchy.
+    // Instead, let's check for calls to stopPropagation.
+    // https://airbnb.io/enzyme/docs/api/ShallowWrapper/simulate.html
+    const targetClassName = 'ms-Layer-content';
+    let stopPropagationCount = 0;
+
+    const eventObject = (event: string) => {
+      return {
+        eventPhase: Event.BUBBLING_PHASE,
+        stopPropagation: () => {
+          // Debug code for figuring out which events are firing on test failures:
+          // console.log(event);
+          stopPropagationCount++;
+        },
+      };
+    };
+
+    const wrapper = mount(<Layer eventBubblingEnabled={true} />);
+
+    const targetContent = wrapper.find(`.${targetClassName}`).at(0);
+
+    testEvents.forEach(event => {
+      targetContent.simulate(event, eventObject(event));
+    });
+
+    expect(stopPropagationCount).toEqual(0);
+
+    // These events should always bubble
+    targetContent.simulate('mouseenter', eventObject('mouseenter'));
+    targetContent.simulate('mouseleave', eventObject('mouseleave'));
+
+    expect(stopPropagationCount).toEqual(0);
+  });
+});

--- a/packages/react-next/src/components/Layer/Layer.tsx
+++ b/packages/react-next/src/components/Layer/Layer.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { styled } from '../../Utilities';
+import { ILayerProps, ILayerStyleProps, ILayerStyles } from './Layer.types';
+import { LayerBase } from './Layer.base';
+import { getStyles } from './Layer.styles';
+
+export const Layer: React.FunctionComponent<ILayerProps> = styled<ILayerProps, ILayerStyleProps, ILayerStyles>(
+  LayerBase,
+  getStyles,
+  undefined,
+  {
+    scope: 'Layer',
+    fields: ['hostId', 'theme', 'styles'],
+  },
+);

--- a/packages/react-next/src/components/Layer/Layer.types.ts
+++ b/packages/react-next/src/components/Layer/Layer.types.ts
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { LayerBase } from './Layer.base';
+import { IStyle, ITheme } from '../../Styling';
+import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+
+/**
+ * {@docCategory Layer}
+ */
+export interface ILayer {}
+
+/**
+ * {@docCategory Layer}
+ */
+export interface ILayerProps extends React.HTMLAttributes<HTMLDivElement | LayerBase> {
+  /**
+   * Optional callback to access the ILayer interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: IRefObject<ILayer>;
+
+  /**
+   * Call to provide customized styling that will layer on top of the variant rules
+   */
+  styles?: IStyleFunctionOrObject<ILayerStyleProps, ILayerStyles>;
+
+  /**
+   * Theme provided by HOC.
+   */
+  theme?: ITheme;
+
+  /**
+   * Additional css class to apply to the Layer
+   * @defaultvalue undefined
+   */
+  className?: string;
+
+  /**
+   * Callback for when the layer is mounted.
+   * @deprecated Use onLayerDidMount.
+   */
+  onLayerMounted?: () => void;
+
+  /**
+   * Callback for when the layer is mounted.
+   */
+  onLayerDidMount?: () => void;
+
+  /**
+   * Callback for when the layer is unmounted.
+   */
+  onLayerWillUnmount?: () => void;
+
+  /**
+   * The optional id property provided on a LayerHost that this Layer should render within. The LayerHost does
+   * not need to be immediately available but once has been rendered, and if missing, we'll avoid trying
+   * to render the Layer content until the host is available. If an id is not provided, we will render the Layer
+   * content in a fixed position element rendered at the end of the document.
+   */
+  hostId?: string;
+
+  /**
+   * When enabled, Layer allows events to bubble up from Layer content.
+   * Traditionally Layer has not had this behavior. This prop preserves backwards compatibility by
+   * default while allowing users to opt in to the new event bubbling functionality.
+   */
+  eventBubblingEnabled?: boolean;
+
+  /**
+   * Whether the layer should be added as the first child of the host.
+   * If true, the layer will be inserted as the first child of the host
+   * By default, the layer will be appended at the end to the host
+   */
+  insertFirst?: boolean;
+}
+
+/**
+ * {@docCategory Layer}
+ */
+export interface ILayerStyleProps {
+  /**
+   * Accept theme prop.
+   */
+  theme: ITheme;
+
+  /**
+   * Accept custom classNames
+   */
+  className?: string;
+
+  /**
+   * Check if Host
+   */
+  isNotHost?: boolean;
+}
+
+/**
+ * {@docCategory Layer}
+ */
+export interface ILayerStyles {
+  /**
+   * Style for the root element when fixed.
+   */
+  root?: IStyle;
+  /**
+   * Style for the Fabric component.
+   */
+  content?: IStyle;
+}

--- a/packages/react-next/src/components/Layer/LayerHost.tsx
+++ b/packages/react-next/src/components/Layer/LayerHost.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { css } from '../../Utilities';
+import { ILayerHostProps } from './LayerHost.types';
+import { notifyHostChanged } from './Layer.notification';
+
+export class LayerHost extends React.Component<ILayerHostProps> {
+  public shouldComponentUpdate() {
+    return false;
+  }
+
+  public componentDidMount(): void {
+    notifyHostChanged(this.props.id!);
+  }
+
+  public componentWillUnmount(): void {
+    notifyHostChanged(this.props.id!);
+  }
+
+  public render(): JSX.Element {
+    return <div {...this.props} className={css('ms-LayerHost', this.props.className)} />;
+  }
+}

--- a/packages/react-next/src/components/Layer/LayerHost.types.ts
+++ b/packages/react-next/src/components/Layer/LayerHost.types.ts
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { IRefObject } from '../../Utilities';
+
+export interface ILayerHost {}
+
+export interface ILayerHostProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Optional callback to access the ILayerHost interface. Use this instead of ref for accessing
+   * the public methods and properties of the component.
+   */
+  componentRef?: IRefObject<ILayerHost>;
+
+  /**
+   * Defines the id for the layer host that Layers can target (using the hostId property.)
+   */
+  id?: string;
+}

--- a/packages/react-next/src/components/Layer/__snapshots__/Layer.test.tsx.snap
+++ b/packages/react-next/src/components/Layer/__snapshots__/Layer.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Layer renders Layer correctly 1`] = `
+<span
+  className="ms-layer"
+>
+  <div
+    className=
+        ms-Fabric
+        ms-Layer-content
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          visibility: visible;
+        }
+        & button {
+          font-family: inherit;
+        }
+        & input {
+          font-family: inherit;
+        }
+        & textarea {
+          font-family: inherit;
+        }
+    onBlur={[Function]}
+    onChange={[Function]}
+    onClick={[Function]}
+    onContextMenu={[Function]}
+    onDoubleClick={[Function]}
+    onDrag={[Function]}
+    onDragEnd={[Function]}
+    onDragEnter={[Function]}
+    onDragExit={[Function]}
+    onDragLeave={[Function]}
+    onDragOver={[Function]}
+    onDragStart={[Function]}
+    onDrop={[Function]}
+    onFocus={[Function]}
+    onInput={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
+    onMouseMove={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
+    onMouseUp={[Function]}
+    onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
+  >
+    Content
+  </div>
+</span>
+`;

--- a/packages/react-next/src/components/Layer/docs/LayerDonts.md
+++ b/packages/react-next/src/components/Layer/docs/LayerDonts.md
@@ -1,0 +1,1 @@
+- Use string refs: `ref='root'`

--- a/packages/react-next/src/components/Layer/docs/LayerDos.md
+++ b/packages/react-next/src/components/Layer/docs/LayerDos.md
@@ -1,0 +1,1 @@
+- Use functional refs: `ref={ (el) => { this._root = el; }`

--- a/packages/react-next/src/components/Layer/docs/LayerOverview.md
+++ b/packages/react-next/src/components/Layer/docs/LayerOverview.md
@@ -1,0 +1,5 @@
+A Layer is a technical component that does not have specific Design guidance.
+
+Layers are used to render content outside of a DOM tree, at the end of the document. This allows content to escape traditional boundaries caused by "overflow: hidden" css rules and keeps it on the top without using z-index rules. This is useful for example in ContextualMenu and Tooltip scenarios, where the content should always overlay everything else.
+
+There are some special considerations. Due to the nature of rendering content elsewhere asynchronously, React refs within content will not be resolvable synchronously at the time the Layer is mounted. Therefore, to use refs correctly, use functional refs `ref={ (el) => { this._root = el; }` rather than string refs `ref='root'`. Additionally measuring the physical Layer element will not include any of the children, since it won't render it. Events that propgate from within the content will not go through the Layer element as well.

--- a/packages/react-next/src/components/Layer/examples/Layer.Basic.Example.tsx
+++ b/packages/react-next/src/components/Layer/examples/Layer.Basic.Example.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { AnimationClassNames, mergeStyles, getTheme } from '@fluentui/react-next/lib/Styling';
+import { Layer } from '@fluentui/react-next/lib/Layer';
+import { Toggle } from '@fluentui/react-next/lib/Toggle';
+import { useBoolean } from '@uifabric/react-hooks';
+
+export const LayerBasicExample: React.FunctionComponent = () => {
+  const [showLayer, { toggle: toggleShowLayer }] = useBoolean(false);
+
+  const content = <div className={contentClass}>Hello world</div>;
+
+  return (
+    <div>
+      <Toggle
+        label="Wrap the content box below in a Layer"
+        inlineLabel
+        checked={showLayer}
+        onChange={toggleShowLayer}
+      />
+
+      {showLayer ? <Layer>{content}</Layer> : content}
+    </div>
+  );
+};
+
+const theme = getTheme();
+const contentClass = mergeStyles([
+  {
+    backgroundColor: theme.palette.themePrimary,
+    color: theme.palette.white,
+    lineHeight: '50px',
+    padding: '0 20px',
+  },
+  AnimationClassNames.scaleUpIn100,
+]);

--- a/packages/react-next/src/components/Layer/examples/Layer.Customized.Example.tsx
+++ b/packages/react-next/src/components/Layer/examples/Layer.Customized.Example.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Toggle } from '@fluentui/react-next/lib/Toggle';
+import { LayerHost, ILayerProps } from '@fluentui/react-next/lib/Layer';
+import { Panel } from '@fluentui/react-next/lib/Panel';
+import { IFocusTrapZoneProps } from '@fluentui/react-next/lib/FocusTrapZone';
+import { mergeStyles } from '@fluentui/react-next/lib/Styling';
+import { Customizer } from '@fluentui/react-next/lib/Utilities';
+import { useId, useBoolean } from '@uifabric/react-hooks';
+
+export const LayerCustomizedExample: React.FunctionComponent = () => {
+  const [isPanelOpen, { setTrue: showPanel, setFalse: dismissPanel }] = useBoolean(false);
+  const [trapPanel, { toggle: toggleTrapPanel }] = useBoolean(false);
+
+  // Use useId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string and manually ensure uniqueness.)
+  const layerHostId = useId('layerHost');
+
+  const scopedSettings = useLayerSettings(trapPanel, layerHostId);
+
+  return (
+    <div>
+      <p>
+        A <code>Panel</code> is rendered, trapped in a specified container. Use <b>Show panel</b> to show/hide the panel
+        (or select the X to dismiss it). Use <b>Trap panel</b> to release the panel from its bounds.
+      </p>
+      <Toggle label="Show panel" inlineLabel checked={isPanelOpen} onChange={isPanelOpen ? dismissPanel : showPanel} />
+      <Toggle label="Trap panel" inlineLabel checked={trapPanel} onChange={toggleTrapPanel} />
+      <Customizer scopedSettings={scopedSettings}>
+        {isPanelOpen && (
+          <Panel
+            isOpen
+            hasCloseButton
+            headerText="Sample panel"
+            focusTrapZoneProps={focusTrapZoneProps}
+            onDismiss={dismissPanel}
+          >
+            This panel {trapPanel ? 'is' : 'is not'} trapped.
+          </Panel>
+        )}
+      </Customizer>
+      <LayerHost id={layerHostId} className={layerHostClass} />
+    </div>
+  );
+};
+
+const layerHostClass = mergeStyles({
+  position: 'relative',
+  height: 400,
+  overflow: 'hidden',
+  border: '1px solid #ccc',
+});
+
+const focusTrapZoneProps: IFocusTrapZoneProps = {
+  isClickableOutsideFocusTrap: true,
+  forceFocusInsideTrap: false,
+};
+
+function useLayerSettings(trapPanel: boolean, layerHostId: string): { Layer?: ILayerProps } {
+  return React.useMemo(() => {
+    if (trapPanel) {
+      const layerProps: ILayerProps = { hostId: layerHostId };
+      return { Layer: layerProps };
+    }
+    return {};
+  }, [trapPanel, layerHostId]);
+}

--- a/packages/react-next/src/components/Layer/examples/Layer.Hosted.Example.tsx
+++ b/packages/react-next/src/components/Layer/examples/Layer.Hosted.Example.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import { Toggle } from '@fluentui/react-next/lib/Toggle';
+import { Layer, LayerHost } from '@fluentui/react-next/lib/Layer';
+import { AnimationClassNames, mergeStyleSets, getTheme } from '@fluentui/react-next/lib/Styling';
+import { IToggleStyles } from '@fluentui/react-next/lib/Toggle';
+import { useId, useBoolean } from '@uifabric/react-hooks';
+
+export const LayerHostedExample: React.FunctionComponent = () => {
+  const [showLayer, { toggle: toggleShowLayer }] = useBoolean(false);
+  const [showLayerNoId, { toggle: toggleShowLayerNoId }] = useBoolean(false);
+  const [showHost, { toggle: toggleShowHost }] = useBoolean(true);
+
+  // Use useId() to ensure that the ID is unique on the page.
+  // (It's also okay to use a plain string without getId() and manually ensure uniqueness.)
+  const layerHostId = useId('layerHost');
+
+  const content = <div className={styles.content}>This is example layer content.</div>;
+
+  return (
+    <div className={styles.root}>
+      <Toggle label="Show host" inlineLabel checked={showHost} onChange={toggleShowHost} />
+
+      {showHost && <LayerHost id={layerHostId} className={styles.customHost} />}
+
+      <p>
+        In some cases, you may need to contain layered content within an area. Create an instance of a LayerHost along
+        with an id, and provide a hostId on the layer to render it within the specific host. (Note that it's important
+        that you don't include children within the LayerHost. It's meant to contain Layered content only.)
+      </p>
+
+      <Toggle
+        styles={styles.toggle}
+        label={`Render the box below in a Layer and target it at hostId=${layerHostId}`}
+        inlineLabel
+        checked={showLayer}
+        onChange={toggleShowLayer}
+      />
+
+      {showLayer ? (
+        <Layer hostId={layerHostId} onLayerDidMount={logDidMount} onLayerWillUnmount={logWillUnmount}>
+          {content}
+        </Layer>
+      ) : (
+        content
+      )}
+
+      <div className={styles.nonLayered}>I am normally below the content.</div>
+
+      <p>If you do not specify a hostId, the hosted layer will default to being fixed to the page by default.</p>
+
+      <Toggle
+        styles={styles.toggle}
+        label="Render the box below in a Layer without specifying a host, fixing it to the top of the page"
+        inlineLabel
+        checked={showLayerNoId}
+        onChange={toggleShowLayerNoId}
+      />
+
+      {showLayerNoId ? (
+        <Layer onLayerDidMount={logDidMount} onLayerWillUnmount={logWillUnmount}>
+          {content}
+        </Layer>
+      ) : (
+        content
+      )}
+    </div>
+  );
+};
+
+const logDidMount = () => console.log('layer did mount');
+const logWillUnmount = () => console.log('layer will unmount');
+
+const toggleStyles: Partial<IToggleStyles> = {
+  root: { margin: '10px 0' },
+};
+const theme = getTheme();
+const styles = {
+  toggle: toggleStyles,
+  ...mergeStyleSets({
+    root: {
+      selectors: { p: { marginTop: 30 } },
+    },
+    customHost: {
+      height: 100,
+      padding: 20,
+      background: 'rgba(255, 0, 0, 0.2)',
+      border: '1px dashed ' + theme.palette.black,
+      position: 'relative',
+      selectors: {
+        '&:before': {
+          position: 'absolute',
+          left: '50%',
+          top: '50%',
+          transform: 'translate(-50%, -50%)',
+          // double quotes required to make the string show up
+          content: '"I am a LayerHost with id=layerhost1"',
+        },
+      },
+    },
+    content: [
+      {
+        backgroundColor: theme.palette.themePrimary,
+        color: theme.palette.white,
+        lineHeight: '50px',
+        padding: '0 20px',
+      },
+      AnimationClassNames.scaleUpIn100,
+    ],
+    nonLayered: {
+      backgroundColor: theme.palette.neutralTertiaryAlt,
+      lineHeight: '50px',
+      padding: '0 20px',
+      margin: '8px 0',
+    },
+  }),
+};

--- a/packages/react-next/src/components/Layer/examples/Layer.NestedLayers.Example.tsx
+++ b/packages/react-next/src/components/Layer/examples/Layer.NestedLayers.Example.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { DefaultButton, PrimaryButton } from '@fluentui/react-next/lib/compat/Button';
+import { Dialog, DialogFooter, DialogType, IDialogContentProps } from 'office-ui-fabric-react/lib/Dialog';
+import { Panel, PanelType } from '@fluentui/react-next/lib/Panel';
+import { IModalProps } from 'office-ui-fabric-react/lib/Modal';
+import { useBoolean } from '@uifabric/react-hooks';
+
+export const LayerNestedLayersExample: React.FunctionComponent = () => {
+  const [isDialogOpen, { setTrue: showDialog, setFalse: hideDialog }] = useBoolean(false);
+  const [isPanelOpen, { setTrue: showPanel, setFalse: dismissPanel }] = useBoolean(false);
+
+  return (
+    <div>
+      <DefaultButton secondaryText="Opens the Sample Panel" onClick={showPanel} text="Open Panel" />
+      <Panel
+        isOpen={isPanelOpen}
+        type={PanelType.smallFixedFar}
+        onDismiss={dismissPanel}
+        headerText="This panel makes use of Layer and FocusTrapZone. Focus should be trapped in the panel."
+        closeButtonAriaLabel="Close"
+      >
+        <DefaultButton secondaryText="Opens the Sample Dialog" onClick={showDialog} text="Open Dialog" />
+        <Dialog
+          hidden={!isDialogOpen}
+          onDismiss={hideDialog}
+          isBlocking={true}
+          dialogContentProps={dialogContentProps}
+          modalProps={modalProps}
+        >
+          <DialogFooter>
+            <PrimaryButton onClick={hideDialog} text="OK" />
+            <DefaultButton onClick={hideDialog} text="Cancel" />
+          </DialogFooter>
+        </Dialog>
+      </Panel>
+    </div>
+  );
+};
+
+const dialogContentProps: IDialogContentProps = {
+  type: DialogType.normal,
+  title:
+    'This dialog uses Modal, which also makes use of Layer and FocusTrapZone. Focus should be trapped in the dialog.',
+  subText: "Focus will move back to the panel if you press 'OK' or 'Cancel'.",
+};
+const modalProps: IModalProps = {
+  isBlocking: false,
+  styles: { main: { maxWidth: 450 } },
+};

--- a/packages/react-next/src/components/Layer/index.ts
+++ b/packages/react-next/src/components/Layer/index.ts
@@ -1,0 +1,4 @@
+export * from './Layer';
+export * from './Layer.base';
+export * from './Layer.types';
+export * from './LayerHost';


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes

This change does not modify `Layer `; it simply moves it to react-next for better diffing in the actual conversion PR.
`Layer` needs to converted before `Modal` as it doesn't pass an HTML element ref.

#### Focus areas to test
`Layer `
