### PR TITLE
Calendar: Adding aria-current=date to present day

### DIFF
--- a/change/@uifabric-date-time-2020-08-28-13-49-36-master.json
+++ b/change/@uifabric-date-time-2020-08-28-13-49-36-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Calendar: Adding aria-current=date to present day.",
+  "packageName": "@uifabric/date-time",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-28T20:49:35.012Z"
+}

--- a/change/office-ui-fabric-react-2020-08-28-13-49-36-master.json
+++ b/change/office-ui-fabric-react-2020-08-28-13-49-36-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Calendar: Adding aria-current=date to present day.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-28T20:49:36.671Z"
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarGridDayCell.tsx
@@ -238,6 +238,7 @@ export const CalendarGridDayCell: React.FunctionComponent<ICalendarGridDayCellPr
         onKeyDown={!ariaHidden ? onDayKeyDown : undefined}
         aria-label={ariaLabel}
         id={isNavigatedDate ? activeDescendantId : undefined}
+        aria-current={day.isSelected ? 'date' : undefined}
         aria-selected={day.isInBounds ? day.isSelected : undefined}
         data-is-focusable={!ariaHidden && (allFocusable || (day.isInBounds ? true : undefined))}
         ref={isNavigatedDate ? navigatedDayRef : undefined}

--- a/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
+++ b/packages/date-time/src/components/WeeklyDayPicker/__snapshots__/WeeklyDayPicker.test.tsx.snap
@@ -1964,6 +1964,7 @@ exports[`WeeklyDayPicker renders WeeklyDayPicker with FirstDayOfWeek=Wednesday c
             onMouseUp={[Function]}
           >
             <button
+              aria-current="date"
               aria-disabled={false}
               aria-label="January 1, 2019"
               aria-readonly={true}
@@ -4843,6 +4844,7 @@ exports[`WeeklyDayPicker renders default WeeklyDayPicker correctly 1`] = `
             onMouseUp={[Function]}
           >
             <button
+              aria-current="date"
               aria-disabled={false}
               aria-label="January 1, 2019"
               aria-readonly={true}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -361,6 +361,7 @@ export class CalendarDay extends React.Component<ICalendarDayProps, ICalendarDay
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}
                           aria-readonly={true}
+                          aria-current={day.isToday ? 'date' : undefined}
                           aria-selected={day.isInBounds ? day.isSelected : undefined}
                           data-is-focusable={allFocusable || (day.isInBounds ? true : undefined)}
                           ref={element => this._setDayRef(element, day, isNavigatedDate)}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14611
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue with the `Calendar` and `DatePicker` components where the present day was visually communicated to users but wasn't read by screen readers. This is done by adding `aria-current="date"` to the element.

#### Focus areas to test

(optional)
