### PR TITLE
react-cards: Updating imports to remove duplicated dependencies

### DIFF
--- a/change/@uifabric-react-cards-2020-08-20-11-57-01-cardImports.json
+++ b/change/@uifabric-react-cards-2020-08-20-11-57-01-cardImports.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "react-cards: Updating imports to remove duplicated dependencies.",
+  "packageName": "@uifabric/react-cards",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-20T18:57:01.750Z"
+}

--- a/packages/react-cards/etc/react-cards.api.md
+++ b/packages/react-cards/etc/react-cards.api.md
@@ -4,17 +4,17 @@
 
 ```ts
 
-import { IBaseProps } from 'office-ui-fabric-react';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 import { IComponent } from '@uifabric/foundation';
 import { IComponentStyles } from '@uifabric/foundation';
 import { ISlotProp } from '@uifabric/foundation';
-import { IStackItemProps } from 'office-ui-fabric-react';
-import { IStackItemSlots } from 'office-ui-fabric-react';
-import { IStackItemTokens } from 'office-ui-fabric-react';
-import { IStackProps } from 'office-ui-fabric-react';
-import { IStackSlot } from 'office-ui-fabric-react';
-import { IStackSlots } from 'office-ui-fabric-react';
-import { IStackTokens } from 'office-ui-fabric-react';
+import { IStackItemProps } from 'office-ui-fabric-react/lib/Stack';
+import { IStackItemSlots } from 'office-ui-fabric-react/lib/Stack';
+import { IStackItemTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IStackProps } from 'office-ui-fabric-react/lib/Stack';
+import { IStackSlot } from 'office-ui-fabric-react/lib/Stack';
+import { IStackSlots } from 'office-ui-fabric-react/lib/Stack';
+import { IStackTokens } from 'office-ui-fabric-react/lib/Stack';
 import { IStyleableComponentProps } from '@uifabric/foundation';
 import * as React from 'react';
 

--- a/packages/react-cards/etc/react-cards.api.md
+++ b/packages/react-cards/etc/react-cards.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 
-import { IBaseProps } from '@uifabric/utilities';
+import { IBaseProps } from 'office-ui-fabric-react';
 import { IComponent } from '@uifabric/foundation';
 import { IComponentStyles } from '@uifabric/foundation';
 import { ISlotProp } from '@uifabric/foundation';

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -35,9 +35,11 @@
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",
+    "@uifabric/azure-themes": "^7.4.1",
     "@uifabric/build": "^7.0.0",
     "@uifabric/example-app-base": "^7.14.0",
     "@uifabric/jest-serializer-merge-styles": "^7.0.36",
+    "@uifabric/theme-samples": "^7.1.1",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
@@ -47,19 +49,15 @@
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.10.26",
-    "@uifabric/azure-themes": "^7.4.1",
     "@uifabric/file-type-icons": "^7.5.1",
     "@uifabric/foundation": "^7.8.1",
     "@uifabric/set-version": "^7.0.22",
-    "@uifabric/styling": "^7.15.1",
-    "@uifabric/theme-samples": "^7.1.1",
-    "@uifabric/utilities": "^7.29.1",
-    "office-ui-fabric-react": "^7.129.1",
     "tslib": "^1.10.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <17.0.0",
     "@types/react-dom": ">=16.8.0 <17.0.0",
+    "office-ui-fabric-react": "^7.129.1",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -52,12 +52,12 @@
     "@uifabric/file-type-icons": "^7.5.1",
     "@uifabric/foundation": "^7.8.1",
     "@uifabric/set-version": "^7.0.22",
+    "office-ui-fabric-react": "^7.129.1",
     "tslib": "^1.10.0"
   },
   "peerDependencies": {
     "@types/react": ">=16.8.0 <17.0.0",
     "@types/react-dom": ">=16.8.0 <17.0.0",
-    "office-ui-fabric-react": "^7.129.1",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, HighContrastSelector } from '@uifabric/styling';
+import { getGlobalClassNames, HighContrastSelector } from 'office-ui-fabric-react';
 import { ICardComponent, ICardStylesReturnType, ICardTokenReturnType } from './Card.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, HighContrastSelector } from 'office-ui-fabric-react';
+import { getGlobalClassNames, HighContrastSelector } from 'office-ui-fabric-react/lib/Styling';
 import { ICardComponent, ICardStylesReturnType, ICardTokenReturnType } from './Card.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { IBaseProps, IStackSlot, IStackTokens } from 'office-ui-fabric-react';
+import { IStackSlot, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 import { IComponent, IComponentStyles, IStyleableComponentProps } from '@uifabric/foundation';
 
 /**

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { IBaseProps } from '@uifabric/utilities';
-import { IStackSlot, IStackTokens } from 'office-ui-fabric-react';
+import { IBaseProps, IStackSlot, IStackTokens } from 'office-ui-fabric-react';
 import { IComponent, IComponentStyles, IStyleableComponentProps } from '@uifabric/foundation';
 
 /**

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -1,8 +1,8 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { withSlots, getSlots } from '@uifabric/foundation';
-import { getNativeProps, htmlElementProperties, warn, KeyCodes } from '@uifabric/utilities';
 import { Stack, IStackComponent } from 'office-ui-fabric-react/lib/Stack';
+import { getNativeProps, htmlElementProperties, warn, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
 
 import { ICardComponent, ICardProps, ICardSlots, ICardTokens } from './Card.types';
 import { CardItem } from './CardItem/CardItem';

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames } from 'office-ui-fabric-react';
+import { getGlobalClassNames } from 'office-ui-fabric-react/lib/Styling';
 import { ICardItemComponent, ICardItemStylesReturnType, ICardItemTokenReturnType } from './CardItem.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames } from '@uifabric/styling';
+import { getGlobalClassNames } from 'office-ui-fabric-react';
 import { ICardItemComponent, ICardItemStylesReturnType, ICardItemTokenReturnType } from './CardItem.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
@@ -1,6 +1,5 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
-import { IBaseProps } from '@uifabric/utilities';
-import { IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react';
+import { IBaseProps, IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react';
 
 /**
  * {@docCategory Card}

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.types.ts
@@ -1,5 +1,6 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
-import { IBaseProps, IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react';
+import { IStackItemProps, IStackItemSlots, IStackItemTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 
 /**
  * {@docCategory Card}

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames } from 'office-ui-fabric-react';
+import { getGlobalClassNames } from 'office-ui-fabric-react/lib/Styling';
 import { ICardSectionComponent, ICardSectionStylesReturnType, ICardSectionTokenReturnType } from './CardSection.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames } from '@uifabric/styling';
+import { getGlobalClassNames } from 'office-ui-fabric-react';
 import { ICardSectionComponent, ICardSectionStylesReturnType, ICardSectionTokenReturnType } from './CardSection.types';
 
 const GlobalClassNames = {

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
@@ -1,6 +1,5 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
-import { IBaseProps } from '@uifabric/utilities';
-import { IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react';
+import { IBaseProps, IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react';
 
 /**
  * {@docCategory Card}

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.types.ts
@@ -1,5 +1,6 @@
 import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
-import { IBaseProps, IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react';
+import { IStackProps, IStackSlots, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
+import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 
 /**
  * {@docCategory Card}

--- a/packages/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx
+++ b/packages/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx
@@ -1,8 +1,7 @@
 // @codepen
 import * as React from 'react';
 import { Card, ICardTokens, ICardSectionStyles, ICardSectionTokens } from '@uifabric/react-cards';
-import { FontWeights } from '@uifabric/styling';
-import { Icon, IIconStyles, Image, Stack, IStackTokens, Text, ITextStyles } from 'office-ui-fabric-react';
+import { FontWeights, Icon, IIconStyles, Image, Stack, IStackTokens, Text, ITextStyles } from 'office-ui-fabric-react';
 
 const alertClicked = (): void => {
   alert('Clicked');

--- a/packages/react-cards/src/components/Card/examples/Card.Vertical.Example.tsx
+++ b/packages/react-cards/src/components/Card/examples/Card.Vertical.Example.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { Card, ICardTokens, ICardSectionStyles, ICardSectionTokens } from '@uifabric/react-cards';
-import { FontWeights } from '@uifabric/styling';
 import {
   ActionButton,
+  FontWeights,
   IButtonStyles,
   Icon,
   IIconStyles,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14605
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR does a couple of things:
- Moves `@uifabric/azure-themes` and `@uifabric/theme-samples` from `dependencies` to `devDependencies`.
- Changes the imports from `@uifabric/styling` and `@uifabric/utilities` to import from `office-ui-fabric-react` and removes those packages from `package.json`.


#### Focus areas to test

(optional)
