### PR TITLE
Remove ngrok dependency

### DIFF
--- a/scripts/local-codepen.js
+++ b/scripts/local-codepen.js
@@ -11,7 +11,15 @@ const webpackConfigFilePath = options.webpackConfig || 'webpack.codepen.config.j
 const configPath = path.resolve(process.cwd(), webpackConfigFilePath);
 
 if (fs.existsSync(configPath)) {
-  const ngrok = require('ngrok');
+  let ngrok;
+  try {
+    ngrok = require('ngrok');
+  } catch (err) {
+    // ngrok has a postbuild step which was slowing down yarn install, so it's been removed
+    // from the repo dependency list (since this script is the only place it's used)
+    console.error('This script requires a global install of ngrok: "npm i -g ngrok@3"');
+    process.exit(1);
+  }
   const webpackConfig = require(configPath);
   const compiler = webpack(webpackConfig);
   const devServerOptions = Object.assign({}, webpackConfig.devServer, {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -107,7 +107,6 @@
     "lerna-alias": "^3.0.3-0",
     "license-webpack-plugin": "^2.1.1",
     "markdown-table": "^2.0.0",
-    "ngrok": "^3.0.1",
     "node-plop": "^0.25.0",
     "node-sass": "^4.14.1",
     "p-queue": "^6.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4231,7 +4231,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.13.tgz#ccebcdb990bd6139cd16e84c39dc2fb1023ca90c"
   integrity sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==
 
-"@types/node@8.10.54", "@types/node@^8.0.19", "@types/node@^8.10.30":
+"@types/node@8.10.54", "@types/node@^8.0.19":
   version "8.10.54"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.54.tgz#1c88eb253ac1210f1a5876953fb70f7cc4928402"
   integrity sha512-kaYyLYf6ICn6/isAyD4K1MyWWd5Q3JgH6bnMN089LUx88+s4W8GvK9Q6JMBVu5vsFFp7pMdSxdKmlBXwH/VFRg==
@@ -17075,17 +17075,6 @@ next-tick@^1.0.0, next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
-
-ngrok@^3.0.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/ngrok/-/ngrok-3.2.1.tgz#b9db022fce862711122e404b4763145eb6387aa3"
-  integrity sha512-gbRPHmAfBgIsgRGXE25c3NZXZXs4mpgPuQSPSq02r8QBk4VMoByiLJXKXrUCQm37x/Kfl8cIsWreWDgdNobtOQ==
-  dependencies:
-    "@types/node" "^8.10.30"
-    decompress-zip "^0.3.2"
-    request "^2.88.0"
-    request-promise-native "^1.0.5"
-    uuid "^3.3.2"
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
Remove `ngrok` dependency which was only used for the `local-codepen` script. The script now attempts to use a global install of `ngrok` instead, and instructs the user to install it if not found.

This doesn't fix the main issue which was blocking VMSS use since that was with `screener-ngrok` (not original `ngrok`), but it does speed up install a little since regular `ngrok` also has a slow postinstall script.