### PR TITLE
fix(felaRenderer): disableAnimations plugin should handle fallback values

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `Tree` component to correctly keep track of the `activeItemIds` @assuncaocharles ([#14507](https://github.com/microsoft/fluentui/pull/14507))
 - Fix `Menu` underlined focus style @assuncaocharles ([#14525](https://github.com/microsoft/fluentui/pull/14525))
 - Do not always `preventDefault()` in `RadioGroupItem` @layershifter ([#14717](https://github.com/microsoft/fluentui/pull/14717))
+- Fela `disableAnimations` plugin should handle fallback values @layershifter ([#14778](https://github.com/microsoft/fluentui/pull/14778))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/react-northstar-fela-renderer/src/felaDisableAnimationsPlugin.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/src/felaDisableAnimationsPlugin.ts
@@ -13,6 +13,10 @@ const animationProps: (keyof ICSSInJSStyle)[] = [
   'animationPlayState',
 ];
 
+function isPlainObject(val: any) {
+  return val != null && typeof val === 'object' && Array.isArray(val) === false;
+}
+
 /**
  * Fela plugin for disabling animations. The animations are disabled or not based on the
  * props' disableAnimations param. If the value of the prop is true, all animation related
@@ -35,7 +39,7 @@ export const felaDisableAnimationsPlugin = (
         return acc;
       }
 
-      if (typeof cssPropertyValue === 'object') {
+      if (isPlainObject(cssPropertyValue)) {
         return {
           ...acc,
           [cssPropertyName]: felaDisableAnimationsPlugin(cssPropertyValue, type, renderer, props),

--- a/packages/fluentui/react-northstar-fela-renderer/test/felaDisableAnimationsPlugin-test.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/test/felaDisableAnimationsPlugin-test.ts
@@ -55,7 +55,7 @@ describe('felaDisableAnimationsPlugin', () => {
     ).toMatchObject({ margin: '0px 10px' });
   });
 
-  test('keeps fallback values', () => {
+  test('keeps unrelated fallback values', () => {
     expect(
       felaDisableAnimationsPlugin(stylesWithFallbackValues, 'RULE', undefined, {
         disableAnimations: true,

--- a/packages/fluentui/react-northstar-fela-renderer/test/felaDisableAnimationsPlugin-test.ts
+++ b/packages/fluentui/react-northstar-fela-renderer/test/felaDisableAnimationsPlugin-test.ts
@@ -6,6 +6,10 @@ const stylesWithAnimationShorthand: ICSSInJSStyle = {
   margin: '0px 10px',
 };
 
+const stylesWithFallbackValues: ICSSInJSStyle = {
+  display: ['grid', '-ms-grid'],
+};
+
 const stylesWithAnimationProps: ICSSInJSStyle = {
   animationName: 'k1',
   animationDuration: '1s',
@@ -49,5 +53,13 @@ describe('felaDisableAnimationsPlugin', () => {
         disableAnimations: true,
       }),
     ).toMatchObject({ margin: '0px 10px' });
+  });
+
+  test('keeps fallback values', () => {
+    expect(
+      felaDisableAnimationsPlugin(stylesWithFallbackValues, 'RULE', undefined, {
+        disableAnimations: true,
+      }),
+    ).toMatchObject({ display: ['grid', '-ms-grid'] });
   });
 });


### PR DESCRIPTION
Fixes #14777.

#### Description of changes

See the issue for details. `disableAnimations` plugin should handle fallback values i.e. arrays as it goes before [fela-plugin-fallback-value](https://github.com/robinweser/fela/tree/master/packages/fela-plugin-fallback-value) in pipeline.
