### PR TITLE
Removing MsHighContrastAdjust:none from MessageBar and CompoundButton

### DIFF
--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
@@ -81,7 +81,6 @@ export const getStyles = memoizeFunction(
           [HighContrastSelector]: {
             backgroundColor: 'WindowText',
             color: 'Window',
-            MsHighContrastAdjust: 'none',
           },
         },
       },
@@ -103,7 +102,6 @@ export const getStyles = memoizeFunction(
           [HighContrastSelector]: {
             color: 'Window',
             backgroundColor: 'WindowText',
-            MsHighContrastAdjust: 'none',
           },
         },
       },
@@ -115,7 +113,6 @@ export const getStyles = memoizeFunction(
           [HighContrastSelector]: {
             color: 'Window',
             backgroundColor: 'WindowText',
-            MsHighContrastAdjust: 'none',
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -144,7 +144,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
             },
           },
           [HighContrastSelector]: {
-            MsHighContrastAdjust: 'none',
             background: highContrastBackgroundColor[messageBarType],
             border: '1px solid WindowText',
             color: 'WindowText',
@@ -179,7 +178,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
       color: semanticColors[iconColor[messageBarType]],
       selectors: {
         [HighContrastSelector]: {
-          MsHighContrastAdjust: 'none',
           color: 'WindowText',
         },
       },
@@ -194,7 +192,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         ...fonts.small,
         selectors: {
           [HighContrastSelector]: {
-            MsHighContrastAdjust: 'none',
             color: 'WindowText',
           },
         },
@@ -210,6 +207,9 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         selectors: {
           '& span a': {
             paddingLeft: 4,
+          },
+          [HighContrastSelector]: {
+            color: 'WindowText',
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -190,11 +190,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         flexGrow: 1,
         margin: 8,
         ...fonts.small,
-        selectors: {
-          [HighContrastSelector]: {
-            color: 'WindowText',
-          },
-        },
       },
       !onDismiss && {
         marginRight: 12,
@@ -207,9 +202,6 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         selectors: {
           '& span a': {
             paddingLeft: 4,
-          },
-          [HighContrastSelector]: {
-            color: 'WindowText',
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -195,6 +195,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
         selectors: {
           [HighContrastSelector]: {
             MsHighContrastAdjust: 'none',
+            color: 'WindowText',
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -100,6 +100,7 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){& {
             -ms-high-contrast-adjust: none;
+            color: WindowText;
           }
       id="MessageBar0"
       role="status"

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -26,7 +26,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
         color: #004578;
       }
       @media screen and (-ms-high-contrast: active){& {
-        -ms-high-contrast-adjust: none;
         background: Window;
         border: 1px solid WindowText;
         color: WindowText;
@@ -72,7 +71,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
               speak: none;
             }
             @media screen and (-ms-high-contrast: active){& {
-              -ms-high-contrast-adjust: none;
               color: WindowText;
             }
         data-icon-name="Info"
@@ -99,7 +97,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
             min-width: 0px;
           }
           @media screen and (-ms-high-contrast: active){& {
-            -ms-high-contrast-adjust: none;
             color: WindowText;
           }
       id="MessageBar0"
@@ -113,6 +110,9 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
             }
             & span a {
               padding-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
             }
       />
     </div>

--- a/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/__snapshots__/MessageBar.test.tsx.snap
@@ -96,9 +96,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
             margin-top: 8px;
             min-width: 0px;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            color: WindowText;
-          }
       id="MessageBar0"
       role="status"
     >
@@ -110,9 +107,6 @@ exports[`MessageBar renders MessageBar correctly 1`] = `
             }
             & span a {
               padding-left: 4px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: WindowText;
             }
       />
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
@@ -269,7 +269,6 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
           color: inherit;
         }
         @media screen and (-ms-high-contrast: active){&:active .ms-Button-description {
-          -ms-high-contrast-adjust: none;
           background-color: WindowText;
           color: Window;
         }
@@ -339,7 +338,6 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
                 line-height: 100%;
               }
               @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
                 background-color: WindowText;
                 color: Window;
               }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14655
- [x] Include a change request file using `$ yarn change`
    - Ran `yarn change`, it said no change file was needed


#### Description of changes

Removed MsHighContrastAdjust:none from MessageBar and CompoundButton

#### Focus areas to test

The main open question is : **why were they set to none in the first place?**

See attached issue for more information, but it means that children of these components weren't having their text color overridden in HighContrastMode