### PR TITLE
Remove references to global React namespace and add lint rule against it

### DIFF
--- a/apps/a11y-tests/src/getSarifReport.ts
+++ b/apps/a11y-tests/src/getSarifReport.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import * as ReactDOMServer from 'react-dom/server';
 import { AxePuppeteer } from 'axe-puppeteer';
 import * as puppeteer from 'puppeteer';

--- a/apps/fabric-website/src/components/PageHeader/PageHeader.ts
+++ b/apps/fabric-website/src/components/PageHeader/PageHeader.ts
@@ -1,1 +1,3 @@
+import * as React from 'react';
+
 export const PageHeader: React.FunctionComponent<any> = () => null;

--- a/change/@fluentui-eslint-plugin-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@fluentui-eslint-plugin-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add no-global-react rule",
+  "packageName": "@fluentui/eslint-plugin",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:39.372Z"
+}

--- a/change/@fluentui-react-button-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@fluentui-react-button-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:49.562Z"
+}

--- a/change/@fluentui-react-compose-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@fluentui-react-compose-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:53.035Z"
+}

--- a/change/@fluentui-react-next-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@fluentui-react-next-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:56.347Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@fluentui-react-theme-provider-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:58.635Z"
+}

--- a/change/@uifabric-azure-themes-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-azure-themes-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:24.622Z"
+}

--- a/change/@uifabric-charting-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-charting-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:27.367Z"
+}

--- a/change/@uifabric-example-app-base-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-example-app-base-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:43.200Z"
+}

--- a/change/@uifabric-experiments-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-experiments-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:45.409Z"
+}

--- a/change/@uifabric-fabric-website-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-fabric-website-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:22.181Z"
+}

--- a/change/@uifabric-foundation-2020-08-19-14-28-58-no-react-global.json
+++ b/change/@uifabric-foundation-2020-08-19-14-28-58-no-react-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove references to React global (add explicit imports)",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-19T21:28:47.671Z"
+}

