### PR TITLE
CodeMods: Add Result to prop utility functions

### DIFF
--- a/change/@fluentui-codemods-2020-08-20-22-26-14-CodeMods-AddResultToRenameProp.json
+++ b/change/@fluentui-codemods-2020-08-20-22-26-14-CodeMods-AddResultToRenameProp.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add Maybe to prop utilities",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-21T02:26:14.320Z"
+}

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -52,7 +52,7 @@ export type PropTransform = (
   node: JsxExpression | JsxOpeningElement | JsxSelfClosingElement,
   toRename: string,
   replacementName: string,
-) => void;
+) => Result<string, NoOp>;
 
 /**
  * Enum that defines the cases by which this codemod can

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-throw-literal */
 import {
   ts,
   Node,
@@ -11,8 +10,9 @@ import {
   Block,
   VariableStatement,
 } from 'ts-morph';
-import { ValueMap, SpreadPropInStatement } from '../../types';
+import { ValueMap, SpreadPropInStatement, NoOp } from '../../types';
 import { Maybe } from '../../../helpers/maybe';
+import { Result, Err, Ok } from '../../../../src/helpers/result';
 
 /* Helper function to rename a prop if in a spread operator.
 
@@ -31,7 +31,7 @@ export function renamePropInSpread(
   replacementName: string,
   changeValueMap?: ValueMap<string>,
   replacementValue?: string,
-) {
+): Result<string, NoOp> {
   /* Step 1: Figure out which attribute contains the spread prop. */
   const allAttributes = element.getAttributes();
   allAttributes.forEach(attribute => {
@@ -40,7 +40,7 @@ export function renamePropInSpread(
         const firstIdentifier = attribute.getFirstChildByKind(SyntaxKind.Identifier);
         const propertyAccess = attribute.getFirstChildByKind(SyntaxKind.PropertyAccessExpression);
         if (!attribute || (!firstIdentifier && !propertyAccess)) {
-          throw 'Invalid spread prop. Could access internal identifiers successfully.';
+          return Err({ reason: 'Invalid spread prop. Could access internal identifiers successfully.' });
         }
         /* SPREADISIDENTIFIER tells us whether we should look at an Identifier or a P.A.E. node. */
         const spreadIsIdentifier = firstIdentifier !== undefined;
@@ -67,20 +67,20 @@ export function renamePropInSpread(
               blockContainer = containerMaybe.value;
               newJSXFlag = true;
             } else {
-              throw 'attempt to create a new block around prop failed.';
+              return Err({ reason: 'Attempted to create a new block around prop failed.' });
             }
           }
 
           /* Step 5: Get the parent of BLOCKCONTAINER so that we can insert our own variable statements. */
           const parentContainer = blockContainer!.getParentIfKind(SyntaxKind.Block);
           if (parentContainer === undefined) {
-            throw 'unable to get parent container from block';
+            return Err({ reason: 'Unable to get parent container from block.' });
           }
 
           /* Step 6: Get the index of BLOCKCONTAINER within PARENTCONTAINER that we'll use to insert our variables. */
           const insertIndex = blockContainer!.getChildIndex();
           if (insertIndex === undefined) {
-            throw 'unable to find child index';
+            return Err({ reason: 'unable to find child index' });
           }
 
           /* Step 7: Look to see if the prop we're looking for exists already. Manually
@@ -198,6 +198,7 @@ export function renamePropInSpread(
       }
     }
   });
+  return Ok('Successfully modified the given prop in the spread operator');
 }
 
 /* Helper function that identifies the location of a spread prop within
@@ -250,7 +251,7 @@ function propAlreadyExists(parentContainer: Block, toRename: string): boolean {
 /* Looks to see if the spread prop in question already exists, and if so
    attempts to insert the desired prop into its decomposition. Returns TRUE
    if it successfully inserts OLDPROP into the spread deconstruction, false if otherwise. */
-function tryInsertExistingDecomposedProp(oldProp: string, statement: VariableStatement) {
+function tryInsertExistingDecomposedProp(oldProp: string, statement: VariableStatement): boolean {
   const decompObject = statement.getFirstDescendantByKind(SyntaxKind.ObjectBindingPattern);
   if (decompObject) {
     let objectText = decompObject.getText();
@@ -266,7 +267,7 @@ function tryInsertExistingDecomposedProp(oldProp: string, statement: VariableSta
    will be inserted following. */
 function createAuxiliaryVariable(kind: VariableDeclarationKind, varName: string, varValue: string) {
   return {
-    declarationKind: VariableDeclarationKind.Const,
+    declarationKind: kind,
     declarations: [
       {
         name: varName,

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -1,7 +1,8 @@
 import { renamePropInSpread } from './helpers/propHelpers';
 import { JsxOpeningElement, JsxSelfClosingElement, SyntaxKind } from 'ts-morph';
 import { Maybe } from '../../helpers/maybe';
-import { PropTransform } from '../types';
+import { PropTransform, NoOp } from '../types';
+import { Result, Ok, Err } from '../../../src/helpers/result';
 
 export function renameProp(
   instances: (JsxOpeningElement | JsxSelfClosingElement)[],
@@ -9,31 +10,43 @@ export function renameProp(
   replacementName: string,
   replacementValue?: string,
   transform?: PropTransform,
-) {
+): Result<string, NoOp> {
   instances.forEach(val => {
     /* For each instance, first see if desired prop exists in the open. */
     const foundProp = Maybe(val.getAttribute(toRename));
-
     if (foundProp.something) {
       /* If found, do a simple name-replacementName. */
       foundProp.value.set({ name: replacementName });
       if (replacementValue) {
-        foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression)?.replaceWithText(`{${replacementValue}}`);
+        const childElem = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
+        if (childElem.something) {
+          childElem.value.replaceWithText(`{${replacementValue}}`);
+        } else {
+          return Err({ reason: 'Could not access prop from JSX tag' });
+        }
       } else {
         const enumInJsx = Maybe(foundProp.value.getFirstChildByKind(SyntaxKind.JsxExpression));
         if (enumInJsx.something) {
           if (transform) {
-            transform(enumInJsx.value, toRename, replacementName);
+            const res: Result<string, NoOp> = transform(enumInJsx.value, toRename, replacementName);
+            if (!res.ok) {
+              return Err({ reason: res.value.reason });
+            }
           }
         }
       }
     } else {
       /* If the prop is not found, check to see if the prop is in a spread attribute. */
+      let res: Result<string, NoOp>;
       if (transform) {
-        transform(val, toRename, replacementName);
+        res = transform(val, toRename, replacementName);
       } else {
-        renamePropInSpread(val, toRename, replacementName, undefined, replacementValue);
+        res = renamePropInSpread(val, toRename, replacementName, undefined, replacementValue);
+      }
+      if (!res.ok) {
+        return Err({ reason: res.value.reason });
       }
     }
   });
+  return Ok('Successfully renamed the given props.');
 }

--- a/packages/codemods/src/codeMods/utilities/transforms.ts
+++ b/packages/codemods/src/codeMods/utilities/transforms.ts
@@ -1,6 +1,7 @@
 import { PropTransform, ValueMap } from '../types';
 import { JsxExpression, SyntaxKind, JsxOpeningElement, JsxSelfClosingElement } from 'ts-morph';
 import { renamePropInSpread } from './helpers/propHelpers';
+import { Err, Ok } from '../../../src/helpers/result';
 
 /*
 Steps to writing a transform:
@@ -48,9 +49,11 @@ export function boolTransform(newValue?: boolean, map?: ValueMap<string>): PropT
       if (toChange) {
         const oldText = toChange.getText();
         toChange.replaceWithText(map ? map[oldText] : newValue !== undefined ? newValue.toString() : toRename);
+        return Ok('Prop value transformed successfully');
       }
+      return Err({ reason: 'Could not access prop value to transform.' });
     } else {
-      renamePropInSpread(
+      return renamePropInSpread(
         element as JsxOpeningElement | JsxSelfClosingElement,
         toRename,
         replacementName,
@@ -74,9 +77,11 @@ export function stringTransform(newValue?: string, map?: ValueMap<string>): Prop
       if (toChange) {
         const oldText = toChange.getText();
         toChange.replaceWithText(map ? `'${map[oldText]}'` : newValue ? newValue : toRename);
+        return Ok('Prop value transformed successfully');
       }
+      return Err({ reason: 'Could not access prop value to transform.' });
     } else {
-      renamePropInSpread(
+      return renamePropInSpread(
         element as JsxOpeningElement | JsxSelfClosingElement,
         toRename,
         replacementName,
@@ -100,9 +105,11 @@ export function numberTransform(newValue?: number, map?: ValueMap<string>): Prop
       if (toChange) {
         const oldText = toChange.getText();
         toChange.replaceWithText(map ? map[oldText] : newValue !== undefined ? newValue.toString() : toRename);
+        return Ok('Prop value transformed successfully');
       }
+      return Err({ reason: 'Could not access prop value to transform.' });
     } else {
-      renamePropInSpread(
+      return renamePropInSpread(
         element as JsxOpeningElement | JsxSelfClosingElement,
         toRename,
         replacementName,
@@ -123,16 +130,18 @@ export function enumTransform(map: ValueMap<string>): PropTransform {
     replacementName: string,
   ) => {
     if (!map) {
-      return;
+      return Err({ reason: 'Cannot perform an enum transform without a map!' });
     }
     if (elementNotInSpread(element)) {
       const toChange = getValueToChange(element as JsxExpression);
       if (toChange) {
         const oldText = toChange.getText();
         toChange.replaceWithText(map[oldText]);
+        return Ok('Prop value transformed successfully');
       }
+      return Err({ reason: 'Could not access prop value to transform.' });
     } else {
-      renamePropInSpread(element as JsxOpeningElement | JsxSelfClosingElement, toRename, replacementName, map);
+      return renamePropInSpread(element as JsxOpeningElement | JsxSelfClosingElement, toRename, replacementName, map);
     }
   };
 }


### PR DESCRIPTION
Added Jon's `result` type to some of the helper functions for prop-renaming utilities. This will allow for more detailed error logging. Woot woot!

This brought up an interesting point about the 'sweet spot' of logging amounts. There were functions like `getBlockContainer()` where I could have added result at the end, but the return type is already checked for `undefined`, and an error is returned anyway to a subsequent result -- not sure the nested result would make any difference.