### PR TITLE
OUFR Calendar year picker aria label

### DIFF
--- a/change/office-ui-fabric-react-2020-08-24-18-10-30-master.json
+++ b/change/office-ui-fabric-react-2020-08-24-18-10-30-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "adding aria label on button to clarify what it does",
+  "packageName": "office-ui-fabric-react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T01:10:30.036Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2075,6 +2075,7 @@ export interface ICalendarStrings {
     closeButtonAriaLabel?: string;
     days: string[];
     goToToday: string;
+    monthPickerHeaderAriaLabel?: string;
     months: string[];
     nextMonthAriaLabel?: string;
     nextYearAriaLabel?: string;
@@ -2085,6 +2086,7 @@ export interface ICalendarStrings {
     shortDays: string[];
     shortMonths: string[];
     weekNumberFormatString?: string;
+    yearPickerHeaderAriaLabel?: string;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -265,6 +265,19 @@ export interface ICalendarStrings {
    * Aria-label format string for the week number header. Should have 1 string param e.g. "week number \{0\}"
    */
   weekNumberFormatString?: string;
+
+  /**
+   * Aria-label format string for the header button in the month picker. Should have 1 string param, e.g. "`{0}`,
+   * select to change the year". This aria-label will only be applied if the year picker is enabled; otherwise
+   * the label will default to the header string, e.g. "2019".
+   */
+  monthPickerHeaderAriaLabel?: string;
+
+  /**
+   * Aria-label format string for the header button in the year picker.
+   * Should have 1 string param, e.g. "`{0}`, select to change the month"
+   */
+  yearPickerHeaderAriaLabel?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { KeyCodes, css, getRTL, IRefObject, initializeComponentRef } from '../../Utilities';
+import { KeyCodes, css, getRTL, IRefObject, initializeComponentRef, format } from '../../Utilities';
 import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.types';
 import { FocusZone } from '../../FocusZone';
 import {
@@ -114,6 +114,7 @@ export class CalendarMonth extends React.Component<ICalendarMonthProps, ICalenda
             rangeAriaLabel: this._yearRangeToString,
             prevRangeAriaLabel: this._yearRangeToPrevDecadeLabel,
             nextRangeAriaLabel: this._yearRangeToNextDecadeLabel,
+            headerAriaLabelFormatString: strings.yearPickerHeaderAriaLabel,
           }}
           ref={this._onCalendarYearRef}
         />
@@ -132,6 +133,11 @@ export class CalendarMonth extends React.Component<ICalendarMonthProps, ICalenda
     const isPrevYearInBounds = minDate ? compareDatePart(minDate, getYearStart(navigatedDate)) < 0 : true;
     const isNextYearInBounds = maxDate ? compareDatePart(getYearEnd(navigatedDate), maxDate) < 0 : true;
 
+    const yearString = dateTimeFormatter.formatYear(navigatedDate);
+    const headerAriaLabel = strings.monthPickerHeaderAriaLabel
+      ? format(strings.monthPickerHeaderAriaLabel, yearString)
+      : yearString;
+
     return (
       <div className={css('ms-DatePicker-monthPicker', styles.monthPicker)}>
         <div className={css('ms-DatePicker-header', styles.header)}>
@@ -144,7 +150,7 @@ export class CalendarMonth extends React.Component<ICalendarMonthProps, ICalenda
               )}
               onClick={this._onHeaderSelect}
               onKeyDown={this._onHeaderKeyDown}
-              aria-label={dateTimeFormatter.formatYear(navigatedDate)}
+              aria-label={headerAriaLabel}
               role="button"
               aria-atomic={true}
               aria-live="polite"

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { KeyCodes, css, getRTL } from '../../Utilities';
+import { KeyCodes, css, getRTL, format } from '../../Utilities';
 import { ICalendarIconStrings } from './Calendar.types';
 import { FocusZone } from '../../FocusZone';
 import * as stylesImport from './Calendar.scss';
@@ -22,6 +22,7 @@ export interface ICalendarYearStrings {
   rangeAriaLabel?: string | ICalendarYearRangeToString;
   prevRangeAriaLabel?: string | ICalendarYearRangeToString;
   nextRangeAriaLabel?: string | ICalendarYearRangeToString;
+  headerAriaLabelFormatString?: string;
 }
 
 export interface ICalendarYear {
@@ -294,11 +295,16 @@ class CalendarYearTitle extends React.Component<ICalendarYearHeaderProps, any> {
     if (onHeaderSelect) {
       const strings = this.props.strings || DefaultCalendarYearStrings;
       const rangeAriaLabel = strings.rangeAriaLabel;
-      const ariaLabel = rangeAriaLabel
+      const currentDateRange = rangeAriaLabel
         ? typeof rangeAriaLabel === 'string'
           ? (rangeAriaLabel as string)
           : (rangeAriaLabel as ICalendarYearRangeToString)(this.props)
         : undefined;
+
+      const ariaLabel = strings.headerAriaLabelFormatString
+        ? format(strings.headerAriaLabelFormatString, currentDateRange)
+        : currentDateRange;
+
       return (
         <div
           className={css(

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -32,6 +32,8 @@ const DayPickerStrings = {
   prevYearRangeAriaLabel: 'Previous year range',
   nextYearRangeAriaLabel: 'Next year range',
   closeButtonAriaLabel: 'Close',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 };
 
 export interface ICalendarButtonExampleProps {

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -49,6 +49,8 @@ const dayPickerStrings = {
   prevYearRangeAriaLabel: 'Previous year range',
   nextYearRangeAriaLabel: 'Next year range',
   closeButtonAriaLabel: 'Close',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 };
 const divStyle: React.CSSProperties = {
   height: 'auto',

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -30,6 +30,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 };
 
 const controlClass = mergeStyleSets({

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -38,6 +38,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 
   isRequiredErrorMessage: 'Field is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
@@ -30,6 +30,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 };
 
 const controlClass = mergeStyleSets({

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -31,6 +31,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 
   isRequiredErrorMessage: 'Start date is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
@@ -31,6 +31,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 
   isRequiredErrorMessage: 'Start date is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -30,6 +30,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 
   isRequiredErrorMessage: 'Field is required.',
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -31,6 +31,8 @@ const DayPickerStrings: IDatePickerStrings = {
   prevYearAriaLabel: 'Go to previous year',
   nextYearAriaLabel: 'Go to next year',
   closeButtonAriaLabel: 'Close date picker',
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month',
 };
 
 const controlClass = mergeStyleSets({


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14103 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding an aria-label for the OUFR Calendar component for the year picker and month picker switch button. This fix was previously made for the date-time calendar, porting it over here as well.

#### Focus areas to test

(optional)
