### PR TITLE
Codemods: add npx support for configmod

### DIFF
--- a/change/@fluentui-codemods-2020-08-31-21-05-37-t-dama-addConfigMod.json
+++ b/change/@fluentui-codemods-2020-08-31-21-05-37-t-dama-addConfigMod.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Support for configmod",
+  "packageName": "@fluentui/codemods",
+  "email": "t-dama@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T01:05:37.407Z"
+}

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.mod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.mod.ts
@@ -1,8 +1,6 @@
 import { SourceFile } from 'ts-morph';
 import {
   CodeMod,
-  UpgradeJSONType,
-  ModTypes,
   RenamePropModType,
   RepathImportModType,
   CodeModMapType,
@@ -14,7 +12,7 @@ import {
 import { findJsxTag, renameProp, getImportsByPath, repathImport, renameImport } from '../../utilities/index';
 import { Ok, Err, Result } from '../../../helpers/result';
 
-const jsonObj: UpgradeJSONType = require('../upgrades.json');
+import jsonObj from '../upgrades.json';
 
 /* Creates and returns an array of CodeMod objects from a JSON file. Optionally takes in
    an array of functions from user to turn into codemods as well. */
@@ -33,7 +31,7 @@ export function createCodeModsFromJson(userMods?: CodeMod[]): CodeMod[] | undefi
    an array that is returned to the user. */
 export function getCodeModsFromJson(): CodeMod[] {
   const mods = [];
-  const modDetails: ModTypes[] = jsonObj.upgrades;
+  const modDetails = jsonObj.upgrades;
   for (let i = 0; i < modDetails.length; i++) {
     /* Try and get the codemod function associated with the mod type. */
     const func = codeModMap[modDetails[i].type](modDetails[i]);

--- a/packages/codemods/src/codeMods/mods/configMod/configMod.ts
+++ b/packages/codemods/src/codeMods/mods/configMod/configMod.ts
@@ -111,3 +111,27 @@ const codeModMap: CodeModMapType = {
     };
   },
 };
+
+/* ConfigMod is also an exportable code mod. All it does is wrap all of
+   the codemods from the json file into a single code mod, so that devs
+   can very easily run mods from json with a (npx fluent... -n "configMod"). */
+const configMod: CodeMod = {
+  run: (file: SourceFile) => {
+    const mods = getCodeModsFromJson();
+    if (mods === undefined || mods.length === 0) {
+      return Err({ reason: `failed to get any mods from json. Perhaps the file is missing or malformed?` });
+    }
+    mods.forEach(mod => {
+      const res = mod.run(file);
+      if (!res.ok) {
+        return Err({ reason: `code mod ${mod.name} failed to run on ${file.getBaseName()}` });
+      }
+    });
+    return Ok({ logs: [`ran modConfig successfully on ${file.getBaseName()}`] });
+  },
+  name: 'configMod',
+  version: '1.0.0',
+  enabled: true,
+};
+
+export default configMod;

--- a/packages/codemods/src/codeMods/mods/upgrades.json
+++ b/packages/codemods/src/codeMods/mods/upgrades.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fluent-ui codemods",
+  "upgrades": [
+    {
+      "name": "",
+      "type": "",
+      "version": "",
+      "options": {
+        "from": {},
+        "to": {}
+      }
+    }
+  ]
+}

--- a/packages/codemods/tsconfig.json
+++ b/packages/codemods/tsconfig.json
@@ -18,7 +18,8 @@
     "preserveConstEnums": true,
     "esModuleInterop": true,
     "lib": ["dom", "es2015.promise", "es2017"],
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
It turned out that configmod was invisible to npx, so it wasn't possible to simply run configmod from the command line. Boo!

The fix was to change configMod to be a `.mod.ts` file, and then I had to change the way the json obj was imported because... javascript.

I then needed to actually write a function that created a single code mod from the json file -- currently the parsing function returns a list of mods. Once I wrote that function, I exported it allowing it to be seen!

I also changed upgrades.json because it being a blank file was a little annoying -- even I found it annoying, so I can imagine how annoying it would be for a dev to have nothing there.