### PR TITLE
Use consistent webpack version

### DIFF
--- a/apps/ssr-tests/package.json
+++ b/apps/ssr-tests/package.json
@@ -25,7 +25,7 @@
     "react": "16.8.6",
     "react-app-polyfill": "~1.0.1",
     "react-dom": "16.8.6",
-    "webpack": "4.35.0"
+    "webpack": "4.43.0"
   },
   "dependencies": {
     "tslib": "^1.10.0"

--- a/change/@uifabric-webpack-utils-2020-08-19-16-32-04-webpack.json
+++ b/change/@uifabric-webpack-utils-2020-08-19-16-32-04-webpack.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update stated webpack version to match actual version used",
+  "packageName": "@uifabric/webpack-utils",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-08-19T23:32:04.451Z"
+}

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   },
   "resolutions": {
     "eslint": "^7.1.0",
-    "webpack": "^4.35.0",
     "autoprefixer": "9.7.6",
     "copy-to-clipboard": "3.2.0"
   }

--- a/packages/fluentui/digest/package.json
+++ b/packages/fluentui/digest/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "just-scripts": "0.43.1",
     "querystring": "^0.2.0",
-    "webpack": "4.35.0"
+    "webpack": "4.43.0"
   },
   "devDependencies": {
     "@types/node": "^10.3.2",

--- a/packages/fluentui/local-sandbox/package.json
+++ b/packages/fluentui/local-sandbox/package.json
@@ -24,7 +24,7 @@
     "source-map-loader": "^0.2.4",
     "terser-webpack-plugin": "^1.4.3",
     "typescript": "3.7.2",
-    "webpack": "4.35.0",
+    "webpack": "4.43.0",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10"
   },

--- a/packages/webpack-utils/package.json
+++ b/packages/webpack-utils/package.json
@@ -21,7 +21,7 @@
     "@types/loader-utils": "1.1.3",
     "@types/webpack": "4.4.0",
     "@uifabric/build": "^7.0.0",
-    "webpack": "4.35.0"
+    "webpack": "4.43.0"
   },
   "dependencies": {
     "loader-utils": "^1.1.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -140,7 +140,7 @@
     "ts-node": "^7.0.0",
     "tsconfig-paths": "^3.9.0",
     "typescript": "3.7.2",
-    "webpack": "4.35.0",
+    "webpack": "4.43.0",
     "webpack-bundle-analyzer": "^3.6.0",
     "webpack-cli": "^3.3.10",
     "webpack-dev-middleware": "^3.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24590,7 +24590,7 @@ webpack-virtual-modules@^0.2.0:
   dependencies:
     debug "^3.0.0"
 
-webpack@4.35.0, webpack@^4.33.0, webpack@^4.35.0, webpack@^4.38.0, webpack@^4.43.0:
+webpack@4.43.0, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.43.0:
   version "4.43.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.43.0.tgz#c48547b11d563224c561dad1172c8aa0b8a678e6"
   integrity sha512-GW1LjnPipFW2Y78OOab8NJlCflB7EFskMih2AHdvjbpKMeDJqEgSx24cXXXiPS65+WSwVyxtDsJH6jGX2czy+g==


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The change I recently made to the root package.json to add `resolutions: { webpack: ^4.35.0 }` accidentally caused webpack to be upgraded to 4.43.0, despite most of our packages depending specifically on 4.35.0. (You can see from yarn.lock that only 4.43.0 is being installed.) 

While the upgrade was not intentional, it doesn't seem to have broken anything--so this PR removes the resolution entry (which wasn't needed) and updates our packages/ stated webpack dependency to 4.43.0.