### PR TITLE
useMergedRefs: now returns React.RefObject so that the current value can be referenced easily

### DIFF
--- a/change/@uifabric-react-hooks-2020-09-03-14-55-01-fix-useMergedRefs.json
+++ b/change/@uifabric-react-hooks-2020-09-03-14-55-01-fix-useMergedRefs.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "useMergedRefs now properly returns a more usable React.RefObject type.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "dzearing@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-03T21:55:01.177Z"
+}

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -8,7 +8,6 @@ import { Async } from '@uifabric/utilities';
 import { ISettingsMap } from '@uifabric/utilities/lib/warn';
 import { IWarnControlledUsageParams } from '@uifabric/utilities/lib/warn';
 import * as React from 'react';
-import { Ref } from 'react';
 
 // @public (undocumented)
 export type ChangeCallback<TElement extends HTMLElement, TValue, TEvent extends React.SyntheticEvent<TElement> | undefined> = (ev: TEvent, newValue: TValue | undefined) => void;
@@ -63,7 +62,7 @@ export function useForceUpdate(): () => void;
 export function useId(prefix?: string, providedId?: string): string;
 
 // @public
-export function useMergedRefs<T>(...refs: (Ref<T> | undefined)[]): (instance: T) => void;
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefObject<T>;
 
 // @public
 export function useOnEvent<TElement extends Element, TEvent extends Event>(element: React.RefObject<TElement | undefined | null> | TElement | Window | Document | undefined | null, eventName: string, callback: (ev: TEvent) => void, useCapture?: boolean): void;

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -37,7 +37,7 @@ export interface IWarningOptions<P> {
 // @public
 export type RefCallback<T> = ((value: T | null) => void) & React.RefObject<T>;
 
-// @public (undocumented)
+// @public
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 // @public

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -62,7 +62,7 @@ export function useForceUpdate(): () => void;
 export function useId(prefix?: string, providedId?: string): string;
 
 // @public
-export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefObject<T>;
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): ((value: T) => void) & React.RefObject<T>;
 
 // @public
 export function useOnEvent<TElement extends Element, TEvent extends Event>(element: React.RefObject<TElement | undefined | null> | TElement | Window | Document | undefined | null, eventName: string, callback: (ev: TEvent) => void, useCapture?: boolean): void;

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -37,6 +37,9 @@ export interface IWarningOptions<P> {
 // @public
 export type RefCallback<T> = ((value: T | null) => void) & React.RefObject<T>;
 
+// @public (undocumented)
+export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
+
 // @public
 export function useAsync(): Async;
 
@@ -62,7 +65,7 @@ export function useForceUpdate(): () => void;
 export function useId(prefix?: string, providedId?: string): string;
 
 // @public
-export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): ((value: T) => void) & React.RefObject<T>;
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T>;
 
 // @public
 export function useOnEvent<TElement extends Element, TEvent extends Event>(element: React.RefObject<TElement | undefined | null> | TElement | Window | Document | undefined | null, eventName: string, callback: (ev: TEvent) => void, useCapture?: boolean): void;

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -49,7 +49,10 @@ describe('useMergedRefs', () => {
     let refValue: boolean | null = null;
     const TestComponent: React.FunctionComponent = () => {
       const mergedRef = useMergedRefs<boolean>(refObject, val => (refValue = val));
-      mergedRef(true);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mergedRef as any)(true);
+
       return null;
     };
     wrapper = mount(<TestComponent />);
@@ -58,13 +61,30 @@ describe('useMergedRefs', () => {
     expect(refValue).toBe(true);
   });
 
+  it('updates the current property', () => {
+    let mergedRef: React.RefObject<string> | undefined = undefined;
+
+    const TestComponent: React.FunctionComponent = () => {
+      mergedRef = useMergedRefs(React.useRef<string>(''), React.useRef<string>(''));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mergedRef as any)('123');
+      return null;
+    };
+
+    wrapper = mount(<TestComponent />);
+
+    expect(mergedRef).toBeTruthy();
+    expect(mergedRef!.current).toEqual('123');
+  });
+
   it('reuses the same ref callback if refs remain stable', () => {
     const refObject: React.RefObject<boolean> = React.createRef<boolean>();
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     const refValueFunc = (val: boolean) => {};
+    let refCallback: React.RefObject<boolean> | undefined = undefined;
 
-    let refCallback: Function | undefined = undefined;
     const TestComponent: React.FunctionComponent = () => {
       refCallback = useMergedRefs<boolean>(refObject, refValueFunc);
       return null;
@@ -88,7 +108,10 @@ describe('useMergedRefs', () => {
 
     const TestComponent: React.FunctionComponent = () => {
       const mergedRef = useMergedRefs<boolean>(refObject, refValueFunc);
-      mergedRef(true);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (mergedRef as any)(true);
+
       return null;
     };
 

--- a/packages/react-hooks/src/useMergedRefs.test.tsx
+++ b/packages/react-hooks/src/useMergedRefs.test.tsx
@@ -50,8 +50,7 @@ describe('useMergedRefs', () => {
     const TestComponent: React.FunctionComponent = () => {
       const mergedRef = useMergedRefs<boolean>(refObject, val => (refValue = val));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mergedRef as any)(true);
+      mergedRef(true);
 
       return null;
     };
@@ -62,13 +61,13 @@ describe('useMergedRefs', () => {
   });
 
   it('updates the current property', () => {
-    let mergedRef: React.RefObject<string> | undefined = undefined;
+    let mergedRef: (React.RefObject<string> & ((val: string) => void)) | undefined = undefined;
 
     const TestComponent: React.FunctionComponent = () => {
       mergedRef = useMergedRefs(React.useRef<string>(''), React.useRef<string>(''));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mergedRef as any)('123');
+      mergedRef('123');
+
       return null;
     };
 
@@ -109,8 +108,7 @@ describe('useMergedRefs', () => {
     const TestComponent: React.FunctionComponent = () => {
       const mergedRef = useMergedRefs<boolean>(refObject, refValueFunc);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (mergedRef as any)(true);
+      mergedRef(true);
 
       return null;
     };

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -5,7 +5,7 @@ import * as React from 'react';
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefObject<T> {
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): ((value: T) => void) & React.RefObject<T> {
   const mergedCallback = (React.useCallback(
     (value: T) => {
       // Update the "current" prop hanging on the function.
@@ -22,7 +22,7 @@ export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.R
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  ) as unknown) as React.RefObject<T>;
+  ) as unknown) as ((value: T) => void) & React.RefObject<T>;
 
   return mergedCallback;
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,14 +1,11 @@
 import * as React from 'react';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export interface MergedRefReturnType<T> extends React.RefObject<T> {}
-
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): MergedRefReturnType<T> {
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefObject<T> {
   const mergedCallback = (React.useCallback(
     (value: T) => {
       // Update the "current" prop hanging on the function.
@@ -25,7 +22,7 @@ export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): MergedR
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  ) as unknown) as MergedRefReturnType<T>;
+  ) as unknown) as React.RefObject<T>;
 
   return mergedCallback;
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -9,7 +9,8 @@ export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
- * @param refs- Refs to collectively update with one ref value.
+ * @param refs - Refs to collectively update with one ref value.
+ * @returns A function with an attached "current" prop, so that it can be treated like a RefObject.
  */
 export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T> {
   const mergedCallback: RefObjectFunction<T> = (React.useCallback(

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,22 +1,31 @@
-import { useCallback, Ref, MutableRefObject } from 'react';
+import * as React from 'react';
+
+// eslint-disable-next-line @typescript-eslint/naming-convention
+export interface MergedRefReturnType<T> extends React.RefObject<T> {}
+
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: (Ref<T> | undefined)[]): (instance: T) => void {
-  return useCallback(
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): MergedRefReturnType<T> {
+  const mergedCallback = (React.useCallback(
     (value: T) => {
+      // Update the "current" prop hanging on the function.
+      ((mergedCallback as unknown) as React.MutableRefObject<T>).current = value;
+
       for (const ref of refs) {
         if (typeof ref === 'function') {
           ref(value);
         } else if (ref) {
           // work around the immutability of the React.Ref type
-          ((ref as unknown) as MutableRefObject<T>).current = value;
+          ((ref as unknown) as React.MutableRefObject<T>).current = value;
         }
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  );
+  ) as unknown) as MergedRefReturnType<T>;
+
+  return mergedCallback;
 }

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,5 +1,9 @@
 import * as React from 'react';
 
+/**
+ * A Ref function which can be treated like a ref object in that it has an attached
+ * current property, which will be updated as the ref is evaluated.
+ */
 export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
 
 /**

--- a/packages/react-hooks/src/useMergedRefs.ts
+++ b/packages/react-hooks/src/useMergedRefs.ts
@@ -1,12 +1,14 @@
 import * as React from 'react';
 
+export type RefObjectFunction<T> = React.RefObject<T> & ((value: T) => void);
+
 /**
  * React hook to merge multiple React refs (either MutableRefObjects or ref callbacks) into a single ref callback that
  * updates all provided refs
  * @param refs- Refs to collectively update with one ref value.
  */
-export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): ((value: T) => void) & React.RefObject<T> {
-  const mergedCallback = (React.useCallback(
+export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): RefObjectFunction<T> {
+  const mergedCallback: RefObjectFunction<T> = (React.useCallback(
     (value: T) => {
       // Update the "current" prop hanging on the function.
       ((mergedCallback as unknown) as React.MutableRefObject<T>).current = value;
@@ -22,7 +24,7 @@ export function useMergedRefs<T>(...refs: (React.Ref<T> | undefined)[]): ((value
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- already exhaustive
     [...refs],
-  ) as unknown) as ((value: T) => void) & React.RefObject<T>;
+  ) as unknown) as RefObjectFunction<T>;
 
   return mergedCallback;
 }


### PR DESCRIPTION
Before:

```jsx
const Foo = React.forwardRef((props, ref) => {
  const mergedRef = useMergedRefs(ref, React.useRef());

  // Does not work because the ref is a function without a `current` prop available.
  return <ContextualMenu target={mergedRef} />
}
```

After:

```jsx
const Foo = React.forwardRef((props, ref) => {
  const mergedRef = useMergedRefs(ref, React.useRef());

  // Works because mergedRef is now a RefObject with `current` available.
  return <ContextualMenu target={mergedRef} />
}
```