### PR TITLE
DetailsRow/DetailsHeader: Remove findDOMNode usage

### DIFF
--- a/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
+++ b/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix typo in docs  ",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-02T22:55:02.427Z"
+}

--- a/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
+++ b/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "Fix typo in docs  ",
+  "comment": "Fix typo in docs",
   "packageName": "@fluentui/react-focus",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "none",

--- a/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
+++ b/change/@fluentui-react-focus-2020-09-02-15-55-10-list-finddomnode.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "Fix typo in docs",
   "packageName": "@fluentui/react-focus",
   "email": "elcraig@microsoft.com",

--- a/change/@uifabric-utilities-2020-09-02-15-55-10-list-finddomnode.json
+++ b/change/@uifabric-utilities-2020-09-02-15-55-10-list-finddomnode.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "createMergedRef: fix internal typings",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-02T22:55:10.828Z"
+}

--- a/change/office-ui-fabric-react-2020-09-01-12-44-02-list-finddomnode.json
+++ b/change/office-ui-fabric-react-2020-09-01-12-44-02-list-finddomnode.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsRow/DetailsHeader: Remove findDOMNode usage",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T19:44:02.836Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -101,17 +101,20 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
 
     this._events.on(selection, SELECTION_CHANGE, this._onSelectionChanged);
 
