### PR TITLE
docs(Datepicker): Add custom header example

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
@@ -15,7 +15,6 @@ const DatepickerHeaderExample = () => {
                   direction={'previous'}
                   title={props.prevMonthAriaLabel}
                   disabled={props.disabledPreviousButton}
-                  icon={{}}
                 />
                 <Text content={props.label} styles={{ paddingTop: pxToRem(5) }} />
                 <Datepicker.CalendarHeaderAction
@@ -23,7 +22,6 @@ const DatepickerHeaderExample = () => {
                   direction={'next'}
                   title={props.nextMonthAriaLabel}
                   disabled={props.disabledNextButton}
-                  icon={{}}
                 />
               </Flex>
             );

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
@@ -1,0 +1,37 @@
+import { Datepicker, Flex, Text, pxToRem } from '@fluentui/react-northstar';
+import * as React from 'react';
+
+const DatepickerHeaderExample = () => {
+  return (
+    <Datepicker
+      today={new Date(2020, 8, 12, 0, 0, 0, 0)}
+      calendar={{
+        header: {
+          children: (ComponentType, props) => {
+            return (
+              <Flex space={'between'} hAlign={'center'}>
+                <Datepicker.CalendarHeaderAction
+                  onClick={props.onPreviousClick}
+                  direction={'previous'}
+                  title={props.prevMonthAriaLabel}
+                  disabled={props.disabledPreviousButton}
+                  icon={{}}
+                />
+                <Text content={props.label} styles={{ paddingTop: pxToRem(5) }} />
+                <Datepicker.CalendarHeaderAction
+                  onClick={props.onNextClick}
+                  direction={'next'}
+                  title={props.nextMonthAriaLabel}
+                  disabled={props.disabledNextButton}
+                  icon={{}}
+                />
+              </Flex>
+            );
+          },
+        },
+      }}
+    />
+  );
+};
+
+export default DatepickerHeaderExample;

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/DatepickerHeaderExample.shorthand.tsx
@@ -9,17 +9,17 @@ const DatepickerHeaderExample = () => {
         header: {
           children: (ComponentType, props) => {
             return (
-              <Flex space={'between'} hAlign={'center'}>
+              <Flex space='between' hAlign='center'>
                 <Datepicker.CalendarHeaderAction
                   onClick={props.onPreviousClick}
-                  direction={'previous'}
+                  direction='previous'
                   title={props.prevMonthAriaLabel}
                   disabled={props.disabledPreviousButton}
                 />
                 <Text content={props.label} styles={{ paddingTop: pxToRem(5) }} />
                 <Datepicker.CalendarHeaderAction
                   onClick={props.onNextClick}
-                  direction={'next'}
+                  direction='next'
                   title={props.nextMonthAriaLabel}
                   disabled={props.disabledNextButton}
                 />

--- a/packages/fluentui/docs/src/examples/components/Datepicker/Slots/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Datepicker/Slots/index.tsx
@@ -24,6 +24,15 @@ const Usage = () => (
       }
       examplePath="components/Datepicker/Slots/DatepickerHeaderCellExample"
     />
+    <ComponentExample
+      title="Custom header slot"
+      description={
+        <>
+          <code>header</code> inside <code>calendar</code> prop can be used for customizing datepicker header
+        </>
+      }
+      examplePath="components/Datepicker/Slots/DatepickerHeaderExample"
+    />
   </ExampleSection>
 );
 

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeader.tsx
@@ -119,7 +119,6 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
       {createShorthand(DatepickerCalendarHeaderAction, previousButton, {
         defaultProps: () =>
           getA11yProps('previousButton', {
-            icon: {},
             title: props.prevMonthAriaLabel,
             direction: 'previous',
             disabled: props.disabledPreviousButton,
@@ -134,7 +133,6 @@ export const DatepickerCalendarHeader: ComponentWithAs<'div', DatepickerCalendar
       {createShorthand(DatepickerCalendarHeaderAction, nextButton, {
         defaultProps: () =>
           getA11yProps('nextButton', {
-            icon: {},
             title: props.nextMonthAriaLabel,
             direction: 'next',
             disabled: props.disabledNextButton,

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -37,3 +37,8 @@ export const DatepickerCalendarHeaderAction = compose<
     },
   }),
 });
+
+DatepickerCalendarHeaderAction.defaultProps = {
+  ...Button.defaultProps,
+  icon: {},
+};

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendarHeaderAction.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import { buttonBehavior } from '@fluentui/accessibility';
 import { compose } from '@fluentui/react-bindings';
 import { ChevronEndIcon, ChevronStartIcon } from '@fluentui/react-icons-northstar';
 import { Button, ButtonProps, ButtonStylesProps } from '../Button/Button';
@@ -39,6 +40,8 @@ export const DatepickerCalendarHeaderAction = compose<
 });
 
 DatepickerCalendarHeaderAction.defaultProps = {
-  ...Button.defaultProps,
+  as: 'button',
+  accessibility: buttonBehavior,
+  size: 'medium',
   icon: {},
 };


### PR DESCRIPTION
Add custom header example with arrows on the sides and the label in the center
![image](https://user-images.githubusercontent.com/2802155/90879864-d91fb980-e3a7-11ea-8054-2c2b44741164.png)

