### PR TITLE
feat(Datepicker): Add advanced keyboard navigation

### DIFF
--- a/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarBehavior.ts
@@ -25,6 +25,18 @@ export const datepickerCalendarBehavior: Accessibility<DatepickerCalendarBehavio
       subtractDay: {
         keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
       },
+      moveToStartOfWeek: {
+        keyCombinations: [{ keyCode: keyboardKey.Home, ctrlKey: false }],
+      },
+      moveToEndOfWeek: {
+        keyCombinations: [{ keyCode: keyboardKey.End, ctrlKey: false }],
+      },
+      moveToStartOfColumn: {
+        keyCombinations: [{ keyCode: keyboardKey.PageUp }],
+      },
+      moveToEndOfColumn: {
+        keyCombinations: [{ keyCode: keyboardKey.PageDown }],
+      },
     },
   },
 });

--- a/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarGridBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Datepicker/datepickerCalendarGridBehavior.ts
@@ -10,6 +10,7 @@ export const datepickerCalendarGridBehavior: Accessibility<DatepickerCalendarGri
   focusZone: {
     props: {
       direction: FocusZoneDirection.bidirectional,
+      pagingSupportDisabled: true,
     },
   },
 });

--- a/packages/fluentui/e2e/tests/datepicker-test.ts
+++ b/packages/fluentui/e2e/tests/datepicker-test.ts
@@ -43,4 +43,36 @@ describe('Datepicker', () => {
     expect(await e2e.isFocused(datepickerCalendarCell(15))).toBe(true); // 15 is a magic number
     expect(await e2e.textOf(datepickerCalendarCell(15))).toBe('3'); // which represents August 3, 2020, cell which should be focused on after the grid update
   });
+
+  it('Advanced keyboard navigation works', async () => {
+    await e2e.focusOn(datepickerButton);
+    await e2e.pressKey('Enter'); // open calendar
+    expect(await e2e.exists(datepickerCalendar)).toBe(true);
+    expect(await e2e.isFocused(datepickerCalendarCell(32))).toBe(true); // 32 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(32))).toBe('23'); // which represents July 23, 2020, cell focused by default
+
+    await e2e.pressKey('Home');
+    expect(await e2e.isFocused(datepickerCalendarCell(29))).toBe(true); // 29 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(29))).toBe('20'); // which represents July 20, 2020, first cell in the same grid row
+
+    await e2e.pressKey('End');
+    expect(await e2e.isFocused(datepickerCalendarCell(35))).toBe(true); // 35 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(35))).toBe('26'); // which represents July 26, 2020, last cell in the same grid row
+
+    await e2e.pressKey('PageUp');
+    expect(await e2e.isFocused(datepickerCalendarCell(14))).toBe(true); // 14 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(14))).toBe('5'); // which represents July 5, 2020, first cell in the same grid column
+
+    await e2e.pressKey('PageDown');
+    expect(await e2e.isFocused(datepickerCalendarCell(42))).toBe(true); // 42 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(42))).toBe('2'); // which represents August 2, 2020, last cell in the same grid column
+
+    await e2e.pressKey('Home', 'Control');
+    expect(await e2e.isFocused(datepickerCalendarCell(8))).toBe(true); // 8 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(8))).toBe('29'); // which represents June 29, 2020, first cell in the grid
+
+    await e2e.pressKey('End', 'Control');
+    expect(await e2e.isFocused(datepickerCalendarCell(42))).toBe(true); // 42 is a magic number
+    expect(await e2e.textOf(datepickerCalendarCell(42))).toBe('2'); // which represents August 2, 2020, last cell in the grid
+  });
 });

