### PR TITLE
TextField: Removing recursive reference in ITextFieldStyles

### DIFF
--- a/change/@fluentui-react-next-2020-08-25-11-20-36-textFieldStylesRecursiveReference.json
+++ b/change/@fluentui-react-next-2020-08-25-11-20-36-textFieldStylesRecursiveReference.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "TextField: Removing recursive reference in ITextFieldStyles.",
+  "packageName": "@fluentui/react-next",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T18:20:36.683Z"
+}

--- a/change/office-ui-fabric-react-2020-08-25-11-20-36-textFieldStylesRecursiveReference.json
+++ b/change/office-ui-fabric-react-2020-08-25-11-20-36-textFieldStylesRecursiveReference.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "TextField: Removing recursive reference in ITextFieldStyles.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T18:20:33.822Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -33,7 +33,6 @@ import { IStyle } from '@uifabric/styling';
 import { IStyleableComponentProps } from '@uifabric/foundation';
 import { IStyleFunction } from '@uifabric/utilities';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
-import { IStyleSet } from '@uifabric/styling';
 import { ITheme } from '@uifabric/styling';
 import { KeyCodes } from '@uifabric/utilities';
 import { Omit } from '@uifabric/utilities';
@@ -7802,7 +7801,7 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> & Pi
 };
 
 // @public (undocumented)
-export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+export interface ITextFieldStyles {
     description: IStyle;
     errorMessage: IStyle;
     field: IStyle;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyle, IStyleSet, ITheme } from '../../Styling';
+import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IIconProps } from '../../Icon';
 
@@ -324,7 +324,7 @@ export interface ITextFieldSubComponentStyles {
 /**
  * {@docCategory TextField}
  */
-export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+export interface ITextFieldStyles {
   /**
    * Style for root element.
    */

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -32,7 +32,6 @@ import { ISelectableDroppableTextProps } from 'office-ui-fabric-react/lib/utilit
 import { ISelectableOption } from 'office-ui-fabric-react/lib/utilities/selectableOption/SelectableOption.types';
 import { IStyle } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
-import { IStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';
 import { ISvgIconProps } from '@fluentui/react-icons';
 import { ITeachingBubble } from 'office-ui-fabric-react/lib/TeachingBubble';
@@ -2038,7 +2037,7 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> & Pi
 };
 
 // @public (undocumented)
-export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+export interface ITextFieldStyles {
     description: IStyle;
     errorMessage: IStyle;
     field: IStyle;

--- a/packages/react-next/src/components/TextField/TextField.types.ts
+++ b/packages/react-next/src/components/TextField/TextField.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IStyle, IStyleSet, ITheme } from '../../Styling';
+import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { IIconProps } from '../../Icon';
 
@@ -325,7 +325,7 @@ export interface ITextFieldSubComponentStyles {
 /**
  * {@docCategory TextField}
  */
-export interface ITextFieldStyles extends IStyleSet<ITextFieldStyles> {
+export interface ITextFieldStyles {
   /**
    * Style for root element.
    */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14711
- [x] Include a change request file using `$ yarn change`

#### Description of changes

An upgrade to TypeScript 4.0 uncovered an error in the definition for `ITextFieldStyles` where it was recursively referencing itself as a base type. This PR fixes this issue by removing this recursive reference.

#### Focus areas to test

(optional)
