### PR TITLE
CodeMods: Debug renamePropInSpread

### DIFF
--- a/change/@fluentui-codemods-2020-08-19-15-27-08-CodeMods-propHelper_bug_fix.json
+++ b/change/@fluentui-codemods-2020-08-19-15-27-08-CodeMods-propHelper_bug_fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "bug fixes in renameProp",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T19:27:08.354Z"
+}

--- a/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/dropdown/mDropdownSpreadProps.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
-import { Dropdown, IDropdownProps } from 'office-ui-fabric-react/lib/Dropdown';
+import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 
 export const RenderDropdown = (props: any) => {
   const propsTest = { options: [], isDisabled: false };
@@ -13,13 +13,3 @@ export const RenderDropdown = (props: any) => {
     </div>
   );
 };
-
-export function RenderDropdownPropsFunc(props: IDropdownProps) {
-  return (
-    <div>
-      <Dropdown {...props}>Dropdown!</Dropdown>
-      {/* include self closing Dropdown check */}
-      <Dropdown {...props} />
-    </div>
-  );
-}

--- a/packages/codemods/src/codeMods/tests/mock/spinner/mSpinnerSpreadProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/spinner/mSpinnerSpreadProps.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable prefer-const */
 /* eslint-disable deprecation/deprecation */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as React from 'react';
-import { Spinner, SpinnerType, ISpinnerProps } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerType } from 'office-ui-fabric-react/lib/Spinner';
 
 export const RenderSpinner = (props: any) => {
   const propsTest = { type: SpinnerType.normal, ariaLabel: 'Spinner!' };
@@ -30,26 +29,6 @@ export const RenderLetSpinner = (props: any) => {
   );
 };
 
-export const RenderSpinnerProps = (props: ISpinnerProps) => {
-  return (
-    <div>
-      <Spinner {...props} id="pl">
-        Spinner
-      </Spinner>
-      <Spinner {...props} />
-    </div>
-  );
-};
+const propsForArrow = { type: SpinnerType.normal, ariaLabel: 'Spinner!' };
 
-export function RenderSpinnerPropsFunc(props: ISpinnerProps) {
-  return (
-    <div>
-      <Spinner {...props} id="pf">
-        Spinner
-      </Spinner>
-      <Spinner {...props} />
-    </div>
-  );
-}
-
-export const RenderSpinnerPropsArrow = (props: ISpinnerProps): any => <Spinner {...props} />;
+export const RenderSpinnerPropsArrow = (): any => <Spinner {...propsForArrow} />;

--- a/packages/codemods/src/codeMods/tests/mock/spinner/mSpinnerSpreadProps.tsx
+++ b/packages/codemods/src/codeMods/tests/mock/spinner/mSpinnerSpreadProps.tsx
@@ -16,19 +16,13 @@ export const RenderSpinner = (props: any) => {
     </div>
   );
 };
-
+/* Render an component awkwardly. */
 export const RenderLetSpinner = (props: any) => {
   let propsTest = { type: SpinnerType.normal, ariaLabel: 'Spinner!' };
-  return (
-    <div>
-      <Spinner {...propsTest} id="l">
-        Woo hoo!
-      </Spinner>
-      <Spinner {...propsTest} />
-    </div>
-  );
+  const someThing = true;
+  return <div>{someThing ? <Spinner {...propsTest} /> : <div />}</div>;
 };
 
 const propsForArrow = { type: SpinnerType.normal, ariaLabel: 'Spinner!' };
 
-export const RenderSpinnerPropsArrow = (): any => <Spinner {...propsForArrow} />;
+export const RenderSpinnerPropsArrow = (props: any): any => <Spinner {...propsForArrow} />;

--- a/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
+++ b/packages/codemods/src/codeMods/tests/utilities/propUtilities.test.ts
@@ -3,15 +3,11 @@ import { Project, SyntaxKind, JsxAttribute } from 'ts-morph';
 import { ValueMap, PropTransform } from '../../types';
 import { Maybe } from '../../../helpers/maybe';
 
