### PR TITLE
fix: center align the start and end slot on tabs

### DIFF
--- a/change/@fluentui-web-components-2020-09-01-14-37-30-users-khamu-tabs-start-end-center.json
+++ b/change/@fluentui-web-components-2020-09-01-14-37-30-users-khamu-tabs-start-end-center.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "center align the start and end slot on tabs",
+  "packageName": "@fluentui/web-components",
+  "email": "37851220+khamudom@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T21:37:30.875Z"
+}

--- a/packages/web-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/src/tabs/tabs.styles.ts
@@ -25,10 +25,12 @@ export const TabsStyles = css`
 
   .start {
     padding: 2px;
+    align-self: center;
   }
 
   .end {
     padding: 2px;
+    align-self: center;
   }
 
   .activeIndicator {

--- a/packages/web-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/src/tabs/tabs.styles.ts
@@ -23,13 +23,8 @@ export const TabsStyles = css`
     align-self: end;
   }
 
-  .start {
-    padding: 2px;
-    align-self: center;
-  }
-
+  .start,
   .end {
-    padding: 2px;
     align-self: center;
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #3810
- [x] Include a change request file using `$ yarn change`

#### Description of changes

set align-self to center on start and end,  to align with the tab list.

#### Focus areas to test

(optional)
