### PR TITLE
fix(Perf): render perf tests using React.createElement

### DIFF
--- a/packages/fluentui/digest/src/bundle/index.digest.tsx
+++ b/packages/fluentui/digest/src/bundle/index.digest.tsx
@@ -27,7 +27,13 @@ const selectedStory = queryParams.selectedStory ? (queryParams.selectedStory as 
 // TODO: make sure decorator impl doesn't affect perf.
 if (selectedKind && selectedStory) {
   ReactDOM.render(
-    decorator(<div>{Array.from({ length: iterations }, () => stories[selectedKind][selectedStory]())}</div>),
+    decorator(
+      <div>
+        {Array.from({ length: iterations }, (_, i) =>
+          React.createElement(stories[selectedKind][selectedStory], { key: i }),
+        )}
+      </div>,
+    ),
     div,
   );
 } else {
@@ -53,7 +59,7 @@ if (selectedKind && selectedStory) {
                         Story:{' '}
                         <a href={`?selectedKind=${kindKey}&selectedStory=${storyKey}&iterations=50`}>{storyKey}</a>
                       </div>
-                      <div>{stories[kindKey][storyKey]()}</div>
+                      <div>{React.createElement(stories[kindKey][storyKey])}</div>
                     </div>
                   );
                 })}


### PR DESCRIPTION
#### Description of changes

Perf tests used by flamegrill were rendered by calling them as a function.
This does not work for cases where hooks are used in the perf test.

Now the tests are rendered using `React.createElement`. Kudos to @layershifter who actually identified and fixed the issue.

#### Focus areas to test

- [ ] `ButtonUseCss` test correctly renders.
