### PR TITLE
feat(Datepicker): Set default popup position

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -45,6 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added icons `FilterIcon`, `MicrophoneDisabledIcon`, `OptionsIcon`, `ReactionsIcon` @TanelVari ([#14745](https://github.com/microsoft/fluentui/pull/14745))
 - Add `foreground5` and `foreground6` in the colorScheme's default definition @assuncaocharles ([#14818](https://github.com/microsoft/fluentui/pull/14818))
 - Add `Form.Datepicker` component @pompomon ([#14820](https://github.com/microsoft/fluentui/pull/14820))
+- Add default position for `Datepicker` popup @pompomon ([#14847](https://github.com/microsoft/fluentui/pull/14847))
 
 ### Documentation
 - Removed parameters from url after switch to store (UI builder) @vyhnalekl ([#14754](https://github.com/microsoft/fluentui/pull/14754))

--- a/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/Datepicker.tsx
@@ -306,6 +306,8 @@ export const Datepicker: ComponentWithAs<'div', DatepickerProps> &
               trapFocus: {
                 disableFirstFocus: true,
               },
+              position: 'below' as const,
+              align: 'end' as const,
               trigger: <Button icon={<CalendarIcon />} title="Open calendar" iconOnly disabled={props.disabled} />,
             }),
             overrideProps: (predefinedProps: PopupProps): PopupProps => ({


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Setting default position to `below` and align to `end`, so Datepicker popup would be shown below the input/button
![image](https://user-images.githubusercontent.com/2802155/91855604-b2923600-ec65-11ea-8aac-7bdd7af06354.png)
