### PR TITLE
making the prop 'showYAxisGridLines' as deprecated.

### DIFF
--- a/change/@uifabric-charting-2020-09-03-11-29-24-user-v-sivar-MakeApropDeprecated.json
+++ b/change/@uifabric-charting-2020-09-03-11-29-24-user-v-sivar-MakeApropDeprecated.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "making the prop 'showYAxisGridLines' as deprecated.",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-03T05:59:24.586Z"
+}

--- a/packages/charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/charting/src/components/AreaChart/AreaChart.base.tsx
@@ -103,6 +103,13 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
   }
 
   public render(): JSX.Element {
+    // eslint-disable-next-line deprecation/deprecation
+    if (this.props.showYAxisGridLines !== undefined) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Warning: the prop showYAxisGridLines is deprecated, please do not use it, now lines are shown by default',
+      );
+    }
     const isXAxisDateType = getXAxisType(this._points);
     this._keys = this._createKeys();
     const legends: JSX.Element = this._getLegendData(this.props.theme!.palette);

--- a/packages/charting/src/components/AreaChart/AreaChart.types.ts
+++ b/packages/charting/src/components/AreaChart/AreaChart.types.ts
@@ -22,6 +22,13 @@ export interface IAreaChartProps extends ICartesianChartProps {
   data: IChartProps;
 
   /**
+   * This prop is used to draw Y axis grid lines on the chart. Default value will be false
+   * @deprecated now lines are shown by default
+   * no need to use this prop
+   */
+  showYAxisGridLines?: boolean;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ICartesianChartStyleProps, ICartesianChartStyles>;

--- a/packages/charting/src/components/AreaChart/examples/AreaChart.Basic.Example.tsx
+++ b/packages/charting/src/components/AreaChart/examples/AreaChart.Basic.Example.tsx
@@ -145,7 +145,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
-          <AreaChart height={this.state.height} width={this.state.width} data={chartData} />
+          <AreaChart height={this.state.height} width={this.state.width} data={chartData} showYAxisGridLines={true} />
         </div>
       </>
     );

--- a/packages/charting/src/components/AreaChart/examples/AreaChart.Styled.Example.tsx
+++ b/packages/charting/src/components/AreaChart/examples/AreaChart.Styled.Example.tsx
@@ -103,7 +103,7 @@ export class AreaChartStyledExample extends React.Component<{}, IAreaChartBasicS
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
         <div style={rootStyle}>
-          <AreaChart height={this.state.height} width={this.state.width} data={chartData} />
+          <AreaChart height={this.state.height} width={this.state.width} data={chartData} showYAxisGridLines={false} />
         </div>
       </>
     );


### PR DESCRIPTION
#### Pull request checklist
- [x] fixes the issue #14873 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

making the prop showYAxisGridLines as deprecated. since it not being used

#### Focus areas to test

area chart