### PR TITLE
fix(UI builder) add check for imports resolver for CodeSandbox

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed top's component debug frame above iframe @vyhnalekl ([#14329](https://github.com/microsoft/fluentui/pull/14329))
 - Hide drop selector on scroll in iframe (UI builder) @vyhnalekl ([#14443](https://github.com/microsoft/fluentui/pull/14443))
 - Add export to CodeSandbox feature (UI builder) @vyhnalekl ([#14558](https://github.com/microsoft/fluentui/pull/14558))
+- Fix unresolved imports error when `moduleName` is missing (UI builder) @vyhnalekl ([#14796](https://github.com/microsoft/fluentui/pull/14796))
 
 <!--------------------------------[ v0.51.0 ]------------------------------- -->
 ## [v0.51.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.51.0) (2020-07-27)

--- a/packages/fluentui/docs-components/src/CodeSandboxExporter/createPackageJson.ts
+++ b/packages/fluentui/docs-components/src/CodeSandboxExporter/createPackageJson.ts
@@ -8,7 +8,7 @@ function createDependencies(code: string, imports: Record<string, CodeSandboxImp
   // Will include only required packages intentionally like "react" or required by a current example
   const filteredPackages = _.pickBy(
     imports,
-    (declaration, name) => declaration && (declaration.required || new RegExp(`from ['|"]${name}['|"]`).exec(code)),
+    (declaration, name) => declaration.required || new RegExp(`from ['|"]${name}['|"]`).exec(code),
   );
 
   return {

--- a/packages/fluentui/react-builder/src/componentInfo/componentInfoContext.ts
+++ b/packages/fluentui/react-builder/src/componentInfo/componentInfoContext.ts
@@ -30,7 +30,7 @@ export const componentInfoContext: {
 } = {} as any;
 
 componentInfoContext.byDisplayName = infoObjects.reduce((acc, next) => {
-  //next.moduleName = '@fluentui/react-northstar';
+  next.moduleName = '@fluentui/react-northstar';
   acc[next.displayName] = next;
   return acc;
 }, {});

--- a/packages/fluentui/react-builder/src/componentInfo/componentInfoContext.ts
+++ b/packages/fluentui/react-builder/src/componentInfo/componentInfoContext.ts
@@ -30,7 +30,7 @@ export const componentInfoContext: {
 } = {} as any;
 
 componentInfoContext.byDisplayName = infoObjects.reduce((acc, next) => {
-  next.moduleName = '@fluentui/react-northstar';
+  //next.moduleName = '@fluentui/react-northstar';
   acc[next.displayName] = next;
   return acc;
 }, {});

--- a/packages/fluentui/react-builder/src/config.tsx
+++ b/packages/fluentui/react-builder/src/config.tsx
@@ -621,7 +621,11 @@ export const getCodeSandboxInfo = (tree: JSONTreeElement, code: string) => {
   };
   for (const [module, components] of Object.entries(imports)) {
     codeSandboxExport += `import {${components.join(', ')}} from "${module}";\n`;
-    packageImports[module] = packageImportList[module];
+    if (module) {
+      packageImports[module] = packageImportList[module];
+    } else {
+      console.error(`Undefined module for export to codesandbox for components {${components.join(', ')}} `);
+    }
   }
   codeSandboxExport += `\n export default function Example() { \n return (\n
   ${code} \n);}`;

--- a/packages/fluentui/react-builder/src/config.tsx
+++ b/packages/fluentui/react-builder/src/config.tsx
@@ -621,7 +621,7 @@ export const getCodeSandboxInfo = (tree: JSONTreeElement, code: string) => {
   };
   for (const [module, components] of Object.entries(imports)) {
     codeSandboxExport += `import {${components.join(', ')}} from "${module}";\n`;
-    if (module) {
+    if (packageImportList[module]) {
       packageImports[module] = packageImportList[module];
     } else {
       console.error(`Undefined module for export to codesandbox for components {${components.join(', ')}} `);

--- a/packages/fluentui/react-builder/src/config.tsx
+++ b/packages/fluentui/react-builder/src/config.tsx
@@ -624,7 +624,9 @@ export const getCodeSandboxInfo = (tree: JSONTreeElement, code: string) => {
     if (packageImportList[module]) {
       packageImports[module] = packageImportList[module];
     } else {
-      console.error(`Undefined module for export to codesandbox for components {${components.join(', ')}} `);
+      console.error(
+        `Undefined module "${module}" for export to codesandbox for components {${components.join(', ')}} `,
+      );
     }
   }
   codeSandboxExport += `\n export default function Example() { \n return (\n


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

These checks shouldn't be nesesary for UI created after this PR: https://github.com/microsoft/fluentui/pull/14558 The problem is that in the PR we have added a `moduleName` parameter to every component. based on it we are resolving imports for CodeSandbox. But UI that were created beforehand have no such attribute thus we get an error.