-    // We need to use native on this to prevent MarqueeSelection from handling the event before us.
-    this._events.on(this._rootElement.current!, 'mousedown', this._onRootMouseDown);
+    // this._rootElement.current will be null in tests using react-test-renderer
+    if (this._rootElement.current) {
+      // We need to use native on this to prevent MarqueeSelection from handling the event before us.
+      this._events.on(this._rootElement.current!, 'mousedown', this._onRootMouseDown);
 
-    this._events.on(this._rootElement.current!, 'keydown', this._onRootKeyDown);
+      this._events.on(this._rootElement.current!, 'keydown', this._onRootKeyDown);
 
-    if (this._getColumnReorderProps()) {
-      this._subscriptionObject = this._dragDropHelper.subscribe(
-        this._rootElement.current!,
-        this._events,
-        this._getHeaderDragDropOptions(),
-      );
+      if (this._getColumnReorderProps()) {
+        this._subscriptionObject = this._dragDropHelper.subscribe(
+          this._rootElement.current!,
+          this._events,
+          this._getHeaderDragDropOptions(),
+        );
+      }
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -120,9 +120,9 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
 
   public componentDidUpdate(prevProps: IDetailsHeaderBaseProps): void {
     if (this._getColumnReorderProps()) {
-      if (!this._subscriptionObject) {
+      if (!this._subscriptionObject && this._rootElement.current) {
         this._subscriptionObject = this._dragDropHelper.subscribe(
-          this._rootElement.current!,
+          this._rootElement.current,
           this._events,
           this._getHeaderDragDropOptions(),
         );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { findDOMNode } from 'react-dom';
 import { IProcessedStyleSet } from '../../Styling';
 import {
   initializeComponentRef,
@@ -52,7 +51,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
   };
 
   private _classNames: IProcessedStyleSet<IDetailsHeaderStyles>;
-  private _rootElement: HTMLElement | undefined;
+  private _rootElement = React.createRef<HTMLElement>();
   private _events: EventGroup;
   private _rootComponent = React.createRef<IFocusZone>();
   private _id: string;
@@ -103,13 +102,13 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     this._events.on(selection, SELECTION_CHANGE, this._onSelectionChanged);
 
     // We need to use native on this to prevent MarqueeSelection from handling the event before us.
-    this._events.on(this._rootElement!, 'mousedown', this._onRootMouseDown);
+    this._events.on(this._rootElement.current!, 'mousedown', this._onRootMouseDown);
 
-    this._events.on(this._rootElement!, 'keydown', this._onRootKeyDown);
+    this._events.on(this._rootElement.current!, 'keydown', this._onRootKeyDown);
 
     if (this._getColumnReorderProps()) {
       this._subscriptionObject = this._dragDropHelper.subscribe(
-        this._rootElement!,
+        this._rootElement.current!,
         this._events,
         this._getHeaderDragDropOptions(),
       );
@@ -120,7 +119,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     if (this._getColumnReorderProps()) {
       if (!this._subscriptionObject) {
         this._subscriptionObject = this._dragDropHelper.subscribe(
-          this._rootElement!,
+          this._rootElement.current!,
           this._events,
           this._getHeaderDragDropOptions(),
         );
@@ -214,7 +213,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
         aria-label={ariaLabel}
         className={classNames.root}
         componentRef={this._rootComponent}
-        ref={this._onRootRef}
+        elementRef={this._rootElement}
         onMouseMove={this._onRootMouseMove}
         data-automationid="DetailsHeader"
         direction={FocusZoneDirection.horizontal}
@@ -350,7 +349,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
 
   /** Set focus to the active thing in the focus area. */
   public focus(): boolean {
-    return Boolean(this._rootComponent.current && this._rootComponent.current.focus());
+    return !!this._rootComponent.current?.focus();
   }
 
   /**
@@ -484,8 +483,8 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     const frozenColumnCountFromEnd = columnReorderProps.frozenColumnCountFromEnd || 0;
 
     for (let i = frozenColumnCountFromStart; i < columns.length - frozenColumnCountFromEnd + 1; i++) {
-      if (this._rootElement) {
-        const dropHintElement = this._rootElement.querySelectorAll('#columnDropHint_' + i)[0] as HTMLElement;
+      if (this._rootElement.current) {
+        const dropHintElement = this._rootElement.current.querySelectorAll('#columnDropHint_' + i)[0] as HTMLElement;
         if (dropHintElement) {
           if (i === frozenColumnCountFromStart) {
             prevX = dropHintElement.offsetLeft;
@@ -521,8 +520,8 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
    */
   private _computeDropHintToBeShown = (clientX: number): void => {
     const isRtl = getRTL(this.props.theme);
-    if (this._rootElement) {
-      const clientRect = this._rootElement.getBoundingClientRect();
+    if (this._rootElement.current) {
+      const clientRect = this._rootElement.current.getBoundingClientRect();
       const headerOriginX = clientRect.left;
       const eventXRelativePosition = clientX - headerOriginX;
       const currentDropHintIndex = this._currentDropHintIndex;
@@ -610,8 +609,8 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
   };
 
   private _isEventOnHeader(event: MouseEvent): ColumnDragEndLocation | undefined {
-    if (this._rootElement) {
-      const clientRect = this._rootElement.getBoundingClientRect();
+    if (this._rootElement.current) {
+      const clientRect = this._rootElement.current.getBoundingClientRect();
       if (
         event.clientX > clientRect.left &&
         event.clientX < clientRect.right &&
@@ -739,16 +738,6 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
 
     if (columnResizeDetails && !isSizing && ev.clientX !== columnResizeDetails.originX) {
       this.setState({ isSizing: true });
-    }
-  };
-
-  private _onRootRef = (focusZone: FocusZone): void => {
-    if (focusZone) {
-      // Need to resolve the actual DOM node, not the component.
-      // The element itself will be used for drag/drop and focusing.
-      this._rootElement = findDOMNode(focusZone) as HTMLElement;
-    } else {
-      this._rootElement = undefined;
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -104,13 +104,13 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     // this._rootElement.current will be null in tests using react-test-renderer
     if (this._rootElement.current) {
       // We need to use native on this to prevent MarqueeSelection from handling the event before us.
-      this._events.on(this._rootElement.current!, 'mousedown', this._onRootMouseDown);
+      this._events.on(this._rootElement.current, 'mousedown', this._onRootMouseDown);
 
-      this._events.on(this._rootElement.current!, 'keydown', this._onRootKeyDown);
+      this._events.on(this._rootElement.current, 'keydown', this._onRootKeyDown);
 
       if (this._getColumnReorderProps()) {
         this._subscriptionObject = this._dragDropHelper.subscribe(
-          this._rootElement.current!,
+          this._rootElement.current,
           this._events,
           this._getHeaderDragDropOptions(),
         );

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import {
   initializeComponentRef,
   EventGroup,
@@ -47,7 +46,7 @@ const NO_COLUMNS: IColumn[] = [];
 
 export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetailsRowState> {
   private _events: EventGroup;
-  private _root: HTMLElement | undefined;
+  private _root = React.createRef<HTMLElement>();
   private _cellMeasurer = React.createRef<HTMLSpanElement>();
   private _focusZone = React.createRef<IFocusZone>();
   private _droppingClassNames: string;
@@ -78,7 +77,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
 
     if (dragDropHelper) {
       this._dragDropSubscription = dragDropHelper.subscribe(
-        this._root as HTMLElement,
+        this._root.current!,
         this._events,
         this._getRowDragDropOptions(),
       );
@@ -112,7 +111,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
 
       if (this.props.dragDropHelper) {
         this._dragDropSubscription = this.props.dragDropHelper.subscribe(
-          this._root as HTMLElement,
+          this._root.current!,
           this._events,
           this._getRowDragDropOptions(),
         );
@@ -271,7 +270,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
             }
           : {})}
         direction={FocusZoneDirection.horizontal}
-        ref={this._onRootRef}
+        elementRef={this._root}
         componentRef={this._focusZone}
         role="row"
         aria-label={ariaLabel}
@@ -362,7 +361,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
   }
 
   public focus(forceIntoFirstElement: boolean = false): boolean {
-    return !!this._focusZone.current && this._focusZone.current.focus(forceIntoFirstElement);
+    return !!this._focusZone.current?.focus(forceIntoFirstElement);
   }
 
   protected _onRenderCheck(props: IDetailsRowCheckProps) {
@@ -373,8 +372,8 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     const { itemIndex, selection } = props;
 
     return {
-      isSelected: !!selection && selection.isIndexSelected(itemIndex),
-      isSelectionModal: !!selection && !!selection.isModal && selection.isModal(),
+      isSelected: !!selection?.isIndexSelected(itemIndex),
+      isSelectionModal: !!selection?.isModal?.(),
     };
   }
 
@@ -385,16 +384,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
       this.setState({
         selectionState: selectionState,
       });
-    }
-  };
-
-  private _onRootRef = (focusZone: FocusZone): void => {
-    if (focusZone) {
-      // Need to resolve the actual DOM node, not the component.
-      // The element itself will be used for drag/drop and focusing.
-      this._root = ReactDOM.findDOMNode(focusZone) as HTMLElement;
-    } else {
-      this._root = undefined;
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -75,9 +75,9 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
   public componentDidMount(): void {
     const { dragDropHelper, selection, item, onDidMount } = this.props;
 
-    if (dragDropHelper) {
+    if (dragDropHelper && this._root.current) {
       this._dragDropSubscription = dragDropHelper.subscribe(
-        this._root.current!,
+        this._root.current,
         this._events,
         this._getRowDragDropOptions(),
       );
@@ -109,9 +109,9 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         delete this._dragDropSubscription;
       }
 
-      if (this.props.dragDropHelper) {
+      if (this.props.dragDropHelper && this._root.current) {
         this._dragDropSubscription = this.props.dragDropHelper.subscribe(
-          this._root.current!,
+          this._root.current,
           this._events,
           this._getRowDragDropOptions(),
         );

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -51,7 +51,7 @@ export interface IFocusZoneProps extends React.HTMLAttributes<HTMLElement | Focu
 
   /**
    * Optional callback to access the root DOM element.
-   *  @deprecated Temporary solution which will be replaced with ref in the V8 release.
+   * @deprecated Temporary solution which will be replaced with ref in the V8 release.
    */
   elementRef?: React.Ref<HTMLElement>;
 

--- a/packages/utilities/src/createMergedRef.ts
+++ b/packages/utilities/src/createMergedRef.ts
@@ -6,7 +6,7 @@ import { arraysEqual } from './array';
  */
 type LocalState<TType, TValue> = {
   refs: (React.Ref<TType | null | TValue> | undefined)[];
-  resolver: (newValue: TType | TValue | null) => void;
+  resolver?: (newValue: TType | TValue | null) => void;
 };
 
 /**
@@ -28,9 +28,9 @@ const createResolver = <TType, TValue>(local: LocalState<TType, TValue>) => (new
  * Helper to merge refs from within class components.
  */
 export const createMergedRef = <TType, TValue = null>(value?: TValue) => {
-  const local: LocalState<TType, TValue> = ({
-    refs: [],
-  } as unknown) as LocalState<TType, TValue>;
+  const local: LocalState<TType, TValue> = {
+    refs: [] as LocalState<TType, TValue>['refs'],
+  };
 
   return (
     ...newRefs: (React.Ref<TType | null | TValue> | undefined)[]
@@ -41,6 +41,6 @@ export const createMergedRef = <TType, TValue = null>(value?: TValue) => {
 
     local.refs = newRefs;
 
-    return local.resolver;
+    return local.resolver!;
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14685
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove `findDOMNode` usage from DetailsRow and DetailsHeader by using the new `IFocusZoneProps.elementRef` @czearing added.