### PR TITLE
feat(compose): replace with reusable styling hooks

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Button/Visual/ButtonExampleComposition.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Visual/ButtonExampleComposition.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { Button, useCSS, ButtonProps } from '@fluentui/react-northstar';
+
+type TertieryButtonProps = ButtonProps & {
+  tertiery?: boolean;
+};
+
+const useTertieryButtonStyles = (props, ...rest) => {
+  const { className, tertiery } = props;
+
+  return useCSS(
+    theme => {
+      const { siteVariables } = theme;
+
+      return tertiery
+        ? {
+            color: 'black',
+            backgroundColor: siteVariables.colorScheme.default.background2,
+          }
+        : {};
+    },
+    ...rest,
+    className,
+  );
+};
+
+const TertieryButton: React.FC<TertieryButtonProps> = props => {
+  const { className, ...rest } = props;
+
+  const resolvedClasses = useTertieryButtonStyles(props);
+
+  return <Button className={resolvedClasses} {...rest} />;
+};
+
+type TertieryCompactButton = TertieryButtonProps;
+
+const useTertieryCompactButtonStyles = (props, ...rest) => {
+  return useTertieryButtonStyles(
+    props,
+    theme => {
+      const { siteVariables } = theme;
+      return {
+        minWidth: '70px',
+        padding: 0,
+        // some overrides
+        ...(props.tertiery && {
+          color: 'white',
+          backgroundColor: siteVariables.colorScheme.red.background,
+        }),
+      };
+    },
+    ...rest,
+  );
+};
+
+const TertieryCompactButton: React.FC<TertieryCompactButton> = props => {
+  const { className, ...rest } = props;
+
+  const resolvedClasses = useTertieryCompactButtonStyles(props);
+
+  return <TertieryButton className={resolvedClasses} {...rest} />;
+};
+
+const ButtonExampleUseCss = () => {
+  const className1 = useCSS(({ siteVariables }) => ({ border: `1px solid ${siteVariables.colors.brand[500]}` }), {
+    color: 'blue',
+  });
+  return (
+    <>
+      <TertieryButton content="Click here" className={className1} />
+      <TertieryButton content="Click here" tertiery />
+      <TertieryButton content="Click here" primary />
+      <TertieryCompactButton content="Click here" tertiery />
+      <TertieryCompactButton content="Click here" />
+    </>
+  );
+};
+
+export default ButtonExampleUseCss;

--- a/packages/fluentui/docs/src/examples/components/Button/Visual/ButtonExampleComposition.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Visual/ButtonExampleComposition.tsx
@@ -25,7 +25,7 @@ const useTertieryButtonStyles = (props, ...rest) => {
 };
 
 const TertieryButton: React.FC<TertieryButtonProps> = props => {
-  const { className, ...rest } = props;
+  const { className, tertiery, ...rest } = props;
 
   const resolvedClasses = useTertieryButtonStyles(props);
 
@@ -54,11 +54,11 @@ const useTertieryCompactButtonStyles = (props, ...rest) => {
 };
 
 const TertieryCompactButton: React.FC<TertieryCompactButton> = props => {
-  const { className, ...rest } = props;
+  const { className, tertiery, ...rest } = props;
 
   const resolvedClasses = useTertieryCompactButtonStyles(props);
 
-  return <TertieryButton className={resolvedClasses} {...rest} />;
+  return <Button className={resolvedClasses} {...rest} />;
 };
 
 const ButtonExampleUseCss = () => {

--- a/packages/fluentui/docs/src/examples/components/Button/Visual/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Visual/index.tsx
@@ -7,6 +7,7 @@ const Types = () => (
   <NonPublicSection title="Visual tests">
     <ComponentExample examplePath="components/Button/Visual/ButtonExampleCompose" />
     <ComponentExample examplePath="components/Button/Visual/ButtonExampleUseCss" />
+    <ComponentExample examplePath="components/Button/Visual/ButtonExampleComposition" />
   </NonPublicSection>
 );
 


### PR DESCRIPTION
This PR showcase how we may replace compose's styling with re-usable styling hooks that can be extended. Currently I am using wrapper components that uses the base component, in this case `<Button />`, but once we have the hooks implementation, we can easily replace this with the usage of the `useButton` hook, which would allow us to not have wrappers. The important thing is that even the `TertieryCompactButton` component uses the same base component, which means that we at least are not exploding the render tree for each new composed components.