--- a/packages/azure-themes/src/stories/components/messageBar.tsx
+++ b/packages/azure-themes/src/stories/components/messageBar.tsx
@@ -168,7 +168,6 @@ export const MessageBarBasicExample: React.FunctionComponent = () => {
           styles={choiceGroupStyles}
           label="Select a MessageBar Example Below. To test in narrator, show one message at a time."
           selectedKey={choice}
-          // eslint-disable-next-line react/jsx-no-bind
           onChange={(e, v) => setChoice(v!.key)}
           options={choiceOptions}
         />

--- a/packages/charting/src/components/CommonComponents/ChartHelper.tsx
+++ b/packages/charting/src/components/CommonComponents/ChartHelper.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { IChartHelperProps, IChartHelperStyleProps, IChartHelperStyles } from './ChartHelper.types';
 import { ChartHelperBaseComponent } from './ChartHelper.base';

--- a/packages/charting/src/components/CommonComponents/ChartHelper.types.ts
+++ b/packages/charting/src/components/CommonComponents/ChartHelper.types.ts
@@ -1,8 +1,8 @@
+import * as React from 'react';
 import { ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IMargins } from '../../utilities/index';
-import { IChildProps } from '../../types/IDataPoint';
-import { ILineChartPoints } from '@uifabric/charting';
+import { IChildProps, ILineChartPoints } from '../../types/IDataPoint';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 
 export interface IChartHelperStyleProps {

--- a/packages/charting/src/components/DonutChart/DonutChart.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IDonutChartProps, IDonutChartStyleProps, IDonutChartStyles } from './DonutChart.types';
 import { DonutChartBase } from './DonutChart.base';

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import {
   IGroupedVerticalBarChartProps,

--- a/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.tsx
+++ b/packages/charting/src/components/HorizontalBarChart/HorizontalBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import {
   IHorizontalBarChartProps,

--- a/packages/charting/src/components/Legends/Legends.tsx
+++ b/packages/charting/src/components/Legends/Legends.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { ILegendsProps, ILegendStyleProps, ILegendsStyles } from './Legends.types';
 import { LegendsBase } from './Legends.base';

--- a/packages/charting/src/components/Legends/Legends.types.ts
+++ b/packages/charting/src/components/Legends/Legends.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ITheme, IStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IHoverCardStyleProps, IHoverCardStyles } from 'office-ui-fabric-react/lib/HoverCard';

--- a/packages/charting/src/components/LineChart/LineChart.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { ILineChartProps, ILineChartStyleProps, ILineChartStyles } from './LineChart.types';
 import { LineChartBase } from './LineChart.base';

--- a/packages/charting/src/components/LineChart/LineChart.types.ts
+++ b/packages/charting/src/components/LineChart/LineChart.types.ts
@@ -12,7 +12,7 @@ export {
   IBasestate,
   IChildProps,
 } from '../../types/IDataPoint';
-import { IChartHelperStyles, IChartHelperStyleProps, IChartHelperProps } from '@uifabric/charting';
+import { IChartHelperStyles, IChartHelperStyleProps, IChartHelperProps } from '../CommonComponents/index';
 import { ILegendsProps } from '../Legends/index';
 
 // export interface ILineChart {}

--- a/packages/charting/src/components/PieChart/PieChart.tsx
+++ b/packages/charting/src/components/PieChart/PieChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { IPieChartProps, IPieChartStyleProps, IPieChartStyles } from './PieChart.types';
 import { PieChartBase } from './PieChart.base';

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import {
   IMultiStackedBarChartProps,

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from 'office-ui-fabric-react/lib/Utilities';
 import { IStackedBarChartProps, IStackedBarChartStyleProps, IStackedBarChartStyles } from './StackedBarChart.types';
 import { StackedBarChartBase } from './StackedBarChart.base';

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IVerticalBarChartProps, IVerticalBarChartStyleProps, IVerticalBarChartStyles } from './VerticalBarChart.types';
 import { VerticalBarChartBase } from './VerticalBarChart.base';

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import {
   IVerticalStackedBarChartProps,

--- a/packages/charting/src/types/IEventAnnotation.ts
+++ b/packages/charting/src/types/IEventAnnotation.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export interface IEventAnnotation {
   date: Date;
   event: string;

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -1,5 +1,5 @@
-import { ILineChartPoints, ILineChartDataPoint, IEventsAnnotationProps } from '@uifabric/charting';
 import { max as d3Max, min as d3Min } from 'd3-array';
+import { IEventsAnnotationProps, ILineChartPoints, ILineChartDataPoint } from '../components/LineChart/index';
 import { axisBottom as d3AxisBottom, axisLeft as d3AxisLeft } from 'd3-axis';
 import { scaleLinear as d3ScaleLinear, scaleTime as d3ScaleTime } from 'd3-scale';
 import { select as d3Select } from 'd3-selection';

--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -62,6 +62,10 @@ The rule requires an options object containing:
 - `max` (required): the maximum line length
 - `ignorePatterns` (optional): ignore the line if it matches any of these regular expressions
 
+### `no-global-react`
+
+Ban references to the `React` global namespace (in favor of explicitly importing React). Implicit global references cause problems for API Extractor and potentially other tools.
+
 ### `no-tslint-comments`
 
 Ban `tslint:disable` and `tslint:enable` comments.

--- a/packages/eslint-plugin/src/configs/react-northstar.js
+++ b/packages/eslint-plugin/src/configs/react-northstar.js
@@ -16,6 +16,7 @@ module.exports = {
   // matched relative to cwd
   ignorePatterns: ['coverage', 'dist', 'etc', 'lib', 'lib-commonjs', 'node_modules', 'temp'],
   rules: {
+    '@fluentui/no-global-react': 'error',
     '@fluentui/no-tslint-comments': 'error',
 
     'react-hooks/exhaustive-deps': 'error',

--- a/packages/eslint-plugin/src/configs/react.js
+++ b/packages/eslint-plugin/src/configs/react.js
@@ -47,6 +47,7 @@ const config = {
     '**/*.scss.ts',
   ],
   rules: {
+    '@fluentui/no-global-react': 'error',
     '@fluentui/max-len': [
       'error',
       {

--- a/packages/eslint-plugin/src/index.js
+++ b/packages/eslint-plugin/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
     'ban-imports': require('./rules/ban-imports'),
     'deprecated-keyboard-event-props': require('./rules/deprecated-keyboard-event-props'),
     'max-len': require('./rules/max-len'),
+    'no-global-react': require('./rules/no-global-react'),
     'no-tslint-comments': require('./rules/no-tslint-comments'),
     'no-visibility-modifiers': require('./rules/no-visibility-modifiers'),
   },

--- a/packages/eslint-plugin/src/rules/no-global-react.js
+++ b/packages/eslint-plugin/src/rules/no-global-react.js
@@ -1,0 +1,49 @@
+// @ts-check
+const { AST_NODE_TYPES } = require('@typescript-eslint/experimental-utils');
+const createRule = require('../utils/createRule');
+
+module.exports = createRule({
+  name: 'no-global-react',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Prevent accidental references to the global React namespace',
+      category: 'Best Practices',
+      recommended: 'error',
+    },
+    messages: {
+      missingImport: 'You must explicitly import React to reference it',
+    },
+    schema: [],
+  },
+  defaultOptions: [],
+  create: context => {
+    let hasReactImport = false;
+
+    return {
+      ImportDeclaration: imprt => {
+        if (
+          imprt.source &&
+          imprt.source.type === AST_NODE_TYPES.Literal &&
+          imprt.source.value === 'react' &&
+          imprt.specifiers.some(spec => spec.local.name === 'React')
+        ) {
+          hasReactImport = true;
+        }
+      },
+      Identifier: identifier => {
+        if (
+          identifier.name === 'React' &&
+          !hasReactImport &&
+          // This one ensures we don't flag the import of React
+          !(identifier.parent && /^Import(.*?)Specifier$/.test(identifier.parent.type))
+        ) {
+          context.report({
+            node: identifier,
+            messageId: 'missingImport',
+          });
+        }
+      },
+    };
+  },
+});

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.types.ts
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTableSet.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IPageJson, ILinkToken, ApiKind } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 /**

--- a/packages/example-app-base/src/components/App/App.types.ts
+++ b/packages/example-app-base/src/components/App/App.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject, ICustomizations } from 'office-ui-fabric-react/lib/Utilities';
 import { IWithResponsiveModeState } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IDropdownStyleProps } from 'office-ui-fabric-react/lib/Dropdown';

--- a/packages/example-app-base/src/components/Markdown/Markdown.types.ts
+++ b/packages/example-app-base/src/components/Markdown/Markdown.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ITheme, IStyleFunctionOrObject, IStyle, ILinkStyleProps, IImageStyleProps } from 'office-ui-fabric-react';
 import { IMarkdownHeaderStyleProps } from './MarkdownHeader';
 import { IMarkdownParagraphStyleProps } from './MarkdownParagraph';

--- a/packages/example-app-base/src/components/TopNav/TopNav.types.ts
+++ b/packages/example-app-base/src/components/TopNav/TopNav.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { INavPage } from '../Nav/index';
 
 /**

--- a/packages/experiments/src/components/Button/Actionable/Actionable.ts
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { composed } from '@uifabric/foundation/lib/next/composed';
 import { ActionableStyles as styles, ActionableTokens as tokens } from './Actionable.styles';

--- a/packages/experiments/src/components/Button/Actionable/Actionable.types.ts
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
 import { IFontWeight, IKeytipProps } from 'office-ui-fabric-react';

--- a/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
@@ -1,4 +1,5 @@
 /** @jsx withSlots */
+import * as React from 'react';
 import { KeytipData } from 'office-ui-fabric-react';
 import { withSlots } from '../../../Foundation';
 import { getNativeProps, anchorProperties, buttonProperties } from '../../../Utilities';

--- a/packages/experiments/src/components/Button/Button.tsx
+++ b/packages/experiments/src/components/Button/Button.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { composed } from '@uifabric/foundation/lib/next/composed';
 import { useButtonState as state } from './Button.state';

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
 import { IRawFontStyle, IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -1,4 +1,5 @@
 /** @jsx withSlots */
+import * as React from 'react';
 import { Text, KeytipData } from 'office-ui-fabric-react';
 import { withSlots } from '../../Foundation';
 import { getNativeProps, anchorProperties, buttonProperties } from '../../Utilities';

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.state.ts
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.state.ts
@@ -1,10 +1,10 @@
-import { useCallback, useRef } from 'react';
+import * as React from 'react';
 import { useControlledState } from '../../../Foundation';
 import { KeyCodes } from '../../../Utilities';
 import { IMenuButtonComponent, IMenuButtonViewProps } from './MenuButton.types';
 
 export const useMenuButtonState: IMenuButtonComponent['state'] = props => {
-  const menuButtonRef = useRef<HTMLButtonElement | null>(null);
+  const menuButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [expanded, setExpanded] = useControlledState(props, 'expanded', {
     defaultPropName: 'defaultExpanded',
     defaultPropValue: false,
@@ -12,12 +12,12 @@ export const useMenuButtonState: IMenuButtonComponent['state'] = props => {
 
   const { disabled, onClick, onKeyDown, onMenuDismiss } = props;
 
-  const _onMenuDismiss = useCallback(() => {
+  const _onMenuDismiss = React.useCallback(() => {
     onMenuDismiss && onMenuDismiss();
     setExpanded(false);
   }, [onMenuDismiss, setExpanded]);
 
-  const _onClick = useCallback(
+  const _onClick = React.useCallback(
     (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>) => {
       if (!disabled) {
         if (onClick) {
@@ -33,7 +33,7 @@ export const useMenuButtonState: IMenuButtonComponent['state'] = props => {
     [disabled, expanded, onClick, setExpanded],
   );
 
-  const _onKeyDown = useCallback(
+  const _onKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>) => {
       if (!disabled) {
         if (onKeyDown) {

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { composed } from '@uifabric/foundation/lib/next/composed';
 import { useMenuButtonState as state } from './MenuButton.state';

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
 import { IComponentStyles, IHTMLSlot, ISlottableProps, ISlotProp, IStyleableComponentProps } from '../../../Foundation';

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.state.ts
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.state.ts
@@ -1,18 +1,18 @@
-import { useCallback, useState } from 'react';
+import * as React from 'react';
 import { ISplitButtonComponent, ISplitButtonViewProps } from './SplitButton.types';
 import { KeyCodes } from '../../../Utilities';
 
 export const useSplitButtonState: ISplitButtonComponent['state'] = props => {
-  const [expanded, setExpanded] = useState<boolean>(false);
+  const [expanded, setExpanded] = React.useState<boolean>(false);
 
   const { disabled, onMenuDismiss, onSecondaryActionClick } = props;
 
-  const _onMenuDismiss = useCallback(() => {
+  const _onMenuDismiss = React.useCallback(() => {
     onMenuDismiss && onMenuDismiss();
     setExpanded(false);
   }, [onMenuDismiss]);
 
-  const _onSecondaryActionClick = useCallback(
+  const _onSecondaryActionClick = React.useCallback(
     (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>) => {
       if (!disabled) {
         if (onSecondaryActionClick) {
@@ -28,7 +28,7 @@ export const useSplitButtonState: ISplitButtonComponent['state'] = props => {
     [disabled, expanded, onSecondaryActionClick],
   );
 
-  const _onKeyDown = useCallback(
+  const _onKeyDown = React.useCallback(
     (ev: React.KeyboardEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement>) => {
       if (!disabled && (ev.altKey || ev.metaKey) && ev.keyCode === KeyCodes.down) {
         setExpanded(!expanded);

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
 import { IComponentStyles, IHTMLSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../../Foundation';

--- a/packages/experiments/src/components/Chiclet/Chiclet.tsx
+++ b/packages/experiments/src/components/Chiclet/Chiclet.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IChicletProps, IChicletStyleProps, IChicletStyles } from './Chiclet.types';
 import { getStyles } from './Chiclet.styles';

--- a/packages/experiments/src/components/Chiclet/ChicletCard.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletCard.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IChicletCardProps, IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 import { getStyles } from './ChicletCard.styles';

--- a/packages/experiments/src/components/Chiclet/ChicletXsmall.tsx
+++ b/packages/experiments/src/components/Chiclet/ChicletXsmall.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IChicletCardStyleProps, IChicletCardStyles } from './ChicletCard.types';
 import { IChicletCardProps } from './ChicletCard.types';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useCallback, useImperativeHandle, useRef } from 'react';
 import { useControlledState } from '../../Foundation';
 import { getRTL, KeyCodes } from '../../Utilities';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { CollapsibleSectionView } from './CollapsibleSection.view';
 import { useCollapsibleSectionState } from './CollapsibleSection.state';
 import { collapsibleSectionStyles } from './CollapsibleSection.styles';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createComponent } from '../../Foundation';
 import { CollapsibleSectionTitleView } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IRefObject } from '../../Utilities';
 import {
   IComponent,

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
@@ -1,4 +1,5 @@
 /** @jsx withSlots */
+import * as React from 'react';
 import { Icon, Text } from 'office-ui-fabric-react';
 import { getNativeProps, buttonProperties } from 'office-ui-fabric-react/lib/Utilities';
 import { withSlots, getSlots } from '../../Foundation';

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsItem.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IStyle, ITheme } from '../../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../../Utilities';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ICalloutProps } from 'office-ui-fabric-react/lib/Callout';
 import { IStyle } from '@uifabric/styling';
 import {

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsItem/FloatingSuggestionsItem.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ITheme, IStyle } from '@uifabric/styling';
 
 export interface IFloatingSuggestionItemProps<T> {

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   IFloatingSuggestionOnRenderItemProps,
   IFloatingSuggestionItemProps,

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '../../Foundation';
 import { ICalloutSlot, IListSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';

--- a/packages/experiments/src/components/Pagination/Pagination.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { IPaginationProps, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
 import { getStyles } from './Pagination.styles';

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { VerticalPersonaView } from './VerticalPersona.view';
 import { VerticalPersonaStyles, VerticalPersonaTokens } from './VerticalPersona.styles';
 import { IVerticalPersonaProps } from './VerticalPersona.types';

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { createComponent } from '../../Foundation';
 import { usePersonaCoinState } from './PersonaCoin.state';
 import { PersonaCoinStyles } from './PersonaCoin.styles';

--- a/packages/experiments/src/components/SelectedItemsList/Items/ItemTrigger.types.ts
+++ b/packages/experiments/src/components/SelectedItemsList/Items/ItemTrigger.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ISelectedItemProps } from '../SelectedItemsList.types';
 
 export type TriggerProps<T> = ISelectedItemProps<T> & {

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
@@ -63,6 +63,7 @@ const SelectedPersonaInner = React.memo(
     } = props;
     const itemId = getId();
     const [root, setRoot] = React.useState<HTMLElement | undefined>();
+    const rootRef = React.useRef<HTMLElement>(null);
     const [dragDropSubscription, setDragDropSubscription] = React.useState<IDisposable>();
     const [isDropping, setIsDropping] = React.useState(false);
     const [droppingClassNames, setDroppingClassNames] = React.useState('');
@@ -79,42 +80,38 @@ const SelectedPersonaInner = React.memo(
       }
     }, []);
 
-    const _updateDroppingState = (newValue: boolean, event: DragEvent) => {
-      if (!newValue) {
-        if (dragDropEvents!.onDragLeave) {
-          dragDropEvents!.onDragLeave(item, event);
-        }
-      } else if (dragDropEvents!.onDragEnter) {
-        setDroppingClassNames(dragDropEvents!.onDragEnter(item, event));
-      }
-
-      if (isDropping !== newValue) {
-        setIsDropping(newValue);
-      }
-    };
-
-    const dragDropOptions: IDragDropOptions = {
-      eventMap: eventsToRegister,
-      selectionIndex: index,
-      context: { data: item, index: index },
-      canDrag: dragDropEvents?.canDrag,
-      canDrop: dragDropEvents?.canDrop,
-      onDragStart: dragDropEvents?.onDragStart,
-      updateDropState: _updateDroppingState,
-      onDrop: dragDropEvents?.onDrop,
-      onDragEnd: dragDropEvents?.onDragEnd,
-      onDragOver: dragDropEvents?.onDragOver,
-    };
-
-    const events = new EventGroup(this);
-
     React.useEffect(() => {
-      setDragDropSubscription(dragDropHelper?.subscribe(root as HTMLElement, events, dragDropOptions));
-      return () => {
-        dragDropSubscription?.dispose();
-        setDragDropSubscription(undefined);
+      const _updateDroppingState = (newValue: boolean, event: DragEvent) => {
+        if (!newValue) {
+          if (dragDropEvents!.onDragLeave) {
+            dragDropEvents!.onDragLeave(item, event);
+          }
+        } else if (dragDropEvents!.onDragEnter) {
+          setDroppingClassNames(dragDropEvents!.onDragEnter(item, event));
+        }
+
+        if (isDropping !== newValue) {
+          setIsDropping(newValue);
+        }
       };
-    }, [dragDropHelper, dragDropSubscription, root, events, dragDropOptions]);
+
+      const dragDropOptions: IDragDropOptions = {
+        eventMap: eventsToRegister,
+        selectionIndex: index,
+        context: { data: item, index: index },
+        ...dragDropEvents,
+        updateDropState: _updateDroppingState,
+      };
+
+      const events = new EventGroup(this);
+
+      const subscription = dragDropHelper?.subscribe(root as HTMLElement, events, dragDropOptions);
+
+      return () => {
+        subscription?.dispose();
+        events.dispose();
+      };
+    }, [dragDropEvents, dragDropHelper, eventsToRegister, index, isDropping, item, root]);
 
     React.useEffect(() => {
       setIsDraggable(dragDropEvents ? !!(dragDropEvents.canDrag && dragDropEvents.canDrop) : undefined);

--- a/packages/experiments/src/components/Sidebar/Sidebar.types.tsx
+++ b/packages/experiments/src/components/Sidebar/Sidebar.types.tsx
@@ -1,7 +1,4 @@
-/*!
- * Copyright (C) Microsoft Corporation. All rights reserved.
- */
-
+import * as React from 'react';
 import { IButtonProps, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';

--- a/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
+++ b/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { styled } from '../../../Utilities';
 import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 import { ShimmerTileBase } from './ShimmerTile.base';

--- a/packages/experiments/src/components/Toggle/Toggle.state.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.state.ts
@@ -1,16 +1,16 @@
-import { useCallback, useImperativeHandle, useRef } from 'react';
+import * as React from 'react';
 import { getControlledDerivedProps, useControlledState } from '../../Foundation';
 import { IToggleComponent, IToggleViewProps } from './Toggle.types';
 
 export const useToggleState: IToggleComponent['state'] = props => {
-  const toggleButtonRef = useRef<HTMLButtonElement | null>(null);
+  const toggleButtonRef = React.useRef<HTMLButtonElement | null>(null);
 
   const [checked, setChecked] = useControlledState(props, 'checked', {
     defaultPropName: 'defaultChecked',
     defaultPropValue: false,
   });
 
-  useImperativeHandle(props.componentRef, () => ({
+  React.useImperativeHandle(props.componentRef, () => ({
     focus: () => {
       toggleButtonRef.current && toggleButtonRef.current.focus();
     },
@@ -18,7 +18,7 @@ export const useToggleState: IToggleComponent['state'] = props => {
 
   const { disabled, onChange } = props;
 
-  const _onClick = useCallback(
+  const _onClick = React.useCallback(
     (ev: React.MouseEvent<HTMLElement>) => {
       if (!disabled) {
         // Only update the state if the user hasn't provided it.

--- a/packages/experiments/src/components/Toggle/Toggle.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ToggleView } from './Toggle.view';
 import { ToggleStyles as styles, ToggleTokens as tokens } from './Toggle.styles';
 import { useToggleState as state } from './Toggle.state';

--- a/packages/fluentui/docs/src/global.d.ts
+++ b/packages/fluentui/docs/src/global.d.ts
@@ -1,6 +1,6 @@
 // Due to the react reference, putting these under /types doesn't work well
 
-/* eslint-disable spaced-comment */
+/* eslint-disable spaced-comment, @fluentui/no-global-react */
 /// <reference types="react" />
 
 declare const __DEV__: boolean;

--- a/packages/fluentui/react-northstar/test/utils/getDisplayName.ts
+++ b/packages/fluentui/react-northstar/test/utils/getDisplayName.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export const getDisplayName = (Component: React.ReactType) => {
   return (
     (Component as React.ComponentType).displayName ||

--- a/packages/foundation/src/next/ISlots.ts
+++ b/packages/foundation/src/next/ISlots.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IStyleSet } from '@uifabric/styling';
 import { ISlottableProps, ValidProps } from '../ISlots';
 import { IComponentOptions } from './IComponent';

--- a/packages/lists/src/components/FixedList/FixedList.types.ts
+++ b/packages/lists/src/components/FixedList/FixedList.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { IViewportState } from '../Viewport/Viewport.types';
 
 /**

--- a/packages/lists/src/components/StaticList/StaticList.types.ts
+++ b/packages/lists/src/components/StaticList/StaticList.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 interface IStaticListProps<T> {
   as?: keyof JSX.IntrinsicElements;
   items?: ReadonlyArray<T>;

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -232,7 +232,7 @@ export const useSplitButtonClasses: (state: Record<string, any>) => void;
 export const useSplitButtonState: (state: SplitButtonState) => void;
 
 // @public (undocumented)
-export const useToggleButton: (props: ToggleButtonProps, ref: import("react").Ref<HTMLElement>, defaultProps?: ToggleButtonProps | undefined) => {
+export const useToggleButton: (props: ToggleButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: ToggleButtonProps | undefined) => {
     state: Record<string, any>;
     render: (state: import("../Button").ButtonState) => JSX.Element;
 };

--- a/packages/react-button/src/components/ToggleButton/useToggleButton.tsx
+++ b/packages/react-button/src/components/ToggleButton/useToggleButton.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useButton } from '../Button/useButton';
 import { ToggleButtonProps } from './ToggleButton.types';
 import { useChecked } from './useChecked';

--- a/packages/react-compose/src/wasComposedPreviously.ts
+++ b/packages/react-compose/src/wasComposedPreviously.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ComposedComponent, Input } from './types';
 
 /**

--- a/packages/react-conformance/src/utils/getComponent.ts
+++ b/packages/react-conformance/src/utils/getComponent.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ReactWrapper } from 'enzyme';
 
 const getDisplayName = (Component: React.ElementType) => {

--- a/packages/react-flex/src/components/Flex/Flex.types.ts
+++ b/packages/react-flex/src/components/Flex/Flex.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ComponentProps, BaseSlots, SlotProps } from '@fluentui/react-compose';
 import { ColorTokenSet } from '@fluentui/react-theme-provider';
 

--- a/packages/react-flex/src/components/Flex/useFlex.ts
+++ b/packages/react-flex/src/components/Flex/useFlex.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { FlexProps, FlexState } from './Flex.types';
 import { ComposePreparedOptions } from '@fluentui/react-compose';
 import { getStyleFromPropsAndOptions } from '@fluentui/react-theme-provider';

--- a/packages/react-flex/src/components/FlexItem/FlexItem.types.ts
+++ b/packages/react-flex/src/components/FlexItem/FlexItem.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ComponentProps, BaseSlots, SlotProps } from '@fluentui/react-compose';
 import { Alignment } from '../Flex/Flex.types';
 import { ColorTokenSet } from '@fluentui/react-theme-provider';

--- a/packages/react-next/tsconfig.json
+++ b/packages/react-next/tsconfig.json
@@ -19,8 +19,6 @@
     "typeRoots": ["../../node_modules/@types", "../../typings"],
     "types": ["jest", "webpack-env", "custom-global"],
     "paths": {
-      "@fluentui/react/lib/*": ["./src/*"],
-      "@fluentui/react": ["./src"],
       "@fluentui/react-next/lib/*": ["./src/*"],
       "@fluentui/react-next": ["./src"]
     }

--- a/packages/react-next/webpack.config.js
+++ b/packages/react-next/webpack.config.js
@@ -16,20 +16,16 @@ function createConfig(config, onlyProduction) {
     {
       entry,
 
-      externals: [
-        {
-          react: 'React',
-        },
-        {
-          'react-dom': 'ReactDOM',
-        },
-      ],
+      externals: {
+        react: 'React',
+        'react-dom': 'ReactDOM',
+      },
 
       resolve: {
         alias: {
-          '@fluentui/react$': path.join(__dirname, 'lib'),
-          '@fluentui/react/src': path.join(__dirname, 'src'),
-          '@fluentui/react/lib': path.join(__dirname, 'lib'),
+          '@fluentui/react-next$': path.join(__dirname, 'lib'),
+          '@fluentui/react-next/src': path.join(__dirname, 'src'),
+          '@fluentui/react-next/lib': path.join(__dirname, 'lib'),
           'Props.ts.js': 'Props',
           'Example.tsx.js': 'Example',
         },

--- a/packages/react-theme-provider/etc/react-theme-provider.api.md
+++ b/packages/react-theme-provider/etc/react-theme-provider.api.md
@@ -49,7 +49,7 @@ export type FontTokens = Partial<{
 }>;
 
 // @public (undocumented)
-export const getStyleFromPropsAndOptions: <TProps extends StyleProps<import("./types").ColorTokenSet>, TOptions extends StyleOptions<TProps>>(props: TProps, options: TOptions, prefix?: string | undefined) => import("react").CSSProperties;
+export const getStyleFromPropsAndOptions: <TProps extends StyleProps<import("./types").ColorTokenSet>, TOptions extends StyleOptions<TProps>>(props: TProps, options: TOptions, prefix?: string | undefined) => React.CSSProperties;
 
 // @public
 export function mergeThemes<TResult = PartialTheme>(...themes: (undefined | PartialTheme | Theme)[]): TResult;
@@ -118,11 +118,11 @@ export type TokenSetType = {
 };
 
 // @public (undocumented)
-export const tokensToStyleObject: (tokens?: TokenSetType | undefined, prefix?: string | undefined, style?: import("react").CSSProperties | undefined) => import("react").CSSProperties;
+export const tokensToStyleObject: (tokens?: TokenSetType | undefined, prefix?: string | undefined, style?: React.CSSProperties | undefined) => React.CSSProperties;
 
 // @public
 export const useInlineTokens: (draftState: {
-    style?: import("react").CSSProperties | undefined;
+    style?: React.CSSProperties | undefined;
     tokens?: TokenSetType | undefined;
 }, prefix: string) => void;
 

--- a/packages/react-theme-provider/src/getStyleFromPropsAndOptions.ts
+++ b/packages/react-theme-provider/src/getStyleFromPropsAndOptions.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { tokensToStyleObject } from './tokensToStyleObject';
 import { StyleProps, StyleOptions } from './types';
 

--- a/packages/react-theme-provider/src/tokensToStyleObject.ts
+++ b/packages/react-theme-provider/src/tokensToStyleObject.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { TokenSetType } from './types';
 
 export const tokensToStyleObject = (

--- a/packages/react-theme-provider/src/useInlineTokens.ts
+++ b/packages/react-theme-provider/src/useInlineTokens.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { TokenSetType } from './types';
 import { tokensToStyleObject } from './tokensToStyleObject';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -23614,7 +23614,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.7.2:
+typescript@3.7.2, typescript@~3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
   integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
@@ -23623,11 +23623,6 @@ typescript@^3.9.0:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
-
-typescript@~3.7.2:
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
-  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 ua-parser-js@0.7.21, ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Accidental references to the `React` global namespace were causing problems for API Extractor and possibly for other tools. I think this might have been the cause of the weird issues @MLoughry was having running `update-api` in #14529, which I spent several hours debugging (and it's been a big time sink in other cases as well).

Fix is to write a new lint rule `no-global-react` to detect and ban implicit references, and fix all the existing ones by adding an explicit import.