### PR TITLE
fix: centered the indeterminate indicator inside the checkbox component

### DIFF
--- a/change/@fluentui-web-components-2020-09-01-14-40-38-users-khamu-indeterminate-indicator.json
+++ b/change/@fluentui-web-components-2020-09-01-14-40-38-users-khamu-indeterminate-indicator.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "update sizing on indeterminate indicator",
+  "packageName": "@fluentui/web-components",
+  "email": "37851220+khamudom@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T21:40:38.506Z"
+}

--- a/packages/web-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/src/checkbox/checkbox.styles.ts
@@ -68,10 +68,11 @@ export const CheckboxStyles = css`
         border-radius: calc(var(--corner-radius) * 1px);
         background: ${neutralForegroundRestBehavior.var};
         position: absolute;
-        top: 25%;
-        right: 25%;
-        bottom: 25%;
-        left: 25%;
+        top: 50%;
+        left: 50%;
+        width: 50%;
+        height: 50%;
+        transform: translate(-50%, -50%);
         opacity: 0;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3796
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update to center the indicator by setting top and left to 50% and shifting it up and left by half of its own width and height, because the indicator is off by a pixel.

#### Focus areas to test

(optional)
