### PR TITLE
Adding .tsv as supported extension for spreadsheet filetype icon.

### DIFF
--- a/change/@uifabric-file-type-icons-2020-08-25-13-18-37-caperez-filetype_tsv.json
+++ b/change/@uifabric-file-type-icons-2020-08-25-13-18-37-caperez-filetype_tsv.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding .tsv as supported extension for spreadsheet filetype icon.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-25T20:18:37.805Z"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -409,7 +409,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   sponews: {},
   spreadsheet: {
-    extensions: ['odc', 'ods', 'gsheet', 'numbers'],
+    extensions: ['odc', 'ods', 'gsheet', 'numbers', 'tsv'],
   },
   stream: {},
   rtf: {

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200817.003/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200821.001/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Added .tsv to filetype icon map
- [x] Include a change request file using `$ yarn change`

#### Description of changes

.tsv files will no longer get a blank generic icon. they will get the same icon as other non-1st-party spreadsheet formats

#### Focus areas to test

filetype icons package when passed a .tsv extension should show green spreadsheet icon (tested)
