### PR TITLE
Modify handling for onDrop function

### DIFF
--- a/change/@uifabric-experiments-2020-09-02-12-03-11-fixdnd.json
+++ b/change/@uifabric-experiments-2020-09-02-12-03-11-fixdnd.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where drop insert function can be called twice",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-02T19:03:11.282Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -20,7 +20,6 @@ import { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from '@uifabric/merge-styles';
 
-
 export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();
   const classNames = getClassNames(getStyles);
@@ -106,11 +105,11 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       const data = event.dataTransfer.items;
       for (let i = 0; i < data.length; i++) {
         if (data[i].kind === 'string' && data[i].type === props.customClipboardType) {
+          isDropHandled = true;
           data[i].getAsString((dropText: string) => {
             if (props.selectedItemsListProps.deserializeItemsFromDrop) {
               const newItems = props.selectedItemsListProps.deserializeItemsFromDrop(dropText);
               _dropItemsAt(insertIndex, newItems);
-              isDropHandled = true;
             }
           });
         }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
getAsString takes a callback function as a parameter. This mean that isHandled was not being set, we were going into the other if statement, then we were going back calling that function. In essence, _dropItemsAt was being called twice for the same drop. Moving it to be before the getAsString function so the fallback logic isn't incorrectly called.
