### PR TITLE
Link: Making High Contrast styling adhere to system settings

### DIFF
--- a/change/@fluentui-react-next-2020-08-25-09-47-32-linkHighContrast.json
+++ b/change/@fluentui-react-next-2020-08-25-09-47-32-linkHighContrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Link: Making High Contrast styling adhere to system settings.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T16:47:32.893Z"
+}

--- a/change/office-ui-fabric-react-2020-08-21-17-14-51-linkHighContrast.json
+++ b/change/office-ui-fabric-react-2020-08-21-17-14-51-linkHighContrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Link: Making High Contrast styling adhere to system settings.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-22T00:14:51.598Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -105,6 +105,12 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           },
           '&:focus': {
             color: linkColor,
+
+            selectors: {
+              [HighContrastSelector]: {
+                color: 'LinkText',
+              },
+            },
           },
         },
       },

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -1,10 +1,4 @@
-import {
-  getEdgeChromiumNoHighContrastAdjustSelector,
-  getGlobalClassNames,
-  HighContrastSelectorWhite,
-  HighContrastSelectorBlack,
-  HighContrastSelector,
-} from '../../Styling';
+import { getEdgeChromiumNoHighContrastAdjustSelector, getGlobalClassNames, HighContrastSelector } from '../../Styling';
 import { ILinkStyleProps, ILinkStyles } from './Link.types';
 
 const GlobalClassNames = {
@@ -68,11 +62,8 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         userSelect: 'text',
         borderBottom: '1px solid transparent', // For Firefox high contrast mode
         selectors: {
-          [HighContrastSelectorBlack]: {
-            color: '#FFFF00',
-          },
-          [HighContrastSelectorWhite]: {
-            color: '#00009F',
+          [HighContrastSelector]: {
+            color: 'LinkText',
           },
           ...getEdgeChromiumNoHighContrastAdjustSelector(),
         },
@@ -107,11 +98,8 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
             textDecoration: 'underline',
 
             selectors: {
-              [HighContrastSelectorBlack]: {
-                color: '#FFFF00',
-              },
-              [HighContrastSelectorWhite]: {
-                color: '#00009F',
+              [HighContrastSelector]: {
+                color: 'LinkText',
               },
             },
           },

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -49,6 +49,9 @@ exports[`Link renders Link correctly 1`] = `
       &:focus {
         color: #0078d4;
       }
+      @media screen and (-ms-high-contrast: active){&:focus {
+        color: LinkText;
+      }
   href="#"
   onClick={[Function]}
 >
@@ -127,6 +130,9 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       &:focus {
         color: #0078d4;
       }
+      @media screen and (-ms-high-contrast: active){&:focus {
+        color: LinkText;
+      }
   onClick={[Function]}
 >
   I'm a div
@@ -182,6 +188,9 @@ exports[`Link renders Link with a custom class name 1`] = `
       }
       &:focus {
         color: #0078d4;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus {
+        color: LinkText;
       }
   href="#"
   onClick={[Function]}
@@ -259,6 +268,9 @@ exports[`Link renders Link with no href as a button 1`] = `
       }
       &:focus {
         color: #0078d4;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus {
+        color: LinkText;
       }
   onClick={[Function]}
   type="button"
@@ -440,6 +452,9 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       }
       &:focus {
         color: #0078d4;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus {
+        color: LinkText;
       }
   onClick={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -29,31 +29,22 @@ exports[`Link renders Link correctly 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active {
+        color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active:hover {
+        color: LinkText;
       }
       &:focus {
         color: #0078d4;
@@ -107,12 +98,7 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       }
       @media screen and (-ms-high-contrast: active){& {
         border-bottom: none;
-      }
-      @media screen and (-ms-high-contrast: white-on-black){& {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){& {
-        color: #00009F;
+        color: LinkText;
       }
       @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
@@ -121,31 +107,22 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active {
+        color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active:hover {
+        color: LinkText;
       }
       &:focus {
         color: #0078d4;
@@ -186,31 +163,22 @@ exports[`Link renders Link with a custom class name 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active {
+        color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active:hover {
+        color: LinkText;
       }
       &:focus {
         color: #0078d4;
@@ -263,12 +231,7 @@ exports[`Link renders Link with no href as a button 1`] = `
       }
       @media screen and (-ms-high-contrast: active){& {
         border-bottom: none;
-      }
-      @media screen and (-ms-high-contrast: white-on-black){& {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){& {
-        color: #00009F;
+        color: LinkText;
       }
       @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
@@ -277,31 +240,22 @@ exports[`Link renders Link with no href as a button 1`] = `
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active {
+        color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active:hover {
+        color: LinkText;
       }
       &:focus {
         color: #0078d4;
@@ -396,12 +350,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
       @media screen and (-ms-high-contrast: active){& {
         border-bottom: none;
-      }
-      @media screen and (-ms-high-contrast: white-on-black){& {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){& {
-        color: #00009F;
+        color: LinkText;
       }
       @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
@@ -463,12 +412,7 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       }
       @media screen and (-ms-high-contrast: active){& {
         border-bottom: none;
-      }
-      @media screen and (-ms-high-contrast: white-on-black){& {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){& {
-        color: #00009F;
+        color: LinkText;
       }
       @media screen and (forced-colors: active){& {
         forced-color-adjust: none;
@@ -477,31 +421,22 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active {
+        color: LinkText;
       }
       &:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:hover {
+        color: LinkText;
       }
       &:active:hover {
         color: #004578;
         text-decoration: underline;
       }
-      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-        color: #FFFF00;
-      }
-      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-        color: #00009F;
+      @media screen and (-ms-high-contrast: active){&:active:hover {
+        color: LinkText;
       }
       &:focus {
         color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -104,12 +104,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -118,31 +113,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -206,12 +192,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -220,31 +201,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -376,12 +348,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -390,31 +357,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -555,12 +513,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -569,31 +522,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -646,12 +590,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -660,31 +599,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -737,12 +667,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -751,31 +676,22 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -133,6 +133,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -220,6 +223,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"
@@ -376,6 +382,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"
@@ -542,6 +551,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -619,6 +631,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -695,6 +710,9 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -209,6 +209,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -522,6 +525,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -599,6 +605,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -675,6 +684,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"
@@ -1043,6 +1055,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -1119,6 +1134,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"
@@ -1547,6 +1565,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           onClick={[Function]}
           type="button"
         >
@@ -1623,6 +1644,9 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           onClick={[Function]}
           type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -180,12 +180,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -194,31 +189,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -507,12 +493,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -521,31 +502,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -598,12 +570,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -612,31 +579,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -689,12 +647,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -703,31 +656,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -1070,12 +1014,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -1084,31 +1023,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -1161,12 +1091,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -1175,31 +1100,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -1602,12 +1518,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -1616,31 +1527,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -1693,12 +1595,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-bottom: none;
-              }
-              @media screen and (-ms-high-contrast: white-on-black){& {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){& {
-                color: #00009F;
+                color: LinkText;
               }
               @media screen and (forced-colors: active){& {
                 forced-color-adjust: none;
@@ -1707,31 +1604,22 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -357,12 +357,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -372,11 +367,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -384,22 +376,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -417,9 +403,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -539,12 +522,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -554,11 +532,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -566,22 +541,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -599,9 +568,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -809,12 +775,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -824,11 +785,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -836,22 +794,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -869,9 +821,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -991,12 +940,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1006,11 +950,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1018,22 +959,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1051,9 +986,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1173,12 +1105,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1188,11 +1115,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1200,22 +1124,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1233,9 +1151,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1355,12 +1270,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1370,11 +1280,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1382,22 +1289,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1415,9 +1316,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1537,12 +1435,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1552,11 +1445,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1564,22 +1454,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1597,9 +1481,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1719,12 +1600,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1734,11 +1610,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1746,22 +1619,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1779,9 +1646,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1902,12 +1766,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1917,11 +1776,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1929,22 +1785,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1962,9 +1812,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -2341,11 +2188,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2353,22 +2197,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2386,9 +2224,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   href="#/controls/web/breadcrumb"
                   onClick={[Function]}
@@ -2592,11 +2427,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2604,22 +2436,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2637,9 +2463,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   href="#/controls/web/breadcrumb"
                   onClick={[Function]}
@@ -2828,12 +2651,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -2843,11 +2661,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2855,22 +2670,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2888,9 +2697,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -3010,12 +2816,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -3025,11 +2826,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -3037,22 +2835,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -3070,9 +2862,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -3349,12 +3138,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -3364,11 +3148,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -3376,22 +3157,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -3409,9 +3184,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -3526,12 +3298,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -3541,11 +3308,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -3553,22 +3317,16 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -3586,9 +3344,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -390,6 +390,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -554,6 +557,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -808,6 +814,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -972,6 +981,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1138,6 +1150,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -1302,6 +1317,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1468,6 +1486,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -1632,6 +1653,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1798,6 +1822,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2211,6 +2238,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -2450,6 +2480,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -2684,6 +2717,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -2848,6 +2884,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -3171,6 +3210,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -3330,6 +3372,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -197,6 +197,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -361,6 +364,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -527,6 +533,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -691,6 +700,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -945,6 +957,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1373,6 +1388,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -1627,6 +1645,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -1860,6 +1881,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -2219,6 +2243,9 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -164,12 +164,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -179,11 +174,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -191,22 +183,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -224,9 +210,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -346,12 +329,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -361,11 +339,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -373,22 +348,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -406,9 +375,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -528,12 +494,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -543,11 +504,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -555,22 +513,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -588,9 +540,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -710,12 +659,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -725,11 +669,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -737,22 +678,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -770,9 +705,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -981,12 +913,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -996,11 +923,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1008,22 +932,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1041,9 +959,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1425,12 +1340,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1440,11 +1350,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1452,22 +1359,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1485,9 +1386,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1696,12 +1594,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1711,11 +1604,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1723,22 +1613,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -1756,9 +1640,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -1947,12 +1828,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -1962,11 +1838,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -1974,22 +1847,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2007,9 +1874,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -2323,12 +2187,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -2338,11 +2197,8 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -2350,22 +2206,16 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -2383,9 +2233,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -333,12 +333,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -348,11 +343,8 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -360,22 +352,16 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -393,9 +379,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"
@@ -604,12 +587,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
+                        color: LinkText;
                       }
                       @media screen and (forced-colors: active){& {
                         forced-color-adjust: none;
@@ -619,11 +597,8 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active {
+                        color: LinkText;
                       }
                       &:hover {
                         background-color: #f3f2f1;
@@ -631,22 +606,16 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         cursor: pointer;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
                       }
                       &:active:hover {
                         background-color: #edebe9;
                         color: #323130;
                         text-decoration: none;
                       }
-                      @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                        color: #00009F;
+                      @media screen and (-ms-high-contrast: active){&:active:hover {
+                        color: LinkText;
                       }
                       &:focus {
                         color: #201f1e;
@@ -664,9 +633,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         right: 1px;
                         top: 1px;
                         z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
                       }
                   onClick={[Function]}
                   type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -366,6 +366,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       &:focus {
                         color: #201f1e;
                       }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
+                      }
                       &::-moz-focus-inner {
                         border: 0;
                       }
@@ -619,6 +622,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       }
                       &:focus {
                         color: #201f1e;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:focus {
+                        color: LinkText;
                       }
                       &::-moz-focus-inner {
                         border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -374,6 +374,9 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       href="https://developer.microsoft.com/en-us/fluentui#/styles/icons"
       onClick={[Function]}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -354,31 +354,22 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -703,6 +703,9 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="https://www.microsoft.com"
           onClick={[Function]}
           target="_blank"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -683,31 +683,22 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -791,12 +791,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -805,31 +800,22 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -879,12 +865,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -893,31 +874,22 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -820,6 +820,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -893,6 +896,9 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                 }
                                 &:focus {
                                   color: #0078d4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
                                 }
                             onClick={[Function]}
                             type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1092,12 +1092,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -1106,31 +1101,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -1641,12 +1627,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -1655,31 +1636,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -2190,12 +2162,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -2204,31 +2171,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -2739,12 +2697,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -2753,31 +2706,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -3288,12 +3232,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -3302,31 +3241,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -3837,12 +3767,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -3851,31 +3776,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -4386,12 +4302,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -4400,31 +4311,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -4935,12 +4837,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -4949,31 +4846,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;
@@ -5484,12 +5372,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 @media screen and (-ms-high-contrast: active){& {
                                   border-bottom: none;
-                                }
-                                @media screen and (-ms-high-contrast: white-on-black){& {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){& {
-                                  color: #00009F;
+                                  color: LinkText;
                                 }
                                 @media screen and (forced-colors: active){& {
                                   forced-color-adjust: none;
@@ -5498,31 +5381,22 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active {
+                                  color: LinkText;
                                 }
                                 &:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:hover {
+                                  color: LinkText;
                                 }
                                 &:active:hover {
                                   color: #004578;
                                   text-decoration: underline;
                                 }
-                                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                                  color: #FFFF00;
-                                }
-                                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                                  color: #00009F;
+                                @media screen and (-ms-high-contrast: active){&:active:hover {
+                                  color: LinkText;
                                 }
                                 &:focus {
                                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1121,6 +1121,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -1655,6 +1658,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 &:focus {
                                   color: #0078d4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
                                 }
                             onClick={[Function]}
                             type="button"
@@ -2191,6 +2197,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -2725,6 +2734,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 &:focus {
                                   color: #0078d4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
                                 }
                             onClick={[Function]}
                             type="button"
@@ -3261,6 +3273,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -3795,6 +3810,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 &:focus {
                                   color: #0078d4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
                                 }
                             onClick={[Function]}
                             type="button"
@@ -4331,6 +4349,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -4866,6 +4887,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 &:focus {
                                   color: #0078d4;
                                 }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
+                                }
                             onClick={[Function]}
                             type="button"
                           >
@@ -5400,6 +5424,9 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 &:focus {
                                   color: #0078d4;
+                                }
+                                @media screen and (-ms-high-contrast: active){&:focus {
+                                  color: LinkText;
                                 }
                             onClick={[Function]}
                             type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -571,31 +571,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active {
+                    color: LinkText;
                   }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: LinkText;
                   }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active:hover {
+                    color: LinkText;
                   }
                   &:focus {
                     color: #0078d4;
@@ -699,31 +690,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active {
+                    color: LinkText;
                   }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: LinkText;
                   }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active:hover {
+                    color: LinkText;
                   }
                   &:focus {
                     color: #0078d4;
@@ -827,31 +809,22 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active {
+                    color: LinkText;
                   }
                   &:hover {
                     color: #0078d4;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: LinkText;
                   }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active:hover {
+                    color: LinkText;
                   }
                   &:focus {
                     color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -591,6 +591,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   &:focus {
                     color: #0078d4;
                   }
+                  @media screen and (-ms-high-contrast: active){&:focus {
+                    color: LinkText;
+                  }
                   &::-moz-focus-inner {
                     border: 0;
                   }
@@ -710,6 +713,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   &:focus {
                     color: #0078d4;
                   }
+                  @media screen and (-ms-high-contrast: active){&:focus {
+                    color: LinkText;
+                  }
                   &::-moz-focus-inner {
                     border: 0;
                   }
@@ -828,6 +834,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   }
                   &:focus {
                     color: #0078d4;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:focus {
+                    color: LinkText;
                   }
                   &::-moz-focus-inner {
                     border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -152,31 +152,22 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active {
+                  color: LinkText;
                 }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: LinkText;
                 }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active:hover {
+                  color: LinkText;
                 }
                 &:focus {
                   color: #0078d4;
@@ -280,31 +271,22 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active {
+                  color: LinkText;
                 }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: LinkText;
                 }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active:hover {
+                  color: LinkText;
                 }
                 &:focus {
                   color: #0078d4;
@@ -408,31 +390,22 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active {
+                  color: LinkText;
                 }
                 &:hover {
                   color: #0078d4;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  color: LinkText;
                 }
                 &:active:hover {
                   color: #004578;
                   text-decoration: underline;
                 }
-                @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                  color: #FFFF00;
-                }
-                @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                  color: #00009F;
+                @media screen and (-ms-high-contrast: active){&:active:hover {
+                  color: LinkText;
                 }
                 &:focus {
                   color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -172,6 +172,9 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                 &:focus {
                   color: #0078d4;
                 }
+                @media screen and (-ms-high-contrast: active){&:focus {
+                  color: LinkText;
+                }
                 &::-moz-focus-inner {
                   border: 0;
                 }
@@ -291,6 +294,9 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                 &:focus {
                   color: #0078d4;
                 }
+                @media screen and (-ms-high-contrast: active){&:focus {
+                  color: LinkText;
+                }
                 &::-moz-focus-inner {
                   border: 0;
                 }
@@ -409,6 +415,9 @@ Created by Annie Lindqvist in February 23, 2016. 432 views."
                 }
                 &:focus {
                   color: #0078d4;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus {
+                  color: LinkText;
                 }
                 &::-moz-focus-inner {
                   border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -426,31 +426,22 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -446,6 +446,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       href="https://bing.com"
       onClick={[Function]}
       target="_blank"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -628,6 +628,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             &:focus {
               color: #0078d4;
             }
+            @media screen and (-ms-high-contrast: active){&:focus {
+              color: LinkText;
+            }
         href="https://bing.com"
         onClick={[Function]}
         target="_blank"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -608,31 +608,22 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:active {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:active {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:active {
+              color: LinkText;
             }
             &:hover {
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:hover {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:hover {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: LinkText;
             }
             &:active:hover {
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:active:hover {
+              color: LinkText;
             }
             &:focus {
               color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -629,6 +629,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             &:focus {
               color: #0078d4;
             }
+            @media screen and (-ms-high-contrast: active){&:focus {
+              color: LinkText;
+            }
         href="https://bing.com"
         onClick={[Function]}
         target="_blank"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -609,31 +609,22 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:active {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:active {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:active {
+              color: LinkText;
             }
             &:hover {
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:hover {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:hover {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: LinkText;
             }
             &:active:hover {
               color: #004578;
               text-decoration: underline;
             }
-            @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-              color: #FFFF00;
-            }
-            @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-              color: #00009F;
+            @media screen and (-ms-high-contrast: active){&:active:hover {
+              color: LinkText;
             }
             &:focus {
               color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -265,6 +265,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="http://placehold.it/100x100"
           onClick={[Function]}
         >
@@ -956,6 +959,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           href="http://placehold.it/100x101"
           onClick={[Function]}
@@ -1649,6 +1655,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="http://placehold.it/100x102"
           onClick={[Function]}
         >
@@ -2340,6 +2349,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           href="http://placehold.it/100x103"
           onClick={[Function]}
@@ -3033,6 +3045,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="http://placehold.it/100x104"
           onClick={[Function]}
         >
@@ -3724,6 +3739,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           href="http://placehold.it/100x105"
           onClick={[Function]}
@@ -4417,6 +4435,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="http://placehold.it/100x106"
           onClick={[Function]}
         >
@@ -5108,6 +5129,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           href="http://placehold.it/100x107"
           onClick={[Function]}
@@ -5801,6 +5825,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
+              }
           href="http://placehold.it/100x108"
           onClick={[Function]}
         >
@@ -6492,6 +6519,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               &:focus {
                 color: #0078d4;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus {
+                color: LinkText;
               }
           href="http://placehold.it/100x109"
           onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -245,31 +245,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -946,31 +937,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -1647,31 +1629,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -2348,31 +2321,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -3049,31 +3013,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -3750,31 +3705,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -4451,31 +4397,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -5152,31 +5089,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -5853,31 +5781,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;
@@ -6554,31 +6473,22 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active {
+                color: LinkText;
               }
               &:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:hover {
+                color: LinkText;
               }
               &:active:hover {
                 color: #004578;
                 text-decoration: underline;
               }
-              @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                color: #FFFF00;
-              }
-              @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                color: #00009F;
+              @media screen and (-ms-high-contrast: active){&:active:hover {
+                color: LinkText;
               }
               &:focus {
                 color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1181,31 +1181,22 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active {
+                    color: LinkText;
                   }
                   &:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    color: LinkText;
                   }
                   &:active:hover {
                     color: #004578;
                     text-decoration: underline;
                   }
-                  @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-                    color: #FFFF00;
-                  }
-                  @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-                    color: #00009F;
+                  @media screen and (-ms-high-contrast: active){&:active:hover {
+                    color: LinkText;
                   }
                   &:focus {
                     color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1201,6 +1201,9 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                   &:focus {
                     color: #0078d4;
                   }
+                  @media screen and (-ms-high-contrast: active){&:focus {
+                    color: LinkText;
+                  }
               data-ktp-execute-target="ktp-a-2"
               data-ktp-target="ktp-a-2"
               href="http://www.bing.com"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -66,6 +66,9 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       href="https://developer.microsoft.com/en-us/fluentui#/controls/web/link"
       onClick={[Function]}
     >
@@ -141,6 +144,9 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           }
           &:focus {
             color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
           }
       onClick={[Function]}
       type="button"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -46,31 +46,22 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;
@@ -122,12 +113,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -136,31 +122,22 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -69,12 +69,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -83,31 +78,22 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;
@@ -167,12 +153,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -181,31 +162,22 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;
@@ -265,12 +237,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -279,31 +246,22 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -98,6 +98,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       onClick={[Function]}
       role="menuitem"
       type="button"
@@ -182,6 +185,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       onClick={[Function]}
       role="menuitem"
       type="button"
@@ -265,6 +271,9 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           &:focus {
             color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
           }
       onClick={[Function]}
       role="menuitem"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -242,6 +242,9 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       onClick={[Function]}
       role="menuitem"
       type="button"
@@ -326,6 +329,9 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           &:focus {
             color: #0078d4;
           }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
+          }
       onClick={[Function]}
       role="menuitem"
       type="button"
@@ -409,6 +415,9 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           }
           &:focus {
             color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            color: LinkText;
           }
       onClick={[Function]}
       role="menuitem"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.BasicReversed.Example.tsx.shot
@@ -213,12 +213,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -227,31 +222,22 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;
@@ -311,12 +297,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -325,31 +306,22 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;
@@ -409,12 +381,7 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
           }
           @media screen and (-ms-high-contrast: active){& {
             border-bottom: none;
-          }
-          @media screen and (-ms-high-contrast: white-on-black){& {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){& {
-            color: #00009F;
+            color: LinkText;
           }
           @media screen and (forced-colors: active){& {
             forced-color-adjust: none;
@@ -423,31 +390,22 @@ exports[`Component Examples renders OverflowSet.BasicReversed.Example.tsx correc
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active {
+            color: LinkText;
           }
           &:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:hover {
+            color: LinkText;
           }
           &:active:hover {
             color: #004578;
             text-decoration: underline;
           }
-          @media screen and (-ms-high-contrast: white-on-black){&:active:hover {
-            color: #FFFF00;
-          }
-          @media screen and (-ms-high-contrast: black-on-white){&:active:hover {
-            color: #00009F;
+          @media screen and (-ms-high-contrast: active){&:active:hover {
+            color: LinkText;
           }
           &:focus {
             color: #0078d4;

--- a/packages/react-next/src/components/Link/Link.scss
+++ b/packages/react-next/src/components/Link/Link.scss
@@ -39,11 +39,9 @@
     text-overflow: inherit;
     user-select: text;
 
-    @include high-contrast-black-on-white {
-      color: #ffff00;
-    }
-    @include high-contrast-white-on-black {
-      color: #00009f;
+    @include high-contrast {
+      color: LinkText;
+      -ms-high-contrast-adjust: none;
     }
   }
 
@@ -63,10 +61,18 @@
     &:active:hover {
       color: var($semanticColorsLinkHovered);
       text-decoration: underline;
+
+      @include high-contrast {
+        color: LinkText;
+      }
     }
 
     &:focus {
       color: var($semanticColorsLink);
+
+      @include high-contrast {
+        color: LinkText;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14683
- [x] Include a change request file using `$ yarn change`

#### Description of changes

We were forcing `Links` rendered as buttons to take in the color of the default High Contrast theme `Hyperlink` color. However, this wasn't working for custom theme scenarios. This PR changes this by making use of the system color.

#### Focus areas to test

(optional)
