### PR TITLE
fix date picker controlled scenario

### DIFF
--- a/change/@uifabric-date-time-2020-08-26-10-38-21-lorejoh12-fixDatePickerControlled.json
+++ b/change/@uifabric-date-time-2020-08-26-10-38-21-lorejoh12-fixDatePickerControlled.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "adding fix for scenario where DatePicker is fully controlled and the internal selected date updates, but the formatted date does not. Also adding example to verify in the future",
+  "packageName": "@uifabric/date-time",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T17:38:21.922Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -132,9 +132,7 @@ function useSelectedDate({ formatDate, value, onSelectDate }: IDatePickerProps) 
 
   React.useEffect(() => {
     setFormattedDate(value && formatDate ? formatDate(value) : '');
-    // setSelectedDate already updates the formatetd date if value changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [formatDate]);
+  }, [formatDate, value]);
 
   return [selectedDate, formattedDate, setSelectedDate, setFormattedDate] as const;
 }
@@ -418,6 +416,10 @@ export const DatePickerBase = React.forwardRef(
       // don't need to focus the text box, if necessary the focusTrapZone will do it
     };
 
+    const calloutDismissed = (ev: React.MouseEvent<HTMLElement>): void => {
+      calendarDismissed();
+    };
+
     const handleEscKey = (ev: React.KeyboardEvent<HTMLElement>): void => {
       ev.stopPropagation();
       calendarDismissed();
@@ -487,7 +489,7 @@ export const DatePickerBase = React.forwardRef(
             {...calloutProps}
             className={css(classNames.callout, calloutProps && calloutProps.className)}
             // eslint-disable-next-line react/jsx-no-bind
-            onDismiss={calendarDismissed}
+            onDismiss={calloutDismissed}
             // eslint-disable-next-line react/jsx-no-bind
             onPositioned={onCalloutPositioned}
           >

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.ExternalControls.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.ExternalControls.Example.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import { DatePicker, defaultDayPickerStrings } from '@uifabric/date-time';
+import './DatePicker.Examples.scss';
+import { addDays } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { mergeStyleSets } from '@uifabric/styling';
+
+const styles = mergeStyleSets({
+  button: { margin: '17px 10px 0 0' },
+});
+
+export const DatePickerExternalControlsExample = () => {
+  const [selectedDate, setSelectedDate] = React.useState<Date | undefined>(new Date());
+
+  const onSelectDate = React.useCallback((date: Date | null | undefined) => {
+    setSelectedDate(date || undefined);
+  }, []);
+
+  const goPrevious = React.useCallback(() => {
+    if (selectedDate) {
+      const newSelectedDate = addDays(selectedDate, -1);
+      setSelectedDate(newSelectedDate);
+    }
+  }, [selectedDate]);
+
+  const goNext = React.useCallback(() => {
+    if (selectedDate) {
+      const newSelectedDate = addDays(selectedDate, 1);
+      setSelectedDate(newSelectedDate);
+    }
+  }, [selectedDate]);
+
+  return (
+    <div className="docs-DatePickerExample">
+      <DatePicker
+        value={selectedDate}
+        onSelectDate={onSelectDate}
+        strings={defaultDayPickerStrings}
+        placeholder="Select a date..."
+        ariaLabel="Select a date"
+      />
+      <div>
+        <DefaultButton className={styles.button} onClick={goPrevious} text="Previous" />
+        <DefaultButton className={styles.button} onClick={goNext} text="Next" />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

adding fix for scenario where DatePicker is fully controlled and the internal selected date updates, but the formatted date does not. Also adding example to verify in the future.

Comments seem to suggest that updating the passed value prop to DatePicker was expected to call setSelectedDate somewhere, but value isn't a dependency of any useEffects and that function never gets called. Might have been left over from an earlier commit.

#### Focus areas to test

(optional)
