### PR TITLE
CodeMods: Sreamline CodeMod creation process with createCodeMod

### DIFF
--- a/change/@fluentui-codemods-2020-08-17-18-55-57-t-dama-CodemodsConfig_make_mods_array.json
+++ b/change/@fluentui-codemods-2020-08-17-18-55-57-t-dama-CodemodsConfig_make_mods_array.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add support for non-json codemod creation",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-17T22:55:57.844Z"
+}

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.ts
@@ -51,9 +51,9 @@ export function createCodeMod(modName: string, mod: (file: SourceFile) => void):
         /* Codemod body. */
         mod(file);
       } catch (e) {
-        return { success: false };
+        return Err({ reason: `Mod failed: ${e}` });
       }
-      return { success: true };
+      return Ok({ logs: ['Upgrade completed'] });
     },
     version: '100000',
     name: modName,
@@ -63,9 +63,7 @@ export function createCodeMod(modName: string, mod: (file: SourceFile) => void):
 
 /* Dictionary that maps codemod names to functions that execute said mod.
    Used by getCodeModUtilitiesFromJson to easily get the desired function
-   from the json object.
-
-   TODO: How well does this scale for devs who want to add mods but don't care about json?*/
+   from the json object. */
 const codeModMap: CodeModMapType = {
   renameProp: function(mod: RenamePropModType) {
     return function(file: SourceFile) {

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.ts
@@ -12,45 +12,53 @@ import { Ok, Err } from '../../../helpers/result';
 
 const jsonObj: UpgradeJSONType = require('../upgrades.json');
 
-/* Intermediate file that reads upgrades.json and returns
-   a codemod object to be run. */
-export function createCodeModFromJson(): CodeMod | undefined {
-  return {
-    run: (file: SourceFile) => {
-      try {
-        /* Codemod body, which can be added to */
-        const funcs = getCodeModUtilitiesFromJson(file);
-        funcs.forEach(func => {
-          func();
-        });
-      } catch (e) {
-        Err({ reason: 'Error' });
-      }
-      return Ok({ logs: ['Updated Successfully'] });
-    },
-    version: '100000',
-    name: jsonObj.name,
-    enabled: true,
-  };
+/* Creates and returns an array of CodeMod objects from a JSON file. Optionally takes in
+   an array of functions from user to turn into codemods as well. */
+export function createCodeModsFromJson(userMods?: CodeMod[]): CodeMod[] | undefined {
+  const funcs = getCodeModsFromJson();
+  /* If the user wants to supply any codemods (as a void function that takes in a sourcefile),
+     add those offerings right now! */
+  if (userMods) {
+    funcs.concat(userMods);
+  }
+  return funcs;
 }
 
 /* Helper function that parses a json object for details about individual
    codemods and formats each into a function. These functions are stored in
    an array that is returned to the user. */
-export function getCodeModUtilitiesFromJson(file: SourceFile): (() => void)[] {
-  const functions = [];
+export function getCodeModsFromJson(): CodeMod[] {
+  const mods = [];
   const modDetails: ModTypes[] = jsonObj.upgrades;
   for (let i = 0; i < modDetails.length; i++) {
     /* Try and get the codemod function associated with the mod type. */
-    const func = codeModMap[modDetails[i].type](file, modDetails[i]);
+    const func = codeModMap[modDetails[i].type](modDetails[i]);
     if (func) {
-      functions.push(func);
+      mods.push(createCodeMod(modDetails[i].name, func));
     } else {
       // eslint-disable-next-line no-throw-literal
       throw 'Error: attempted to access a codeMod mapping from an unsupported type.';
     }
   }
-  return functions;
+  return mods;
+}
+
+/* Helper function that creates a codeMod given a name and a list of functions that compose the mod. */
+export function createCodeMod(modName: string, mod: (file: SourceFile) => void): CodeMod {
+  return {
+    run: (file: SourceFile) => {
+      try {
+        /* Codemod body. */
+        mod(file);
+      } catch (e) {
+        return { success: false };
+      }
+      return { success: true };
+    },
+    version: '100000',
+    name: modName,
+    enabled: true,
+  };
 }
 
 /* Dictionary that maps codemod names to functions that execute said mod.
@@ -59,14 +67,14 @@ export function getCodeModUtilitiesFromJson(file: SourceFile): (() => void)[] {
 
    TODO: How well does this scale for devs who want to add mods but don't care about json?*/
 const codeModMap: CodeModMapType = {
-  renameProp: function(file: SourceFile, mod: RenamePropModType) {
-    return function() {
+  renameProp: function(mod: RenamePropModType) {
+    return function(file: SourceFile) {
       const tags = findJsxTag(file, mod.options.from.importName);
       renameProp(tags, mod.options.from.toRename, mod.options.to.replacementName);
     };
   },
-  repathImport: function(file: SourceFile, mod: RepathImportModType) {
-    return function() {
+  repathImport: function(mod: RepathImportModType) {
+    return function(file: SourceFile) {
       /* If the json indicates our search string is a regex, convert it. */
       const searchString = mod.options.from.isRegex
         ? new RegExp(

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.ts
@@ -6,6 +6,7 @@ import {
   RenamePropModType,
   RepathImportModType,
   CodeModMapType,
+  ModOptions,
 } from '../../types';
 import { findJsxTag, renameProp, getImportsByPath, repathImport } from '../../utilities/index';
 import { Ok, Err } from '../../../helpers/result';
@@ -34,7 +35,11 @@ export function getCodeModsFromJson(): CodeMod[] {
     /* Try and get the codemod function associated with the mod type. */
     const func = codeModMap[modDetails[i].type](modDetails[i]);
     if (func) {
-      mods.push(createCodeMod(modDetails[i].name, func));
+      const options: ModOptions = {
+        name: modDetails[i].name,
+        version: modDetails[i].version ? modDetails[i].version! : '100000',
+      };
+      mods.push(createCodeMod(options, func));
     } else {
       // eslint-disable-next-line no-throw-literal
       throw 'Error: attempted to access a codeMod mapping from an unsupported type.';
@@ -44,7 +49,7 @@ export function getCodeModsFromJson(): CodeMod[] {
 }
 
 /* Helper function that creates a codeMod given a name and a list of functions that compose the mod. */
-export function createCodeMod(modName: string, mod: (file: SourceFile) => void): CodeMod {
+export function createCodeMod(options: ModOptions, mod: (file: SourceFile) => void): CodeMod {
   return {
     run: (file: SourceFile) => {
       try {
@@ -55,8 +60,8 @@ export function createCodeMod(modName: string, mod: (file: SourceFile) => void):
       }
       return Ok({ logs: ['Upgrade completed'] });
     },
-    version: '100000',
-    name: modName,
+    version: options.version,
+    name: options.name,
     enabled: true,
   };
 }

--- a/packages/codemods/src/codeMods/mods/upgrades.json
+++ b/packages/codemods/src/codeMods/mods/upgrades.json
@@ -4,6 +4,7 @@
     {
       "name": "Renaming 'isDisabled' to 'disabled' in Dropdown",
       "type": "renameProp",
+      "version": "100000",
       "options": {
         "from": {
           "importName": "Dropdown",

--- a/packages/codemods/src/codeMods/tests/configMod/configMod.test.ts
+++ b/packages/codemods/src/codeMods/tests/configMod/configMod.test.ts
@@ -1,5 +1,5 @@
 import { Project } from 'ts-morph';
-import { createCodeModFromJson } from '../../mods/configMod/configMod';
+import { createCodeModsFromJson } from '../../mods/configMod/configMod';
 import { Maybe } from '../../../helpers/maybe';
 import { runMods } from '../../../modRunner/runnerUtilities';
 
@@ -20,11 +20,9 @@ describe('Tests a simple data-driven codeMod', () => {
   });
 
   it('can run all mods in upgrades.json successfully', () => {
-    const mod = Maybe(createCodeModFromJson());
-    if (mod.something) {
-      const mods = [];
-      mods.push(mod.value);
-      runMods(mods, project.getSourceFiles(), result => {
+    const mods = Maybe(createCodeModsFromJson());
+    if (mods.something) {
+      runMods(mods.value, project.getSourceFiles(), result => {
         if (result.error) {
           console.error(`Error running mod ${result.mod.name} on file ${result.file.getBaseName()}`, result.error);
         } else {

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -75,7 +75,7 @@ export enum SpreadPropInStatement {
    in configMod.ts. */
 export type CodeModMapType = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: (file: SourceFile, mod: any) => () => void;
+  [key: string]: (mod: any) => (file: SourceFile) => void;
 };
 
 /* Type definition for a CodeMod object representing a renameProp mod. */

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -82,6 +82,7 @@ export type CodeModMapType = {
 export type RenamePropModType = {
   name: string;
   type: 'renameProp';
+  version?: string;
   options: {
     from: {
       importName: string;
@@ -99,6 +100,7 @@ export type RenamePropModType = {
 export type RepathImportModType = {
   name: string;
   type: 'repathImport';
+  version?: string;
   options: {
     from: {
       searchString: string | RegExp;
@@ -117,4 +119,10 @@ export type ModTypes = RenamePropModType | RepathImportModType;
 export type UpgradeJSONType = {
   name: string;
   upgrades: ModTypes[];
+};
+
+/* Type storing codemod metadata. */
+export type ModOptions = {
+  name: string;
+  version: string;
 };

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -32,12 +32,14 @@ export function renamePropInSpread(
         if (!attribute || (!firstIdentifier && !propertyAccess)) {
           throw 'Invalid spread prop. Could access internal identifiers successfully.';
         }
+        /* SPREADISIDENTIFIER tells us whether we should look at an Identifier or a P.A.E. node. */
         const spreadIsIdentifier = firstIdentifier !== undefined;
         /* Verify this attribute contains the name of our desired prop. */
         if (spreadContains(toRename, spreadIsIdentifier, attribute)) {
           /* Step 3: Create names for your new potential objects. */
+          const componentName = element.getFirstChildByKind(SyntaxKind.Identifier)?.getText();
           const propSpreadName = spreadIsIdentifier ? firstIdentifier!.getText() : propertyAccess!.getText();
-          let newSpreadName = '__migProps';
+          let newSpreadName = `__mig${componentName}Props`;
           const newMapName = '__migEnumMap';
           /* Metadata in case we need to reacquire the current element (AST modification). */
           let newJSXFlag = false;
@@ -119,6 +121,7 @@ export function renamePropInSpread(
               }
             }
           } else {
+            /* If a viable spread prop wasn't found, make a new one. */
             if (!propAlreadyExists(parentContainer, toRename)) {
               parentContainer.insertVariableStatement(
                 insertIndex,
@@ -180,8 +183,6 @@ export function renamePropInSpread(
               ? `{${replacementValue}}`
               : `{${toRename}}`,
           }); // Add the updated prop name and set its value.
-        } else {
-          throw 'Could not find prop in component specified.';
         }
       }
     }


### PR DESCRIPTION
Implemented `createCodeMod()`, a helper function that takes in a string codemod name and a function that mirrors a "run" body in an actual code mod. This function will return a nicely packaged codemod that is ready-to-run. This is great because I previously wrote some transforms that devs can use to change prop values that are only accessible if they can invoke `renameProp()` directly. Hopefully this should give devs the flexibility they need when writing codemods!

Here's how it could be used to rename a prop.

```
    // Rename 'checked' to 'toggled' in Button
    const renamePropCodeMod = (file : SourceFile) => void { 
        // Example body of a code mod. Easily customizable by a developer!
        const tags = findJsxTag(file, 'Button');
        renameProp(tags, 'checked', 'toggled');         
    };
    const shinyNewCodeMod = createCodeMod('Rename checked to toggled in Button', renamePropCodeMod);
    // run shinyNewCodeMod with runMods() on some source files!
```

`createCodeMod()` is also used by `getCodeModsFromJson()` since it's such a generic function. Woo hoo!

In other news, the codeMod generator no longer packages all mods in the json into a single mod. Although this could hurt performance (more mods = more runs), now that mods are individual, one could group them for better logging or potentially less redundancy with file visitation. More metadata might be needed there, though.