### PR TITLE
Remove tslint references from react-avatar

### DIFF
--- a/change/@fluentui-react-avatar-2020-08-28-15-48-29-no-avatar-tslint.json
+++ b/change/@fluentui-react-avatar-2020-08-28-15-48-29-no-avatar-tslint.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing explicit references to React",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-28T22:48:29.233Z"
+}

--- a/packages/react-avatar/.eslintrc.json
+++ b/packages/react-avatar/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["plugin:@fluentui/eslint-plugin/react"],
+  "root": true
+}

--- a/packages/react-avatar/.npmignore
+++ b/packages/react-avatar/.npmignore
@@ -5,6 +5,8 @@
 *.test.*
 *.yml
 .editorconfig
+.eslintrc*
+.eslintcache
 .gitattributes
 .gitignore
 .vscode

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -27,6 +27,7 @@
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
+    "@fluentui/eslint-plugin": "^0.54.0",
     "@fluentui/react-conformance": "^0.1.0",
     "@fluentui/storybook": "^0.4.0",
     "@types/enzyme": "3.10.3",

--- a/packages/react-avatar/src/components/Avatar/Avatar.types.tsx
+++ b/packages/react-avatar/src/components/Avatar/Avatar.types.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { StatusProps } from '../Status/index';
 import { ComponentProps, ShorthandValue } from '../utils/commonTypes';
 

--- a/packages/react-avatar/src/components/Image/Image.types.tsx
+++ b/packages/react-avatar/src/components/Image/Image.types.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import { ComponentProps } from '../utils/commonTypes';
 
-// tslint:disable-next-line:no-any
 export interface ImageProps extends ComponentProps, React.ImgHTMLAttributes<HTMLImageElement> {}
 
 export type ImageState = ImageProps;

--- a/packages/react-avatar/src/components/Status/Status.stories.tsx
+++ b/packages/react-avatar/src/components/Status/Status.stories.tsx
@@ -2,8 +2,6 @@ import * as React from 'react';
 import { Status } from '../Status/Status';
 import { StoryExample } from '../utils/StoryExample';
 
-// tslint:disable:no-any
-
 export const StatusCss = () => (
   <StoryExample title="Status (css)">
     <Status size="smallest" state="error" />

--- a/packages/react-avatar/src/components/Status/Status.types.tsx
+++ b/packages/react-avatar/src/components/Status/Status.types.tsx
@@ -1,6 +1,6 @@
+import * as React from 'react';
 import { ComponentProps, ShorthandValue, SizeValue } from '../utils/commonTypes';
 
-// tslint:disable-next-line:no-any
 export interface StatusProps extends ComponentProps, React.HTMLAttributes<HTMLElement> {
   /**
    * Renders the status using a custom color to be inlined using  `style`.

--- a/packages/react-avatar/src/components/utils/commonTypes.ts
+++ b/packages/react-avatar/src/components/utils/commonTypes.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export type SizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';
 
 export type ComponentClasses<TClasses, TState> = Partial<TClasses> | ((state: TState) => Partial<TClasses>);

--- a/packages/react-avatar/tslint.json
+++ b/packages/react-avatar/tslint.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["@uifabric/tslint-rules"],
-  "rules": {
-    "interface-name": false
-  }
-}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Somehow some references to tslint instead of eslint snuck into react-avatar. Change it to use eslint and fix violations.