### PR TITLE
Fix callout positioning when screen is too small for any direction

### DIFF
--- a/change/office-ui-fabric-react-2020-08-26-17-13-35-lorejoh12-fixCalloutPositioning.json
+++ b/change/office-ui-fabric-react-2020-08-26-17-13-35-lorejoh12-fixCalloutPositioning.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing callout positioning when screen is too small to position and DirectionalHint = left* or right* due to using last value from for loop",
+  "packageName": "office-ui-fabric-react",
+  "email": "lorejoh12@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T00:13:35.584Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -250,7 +250,7 @@ function _flipToFit(
   return {
     elementRectangle: rect,
     targetEdge: positionData.targetEdge,
-    alignmentEdge: currentAlignment,
+    alignmentEdge: positionData.alignmentEdge,
   };
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This ended up being really hard to repro the specific circumstances of in the example page, being a combination of DirectionalHint, size of the callout, and position of the target on the page.

From what I can tell, the positioning logic does it's best to take into account whatever DirectionalHint is provided by the consumer, and then measures the positioning around the page to see where to actually lay out. It does this by trying alignment on all 4 edges of the screen to see if any of them fit. As the comment for _flipToFit function states,

```
 * Attempts to move the rectangle through various sides of the target to find a place to fit.
 * If no fit is found, the original position should be returned.
```

However, if no fit is found, the alignmentEdge returned from the function was set to currentAlignment, the variable that's used in the inner loop. So if no edge fits, this function always returned whatever the last value checked was (dependent on the starting targetEdge), rather than the initial aligmentEdge.

This was noticeable in outlook.com when testing a scenario with targetEdge = -2 (using DirectionalHint = RightCenter). After this function ran, if the page was shrunk really small, the alignmentEdge would come out as +2 (the last value checked). When the positioning logic then runs, it tries to set the style `left` for targetEdge, and also set the style `left` for alignment edge (which gets reversed), meaning we never set a `top` or `bottom` value, which results in the Callout always sitting at the top of the page. In the case where no alignment edge was given, this function seems like it should return undefined, so that the styling logic can pick the best edge that's orthogonal to the target edge.

#### Focus areas to test

(optional)
