### PR TITLE
Removing unused eslint-disable rules from ContextualMenu

### DIFF
--- a/packages/react-next/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react-next/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -363,7 +363,6 @@ export class ContextualMenuBase extends React.Component<IContextualMenuProps, IC
             aria-label={ariaLabel}
             aria-labelledby={labelElementId}
             style={contextMenuStyle}
-            // eslint-disable-next-line react/jsx-no-bind
             ref={(host: HTMLDivElement) => (this._host = host)}
             id={id}
             className={this._classNames.container}

--- a/packages/react-next/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/react-next/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -81,7 +81,6 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
         (keytipAttributes: any): JSX.Element => (
           <div
             data-ktp-target={keytipAttributes['data-ktp-target']}
-            // eslint-disable-next-line react/jsx-no-bind
             ref={(splitButton: HTMLDivElement) => (this._splitButton = splitButton)}
             role={getMenuItemAriaRole(item)}
             aria-label={item.ariaLabel}
@@ -94,7 +93,6 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
             aria-posinset={focusableElementIndex + 1}
             aria-setsize={totalItemCount}
             onMouseEnter={this._onItemMouseEnterPrimary}
-            // eslint-disable-next-line react/jsx-no-bind
             onMouseLeave={
               onItemMouseLeave ? onItemMouseLeave.bind(this, { ...item, subMenuProps: null, items: null }) : undefined
             }


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Removing unused eslint-disable rules from `ContextualMenu.base.tsx` and `ContextualMenuSplitButton.tsx`
#### Focus areas to test

(optional)
