### PR TITLE
Codemods: Add config to streamline mod running process

### DIFF
--- a/change/@fluentui-codemods-2020-08-26-13-21-01-t-dama-npx_config.json
+++ b/change/@fluentui-codemods-2020-08-26-13-21-01-t-dama-npx_config.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add support for a config-based codemod execution",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T17:21:01.347Z"
+}

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -53,6 +53,22 @@ from the codemods package root to create a tar file for testing. Move the create
 npx <tarFileName>
 ```
 
+## npx Flags & Config
+
+- There are currently 4 npx flags:
+  - `-n` Specify name(s) of codemod(s) to run. You can find these names in `codemods/src/codemods/mods`. Make sure that they are `enabled` before running them, or else they won't run!
+  - `-r` Specify regex pattern(s) to identify mod(s) to run.
+  - `-e` Boolean flag that flips the inclusion of the specify mods. Use this flag with the selective flags `-n` or `-r` to opt to _exclude_ the selected mods rather than include them.
+  - `-c` For developers who don't want to worry about the command line, they can create a `modConfig.json` file in their repo. The template for the file looks like this, where `stringFilters` and `regexFilters` would correspond to inputs following `-n` and `-c`, respectively:
+  ```jsonld=
+  {
+  "stringFilters": [],
+  "regexFilters": [],
+  "includeMods": true
+  }
+  ```
+- If you specify no flags, npx will run all `enabled` codeods.
+
 ## Todos
 
 - Write a `flag` utility that will enable devs to note when a part of a file needs to be changed, but cannot be done via codemod.

--- a/packages/codemods/src/codeMods/types.ts
+++ b/packages/codemods/src/codeMods/types.ts
@@ -144,3 +144,13 @@ export type ModOptions = {
   name: string;
   version: string;
 };
+
+/* A configuration type for running codemods, stored in modConfig.json.
+   Users can specify either string or regex filters to specify which mods
+   they want to run. They can also specify whether they want their selected
+   mods to be included OR excluded when running mods. */
+export type ModRunnerConfigType = {
+  stringFilters: string[];
+  regexFilters: string[];
+  includeMods: boolean;
+};

--- a/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
+++ b/packages/codemods/src/codeMods/utilities/helpers/propHelpers.ts
@@ -12,7 +12,7 @@ import {
 } from 'ts-morph';
 import { ValueMap, SpreadPropInStatement, NoOp } from '../../types';
 import { Maybe } from '../../../helpers/maybe';
-import { Result, Err, Ok } from '../../../../src/helpers/result';
+import { Result, Err, Ok } from '../../../helpers/result';
 
 /* Helper function to rename a prop if in a spread operator.
 

--- a/packages/codemods/src/codeMods/utilities/props.ts
+++ b/packages/codemods/src/codeMods/utilities/props.ts
@@ -2,7 +2,7 @@ import { renamePropInSpread } from './helpers/propHelpers';
 import { JsxOpeningElement, JsxSelfClosingElement, SyntaxKind } from 'ts-morph';
 import { Maybe } from '../../helpers/maybe';
 import { PropTransform, NoOp } from '../types';
-import { Result, Ok, Err } from '../../../src/helpers/result';
+import { Result, Ok, Err } from '../../helpers/result';
 
 export function renameProp(
   instances: (JsxOpeningElement | JsxSelfClosingElement)[],

--- a/packages/codemods/src/codeMods/utilities/transforms.ts
+++ b/packages/codemods/src/codeMods/utilities/transforms.ts
@@ -1,7 +1,7 @@
 import { PropTransform, ValueMap } from '../types';
 import { JsxExpression, SyntaxKind, JsxOpeningElement, JsxSelfClosingElement } from 'ts-morph';
 import { renamePropInSpread } from './helpers/propHelpers';
-import { Err, Ok } from '../../../src/helpers/result';
+import { Err, Ok } from '../../helpers/result';
 
 /*
 Steps to writing a transform:

--- a/packages/codemods/src/command.ts
+++ b/packages/codemods/src/command.ts
@@ -57,7 +57,7 @@ export class CommandParser {
     let configObj: ModRunnerConfigType = { stringFilters: [], regexFilters: [], includeMods: false };
     if (parsed.config) {
       /* Attempt to locate the modConfig file in the user's repo. */
-      const configResult = runConfig();
+      const configResult = getModRunnerConfig();
       if (configResult.ok) {
         configObj = configResult.value;
       } else {
@@ -81,24 +81,19 @@ export class CommandParser {
   }
 }
 
-function runConfig(): Result<ModRunnerConfigType, NoOp> {
-  const foundJsonFile = getModRunnerConfig();
-  let configObj: ModRunnerConfigType = { stringFilters: [], regexFilters: [], includeMods: false };
-  console.log('Configuration detected. Attempting to run mods from config...');
-  if (!foundJsonFile || foundJsonFile.length !== 1) {
-    return Err({ reason: 'Error, could not locate correct config file.' });
-  } else {
-    configObj = require(foundJsonFile[0]);
-    return Ok(configObj);
-  }
-}
-
-function getModRunnerConfig(): string[] {
+function getModRunnerConfig(): Result<ModRunnerConfigType, NoOp> {
   const foundJsonFile = new Glob('/**/modConfig.json', {
     absolute: false,
     root: process.cwd(),
     ignore: ['**/node_modules/**'],
     sync: true,
   });
-  return foundJsonFile.found;
+  let configObj: ModRunnerConfigType = { stringFilters: [], regexFilters: [], includeMods: false };
+  console.log('Configuration detected. Attempting to run mods from config...');
+  if (!foundJsonFile.found || foundJsonFile.found.length !== 1) {
+    return Err({ reason: 'Error, could not locate correct config file.' });
+  } else {
+    configObj = require(foundJsonFile.found[0]);
+    return Ok(configObj);
+  }
 }

--- a/packages/codemods/src/modRunner/modConfig.json
+++ b/packages/codemods/src/modRunner/modConfig.json
@@ -1,5 +1,0 @@
-{
-  "stringFilters": [],
-  "regexFilters": [],
-  "includeMods": true
-}

--- a/packages/codemods/src/modRunner/modConfig.json
+++ b/packages/codemods/src/modRunner/modConfig.json
@@ -1,0 +1,5 @@
+{
+  "stringFilters": [],
+  "regexFilters": [],
+  "includeMods": true
+}


### PR DESCRIPTION
Added a config option for devs running their codemods. Now, devs can fill out a simple config file, and let that file determine what mods to run instead of dealing with the command line!

Here's the file devs would need to add to their repo:
`modConfig.json`
  ```
  {
  "stringFilters": [],
  "regexFilters": [],
  "includeMods": true
  }
  ```
where stringFilters corresponds to the -n flag and regexFilters corresponds to the -r flag when normally running mods. includeMods acts as the inverse of the -e flag.

I also had to change a couple import paths that were crashing the modrunner.