### PR TITLE
DetailsList: Set selectAllVisibility to hidden when there are no items to select

### DIFF
--- a/change/office-ui-fabric-react-2020-08-28-17-06-34-detailslist-selectall.json
+++ b/change/office-ui-fabric-react-2020-08-28-17-06-34-detailslist-selectall.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Do not make \"Select all\" visible when there are no items to select",
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-29T00:06:34.370Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -252,7 +252,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
                             ? `${this._id}-checkTooltip`
                             : undefined
                         }
-                        data-is-focusable={!isCheckboxHidden || undefined}
+                        data-is-focusable={!isCheckboxHidden || false}
                         isHeader={true}
                         selected={isAllSelected}
                         anySelected={false}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -366,7 +366,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       if (isCollapsedGroupSelectVisible === undefined) {
         isCollapsedGroupSelectVisible = true;
       }
-      const isSelectAllVisible = isCollapsedGroupSelectVisible || !groups || isSomeGroupExpanded;
+      const isSelectAllVisible = items.length && (isCollapsedGroupSelectVisible || !groups || isSomeGroupExpanded);
       selectAllVisibility = isSelectAllVisible ? SelectAllVisibility.visible : SelectAllVisibility.hidden;
     }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -1068,6 +1068,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               top: 1px;
               z-index: 1;
             }
+        data-is-focusable={false}
         id="header2-check"
       />
     </span>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The "Select all" button is currently visible in DetailsList even where there are no items to select. This can be especially confusing for keyboard users using a screenreader.

This change sets `selectAllVisibility` to `hidden` when there are no items and makes the the checkbox not focusable.

#### Focus areas to test

(optional)
