### PR TITLE
docs(Datepicker): Add cell customization

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerCellExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerCellExample.shorthand.steps.ts
@@ -1,0 +1,17 @@
+import { inputClassName, datepickerCalendarCellClassName } from '@fluentui/react-northstar';
+
+const config: ScreenerTestsConfig = {
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
+  steps: [
+    builder =>
+      builder
+        .click(`.${inputClassName}`)
+        .snapshot('Shows datepicker popup')
+        .hover(`.${datepickerCalendarCellClassName}:nth-child(19)`)
+        .snapshot("Does not show tooltip on not today's date")
+        .hover(`.${datepickerCalendarCellClassName}:nth-child(20)`)
+        .snapshot("Shows tooltip on today's date"),
+  ],
+};
+
+export default config;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerCellExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerCellExample.shorthand.tsx
@@ -1,0 +1,22 @@
+import { Datepicker, Tooltip } from '@fluentui/react-northstar';
+import * as React from 'react';
+
+const DatepickerCellExample = () => {
+  return (
+    <Datepicker
+      today={new Date(2020, 8, 12, 0, 0, 0, 0)}
+      calendar={{
+        calendarCell: {
+          children: (ComponentType, props) =>
+            props.isToday ? (
+              <Tooltip content="TODAY!" trigger={<ComponentType {...props} />} />
+            ) : (
+              <ComponentType {...props} />
+            ),
+        },
+      }}
+    />
+  );
+};
+
+export default DatepickerCellExample;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderCellExample.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderCellExample.shorthand.steps.ts
@@ -1,0 +1,15 @@
+import { inputClassName, datepickerCalendarHeaderCellClassName } from '@fluentui/react-northstar';
+
+const config: ScreenerTestsConfig = {
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
+  steps: [
+    builder =>
+      builder
+        .click(`.${inputClassName}`)
+        .snapshot('Shows datepicker popup')
+        .hover(`.${datepickerCalendarHeaderCellClassName}:nth-child(1)`)
+        .snapshot("Shows tooltip on today's date"),
+  ],
+};
+
+export default config;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderCellExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderCellExample.shorthand.tsx
@@ -1,0 +1,19 @@
+import { Datepicker, Tooltip } from '@fluentui/react-northstar';
+import * as React from 'react';
+
+const DatepickerHeaderCellExample = () => {
+  return (
+    <Datepicker
+      today={new Date(2020, 8, 12, 0, 0, 0, 0)}
+      calendar={{
+        calendarHeaderCell: {
+          children: (ComponentType, props) => (
+            <Tooltip content={props['aria-label']} trigger={<ComponentType {...props} />} />
+          ),
+        },
+      }}
+    />
+  );
+};
+
+export default DatepickerHeaderCellExample;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/index.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
+import ExampleSection from '../../../../components/ComponentDoc/ExampleSection';
+
+const Usage = () => (
+  <ExampleSection title="Slots">
+    <ComponentExample
+      title="Custom cell slot"
+      description={
+        <>
+          <code>calendarCell</code> inside <code>calendar</code> prop can be used for customizing datepicker cell
+        </>
+      }
+      examplePath="components/Datepicker/Slots/DatepickerCellExample"
+    />
+    <ComponentExample
+      title="Custom header cell slot"
+      description={
+        <>
+          <code>calendarHeaderCell</code> inside <code>calendar</code> prop can be used for customizing datepicker
+          header cell
+        </>
+      }
+      examplePath="components/Datepicker/Slots/DatepickerHeaderCellExample"
+    />
+  </ExampleSection>
+);
+
+export default Usage;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/index.tsx
@@ -2,12 +2,14 @@ import * as React from 'react';
 
 import Types from './Types';
 import States from './States';
+import Slots from './Slots';
 import Usage from './Usage';
 
 const DatepickerExamples = () => (
   <>
     <Types />
     <States />
+    <Slots />
     <Usage />
   </>
 );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Added examples for `calendarCell` and `calendarHeaderCell` customization using slots and children API

HeaderCell with Tooltip
![image](https://user-images.githubusercontent.com/2802155/90541197-8adda100-e182-11ea-9a02-b405196ff8a7.png)

Cell with Tooltip
![image](https://user-images.githubusercontent.com/2802155/90541249-9b8e1700-e182-11ea-84bb-3cf50d4c52df.png)
