### PR TITLE
fix(BasePicker): suggestion list is opened event if the inputvalue is…

### DIFF
--- a/change/office-ui-fabric-react-2020-08-24-18-29-52-fix-BasePicker.json
+++ b/change/office-ui-fabric-react-2020-08-24-18-29-52-fix-BasePicker.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix(BasePicker): suggestion list is opened event if the inputvalue is empty",
+  "packageName": "office-ui-fabric-react",
+  "email": "tdetugny@clever-age.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-24T16:29:52.488Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -495,13 +495,19 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends React.Componen
     // Only set suggestionloading to false after there has been time for the new suggestions to flow
     // to the suggestions list. This is to ensure that the suggestions are available before aria-activedescendant
     // is set so that screen readers will read out the first selected option.
-    this.setState(
-      {
+    if (updatedValue === '') {
+      this.suggestionStore.deselectAllSuggestions();
+      this.forceUpdate();
+      this.setState({
+        suggestedDisplayValue: '',
+        suggestionsVisible: true,
+      }, function () { return this.setState({ suggestionsLoading: false }); });
+    } else {
+      this.setState({
         suggestedDisplayValue: itemValue,
         suggestionsVisible: this._getShowSuggestions(),
-      },
-      () => this.setState({ suggestionsLoading: false }),
-    );
+      }, function () { return this.setState({ suggestionsLoading: false }); });
+    }
   }
 
   protected onChange(items?: T[]) {

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsController.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/SuggestionsController.ts
@@ -77,7 +77,7 @@ export class SuggestionsController<T> {
   }
 
   public hasSelectedSuggestion(): boolean {
-    return this.currentSuggestion ? true : false;
+    return this.currentSuggestion && this.currentSuggestion.selected ? true : false;
   }
 
   public removeSuggestion(index: number): void {
@@ -86,7 +86,7 @@ export class SuggestionsController<T> {
 
   public createGenericSuggestion(itemToConvert: ISuggestionModel<T> | T) {
     const itemToAdd = this.convertSuggestionsToSuggestionItems([itemToConvert])[0];
-    this.currentSuggestion = itemToAdd;
+    this.currentSuggestion = { ...itemToAdd, selected: true };
   }
 
   public convertSuggestionsToSuggestionItems(suggestions: Array<ISuggestionModel<T> | T>): ISuggestionModel<T>[] {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes
currently:
When user enter value then remove it, the suggestion is closed
Expected:
When user enter value then remove it, the suggestion **should always be open**

#### Focus areas to test

(optional)
