### PR TITLE
fix: button and accordion controls not inheriting font-family styles and update fast packages

### DIFF
--- a/change/@fluentui-web-components-2020-08-31-12-53-27-master.json
+++ b/change/@fluentui-web-components-2020-08-31-12-53-27-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update fast packages and add font-family inherit to controls of button and accordion-item",
+  "packageName": "@fluentui/web-components",
+  "email": "sethdonohue@Admins-MBP.guest.corp.microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-08-31T19:53:27.723Z"
+}

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -94,8 +94,8 @@
   "dependencies": {
     "@microsoft/fast-colors": "^5.1.0",
     "@microsoft/fast-components-styles-msft": "^4.29.0",
-    "@microsoft/fast-element": "^0.16.0",
-    "@microsoft/fast-foundation": "^1.7.0",
+    "@microsoft/fast-element": "^0.17.0",
+    "@microsoft/fast-foundation": "^1.7.1",
     "tslib": "^1.13.0"
   }
 }

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -95,7 +95,7 @@
     "@microsoft/fast-colors": "^5.1.0",
     "@microsoft/fast-components-styles-msft": "^4.29.0",
     "@microsoft/fast-element": "^0.17.0",
-    "@microsoft/fast-foundation": "^1.7.1",
+    "@microsoft/fast-foundation": "^1.7.0",
     "tslib": "^1.13.0"
   }
 }

--- a/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/src/accordion/accordion-item/accordion-item.styles.ts
@@ -20,7 +20,7 @@ export const AccordionItemStyles = css`
         line-height: var(--type-ramp-minus-1-line-height);
         border-bottom: calc(var(--outline-width) * 1px) solid ${neutralDividerRestBehavior.var};
     }
-    
+
     .region {
         display: none;
         padding: calc((6 + (var(--design-unit) * 2 * var(--density))) * 1px);
@@ -45,6 +45,7 @@ export const AccordionItemStyles = css`
         height: calc(${heightNumber} * 1px);
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
+        font-family: inherit;
     }
 
     .button:hover {
@@ -97,7 +98,7 @@ export const AccordionItemStyles = css`
     slot[name="expanded-icon"] {
         display: none;
     }
-    
+
     :host(.expanded) slot[name="expanded-icon"] {
         display: flex;
     }

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -58,6 +58,7 @@ export const BaseButtonStyles: ElementStyles = css`
         border-radius: inherit;
         fill: inherit;
         cursor: inherit;
+        font-family: inherit;
     }
 
     :host(:hover) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2395,17 +2395,17 @@
     "@microsoft/fast-jss-utilities" "^4.8.0"
     "@microsoft/fast-web-utilities" "^4.6.0"
 
-"@microsoft/fast-element@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-0.16.0.tgz#0c60394d54f37478a359d9965d6c102c1e09bbf1"
-  integrity sha512-cW8Vj1+VpwRPoC7wK0gG7GCt5W4ZcluUPJZfcOHA7ViVPMaW50Fkfv+jrunJLXCw1FuXE5caIUh2h/8aorYgRA==
+"@microsoft/fast-element@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-0.17.0.tgz#2d52b6c83375fbf2c6d05bc45211dad3960dff1a"
+  integrity sha512-bPkPPYcZ+hojPQ3m1WPdI5Z3d+fJbpddCdSspZy6T6NV9JoIDRg+gaJcBWWQmeBDsCsG+dVNK1RezXuWLP5qpA==
 
 "@microsoft/fast-foundation@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-1.7.0.tgz#084102ca3ee3ded043db1fccd6e98edebe4b1981"
-  integrity sha512-hJmzCdsX6s+BT/HRj5OhUMSUGZ27WCbCE7sXVE+0BU7NeQPYY1w6sG0sJz9fu8UBLsuesU7aWpVCEpVu277K6g==
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@microsoft/fast-foundation/-/fast-foundation-1.7.1.tgz#17fede34bf76bd0195b5c5b76a73ce765d69edd1"
+  integrity sha512-8eTpcBRz6aLiVP6/FMUEiFw/t3DxA6xnT/8UkFI8NJQtBlZdIatt5+2PSwj5IsS4sqkniCeIv+wWa5jX6FHrSQ==
   dependencies:
-    "@microsoft/fast-element" "^0.16.0"
+    "@microsoft/fast-element" "^0.17.0"
     "@microsoft/fast-web-utilities" "^4.6.0"
     "@microsoft/tsdoc-config" "^0.13.4"
     tabbable "^4.0.0"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Fixes a bug where the `button` element on the shadow DOM for the accordion-item and button components does not inherit the font-family as it should.
- Also updates fast dependencies
