### PR TITLE
chore: update positioning in ToolbarExampleVariables

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleVariables.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Toolbar/Visual/ToolbarExampleVariables.shorthand.tsx
@@ -68,6 +68,10 @@ const ToolbarExampleVariables = () => {
           key: 'item-menu',
           menu: {
             accessibility: notAutoFocusToolbarMenuBehavior,
+            popper: {
+              align: 'start',
+              position: 'below',
+            },
             items: [
               // ToolbarMenuDivider
               { kind: 'divider', key: 'divider' },
@@ -119,6 +123,10 @@ const ToolbarExampleVariables = () => {
           key: 'item-menu-variables',
           menu: {
             accessibility: notAutoFocusToolbarMenuBehavior,
+            popper: {
+              align: 'start',
+              position: 'below',
+            },
             items: [
               { kind: 'divider', key: 'divider' },
               { kind: 'divider', key: 'divider-variables', variables: { menuDividerBorder: 'orange' } },


### PR DESCRIPTION
This PR should improve stability of the `ToolbarExampleVariables` visual test as initial positions for `ToolbarMenu` are different.