-const personaPropsFile = 'mPersonaProps.tsx';
 const personaSpreadPropsFile = 'mPersonaSpreadProps.tsx';
 const spinnerPropsFile = 'mSpinnerProps.tsx';
 const spinnerSpreadPropsFile = 'mSpinnerSpreadProps.tsx';
 const DropdownPropsFile = 'mDropdownProps.tsx';
 const DropdownSpreadPropsFile = 'mDropdownSpreadProps.tsx';
-
-const deprecatedPropName = 'imageShouldFadeIn';
-const newPropName = 'imageShouldFadeInwootwoot';
 
 /* Developer will provide a mapping of Enum Values, if necessary. */
 // TODO it's not ideal that devs need to write the enum name before every token.
@@ -27,18 +23,21 @@ describe('Props Utilities Test', () => {
     project.addSourceFilesAtPaths(`${process.cwd()}/**/tests/mock/**/*.tsx`);
   });
   describe('Normal Prop Renaming', () => {
-    it('[SANITY] can ID the correct file and get the JSX elements', () => {
-      const file = project.getSourceFileOrThrow(personaPropsFile);
-      const tags = findJsxTag(file, 'Persona');
-      expect(tags.length).toEqual(2);
+    it('[SANITY] can handle a no-op case', () => {
+      const file = project.getSourceFileOrThrow(DropdownPropsFile);
+      const tags = findJsxTag(file, 'Dropdown');
+      renameProp(tags, 'cannot find this tag!', 'nor this one!');
+      tags.forEach(tag => {
+        expect(tag.getText().includes('cannot find this tag!') || tag.getText().includes('nor this one!')).toBeFalsy();
+      });
     });
 
-    it('can rename props in a primitive', () => {
-      const file = project.getSourceFileOrThrow(personaPropsFile);
-      const tags = findJsxTag(file, 'Persona');
-      renameProp(tags, deprecatedPropName, newPropName);
+    it('[SANITY] can handle a no-op case in the spread case', () => {
+      const file = project.getSourceFileOrThrow(DropdownSpreadPropsFile);
+      const tags = findJsxTag(file, 'Dropdown');
+      renameProp(tags, 'cannot find this tag!', 'nor this one!');
       tags.forEach(tag => {
-        expect(tag.getAttribute('imageShouldFadeIn')).toBeFalsy();
+        expect(tag.getText().includes('cannot find this tag!') || tag.getText().includes('nor this one!')).toBeFalsy();
       });
     });
 

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -14,7 +14,17 @@ import {
 import { ValueMap, SpreadPropInStatement } from '../../types';
 import { Maybe } from '../../../helpers/maybe';
 
-/* Helper function to rename a prop if in a spread operator.  */
+/* Helper function to rename a prop if in a spread operator.
+
+   Known cases that can't be handled:
+   * If the prop is a union type with UNDEFINED, ts-morph might not pick
+     up on that union, so it will try and extract the component when it
+     might not exist -- this will cause an error.
+   * If the spread prop's TYPE comes from a local file that is imported,
+     ts-morph's getType() might not identify it, causing nothing to be changed.
+     If, instead, one uses getContextualType(), ts-morph tends to infer the prop
+     type as the default for the component, leading to potentially incorrect behavior.
+*/
 export function renamePropInSpread(
   element: JsxOpeningElement | JsxSelfClosingElement,
   toRename: string,


### PR DESCRIPTION
Fixed a strange bug in the `renamePropInSpread()` helper utility where the desired prop would be added to a component, when the deprecated prop was nowhere to be found. Turns out that 99% of the time, the props interfaces that contain the deprecated item ALSO contain the new one, so I changed `spreadContains()` to verify that should only try and change things if a prop interface could be found that contains the deprecated prop but NOT the new one.

^ this caused a lot of problems in the tests, which are reflected in the changed testing files. More or less, whenever the default props are used (i.e. a variation of IComponentProps), there's no need to do anything in the spread case. The good news is that although  `renamePropInSpread()` is very temperamental, it shouldn't have to do big things that frequently, and I'm also trying to document its quirks.