### PR TITLE
Release build should only build published packages

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -19,11 +19,11 @@ schedules:
       include:
         - master
 
+workspace:
+  clean: all
+
 steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '10.x'
-    displayName: 'Install Node.js'
+  - template: azure-pipelines.tools.yml
 
   - script: |
       git config user.name "Fluent UI Build"
@@ -40,8 +40,20 @@ steps:
     displayName: yarn generate-version-files
 
   - script: |
-      yarn buildci:prod
-    displayName: yarn buildci:prod (Create production build)
+      yarn run:published build --production
+    displayName: yarn build (Create production build)
+
+  - script: |
+      yarn run:published test --production
+    displayName: yarn test
+
+  - script: |
+      yarn run:published lint
+    displayName: yarn lint
+
+  - script: |
+      yarn run:published bundle --production
+    displayName: yarn bundle
 
   - script: |
       echo Making $(Build.ArtifactStagingDirectory)/api &&

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,12 +50,6 @@ jobs:
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
 
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)
-          Contents: '**/*'
-        condition: always()
-
   - job: Deploy
     workspace:
       clean: all
@@ -105,13 +99,9 @@ jobs:
           ContainerName: '$web'
           BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
 
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)
-          Contents: '**/*'
-        condition: always()
-
   - job: ScreenerFluent
+    workspace:
+      clean: all
     steps:
       - template: azure-pipelines.tools.yml
 
@@ -126,12 +116,6 @@ jobs:
         displayName: run FUI VR Test
         env:
           SCREENER_API_KEY: $(screener.key)
-
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)
-          Contents: '**/*'
-        condition: always()
 
   - job: Screener
     workspace:
@@ -157,9 +141,3 @@ jobs:
           SCREENER_API_KEY: $(screener.key)
           BACKFILL_CACHE_PROVIDER: 'azure-blob'
           BACKFILL_CACHE_PROVIDER_OPTIONS: '{"connectionString":"$(BACKFILL_CONNECTION_STRING)", "container":"$(BACKFILL_CONTAINER)"}'
-
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourcesDirectory)
-          Contents: '**/*'
-        condition: always()

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "rebuild": "node ./scripts/invalidate-just-cache.js && npm run build",
     "release:fluentui:minor": "yarn workspace @uifabric/build just fluentui:publish:minor",
     "release:fluentui:patch": "yarn workspace @uifabric/build just fluentui:publish:patch",
+    "runto": "node ./scripts/monorepo/runTo.js",
+    "run:published": "node ./scripts/monorepo/runPublished.js",
     "satisfied": "satisfied --skip-invalid",
     "scrub": "node ./scripts/scrub.js",
     "start:legacy": "yarn workspace @uifabric/fabric-website-resources start",

--- a/scripts/monorepo/buildTo.js
+++ b/scripts/monorepo/buildTo.js
@@ -1,12 +1,10 @@
 // @ts-check
 
-const { spawnSync } = require('child_process');
-const lernaBin = require.resolve('lerna/cli.js');
-const getAllPackageInfo = require('./getAllPackageInfo');
+const runTo = require('./runTo');
 
 const argv = process.argv.slice(2);
 
