### PR TITLE
fix(Menu): remove style conflict between hover/active

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.steps.ts
@@ -9,8 +9,8 @@ const config: ScreenerTestsConfig = {
   steps: [
     (builder, keys) =>
       builder
-        .hover(selectors.item(1))
-        .snapshot('Hovers 1st item, open menu')
+        .click(selectors.item(1))
+        .snapshot('Click 1st item, open menu')
         .hover(selectors.item(3))
         .snapshot('Hovers 2nd item, open submenu'),
   ],

--- a/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Usage/MenuExampleWithSubmenuHover.shorthand.tsx
@@ -5,7 +5,6 @@ const items: MenuProps['items'] = [
   {
     key: 'editorials',
     content: 'Editorials',
-    on: 'hover',
     menu: {
       items: [
         { key: '1', content: 'item1' },

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -583,6 +583,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         underlined: props.underlined,
         vertical: props.vertical,
         primary: props.primary,
+        on: props.on,
       },
       menu: {
         accessibility: submenuBehavior,

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItemWrapper.tsx
@@ -37,6 +37,9 @@ interface MenuItemWrapperOwnProps {
 
   /** A vertical menu displays elements vertically. */
   vertical?: boolean;
+
+  /** Menu can be set to open on hover */
+  on?: 'hover';
 }
 
 export interface MenuItemWrapperProps extends BoxProps, MenuItemWrapperOwnProps {}
@@ -53,6 +56,7 @@ export type MenuItemWrapperStylesProps = Required<
     | 'secondary'
     | 'underlined'
     | 'vertical'
+    | 'on'
   >
 >;
 
@@ -75,6 +79,7 @@ export const MenuItemWrapper = compose<'li', MenuItemWrapperProps, MenuItemWrapp
     underlined: props.underlined,
     vertical: props.vertical,
     primary: props.primary,
+    on: props.on,
   }),
   handledProps: [
     'active',
@@ -87,6 +92,7 @@ export const MenuItemWrapper = compose<'li', MenuItemWrapperProps, MenuItemWrapp
     'underlined',
     'vertical',
     'primary',
+    'on',
   ],
 
   overrideStyles: true,

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Menu/menuItemWrapperStyles.ts
@@ -26,6 +26,7 @@ export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperS
       underlined,
       vertical,
       primary,
+      on,
     } = props;
     const colors = getColorScheme(v.colorScheme, null, primary);
 
@@ -76,15 +77,16 @@ export const menuItemWrapperStyles: ComponentSlotStylesPrepared<MenuItemWrapperS
       ...(active && {
         color: v.wrapperColorActive,
 
-        ...(!underlined && {
-          background: v.backgroundColorActive || colors.backgroundActive,
+        ...(!underlined &&
+          on !== 'hover' && {
+            background: v.backgroundColorActive || colors.backgroundActive,
 
-          ...(iconOnly && { background: v.activeIconOnlyWrapperBackgroundColor }),
-          ...(!iconOnly &&
-            primary && {
-              color: colors.foregroundActive,
-            }),
-        }),
+            ...(iconOnly && { background: v.activeIconOnlyWrapperBackgroundColor }),
+            ...(!iconOnly &&
+              primary && {
+                color: colors.foregroundActive,
+              }),
+          }),
 
         ...(underlined && {
           color: v.activeUnderlinedWrapperColor,

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
@@ -64,7 +64,7 @@ describe('Menu', () => {
       menu
         .find('MenuItem')
         .at(1)
-        .simulate('mouseenter');
+        .simulate('click');
 
       expect(menu.find('MenuItem').length).toBe(4);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

There is a requirement that first level menu should be opened by a click only. Tests and examples were updated to reflect this.
The another requirement is that we shouldn't show the active and hover indicator at same time. 

![Screen Shot 2020-09-01 at 14 29 22](https://user-images.githubusercontent.com/8545105/91851607-c76bcb00-ec5f-11ea-9ea0-33192aba9c8d.png)

To solve this styles were updated removing background of active items where `on="hover"` is set

#### Focus areas to test

(optional)