--- a/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
+++ b/packages/fluentui/react-northstar/src/components/Datepicker/DatepickerCalendar.tsx
@@ -15,6 +15,8 @@ import {
   compareDatePart,
   getMonthStart,
   getMonthEnd,
+  getStartDateOfWeek,
+  getEndDateOfWeek,
 } from '@fluentui/date-time-utilities';
 import {
   ComponentWithAs,
@@ -36,7 +38,7 @@ import { Grid } from '../Grid/Grid';
 import { DatepickerCalendarHeader, DatepickerCalendarHeaderProps } from './DatepickerCalendarHeader';
 import { DatepickerCalendarCellProps, DatepickerCalendarCell } from './DatepickerCalendarCell';
 import { DatepickerCalendarHeaderCellProps, DatepickerCalendarHeaderCell } from './DatepickerCalendarHeaderCell';
-import { navigateToNewDate } from './navigateToNewDate';
+import { navigateToNewDate, contstraintNavigatedDate } from './navigateToNewDate';
 import { format } from '@uifabric/utilities';
 
 export interface DatepickerCalendarProps extends UIComponentProps, Partial<ICalendarStrings>, Partial<IDayGridOptions> {
@@ -146,6 +148,53 @@ export const DatepickerCalendar: ComponentWithAs<'div', DatepickerCalendarProps>
       subtractDay: e => {
         e.preventDefault();
         const newNavigatedDate = navigateToNewDate(gridNavigatedDate, 'Day', -1, restrictedDatesOptions);
+
+        if (!!newNavigatedDate) {
+          setShouldFocusInDayGrid(true);
+          setGridNavigatedDate(newNavigatedDate);
+        }
+      },
+      moveToStartOfWeek: e => {
+        e.preventDefault();
+        const targetDate = getStartDateOfWeek(gridNavigatedDate, firstDayOfWeek);
+        const newNavigatedDate = contstraintNavigatedDate(gridNavigatedDate, targetDate, -1, restrictedDatesOptions);
+
+        if (!!newNavigatedDate) {
+          setShouldFocusInDayGrid(true);
+          setGridNavigatedDate(newNavigatedDate);
+        }
+      },
+      moveToEndOfWeek: e => {
+        e.preventDefault();
+        const targetDate = getEndDateOfWeek(gridNavigatedDate, firstDayOfWeek);
+        const newNavigatedDate = contstraintNavigatedDate(gridNavigatedDate, targetDate, -1, restrictedDatesOptions);
+
+        if (!!newNavigatedDate) {
+          setShouldFocusInDayGrid(true);
+          setGridNavigatedDate(newNavigatedDate);
+        }
+      },
+      moveToStartOfColumn: e => {
+        e.preventDefault();
+        const targetDayOfWeek = gridNavigatedDate.getDay();
+        const targetDate = _.find(visibleGrid[0], day => day.originalDate.getDay() === targetDayOfWeek)?.originalDate;
+
+        const newNavigatedDate = contstraintNavigatedDate(gridNavigatedDate, targetDate, -1, restrictedDatesOptions);
+
+        if (!!newNavigatedDate) {
+          setShouldFocusInDayGrid(true);
+          setGridNavigatedDate(newNavigatedDate);
+        }
+      },
+      moveToEndOfColumn: e => {
+        e.preventDefault();
+        const targetDayOfWeek = gridNavigatedDate.getDay();
+        const targetDate = _.find(
+          visibleGrid[visibleGrid.length - 1],
+          day => day.originalDate.getDay() === targetDayOfWeek,
+        )?.originalDate;
+
+        const newNavigatedDate = contstraintNavigatedDate(gridNavigatedDate, targetDate, -1, restrictedDatesOptions);
 
         if (!!newNavigatedDate) {
           setShouldFocusInDayGrid(true);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

Continuation of https://github.com/microsoft/fluentui/pull/14862

Following key shortcuts are supported:
Home – First cell of current row
End – Last cell of current row
Ctrl + Home – First cell of the grid (first row first cell)
Ctrl + End – Last cell of the grid (last row last cell)
Page up – First cell of current column (basically scroll up/down behaviour but in this case there’s no scrollbar)
Page down – Last cell of current column