### PR TITLE
Codemods: Add '--list' flag

### DIFF
--- a/change/@fluentui-codemods-2020-08-27-14-50-44-t-dama-add_list_option_to_modrunner.json
+++ b/change/@fluentui-codemods-2020-08-27-14-50-44-t-dama-add_list_option_to_modrunner.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add list feature to codemods modruner",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-27T18:50:44.336Z"
+}

--- a/packages/codemods/README.md
+++ b/packages/codemods/README.md
@@ -59,6 +59,7 @@ npx <tarFileName>
   - `-n` Specify name(s) of codemod(s) to run. You can find these names in `codemods/src/codemods/mods`. Make sure that they are `enabled` before running them, or else they won't run!
   - `-r` Specify regex pattern(s) to identify mod(s) to run.
   - `-e` Boolean flag that flips the inclusion of the specify mods. Use this flag with the selective flags `-n` or `-r` to opt to _exclude_ the selected mods rather than include them.
+  - `-l` List the names of all enabled codemods. Mods that exist but aren't enabled will not appear, as running them would do nothing.
   - `-c` For developers who don't want to worry about the command line, they can create a `modConfig.json` file in their repo. The template for the file looks like this, where `stringFilters` and `regexFilters` would correspond to inputs following `-n` and `-c`, respectively:
   ```jsonld=
   {

--- a/packages/codemods/src/command.ts
+++ b/packages/codemods/src/command.ts
@@ -49,7 +49,7 @@ export const yargsParse = (passedArgs: string[]) => {
       alias: 'l',
       type: 'boolean',
       default: false,
-      description: 'lists the existing codemods, as well as their enabled status.',
+      description: 'lists the provided enabled codemods.',
     })
     .parse(passedArgs);
 };


### PR DESCRIPTION
Added a `-l` or `--list` flag to the codemod modrunner. Now, developers can run 
`npx fluentui-codemods-versiono -l`
and get back a list of the enabled mods. Knowing the names of the enabled mods is very important because without them, you'll have a hard time specifying which mods you want to run!