### PR TITLE
Delete files after each build job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,6 +50,12 @@ jobs:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
 
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)
+          Contents: '**/*'
+        condition: always()
+
   - job: Deploy
     workspace:
       clean: all
@@ -99,6 +105,12 @@ jobs:
           ContainerName: '$web'
           BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
 
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)
+          Contents: '**/*'
+        condition: always()
+
   - job: ScreenerFluent
     steps:
       - template: azure-pipelines.tools.yml
@@ -145,3 +157,9 @@ jobs:
           SCREENER_API_KEY: $(screener.key)
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
+
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourcesDirectory)
+          Contents: '**/*'
+        condition: always()


### PR DESCRIPTION
Delete the source directory files after each build job. We were doing this before the move to `lage` so hopefully it will fix the "Directory not empty" issue, for example: https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=113016&view=logs&j=e07742bd-189a-5079-918b-43f8b2f94b89&t=22ff51a8-22bd-448a-907f-18266deb7840
![image](https://user-images.githubusercontent.com/5864305/91209255-4db46a00-e6c0-11ea-8e8c-a4f67233af7a.png)