### PR TITLE
fix(RadioGroupItem): do not always `preventDefault()`

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix a warning when the `inverted` prop was used in `TextArea` @layershifter ([#14357](https://github.com/microsoft/fluentui/pull/14357))
 - Fix `Tree` component to correctly keep track of the `activeItemIds` @assuncaocharles ([#14507](https://github.com/microsoft/fluentui/pull/14507))
 - Fix `Menu` underlined focus style @assuncaocharles ([#14525](https://github.com/microsoft/fluentui/pull/14525))
+- Do not always `preventDefault()` in `RadioGroupItem` @layershifter ([#14717](https://github.com/microsoft/fluentui/pull/14717))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/RadioGroup/RadioGroupItem.tsx
@@ -4,7 +4,13 @@ import * as customPropTypes from '@fluentui/react-proptypes';
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import * as _ from 'lodash';
-import { createShorthandFactory, UIComponentProps, ChildrenComponentProps, commonPropTypes } from '../../utils';
+import {
+  createShorthandFactory,
+  UIComponentProps,
+  ChildrenComponentProps,
+  commonPropTypes,
+  shouldPreventDefaultOnKeyDown,
+} from '../../utils';
 import { Box, BoxProps } from '../Box/Box';
 import { ComponentEventHandler, ShorthandValue, FluentComponentStaticProps } from '../../types';
 import {
@@ -129,7 +135,9 @@ export const RadioGroupItem: ComponentWithAs<'div', RadioGroupItemProps> &
     debugName: RadioGroupItem.displayName,
     actionHandlers: {
       performClick: e => {
-        e.preventDefault();
+        if (shouldPreventDefaultOnKeyDown(e)) {
+          e.preventDefault();
+        }
         handleClick(e);
       },
     },

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -14,7 +14,6 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
 import { Ref } from '@fluentui/react-component-ref';
-import { SpacebarKey } from '@fluentui/keyboard-key';
 import {
   childrenExist,
   createShorthandFactory,
@@ -22,6 +21,7 @@ import {
   UIComponentProps,
   ChildrenComponentProps,
   rtlTextContainer,
+  shouldPreventDefaultOnKeyDown,
 } from '../../utils';
 import {
   ComponentEventHandler,
@@ -145,10 +145,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   const getA11Props = useAccessibility(accessibility, {
     actionHandlers: {
       performClick: e => {
-        // This is a temporary fix to only prevent default if it's the space bar pressed to avoid the page scroll
-        // We should handle it correct for all components performing click either by having separated handlers for space or enter
-        // or by dispatching proper event from it
-        if (e.keyCode === SpacebarKey) {
+        if (shouldPreventDefaultOnKeyDown(e)) {
           e.preventDefault();
         }
         e.stopPropagation();

--- a/packages/fluentui/react-northstar/src/utils/index.ts
+++ b/packages/fluentui/react-northstar/src/utils/index.ts
@@ -17,6 +17,7 @@ export { doesNodeContainClick } from './doesNodeContainClick';
 export { pxToRem } from './fontSizeUtility';
 export { createComponent } from './createComponent';
 export { getKindProp } from './getKindProp';
+export { shouldPreventDefaultOnKeyDown } from './shouldPreventDefaultOnKeyDown';
 export * from './whatInput';
 
 export { screenReaderContainerStyles } from './accessibility/Styles/accessibilityStyles';

--- a/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
+++ b/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
@@ -1,0 +1,12 @@
+import { getCode, SpacebarKey, EnterKey } from '@fluentui/keyboard-key';
+import * as React from 'react';
+
+export function shouldPreventDefaultOnKeyDown(e: React.KeyboardEvent) {
+  const code = getCode(e);
+  const target = e.target as HTMLElement;
+
+  const matchesByKey = code === SpacebarKey || code === EnterKey;
+  const ignoredByTag = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true;
+
+  return matchesByKey && !ignoredByTag;
+}

--- a/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
+++ b/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
@@ -4,12 +4,13 @@ import * as React from 'react';
 /**
  * Checks if `preventDefault()` should be called for a passed keyboard event.
  */
-export function shouldPreventDefaultOnKeyDown(e: React.KeyboardEvent) {
+export function shouldPreventDefaultOnKeyDown(e: KeyboardEvent | React.KeyboardEvent) {
   const code = getCode(e);
-  const target = e.target as HTMLElement;
+  const target: HTMLElement | undefined = e.target as HTMLElement;
 
   const matchesByKey = code === SpacebarKey || code === EnterKey;
-  const ignoredByTag = target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable === true;
+  const ignoredByTag =
+    target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable === true;
 
   return matchesByKey && !ignoredByTag;
 }

--- a/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
+++ b/packages/fluentui/react-northstar/src/utils/shouldPreventDefaultOnKeyDown.ts
@@ -1,6 +1,9 @@
 import { getCode, SpacebarKey, EnterKey } from '@fluentui/keyboard-key';
 import * as React from 'react';
 
+/**
+ * Checks if `preventDefault()` should be called for a passed keyboard event.
+ */
 export function shouldPreventDefaultOnKeyDown(e: React.KeyboardEvent) {
   const code = getCode(e);
   const target = e.target as HTMLElement;

--- a/packages/fluentui/react-northstar/test/specs/utils/shouldPreventDefaultOnKeyDown-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/utils/shouldPreventDefaultOnKeyDown-test.ts
@@ -1,6 +1,6 @@
 import { shouldPreventDefaultOnKeyDown } from '../../../src/utils/shouldPreventDefaultOnKeyDown';
 
-describe('fontSizeUtility', () => {
+describe('shouldPreventDefaultOnKeyDown', () => {
   it('handles proper keys', () => {
     expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: 'Backspace' }))).toBe(false);
     expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: 'Delete' }))).toBe(false);

--- a/packages/fluentui/react-northstar/test/specs/utils/shouldPreventDefaultOnKeyDown-test.ts
+++ b/packages/fluentui/react-northstar/test/specs/utils/shouldPreventDefaultOnKeyDown-test.ts
@@ -1,0 +1,36 @@
+import { shouldPreventDefaultOnKeyDown } from '../../../src/utils/shouldPreventDefaultOnKeyDown';
+
+describe('fontSizeUtility', () => {
+  it('handles proper keys', () => {
+    expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: 'Backspace' }))).toBe(false);
+    expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: 'Delete' }))).toBe(false);
+
+    expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: 'Enter' }))).toBe(true);
+    expect(shouldPreventDefaultOnKeyDown(new KeyboardEvent('keydown', { key: ' ' }))).toBe(true);
+  });
+
+  it('ignores for field-like targets', () => {
+    const divEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    const inputEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+    const textareaEvent = new KeyboardEvent('keydown', { key: 'Enter' });
+
+    document.createElement('div').dispatchEvent(divEvent);
+    document.createElement('input').dispatchEvent(inputEvent);
+    document.createElement('textarea').dispatchEvent(textareaEvent);
+
+    expect(shouldPreventDefaultOnKeyDown(divEvent)).toBe(true);
+    expect(shouldPreventDefaultOnKeyDown(inputEvent)).toBe(false);
+    expect(shouldPreventDefaultOnKeyDown(textareaEvent)).toBe(false);
+  });
+
+  it('ignores for editable targets', () => {
+    const event = new KeyboardEvent('keydown', { key: 'Enter' });
+    const element = document.createElement('div');
+
+    // @ts-ignore
+    element.isContentEditable = true;
+    element.dispatchEvent(event);
+
+    expect(shouldPreventDefaultOnKeyDown(event)).toBe(false);
+  });
+});


### PR DESCRIPTION
#### Description of changes

This PR fixes #13065. Adds a shared `shouldPreventDefaultOnKeyDown()` that should determine if `preventDefault()` should be called as for <kbd>Space</kbd> it also prevents user input in text fields.
