### PR TITLE
Fix useControllableValue onChange event typing

### DIFF
--- a/change/@uifabric-react-hooks-2020-08-26-20-32-36-xgao-fix-typing.json
+++ b/change/@uifabric-react-hooks-2020-08-26-20-32-36-xgao-fix-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix useControllableValue onChange event typing.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T03:32:36.922Z"
+}

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -11,7 +11,7 @@ import * as React from 'react';
 import { Ref } from 'react';
 
 // @public (undocumented)
-export type ChangeCallback<TElement extends HTMLElement, TValue> = (ev: React.FormEvent<TElement> | undefined, newValue: TValue | undefined) => void;
+export type ChangeCallback<TElement extends HTMLElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (ev: TEvent, newValue: TValue | undefined) => void;
 
 // @public
 export interface IUseBooleanCallbacks {
@@ -54,7 +54,7 @@ export function useConstCallback<T extends (...args: any[]) => any>(callback: T)
 export function useControllableValue<TValue, TElement extends HTMLElement>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>) => void]>;
 
 // @public (undocumented)
-export function useControllableValue<TValue, TElement extends HTMLElement, TCallback extends ChangeCallback<TElement, TValue> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: TCallback): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
+export function useControllableValue<TValue, TElement extends HTMLElement, TEvent extends React.SyntheticEvent<TElement> | undefined>(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange: ChangeCallback<TElement, TValue, TEvent> | undefined): Readonly<[TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]>;
 
 // @public
 export function useForceUpdate(): () => void;

--- a/packages/react-hooks/src/useControllableValue.ts
+++ b/packages/react-hooks/src/useControllableValue.ts
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { useConst } from './useConst';
 import { useConstCallback } from './useConstCallback';
 
-export type ChangeCallback<TElement extends HTMLElement, TValue> = (
-  ev: React.FormEvent<TElement> | undefined,
-  newValue: TValue | undefined,
-) => void;
+export type ChangeCallback<
+  TElement extends HTMLElement,
+  TValue,
+  TEvent extends React.SyntheticEvent<TElement> | undefined
+> = (ev: TEvent, newValue: TValue | undefined) => void;
 
 /**
  * Hook to manage a value that could be either controlled or uncontrolled, such as a checked state or
@@ -25,19 +26,23 @@ export function useControllableValue<TValue, TElement extends HTMLElement>(
 export function useControllableValue<
   TValue,
   TElement extends HTMLElement,
-  TCallback extends ChangeCallback<TElement, TValue> | undefined
+  TEvent extends React.SyntheticEvent<TElement> | undefined
 >(
   controlledValue: TValue | undefined,
   defaultUncontrolledValue: TValue | undefined,
-  onChange: TCallback,
+  onChange: ChangeCallback<TElement, TValue, TEvent> | undefined,
 ): Readonly<
   [TValue | undefined, (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => void]
 >;
 export function useControllableValue<
   TValue,
   TElement extends HTMLElement,
-  TCallback extends ChangeCallback<TElement, TValue> | undefined
->(controlledValue: TValue | undefined, defaultUncontrolledValue: TValue | undefined, onChange?: TCallback) {
+  TEvent extends React.SyntheticEvent<TElement> | undefined
+>(
+  controlledValue: TValue | undefined,
+  defaultUncontrolledValue: TValue | undefined,
+  onChange?: ChangeCallback<TElement, TValue, TEvent>,
+) {
   const [value, setValue] = React.useState<TValue | undefined>(defaultUncontrolledValue);
   const isControlled = useConst<boolean>(controlledValue !== undefined);
   const currentValue = isControlled ? controlledValue : value;
@@ -53,21 +58,19 @@ export function useControllableValue<
 
   // To match the behavior of the setter returned by React.useState, this callback's identity
   // should never change. This means it MUST NOT directly reference variables that can change.
-  const setValueOrCallOnChange = useConstCallback(
-    (update: React.SetStateAction<TValue | undefined>, ev?: React.FormEvent<TElement>) => {
-      // Assuming here that TValue is not a function, because a controllable value will typically
-      // be something a user can enter as input
-      const newValue = typeof update === 'function' ? (update as Function)(valueRef.current) : update;
+  const setValueOrCallOnChange = useConstCallback((update: React.SetStateAction<TValue | undefined>, ev?: TEvent) => {
+    // Assuming here that TValue is not a function, because a controllable value will typically
+    // be something a user can enter as input
+    const newValue = typeof update === 'function' ? (update as Function)(valueRef.current) : update;
 
-      if (onChangeRef.current) {
-        onChangeRef.current(ev!, newValue);
-      }
+    if (onChangeRef.current) {
+      onChangeRef.current(ev!, newValue);
+    }
 
-      if (!isControlled) {
-        setValue(newValue);
-      }
-    },
-  );
+    if (!isControlled) {
+      setValue(newValue);
+    }
+  });
 
   return [currentValue, setValueOrCallOnChange] as const;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`event` arg in `onChange` is incorrectly typed. it causes error when ts config set with `strict: true`.

#### Focus areas to test

(optional)
