### PR TITLE
chore: update Screener config for Northstar

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,7 +112,7 @@ jobs:
       - script: |
           git config --global user.email "fabrictactical@microsoft.com"
           git config --global user.name "Fabric Tactical"
-          yarn test:fluentui:visual
+          NODE_ENV=production yarn test:fluentui:visual
         displayName: run FUI VR Test
         env:
           SCREENER_API_KEY: $(screener.key)

--- a/packages/fluentui/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Rtl/ButtonExample.rtl.tsx
@@ -3,8 +3,8 @@ import { Button, Flex } from '@fluentui/react-northstar';
 
 const ButtonExampleRtl = () => (
   <Flex gap="gap.smaller">
-    <Button content="مرحبا" />
     <Button content="عالم" primary />
+    <Button content="مرحبا" />
   </Flex>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
@@ -1,12 +1,12 @@
 import { Dropdown, Divider } from '@fluentui/react-northstar';
 import * as React from 'react';
 
-const inputItems = ['Bruce Banner'];
+const inputItems = ['Bruce Wayne'];
 
 const DropdownCustomClearableExample = () => (
   <>
     <Dropdown
-      defaultValue="Bruce Banner"
+      defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -14,7 +14,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Banner"
+      defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -22,7 +22,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Banner"
+      defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -30,7 +30,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Banner"
+      defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -38,7 +38,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Banner"
+      defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
       placeholder="Select your hero"

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
@@ -1,20 +1,20 @@
 import { Dropdown, Divider } from '@fluentui/react-northstar';
 import * as React from 'react';
 
-const inputItems = ['Bruce Wayne'];
+const inputItems = ['Bruce Banner'];
 
 const DropdownCustomClearableExample = () => (
   <>
     <Dropdown
-      defaultValue="Bruce Wayne"
+      defaultValue="Bruce Banner"
       clearable
       items={inputItems}
-      placeholder="Select your super hero"
+      placeholder="Select your hero"
       clearIndicator={{ content: 'clear' }}
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Wayne"
+      defaultValue="Bruce Banner"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -22,7 +22,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Wayne"
+      defaultValue="Bruce Banner"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -30,7 +30,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Wayne"
+      defaultValue="Bruce Banner"
       clearable
       items={inputItems}
       placeholder="Select your hero"
@@ -38,7 +38,7 @@ const DropdownCustomClearableExample = () => (
     />
     <Divider />
     <Dropdown
-      defaultValue="Bruce Wayne"
+      defaultValue="Bruce Banner"
       clearable
       items={inputItems}
       placeholder="Select your hero"

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Visual/DropdownExampleCustomClearable.shorthand.tsx
@@ -9,7 +9,7 @@ const DropdownCustomClearableExample = () => (
       defaultValue="Bruce Wayne"
       clearable
       items={inputItems}
-      placeholder="Select your hero"
+      placeholder="Select your super hero"
       clearIndicator={{ content: 'clear' }}
     />
     <Divider />

--- a/scripts/screener/screener.config.js
+++ b/scripts/screener/screener.config.js
@@ -64,21 +64,9 @@ module.exports = {
   // screenshot every example in maximized mode
   states: require('./screener.states').default,
 
-  // CircleCI config
-  // ...(process.env.CI && {
-  //   baseBranch: 'master',
-  //   // Disable exit code to fail in Github Actions
-  //   // failureExitCode: 0,
-  //   // GITHUB_REF can be:
-  //   // - refs/heads/feature-branch-1 for "push"
-  //   // - refs/pull/2040/merge for "pull_request"
-  //   branch: process.env.GITHUB_REF.split('/')[2],
-  //   commit: process.env.GITHUB_SHA
-  // })
-
   alwaysAcceptBaseBranch: true,
-
   baseBranch,
+  failureExitCode: 0,
 
   ...(sourceBranch && sourceBranch.indexOf('refs/pull') > -1
     ? {


### PR DESCRIPTION
### 📄 Story behind

In this repo we have to separate Screener projects and previously it was impossible to integrate them both 😭 Only the Screener project for Fabric had fully integration, for Northstar it was required to rerun the whole CI job after regressions were accepted 🤕 

With @miroslavstastny we paired to create a [custom Github App](https://github.com/layershifter/screener-proxy) to have a custom integration with Screener for Fluent UI React Northstar. These checks are visible in each PR now:

![image](https://user-images.githubusercontent.com/14183168/91848808-4f9ba180-ec5b-11ea-8c84-1ccbd5d1419a.png)

---

This PR finishes the integration, now CI job will not fail on a Screener failure (now we have a separate check). We tested multiple scenarios with @miroslavstastny and then later I confirmed with @pompomon that the custom check works for forks and will be marked as successful once regressions will be accepted in Screener.
