### PR TITLE
Fix FluentTheme in @uifabric/fluent-theme

### DIFF
--- a/change/@uifabric-fluent-theme-2020-08-26-12-39-37-xgao-fluent-theme-fix.json
+++ b/change/@uifabric-fluent-theme-2020-08-26-12-39-37-xgao-fluent-theme-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix undefined FluentTheme due to circular dep",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-26T19:39:37.522Z"
+}

--- a/packages/fluent-theme/src/fluent/FluentTheme.ts
+++ b/packages/fluent-theme/src/fluent/FluentTheme.ts
@@ -1,31 +1,5 @@
 import { createTheme, ITheme } from '@uifabric/styling';
-import { NeutralColors, SharedColors, Depths } from './index';
 
-export const FluentTheme: ITheme = createTheme({
-  palette: {
-    neutralDark: NeutralColors.gray190,
-    neutralPrimary: NeutralColors.gray160,
-    neutralPrimaryAlt: NeutralColors.gray150,
-    neutralSecondary: NeutralColors.gray130,
-    neutralSecondaryAlt: NeutralColors.gray110,
-    neutralTertiary: NeutralColors.gray90,
-    neutralTertiaryAlt: NeutralColors.gray60,
-    neutralQuaternary: NeutralColors.gray50,
-    neutralQuaternaryAlt: NeutralColors.gray40,
-    neutralLight: NeutralColors.gray30,
-    neutralLighter: NeutralColors.gray20,
-    neutralLighterAlt: NeutralColors.gray10,
-    // Shared Colors
-    red: SharedColors.red10,
-    redDark: SharedColors.red20,
-  },
-  effects: {
-    roundedCorner2: '2px',
-    elevation4: Depths.depth4,
-    elevation8: Depths.depth8,
-    elevation16: Depths.depth16,
-    elevation64: Depths.depth64,
-  },
-});
+export const FluentTheme: ITheme = createTheme({});
 
 export default FluentTheme;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

@JasonGore reported seeing `FluentTheme` undefined. I believe the issue might be caused by [my recent change](https://github.com/microsoft/fluentui/pull/14650/files#diff-e84a2d766b425d3a470bbc34dc426ad3), which adds dep on `index` which cause issue when `index` is importing `FluentTheme`

I also removed some logic since `createTheme` today returns Fluent theme

#### Focus areas to test

(optional)
