### PR TITLE
Update IRawStyleBase tying to allow css variable (string) as value

### DIFF
--- a/change/@uifabric-merge-styles-2020-08-26-20-04-41-xgao-update-fontWeight-type.json
+++ b/change/@uifabric-merge-styles-2020-08-26-20-04-41-xgao-update-fontWeight-type.json
@@ -1,8 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update IRawStyleBase.fontWeight tying to allow css variable (string) as value.",
-  "packageName": "@uifabric/merge-styles",
-  "email": "xgao@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2020-08-27T03:04:41.344Z"
-}

--- a/change/@uifabric-merge-styles-2020-08-26-20-04-41-xgao-update-fontWeight-type.json
+++ b/change/@uifabric-merge-styles-2020-08-26-20-04-41-xgao-update-fontWeight-type.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update IRawStyleBase.fontWeight tying to allow css variable (string) as value.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T03:04:41.344Z"
+}

--- a/change/@uifabric-merge-styles-2020-08-27-13-32-47-xgao-update-fontWeight-type.json
+++ b/change/@uifabric-merge-styles-2020-08-27-13-32-47-xgao-update-fontWeight-type.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Update IRawStyleBase tying to allow css variables (string) as acceptable values.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T20:32:47.535Z"
+}

--- a/change/@uifabric-merge-styles-2020-08-27-13-32-47-xgao-update-fontWeight-type.json
+++ b/change/@uifabric-merge-styles-2020-08-27-13-32-47-xgao-update-fontWeight-type.json
@@ -3,6 +3,6 @@
   "comment": "Update IRawStyleBase tying to allow css variables (string) as acceptable values.",
   "packageName": "@uifabric/merge-styles",
   "email": "xgao@microsoft.com",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "minor",
   "date": "2020-08-27T20:32:47.535Z"
 }

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -97,7 +97,7 @@ export interface IRawFontStyle {
     fontSynthesis?: ICSSRule | string;
     fontVariant?: ICSSRule | string;
     fontVariantAlternates?: ICSSRule | string;
-    fontWeight?: IFontWeight;
+    fontWeight?: IFontWeight | string;
 }
 
 // @public

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -91,9 +91,9 @@ export interface IRawFontStyle {
     // Warning: (ae-forgotten-export) The symbol "ICSSPixelUnitRule" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ICSSPercentageRule" needs to be exported by the entry point index.d.ts
     fontSize?: ICSSRule | 'xx-small' | 'x-small' | 'small' | 'medium' | 'large' | 'x-large' | 'xx-large' | 'larger' | 'smaller' | ICSSPixelUnitRule | ICSSPercentageRule;
-    fontSizeAdjust?: ICSSRule | 'none' | number;
-    fontStretch?: ICSSRule | 'normal' | 'ultra-condensed' | 'extra-condensed' | 'condensed' | 'semi-condensed' | 'semi-expanded' | 'expanded' | 'extra-expanded' | 'ultra-expanded';
-    fontStyle?: ICSSRule | 'normal' | 'italic' | 'oblique';
+    fontSizeAdjust?: ICSSRule | 'none' | number | string;
+    fontStretch?: ICSSRule | 'normal' | 'ultra-condensed' | 'extra-condensed' | 'condensed' | 'semi-condensed' | 'semi-expanded' | 'expanded' | 'extra-expanded' | 'ultra-expanded' | string;
+    fontStyle?: ICSSRule | 'normal' | 'italic' | 'oblique' | string;
     fontSynthesis?: ICSSRule | string;
     fontVariant?: ICSSRule | string;
     fontVariantAlternates?: ICSSRule | string;
@@ -112,18 +112,18 @@ export interface IRawStyle extends IRawStyleBase {
 
 // @public
 export interface IRawStyleBase extends IRawFontStyle {
-    alignContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'stretch';
-    alignItems?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
+    alignContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'stretch' | string;
+    alignItems?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch' | string;
     alignmentAdjust?: ICSSRule | string;
     alignmentBaseline?: ICSSRule | string;
     // Warning: (ae-forgotten-export) The symbol "ICSSBaselinePositionRule" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ICSSOverflowAndSelfPositionRule" needs to be exported by the entry point index.d.ts
-    alignSelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule;
+    alignSelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule | string;
     animation?: ICSSRule | string;
     animationDelay?: ICSSRule | string;
     animationDirection?: ICSSRule | string;
     animationDuration?: ICSSRule | string;
-    animationFillMode?: ICSSRule | 'none' | 'forwards' | 'backwards' | 'both';
+    animationFillMode?: ICSSRule | 'none' | 'forwards' | 'backwards' | 'both' | string;
     animationIterationCount?: ICSSRule | string;
     animationName?: ICSSRule | string;
     animationPlayState?: ICSSRule | string;
@@ -132,9 +132,9 @@ export interface IRawStyleBase extends IRawFontStyle {
     backdropFilter?: ICSSRule | string;
     backfaceVisibility?: ICSSRule | string;
     background?: ICSSRule | string;
-    backgroundAttachment?: ICSSRule | 'scroll' | 'fixed' | 'local';
+    backgroundAttachment?: ICSSRule | 'scroll' | 'fixed' | 'local' | string;
     backgroundBlendMode?: ICSSRule | string;
-    backgroundClip?: ICSSRule | 'border-box' | 'padding-box' | 'content-box' | 'text';
+    backgroundClip?: ICSSRule | 'border-box' | 'padding-box' | 'content-box' | 'text' | string;
     backgroundColor?: ICSSRule | string;
     backgroundComposite?: ICSSRule | string;
     backgroundImage?: ICSSRule | string;
@@ -175,14 +175,14 @@ export interface IRawStyleBase extends IRawFontStyle {
     bottom?: ICSSRule | ICSSPixelUnitRule;
     boxDecorationBreak?: ICSSRule | string;
     boxShadow?: ICSSRule | string;
-    boxSizing?: ICSSRule | 'border-box' | 'content-box';
+    boxSizing?: ICSSRule | 'border-box' | 'content-box' | string;
     breakAfter?: ICSSRule | string;
     breakBefore?: ICSSRule | string;
     breakInside?: ICSSRule | string;
     clear?: ICSSRule | string;
     clipRule?: ICSSRule | string;
     color?: ICSSRule | string;
-    columnCount?: ICSSRule | number | 'auto';
+    columnCount?: ICSSRule | number | 'auto' | string;
     columnFill?: ICSSRule | string;
     columnGap?: ICSSRule | string;
     columnRule?: ICSSRule | string;
@@ -199,21 +199,21 @@ export interface IRawStyleBase extends IRawFontStyle {
     cursor?: ICSSRule | string;
     direction?: ICSSRule | string;
     // Warning: (ae-forgotten-export) The symbol "ICSSDisplayRule" needs to be exported by the entry point index.d.ts
-    display?: ICSSRule | ICSSDisplayRule;
+    display?: ICSSRule | ICSSDisplayRule | string;
     fill?: ICSSRule | string;
     fillOpacity?: ICSSRule | number;
     fillRule?: ICSSRule | string;
     filter?: ICSSRule | string;
     flex?: ICSSRule | string | number;
     flexBasis?: ICSSRule | string | number;
-    flexDirection?: ICSSRule | 'row' | 'row-reverse' | 'column' | 'column-reverse';
+    flexDirection?: ICSSRule | 'row' | 'row-reverse' | 'column' | 'column-reverse' | string;
     flexFlow?: ICSSRule | string;
     flexGrow?: ICSSRule | number | string;
     flexShrink?: ICSSRule | number | string;
-    flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse';
+    flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse' | string;
     float?: ICSSRule | string;
     flowFrom?: ICSSRule | string;
-    forcedColorAdjust?: 'auto' | 'none';
+    forcedColorAdjust?: 'auto' | 'none' | string;
     gridArea?: ICSSRule | string;
     gridAutoColumns?: ICSSRule | string;
     gridAutoFlow?: ICSSRule | string;
@@ -237,8 +237,8 @@ export interface IRawStyleBase extends IRawFontStyle {
     hyphenateLimitLines?: ICSSRule | string;
     hyphenateLimitZone?: ICSSRule | string;
     hyphens?: ICSSRule | string;
-    justifyContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch';
-    justifySelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule | 'left' | 'right' | 'safe left' | 'safe right' | 'unsafe left' | 'unsafe right';
+    justifyContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'space-evenly' | 'stretch' | string;
+    justifySelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule | 'left' | 'right' | 'safe left' | 'safe right' | 'unsafe left' | 'unsafe right' | string;
     left?: ICSSRule | ICSSPixelUnitRule;
     letterSpacing?: ICSSRule | string;
     lineHeight?: ICSSRule | 'normal' | ICSSPixelUnitRule | ICSSPercentageRule;
@@ -267,22 +267,22 @@ export interface IRawStyleBase extends IRawFontStyle {
     minHeight?: ICSSRule | ICSSPixelUnitRule;
     minWidth?: ICSSRule | ICSSPixelUnitRule;
     // Warning: (ae-forgotten-export) The symbol "IMixBlendModes" needs to be exported by the entry point index.d.ts
-    mixBlendMode?: ICSSRule | IMixBlendModes;
-    MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
+    mixBlendMode?: ICSSRule | IMixBlendModes | string;
+    MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased' | string;
     MsHighContrastAdjust?: ICSSRule | string;
-    MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar';
-    objectFit?: ICSSRule | 'cover' | 'contain' | 'fill' | 'none';
+    MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar' | string;
+    objectFit?: ICSSRule | 'cover' | 'contain' | 'fill' | 'none' | string;
     opacity?: ICSSRule | number | string;
-    order?: ICSSRule | number;
-    orphans?: ICSSRule | number;
+    order?: ICSSRule | number | string;
+    orphans?: ICSSRule | number | string;
     outline?: ICSSRule | 0 | string;
     outlineColor?: ICSSRule | string;
     outlineOffset?: ICSSRule | string;
     overflow?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible';
     overflowStyle?: ICSSRule | string;
-    overflowWrap?: ICSSRule | 'normal' | 'break-word';
-    overflowX?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible';
-    overflowY?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible';
+    overflowWrap?: ICSSRule | 'normal' | 'break-word' | string;
+    overflowX?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible' | string;
+    overflowY?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible' | string;
     padding?: ICSSRule | ICSSPixelUnitRule;
     paddingBlockEnd?: ICSSRule | ICSSPixelUnitRule;
     paddingBlockStart?: ICSSRule | ICSSPixelUnitRule;
@@ -304,7 +304,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     position?: ICSSRule | 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
     quotes?: ICSSRule | string;
     regionFragment?: ICSSRule | string;
-    resize?: ICSSRule | 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline';
+    resize?: ICSSRule | 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline' | string;
     restAfter?: ICSSRule | string;
     restBefore?: ICSSRule | string;
     right?: ICSSRule | ICSSPixelUnitRule;
@@ -315,8 +315,8 @@ export interface IRawStyleBase extends IRawFontStyle {
     speak?: ICSSRule | string;
     speakAs?: ICSSRule | string;
     stroke?: ICSSRule | string;
-    strokeLinecap?: ICSSRule | 'butt' | 'round' | 'square';
-    strokeOpacity?: ICSSRule | number;
+    strokeLinecap?: ICSSRule | 'butt' | 'round' | 'square' | string;
+    strokeOpacity?: ICSSRule | number | string;
     strokeWidth?: ICSSRule | ICSSPixelUnitRule;
     tableLayout?: ICSSRule | string;
     tabSize?: ICSSRule | string;
@@ -358,7 +358,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     unicodeBidi?: ICSSRule | string;
     userFocus?: ICSSRule | string;
     userInput?: ICSSRule | string;
-    userSelect?: ICSSRule | 'none' | 'auto' | 'text' | 'all' | 'contain';
+    userSelect?: ICSSRule | 'none' | 'auto' | 'text' | 'all' | 'contain' | string;
     verticalAlign?: ICSSRule | string;
     visibility?: ICSSRule | string;
     voiceBalance?: ICSSRule | string;
@@ -370,12 +370,12 @@ export interface IRawStyleBase extends IRawFontStyle {
     voiceStress?: ICSSRule | string;
     voiceVolume?: ICSSRule | string;
     WebkitBackdropFilter?: ICSSRule | string;
-    WebkitFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
-    WebkitOverflowScrolling?: 'auto' | 'touch';
+    WebkitFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased' | string;
+    WebkitOverflowScrolling?: 'auto' | 'touch' | string;
     WebkitTapHighlightColor?: string;
-    WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
+    WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule | string;
     whiteSpace?: ICSSRule | string;
-    widows?: ICSSRule | number;
+    widows?: ICSSRule | number | string;
     width?: ICSSRule | ICSSPixelUnitRule;
     wordBreak?: ICSSRule | string;
     wordSpacing?: ICSSRule | string;
@@ -383,7 +383,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     wrapFlow?: ICSSRule | string;
     wrapMargin?: ICSSRule | string;
     writingMode?: ICSSRule | string;
-    zIndex?: ICSSRule | 'auto' | number;
+    zIndex?: ICSSRule | 'auto' | number | string;
     zoom?: ICSSRule | 'auto' | number | ICSSPercentageRule;
 }
 

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -236,7 +236,7 @@ export interface IRawFontStyle {
    * Specifies the weight or boldness of the font.
    * See CSS 3 'font-weight' property https://www.w3.org/TR/css-fonts-3/#propdef-font-weight
    */
-  fontWeight?: IFontWeight;
+  fontWeight?: IFontWeight | string;
 }
 
 /**

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -185,7 +185,7 @@ export interface IRawFontStyle {
    * See CSS 3 font-size-adjust property
    * https://www.w3.org/TR/css-fonts-3/#propdef-font-size-adjust
    */
-  fontSizeAdjust?: ICSSRule | 'none' | number;
+  fontSizeAdjust?: ICSSRule | 'none' | number | string;
 
   /**
    * Allows you to expand or condense the widths for a normal, condensed, or expanded
@@ -203,7 +203,8 @@ export interface IRawFontStyle {
     | 'semi-expanded'
     | 'expanded'
     | 'extra-expanded'
-    | 'ultra-expanded';
+    | 'ultra-expanded'
+    | string;
 
   /**
    * The font-style property allows normal, italic, or oblique faces to be selected.
@@ -212,7 +213,7 @@ export interface IRawFontStyle {
    * sloping the glyphs of the regular face.
    * See CSS 3 font-style property https://www.w3.org/TR/css-fonts-3/#propdef-font-style
    */
-  fontStyle?: ICSSRule | 'normal' | 'italic' | 'oblique';
+  fontStyle?: ICSSRule | 'normal' | 'italic' | 'oblique' | string;
 
   /**
    * This value specifies whether the user agent is allowed to synthesize bold or
@@ -285,22 +286,22 @@ export interface IRawStyleBase extends IRawFontStyle {
   /**
    * (Ms specific) scrollbar behavior adjust rule.
    */
-  MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar';
+  MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar' | string;
 
   /**
    * (Moz specific) font smoothing directive.
    */
-  MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
+  MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased' | string;
 
   /**
    * (Webkit specific) font smoothing directive.
    */
-  WebkitFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
+  WebkitFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased' | string;
 
   /**
    * (Webkit specific) momentum scrolling on iOS devices
    */
-  WebkitOverflowScrolling?: 'auto' | 'touch';
+  WebkitOverflowScrolling?: 'auto' | 'touch' | string;
 
   /**
    * (Webkit specific) color of the highlight that appears overa  link while it's being tapped
@@ -311,19 +312,27 @@ export interface IRawStyleBase extends IRawFontStyle {
    * (Webkit specific) controls the text inflation algorithm used on some smartphones and tablets.
    * Other browsers will ignore this property.
    */
-  WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule;
+  WebkitTextSizeAdjust?: 'none' | 'auto' | ICSSPercentageRule | ICSSRule | string;
 
   /**
    * Aligns a flex container's lines within the flex container when there is extra space
    * in the cross-axis, similar to how justify-content aligns individual items within the main-axis.
    */
-  alignContent?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around' | 'stretch';
+  alignContent?:
+    | ICSSRule
+    | 'flex-start'
+    | 'flex-end'
+    | 'center'
+    | 'space-between'
+    | 'space-around'
+    | 'stretch'
+    | string;
 
   /**
    * Sets the default alignment in the cross axis for all of the flex container's items,
    * including anonymous flex items, similarly to how justify-content aligns items along the main axis.
    */
-  alignItems?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
+  alignItems?: ICSSRule | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch' | string;
 
   /**
    * Aligns the box (as the alignment subject) within its containing block (as the alignment container)
@@ -332,7 +341,14 @@ export interface IRawStyleBase extends IRawFontStyle {
    * See CSS align-self property
    * https://www.w3.org/TR/css-align-3/#propdef-align-self
    */
-  alignSelf?: ICSSRule | 'auto' | 'normal' | 'stretch' | ICSSBaselinePositionRule | ICSSOverflowAndSelfPositionRule;
+  alignSelf?:
+    | ICSSRule
+    | 'auto'
+    | 'normal'
+    | 'stretch'
+    | ICSSBaselinePositionRule
+    | ICSSOverflowAndSelfPositionRule
+    | string;
 
   /**
    * This property allows precise alignment of elements, such as graphics, that do not
@@ -381,7 +397,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The animation-fill-mode CSS property specifies how a CSS animation should apply
    * styles to its target before and after its execution.
    */
-  animationFillMode?: ICSSRule | 'none' | 'forwards' | 'backwards' | 'both';
+  animationFillMode?: ICSSRule | 'none' | 'forwards' | 'backwards' | 'both' | string;
 
   /**
    * Specifies how many times an animation cycle should play.
@@ -441,7 +457,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * or scrolls along with its containing block.
    * See CSS 3 background-attachment property https://drafts.csswg.org/css-backgrounds-3/#the-background-attachment
    */
-  backgroundAttachment?: ICSSRule | 'scroll' | 'fixed' | 'local';
+  backgroundAttachment?: ICSSRule | 'scroll' | 'fixed' | 'local' | string;
 
   /**
    * This property describes how the element's background images should blend with each
@@ -461,7 +477,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    *
    * \* The `text` value is experimental and should not be used in production code.
    */
-  backgroundClip?: ICSSRule | 'border-box' | 'padding-box' | 'content-box' | 'text';
+  backgroundClip?: ICSSRule | 'border-box' | 'padding-box' | 'content-box' | 'text' | string;
 
   /**
    * Sets the background color of an element.
@@ -735,7 +751,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The CSS box-sizing property is used to alter the default CSS box model used to
    * calculate width and height of the elements.
    */
-  boxSizing?: ICSSRule | 'border-box' | 'content-box';
+  boxSizing?: ICSSRule | 'border-box' | 'content-box' | string;
 
   /**
    * The CSS break-after property allows you to force a break on multi-column layouts.
@@ -779,7 +795,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * Describes the number of columns of the element.
    * See CSS 3 column-count property https://www.w3.org/TR/css3-multicol/#cc
    */
-  columnCount?: ICSSRule | number | 'auto';
+  columnCount?: ICSSRule | number | 'auto' | string;
 
   /**
    * Specifies how to fill columns (balanced or sequential).
@@ -879,7 +895,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * W3: https://www.w3.org/TR/css-display-3/#the-display-properties
    * MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/display
    */
-  display?: ICSSRule | ICSSDisplayRule;
+  display?: ICSSRule | ICSSDisplayRule | string;
 
   /**
    * The ‘fill’ property paints the interior of the given graphical element. The area to
@@ -931,7 +947,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The flex-direction CSS property describes how flex items are placed in the flex
    * container, by setting the direction of the flex container's main axis.
    */
-  flexDirection?: ICSSRule | 'row' | 'row-reverse' | 'column' | 'column-reverse';
+  flexDirection?: ICSSRule | 'row' | 'row-reverse' | 'column' | 'column-reverse' | string;
 
   /**
    * The flex-flow CSS property defines the flex container's main and cross axis. It is
@@ -957,7 +973,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * the direction in which lines are stacked.
    * See CSS flex-wrap property https://drafts.csswg.org/css-flexbox-1/#flex-wrap-property
    */
-  flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse';
+  flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse' | string;
 
   /**
    * Elements which have the style float are floated horizontally. These elements can
@@ -978,7 +994,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The property which allows authors to opt particular elements out of forced colors mode,
    * restoring full control over the colors to CSS. Currently it's only supported in Edge Chromium.
    */
-  forcedColorAdjust?: 'auto' | 'none';
+  forcedColorAdjust?: 'auto' | 'none' | string;
 
   /**
    * Lays out one or more grid items bound by 4 grid lines. Shorthand for setting
@@ -1146,7 +1162,8 @@ export interface IRawStyleBase extends IRawFontStyle {
     | 'space-between'
     | 'space-around'
     | 'space-evenly'
-    | 'stretch';
+    | 'stretch'
+    | string;
 
   /**
    * Justifies the box (as the alignment subject) within its containing block (as the alignment container)
@@ -1169,10 +1186,11 @@ export interface IRawStyleBase extends IRawFontStyle {
     | 'safe right'
     // prefixed with <overflow-position> value 'unsafe'
     | 'unsafe left'
-    | 'unsafe right';
+    | 'unsafe right'
+    | string;
 
   /**
-   * Sets the left position of an element relative to the nearest anscestor that is set
+   * Sets the left position of an element relative to the nearest ancestor that is set
    * to position absolute, relative, or fixed.
    */
   left?: ICSSRule | ICSSPixelUnitRule;
@@ -1348,14 +1366,14 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The mix-blend-mode CSS property describes how an element's content should blend
    * with the content of the element's direct parent and the element's background.
    */
-  mixBlendMode?: ICSSRule | IMixBlendModes;
+  mixBlendMode?: ICSSRule | IMixBlendModes | string;
 
   /**
    * The ‘object-fit’ property specifies how the contents of a replaced element should
    * be fitted to the box established by its used height and width.
    * See CSS 3 object-fit property https://www.w3.org/TR/css3-images/#the-object-fit
    */
-  objectFit?: ICSSRule | 'cover' | 'contain' | 'fill' | 'none';
+  objectFit?: ICSSRule | 'cover' | 'contain' | 'fill' | 'none' | string;
 
   /**
    * Specifies the transparency of an element.
@@ -1368,14 +1386,14 @@ export interface IRawStyleBase extends IRawFontStyle {
    * Elements are laid out in the ascending order of the order value.
    * See CSS order property https://drafts.csswg.org/css-flexbox-1/#order-property
    */
-  order?: ICSSRule | number;
+  order?: ICSSRule | number | string;
 
   /**
    * In paged media, this property defines the minimum number of lines in
    * a block container that must be left at the bottom of the page.
    * See CSS 3 orphans, widows properties https://drafts.csswg.org/css-break-3/#widows-orphans
    */
-  orphans?: ICSSRule | number;
+  orphans?: ICSSRule | number | string;
 
   /**
    * The CSS outline property is a shorthand property for setting one or more of the
@@ -1421,19 +1439,19 @@ export interface IRawStyleBase extends IRawFontStyle {
    * overflow-wrap will only create a break if an entire word cannot be placed on its
    * own line without overflowing.
    */
-  overflowWrap?: ICSSRule | 'normal' | 'break-word';
+  overflowWrap?: ICSSRule | 'normal' | 'break-word' | string;
 
   /**
    * Controls how extra content exceeding the x-axis of the bounding box of an element
    * is rendered.
    */
-  overflowX?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible';
+  overflowX?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible' | string;
 
   /**
    * Controls how extra content exceeding the y-axis of the bounding box of an element
    * is rendered.
    */
-  overflowY?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible';
+  overflowY?: ICSSRule | 'auto' | 'hidden' | 'scroll' | 'visible' | string;
 
   /**
    * The padding optional CSS property sets the required padding space on one to four
@@ -1614,7 +1632,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * The resize CSS sets whether an element is resizable, and if so, in which direction(s).
    */
 
-  resize?: ICSSRule | 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline';
+  resize?: ICSSRule | 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline' | string;
 
   /**
    * The rest-after property determines how long a speech media agent should pause after
@@ -1693,13 +1711,13 @@ export interface IRawStyleBase extends IRawFontStyle {
    * SVG: The stroke-linecap attribute defines the shape to be used at the end of open subpaths when they are stroked.
    * See SVG 1.1 https://www.w3.org/TR/SVG/painting.html#LineCaps
    */
-  strokeLinecap?: ICSSRule | 'butt' | 'round' | 'square';
+  strokeLinecap?: ICSSRule | 'butt' | 'round' | 'square' | string;
 
   /**
    * SVG: Specifies the opacity of the outline on the current object.
    * See SVG 1.1 https://www.w3.org/TR/SVG/painting.html#StrokeOpacityProperty
    */
-  strokeOpacity?: ICSSRule | number;
+  strokeOpacity?: ICSSRule | number | string;
 
   /**
    * SVG: Specifies the width of the outline on the current object.
@@ -1955,14 +1973,14 @@ export interface IRawStyleBase extends IRawFontStyle {
   userFocus?: ICSSRule | string;
 
   /**
-   * For inputing user content
+   * For inputting user content
    */
   userInput?: ICSSRule | string;
 
   /**
    * Defines the text selection behavior.
    */
-  userSelect?: ICSSRule | 'none' | 'auto' | 'text' | 'all' | 'contain';
+  userSelect?: ICSSRule | 'none' | 'auto' | 'text' | 'all' | 'contain' | string;
 
   /**
    * The vertical-align property controls how inline elements or text are vertically
@@ -2048,7 +2066,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * See CSS 3 orphans, widows properties
    * https://drafts.csswg.org/css-break-3/#widows-orphans
    */
-  widows?: ICSSRule | number;
+  widows?: ICSSRule | number | string;
 
   /**
    * Specifies the width of the content area of an element. The content area of the element
@@ -2100,7 +2118,7 @@ export interface IRawStyleBase extends IRawFontStyle {
    * When elements overlap, z-order determines which one covers the other.
    * See CSS 2 z-index property https://www.w3.org/TR/CSS2/visuren.html#z-index
    */
-  zIndex?: ICSSRule | 'auto' | number;
+  zIndex?: ICSSRule | 'auto' | number | string;
 
   /**
    * Sets the initial zoom factor of a document defined by `@viewport`.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

update IRawStyleBase tying to allow css variable (string) as value

#### Focus areas to test

(optional)
