### PR TITLE
feat(MenuItem): allow submenu to open on hover

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -36,7 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add base `SkeletonText` component @assuncaocharles ([#14460](https://github.com/microsoft/fluentui/pull/14460))
 - Add styling for `Datepicker` component @karymes ([#14469](https://github.com/microsoft/fluentui/pull/14469))
 - Add `readStatus` slot to `ChatMessage` @assuncaocharles ([#14585](https://github.com/microsoft/fluentui/pull/14585))
-- Add `on` property to `Menu` to open in on hover @assuncaocharles ([#14714](https://github.com/microsoft/fluentui/pull/14714))
+- Add `on` property to `MenuItem` to open in on hover @assuncaocharles ([#14714](https://github.com/microsoft/fluentui/pull/14714))
 
 ### Documentation
 - Edited left side menu in UI builder @vyhnalekl ([#14436](https://github.com/microsoft/fluentui/pull/14436))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add base `SkeletonText` component @assuncaocharles ([#14460](https://github.com/microsoft/fluentui/pull/14460))
 - Add styling for `Datepicker` component @karymes ([#14469](https://github.com/microsoft/fluentui/pull/14469))
 - Add `readStatus` slot to `ChatMessage` @assuncaocharles ([#14585](https://github.com/microsoft/fluentui/pull/14585))
+- Add `on` property to `Menu` to open in on hover @assuncaocharles ([#14714](https://github.com/microsoft/fluentui/pull/14714))
 
 ### Documentation
 - Edited left side menu in UI builder @vyhnalekl ([#14436](https://github.com/microsoft/fluentui/pull/14436))

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.steps.ts
@@ -1,0 +1,20 @@
+import { menuClassName } from '@fluentui/react-northstar';
+
+const selectors = {
+  menu: `.${menuClassName}`,
+  item: (itemIndex: number) => `.${menuClassName} li:nth-child(${itemIndex}) a`,
+};
+
+const config: ScreenerTestsConfig = {
+  themes: ['teams', 'teamsDark', 'teamsHighContrast'],
+  steps: [
+    (builder, keys) =>
+      builder
+        .hover(selectors.item(1))
+        .snapshot('Hovers 1st item, open menu')
+        .hover(selectors.item(3))
+        .snapshot('Hovers 2nd item, open submenu'),
+  ],
+};
+
+export default config;

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { Menu, MenuProps } from '@fluentui/react-northstar';
+
+const items: MenuProps['items'] = [
+  {
+    key: 'editorials',
+    content: 'Editorials',
+    on: 'hover',
+    menu: {
+      items: [
+        { key: '1', content: 'item1' },
+        {
+          key: '2',
+          content: 'item2',
+          on: 'hover',
+          menu: [
+            { key: '1', content: 'item2.1' },
+            { key: '2', content: 'item2.2' },
+          ],
+        },
+        {
+          key: '3',
+          content: 'item3',
+          on: 'hover',
+          menu: [
+            { key: '1', content: 'item3.1' },
+            { key: '2', content: 'item3.2' },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+const MenuExampleWithSubMenuHover = () => <Menu defaultActiveIndex={0} items={items} />;
+
+export default MenuExampleWithSubMenuHover;

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/index.tsx
@@ -21,6 +21,11 @@ const Usage = () => (
       examplePath="components/Menu/Usage/MenuExampleWithSubmenu"
     />
     <ComponentExample
+      title="Menu with submenus opening on hover"
+      description="A menu can have submenus that open on hover."
+      examplePath="components/Menu/Usage/MenuExampleWithSubmenuHover"
+    />
+    <ComponentExample
       title="Menu with submenus controlled"
       description="When Submenu in MenuItem is controlled, then its 'menuOpen' prop value could be changed either by parent component, or by user actions (e.g. key press) - thus it is necessary to handle 'onMenuOpenChange' event."
       examplePath="components/Menu/Usage/MenuExampleWithSubmenuControlled"

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -242,15 +242,6 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
       [actualProps, setActiveIndex],
     );
 
-    const handleMouseEnter = React.useCallback(
-      (e, itemProps) => {
-        const { index } = itemProps;
-        setActiveIndex(e, index);
-        _.invoke(actualProps.current, 'onMouseEnter', e, itemProps);
-      },
-      [actualProps, setActiveIndex],
-    );
-
     const handleItemOverrides = (predefinedProps: MenuItemProps): MenuItemProps => ({
       onClick: (e, itemProps) => {
         handleClick(e, itemProps);
@@ -304,8 +295,7 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
 
     const childProps: MenuContextValue = {
       activeIndex: +activeIndex,
-      onItemClick: handleClick,
-      onMouseEnter: handleMouseEnter,
+      onItemSelect: handleClick,
       variables,
 
       slotProps: {

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -242,6 +242,15 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
       [actualProps, setActiveIndex],
     );
 
+    const handleMouseEnter = React.useCallback(
+      (e, itemProps) => {
+        const { index } = itemProps;
+        setActiveIndex(e, index);
+        _.invoke(actualProps.current, 'onMouseEnter', e, itemProps);
+      },
+      [actualProps, setActiveIndex],
+    );
+
     const handleItemOverrides = (predefinedProps: MenuItemProps): MenuItemProps => ({
       onClick: (e, itemProps) => {
         handleClick(e, itemProps);
@@ -296,6 +305,7 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
     const childProps: MenuContextValue = {
       activeIndex: +activeIndex,
       onItemClick: handleClick,
+      onMouseEnter: handleMouseEnter,
       variables,
 
       slotProps: {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -334,7 +334,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
+      _.invoke(props, 'onClick', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -235,7 +235,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
 
     const getTriggerProps = () => {
       const triggerProps: any = {};
-      const normalizedOn = _.isArray(on) ? on : [on];
 
       /**
        * The hover is adding the mouseEnter, mouseLeave events

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -297,7 +297,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     const menuRef = React.useRef<HTMLElement>();
     const itemRef = React.useRef<HTMLElement>();
 
-    const triggerProps: React.HTMLAttributes<HTMLElement> = {
+    const rootHandlers: React.HTMLAttributes<HTMLElement> = {
       ...(on === 'hover' && {
         onMouseEnter: e => {
           setWhatInputSource(context.target, 'mouse');
@@ -410,7 +410,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
     };
 
-    const getRootHandlers = () => (wrapper ? {} : { onClick: handleClick, ...triggerProps });
+    const getRootHandlers = () => (wrapper ? {} : { onClick: handleClick, ...rootHandlers });
 
     const trySetMenuOpen = (
       newValue: boolean,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -297,21 +297,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     const menuRef = React.useRef<HTMLElement>();
     const itemRef = React.useRef<HTMLElement>();
 
-    const rootHandlers: React.HTMLAttributes<HTMLElement> = {
-      ...(on === 'hover' && {
-        onMouseEnter: e => {
-          setWhatInputSource(context.target, 'mouse');
-          trySetMenuOpen(true, e);
-          _.invoke(props, 'onMouseEnter', e, props);
-          _.invoke(parentProps, 'onItemSelect', e, props);
-        },
-        onMouseLeave: e => {
-          trySetMenuOpen(false, e);
-          _.invoke(props, 'onMouseLeave', e, props);
-        },
-      }),
-    };
-
     const handleWrapperBlur = (e: React.FocusEvent) => {
       if (!props.inSubmenu && !e.currentTarget.contains(e.relatedTarget as Node)) {
         trySetMenuOpen(false, e);
@@ -349,8 +334,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-          _.invoke(props, 'onClick', e, props);
-          _.invoke(parentProps, 'onItemSelect', e, props);
+      _.invoke(props, 'onClick', e, props);
+      _.invoke(parentProps, 'onItemSelect', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {
@@ -412,7 +397,23 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
     };
 
-    const getRootHandlers = () => (wrapper ? {} : { onClick: handleClick, ...rootHandlers });
+    const rootHandlers: React.HTMLAttributes<HTMLElement> = {
+      ...(!wrapper && {
+        onClick: handleClick,
+        ...(on === 'hover' && {
+          onMouseEnter: e => {
+            setWhatInputSource(context.target, 'mouse');
+            trySetMenuOpen(true, e);
+            _.invoke(props, 'onMouseEnter', e, props);
+            _.invoke(parentProps, 'onItemSelect', e, props);
+          },
+          onMouseLeave: e => {
+            trySetMenuOpen(false, e);
+            _.invoke(props, 'onMouseLeave', e, props);
+          },
+        }),
+      }),
+    };
 
     const trySetMenuOpen = (
       newValue: boolean,
@@ -446,7 +447,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
             onFocus: handleFocus,
             ...unhandledProps,
           })}
-          {...getRootHandlers()}
+          {...rootHandlers}
         >
           {childrenExist(children) ? (
             children

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -349,7 +349,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
+          _.invoke(props, 'onClick', e, props);
+          _.invoke(parentProps, 'onItemSelect', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -335,7 +335,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       performClick(e);
 
       _.invoke(props, 'onClick', e, props);
-      _.invoke(parentProps, 'onItemSelect', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -233,27 +233,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       initialValue: false,
     });
 
-    const getTriggerProps = () => {
-      const triggerProps: any = {};
-
-      /**
-       * The hover is adding the mouseEnter, mouseLeave events
-       */
-      if (on === 'hover') {
-        triggerProps.onMouseEnter = e => {
-          setWhatInputSource(context.target, 'mouse');
-          trySetMenuOpen(true, e);
-          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...props }, 'onMouseEnter', e, props);
-        };
-        triggerProps.onMouseLeave = e => {
-          trySetMenuOpen(false, e);
-          _.invoke(props, 'onMouseLeave', e, props);
-        };
-      }
-
-      return triggerProps;
-    };
-
     const [isFromKeyboard, setIsFromKeyboard] = React.useState(false);
 
     const ElementType = getElementType(props);
@@ -318,7 +297,19 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     const menuRef = React.useRef<HTMLElement>();
     const itemRef = React.useRef<HTMLElement>();
 
-    const triggerProps = getTriggerProps();
+    const triggerProps: React.HTMLAttributes<HTMLElement> = {
+      ...(on === 'hover' && {
+        onMouseEnter: e => {
+          setWhatInputSource(context.target, 'mouse');
+          trySetMenuOpen(true, e);
+          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...props }, 'onMouseEnter', e, props);
+        },
+        onMouseLeave: e => {
+          trySetMenuOpen(false, e);
+          _.invoke(props, 'onMouseLeave', e, props);
+        },
+      }),
+    };
 
     const handleWrapperBlur = (e: React.FocusEvent) => {
       if (!props.inSubmenu && !e.currentTarget.contains(e.relatedTarget as Node)) {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -334,7 +334,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke(props, 'onClick', e, props);
+      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -40,7 +40,6 @@ import { Popper, PopperShorthandProps, partitionPopperPropsFromShorthand } from 
 
 import { MenuContext, MenuItemSubscribedValue } from './menuContext';
 import { useContextSelectors } from '@fluentui/react-context-selector';
-import { PopupEvents, PopupEventsArray } from '../Popup/Popup';
 
 export interface MenuItemSlotClassNames {
   submenu: string;
@@ -123,8 +122,8 @@ export interface MenuItemProps
   /** Shorthand for the wrapper component. */
   wrapper?: ShorthandValue<MenuItemWrapperProps>;
 
-  /** Events triggering the popup. */
-  on?: PopupEvents | PopupEventsArray;
+  /** Events triggering the menu open. */
+  on?: 'hover';
 
   /** Shorthand for the submenu. */
   menu?:
@@ -188,8 +187,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
 
     const parentProps = (useContextSelectors(MenuContext, {
       active: v => v.activeIndex === inputProps.index,
-      onItemClick: v => v.onItemClick,
-      onMouseEnter: v => v.onMouseEnter,
+      onItemSelect: v => v.onItemSelect,
       variables: v => v.variables,
       menuSlot: v => v.slots.menu,
       slotProps: v => v.slotProps.item,
@@ -240,14 +238,13 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       const normalizedOn = _.isArray(on) ? on : [on];
 
       /**
-       * The hover is adding the mouseEnter, mouseLeave, blur and click event (always opening on click)
-       * If hover and context are provided, there is no need to add onClick
+       * The hover is adding the mouseEnter, mouseLeave events
        */
       if (_.includes(normalizedOn, 'hover')) {
         triggerProps.onMouseEnter = e => {
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);
-          _.invoke({ onMouseEnter: parentProps.onMouseEnter, ...props }, 'onMouseEnter', e, props);
+          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...props }, 'onMouseEnter', e, props);
         };
         triggerProps.onMouseLeave = e => {
           trySetMenuOpen(false, e);
@@ -361,7 +358,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke({ onClick: parentProps.onItemClick, ...props }, 'onClick', e, props);
+      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {
@@ -578,6 +575,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     handledProps: [
       'accessibility',
       'as',
+      'on',
       'children',
       'className',
       'content',
@@ -624,6 +622,7 @@ MenuItem.propTypes = {
   active: PropTypes.bool,
   disabled: PropTypes.bool,
   icon: customPropTypes.shorthandAllowingChildren,
+  on: PropTypes.oneOf(['hover']),
   iconOnly: PropTypes.bool,
   index: PropTypes.number,
   itemPosition: PropTypes.number,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -466,6 +466,28 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       </Ref>
     );
 
+    const handleWrapperOverrides = predefinedProps => ({
+      onBlur: (e: React.FocusEvent) => {
+        handleWrapperBlur(e);
+        _.invoke(predefinedProps, 'onBlur', e, props);
+      },
+      onClick: (e: React.MouseEvent) => {
+        handleClick(e);
+        _.invoke(predefinedProps, 'onClick', e, props);
+      },
+      ...(on === 'hover' && {
+        onMouseEnter: e => {
+          setWhatInputSource(context.target, 'mouse');
+          trySetMenuOpen(true, e);
+          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...predefinedProps }, 'onMouseEnter', e, props);
+        },
+        onMouseLeave: e => {
+          trySetMenuOpen(false, e);
+          _.invoke(predefinedProps, 'onMouseLeave', e, props);
+        },
+      }),
+    });
+
     const maybeSubmenu =
       menu && active && menuOpen ? (
         <>
@@ -491,16 +513,14 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
     if (wrapper) {
       const wrapperElement = createShorthand(composeOptions.slots.wrapper, wrapper, {
         defaultProps: () => getA11yProps('wrapper', slotProps.wrapper),
-        overrideProps: () => ({
+        overrideProps: predefinedProps => ({
           children: (
             <>
               {menuItemInner}
               {maybeSubmenu}
             </>
           ),
-          onClick: handleClick,
-          onBlur: handleWrapperBlur,
-          ...triggerProps,
+          ...handleWrapperOverrides(predefinedProps),
         }),
       });
 

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -302,7 +302,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         onMouseEnter: e => {
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);
-          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...props }, 'onMouseEnter', e, props);
+          _.invoke(props, 'onMouseEnter', e, props);
+          _.invoke(parentProps, 'onItemSelect', e, props);
         },
         onMouseLeave: e => {
           trySetMenuOpen(false, e);

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -240,7 +240,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       /**
        * The hover is adding the mouseEnter, mouseLeave events
        */
-      if (_.includes(normalizedOn, 'hover')) {
+      if (on === 'hover') {
         triggerProps.onMouseEnter = e => {
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -481,7 +481,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         onMouseEnter: e => {
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);
-          _.invoke({ onMouseEnter: parentProps.onItemSelect, ...predefinedProps }, 'onMouseEnter', e, props);
+          _.invoke(predefinedProps, 'onMouseEnter', e, props);
+          _.invoke(parentProps, 'onItemSelect', e, props);
         },
         onMouseLeave: e => {
           trySetMenuOpen(false, e);

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -420,6 +420,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
     };
 
+    const getRootHandlers = () => (wrapper ? {} : { onClick: handleClick, ...triggerProps });
+
     const trySetMenuOpen = (
       newValue: boolean,
       e: MouseEvent | React.FocusEvent | React.KeyboardEvent | React.MouseEvent,
@@ -452,7 +454,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
             onFocus: handleFocus,
             ...unhandledProps,
           })}
-          {...(!wrapper && { onClick: handleClick, ...triggerProps })}
+          {...getRootHandlers()}
         >
           {childrenExist(children) ? (
             children

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -7,6 +7,7 @@ export type MenuContextValue = {
   activeIndex: number;
   variables: ComponentVariablesInput;
   onItemClick: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
+  onMouseEnter: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
 
   slotProps: {
     item: Record<string, any>;
@@ -23,7 +24,7 @@ export type MenuContextValue = {
   };
 };
 
-export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemClick'> & {
+export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemClick' | 'onMouseEnter'> & {
   slotProps: MenuContextValue['slotProps']['item'];
   accessibility: MenuContextValue['behaviors']['item'];
   menuSlot: MenuContextValue['slots']['menu'];
@@ -40,7 +41,7 @@ export const MenuContext = createContext<MenuContextValue>(
     activeIndex: -1,
     variables: {},
     onItemClick: null,
-
+    onMouseEnter: null,
     slotProps: {
       item: {},
       divider: {},

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -6,8 +6,7 @@ import { Accessibility } from '@fluentui/accessibility';
 export type MenuContextValue = {
   activeIndex: number;
   variables: ComponentVariablesInput;
-  onItemClick: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
-  onMouseEnter: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
+  onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
 
   slotProps: {
     item: Record<string, any>;
@@ -24,7 +23,7 @@ export type MenuContextValue = {
   };
 };
 
-export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemClick' | 'onMouseEnter'> & {
+export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemSelect'> & {
   slotProps: MenuContextValue['slotProps']['item'];
   accessibility: MenuContextValue['behaviors']['item'];
   menuSlot: MenuContextValue['slots']['menu'];
@@ -40,8 +39,7 @@ export const MenuContext = createContext<MenuContextValue>(
   {
     activeIndex: -1,
     variables: {},
-    onItemClick: null,
-    onMouseEnter: null,
+    onItemSelect: null,
     slotProps: {
       item: {},
       divider: {},


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes https://github.com/microsoft/fluent-ui-react/issues/1783
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds `on` property to MenuItem to allow opening the submenu on hover. 

![cLG8807FJE](https://user-images.githubusercontent.com/8545105/91049898-33c24b00-e61e-11ea-8359-e8f8b6d56302.gif)

#### Focus areas to test

(optional)
