### PR TITLE
Fixed incorrect margin of Attachment icon after code editing (UI builder)

### DIFF
--- a/packages/fluentui/react-builder/src/utils/codeToTree.ts
+++ b/packages/fluentui/react-builder/src/utils/codeToTree.ts
@@ -1,5 +1,4 @@
 import { transform } from '@babel/standalone';
-import { getUUID } from './getUUID';
 import { JSONTreeElement } from '../components/types';
 
 const prefixElementNamesPlugin = ({ types }) => {
@@ -47,7 +46,7 @@ export const codeToTree: (code: string) => JSONTreeElement = code => {
       }
     }
 
-    const uuid = props?.['data-builder-id'] ?? getUUID();
+    const uuid = props?.['data-builder-id'];
     delete props?.['data-builder-id'];
 
     return {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When the props of `Attachment ` are changed in the code editor of UI builder. The Icon of attachment is moved due to added margin. This PR fix this issue.