### PR TITLE
lowercase filetypeicons

### DIFF
--- a/change/@uifabric-file-type-icons-2020-08-17-13-35-23-caperez-lowercase_filetypeicons.json
+++ b/change/@uifabric-file-type-icons-2020-08-17-13-35-23-caperez-lowercase_filetypeicons.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating to use latest iconset from latest versioned CDN. All filetypes are lowercase. SVGs for 20_1.5x are now available.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T20:35:23.970Z"
+}

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200708.002/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200817.003/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {
@@ -28,15 +28,13 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
 
     // SVGs scale well, so you can generally use the default image.
     // 1.5x is a special case where both SVGs and PNGs need a different image.
-    // Remove if statements when missing image files for 20_1.5x are provided.
-    if (size !== 20) {
-      fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
+
+    fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
         <img src={baseUrl + size + '_1.5x/' + type + '.png'} height="100%" width="100%" />
-      );
-      fileTypeIcons[type + size + '_1.5x' + SVG_SUFFIX] = (
+    );
+    fileTypeIcons[type + size + '_1.5x' + SVG_SUFFIX] = (
         <img src={baseUrl + size + '_1.5x/' + type + '.svg'} height="100%" width="100%" />
-      );
-    }
+    );
 
     fileTypeIcons[type + size + '_2x' + PNG_SUFFIX] = (
       <img src={baseUrl + size + '_2x/' + type + '.png'} height="100%" width="100%" />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #13560
- [x] Include a change request file using `$ yarn change`

#### Description of changes

References the filetype CDN version that has all lowercase filenames. Removes restriction on using 20_1.5x SVG sizes since they are now available.

#### Focus areas to test

Experiments -> File Type Icons