-// Display a usage message when there is no projects specified
+// Display a usage message when there are no projects specified
 if (argv.length < 1) {
   console.log(`Usage:
 
@@ -24,40 +22,4 @@ const restIndex = argv.findIndex(arg => arg.startsWith('--'));
 const projects = restIndex === -1 ? argv : argv.slice(0, restIndex);
 const rest = restIndex === -1 ? [] : argv.slice(argv[restIndex] === '--' ? restIndex + 1 : restIndex);
 
-// This script matches substrings of the input for one more many projects
-const allPackages = getAllPackageInfo();
-
-const foundProjects = /** @type {string[]} */ ([]);
-
-for (const project of projects) {
-  if (allPackages[project]) {
-    foundProjects.push(project);
-  } else {
-    const packagesForProject = Object.keys(allPackages).filter(name => name.includes(project));
-    if (packagesForProject.length === 0) {
-      console.log(`There is no project matching "${project}" in this repo`);
-    } else if (packagesForProject.length > 1) {
-      console.log(`More than one project matched: "${packagesForProject.join('", "')}"`);
-    } else {
-      console.log(`Found a matching project named "${packagesForProject[0]}"`);
-    }
-    foundProjects.push(...packagesForProject);
-  }
-}
-
-const scopes = [];
-foundProjects.forEach(projectName => {
-  // --scope limits build to a specified package
-  scopes.push('--scope');
-  scopes.push(projectName);
-});
-
-// --include-filtered-Dependencies makes the build include dependencies
-// --stream allows the build to proceed in parallel but still in order
-spawnSync(
-  process.execPath,
-  [lernaBin, 'run', 'build', ...scopes, '--include-filtered-dependencies', '--stream', '--', ...rest],
-  {
-    stdio: 'inherit',
-  },
-);
+runTo('build', projects, rest);

--- a/scripts/monorepo/index.d.ts
+++ b/scripts/monorepo/index.d.ts
@@ -4,6 +4,7 @@ export interface PackageJson {
   main: string;
   types?: string;
   module?: string;
+  private?: boolean;
   dependencies?: { [key: string]: string };
   devDependencies?: { [key: string]: string };
   peerDependencies?: { [key: string]: string };

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -1,0 +1,25 @@
+// @ts-check
+const getAllPackageInfo = require('./getAllPackageInfo');
+const runTo = require('./runTo');
+
+const argv = process.argv.slice(2);
+
+if (argv.length < 1) {
+  console.log(`Usage:
+
+  yarn run:published <script> [<args>]
+
+This command runs <script> for all beachball-published packages (and their dependencies).
+`);
+
+  process.exit(0);
+}
+
+const script = argv[0];
+const rest = argv.slice(1);
+
+const beachballPackages = Object.entries(getAllPackageInfo())
+  .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
+  .map(([packageName]) => packageName);
+
+runTo(script, beachballPackages, rest);

--- a/scripts/monorepo/runPublished.js
+++ b/scripts/monorepo/runPublished.js
@@ -18,6 +18,10 @@ This command runs <script> for all beachball-published packages (and their depen
 const script = argv[0];
 const rest = argv.slice(1);
 
+// Only include the packages that are published daily by beachball.
+// This logic does the same thing as "--scope \"!packages/fluentui/*\"" in the root package.json's
+// publishing-related scripts (and excludes private packages, which beachball does internally).
+// It will need to be updated if the --scope changes.
 const beachballPackages = Object.entries(getAllPackageInfo())
   .filter(([, { packageJson, packagePath }]) => !/[\\/]fluentui[\\/]/.test(packagePath) && packageJson.private !== true)
   .map(([packageName]) => packageName);

--- a/scripts/monorepo/runTo.js
+++ b/scripts/monorepo/runTo.js
@@ -1,0 +1,78 @@
+// @ts-check
+
+const { spawnSync } = require('child_process');
+const lernaBin = require.resolve('lerna/cli.js');
+const getAllPackageInfo = require('./getAllPackageInfo');
+
+const argv = process.argv.slice(2);
+
+// @ts-ignore
+if (require.main === module) {
+  // Display a usage message when there are no projects specified
+  if (argv.length < 2) {
+    console.log(`Usage:
+
+  yarn runto <script> <packagename1> [<packagename2> ...] [<args>]
+
+This command runs <script> for all packages up to and including "packagename1" (and "packagename2" etc).
+The package name can be a substring.
+If multiple packages match a pattern, they will all be built (along with their dependencies).
+`);
+
+    process.exit(0);
+  }
+
+  const restIndex = argv.findIndex(arg => arg.startsWith('--'));
+  const script = argv[0];
+  const projects = restIndex === -1 ? argv.slice(1) : argv.slice(1, restIndex);
+  const rest = restIndex === -1 ? [] : argv.slice(argv[restIndex] === '--' ? restIndex + 1 : restIndex);
+
+  runTo(script, projects, rest);
+}
+
+/**
+ * @param {string} script - Script to run
+ * @param {string[]} projects - Projects to run in
+ * @param {string[]} rest - Args to pass on
+ */
+function runTo(script, projects, rest) {
+  // This script matches substrings of the input for one more many projects
+  const allPackages = getAllPackageInfo();
+
+  const foundProjects = /** @type {string[]} */ ([]);
+
+  for (const project of projects) {
+    if (allPackages[project]) {
+      foundProjects.push(project);
+    } else {
+      const packagesForProject = Object.keys(allPackages).filter(name => name.includes(project));
+      if (packagesForProject.length === 0) {
+        console.log(`There is no project matching "${project}" in this repo`);
+      } else if (packagesForProject.length > 1) {
+        console.log(`More than one project matched: "${packagesForProject.join('", "')}"`);
+      } else {
+        console.log(`Found a matching project named "${packagesForProject[0]}"`);
+      }
+      foundProjects.push(...packagesForProject);
+    }
+  }
+
+  const scopes = [];
+  foundProjects.forEach(projectName => {
+    // --scope limits build to a specified package
+    scopes.push('--scope');
+    scopes.push(projectName);
+  });
+
+  // --include-filtered-Dependencies makes the build include dependencies
+  // --stream allows the build to proceed in parallel but still in order
+  spawnSync(
+    process.execPath,
+    [lernaBin, 'run', script, ...scopes, '--include-filtered-dependencies', '--stream', '--', ...rest],
+    {
+      stdio: 'inherit',
+    },
+  );
+}
+
+module.exports = runTo;

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,7 +7,7 @@
     "just-scripts": "./just-scripts.js"
   },
   "scripts": {
-    "build": "node ./just-scripts.js no-op",
+    "build": "echo no-op",
     "bundlesize": "bundlesize --debug",
     "clean": "",
     "code-style": "node ./just-scripts.js code-style"


### PR DESCRIPTION
The release build tasks should be scoped to only the packages which are published with beachball. That should make the release builds faster since we won't be building react-northstar and v0 docs.

I also realized that probably the reason we were getting the intermittent "Directory not empty" error on CI builds was because the ScreenerFluent job was missing the `workspace: clean: all` setting. So I'm adding that and deleting the recently added DeleteFiles.