### PR TITLE
fix(UI builder): Image with no height in build mode

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -49,6 +49,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added icons `BluetoothIcon`, `BreakoutRoomIcon`, `ConferenceRoomDeviceIcon`, `FilesErrorIcon` @TanelVari ([#14043](https://github.com/microsoft/fluentui/pull/14043))
 
 ### Documentation
+- Fixed image with no height in build mode - UI builder @vyhnalekl ([#14893](https://github.com/microsoft/fluentui/pull/14893))
 - Added copy paste keyboard shortcuts to UI builder @vyhnalekl ([#14631](https://github.com/microsoft/fluentui/pull/14631))
 - Removed parameters from url after switch to store (UI builder) @vyhnalekl ([#14754](https://github.com/microsoft/fluentui/pull/14754))
 - Edited left side menu in UI builder @vyhnalekl ([#14436](https://github.com/microsoft/fluentui/pull/14436))

--- a/packages/fluentui/react-builder/src/components/Canvas.tsx
+++ b/packages/fluentui/react-builder/src/components/Canvas.tsx
@@ -166,10 +166,12 @@ export const Canvas: React.FunctionComponent<CanvasProps> = ({
               const { marginTop, marginRight, marginBottom, marginLeft } = iframeWindow.getComputedStyle(element);
               element.setAttribute('data-builder-id', builderId);
 
+              const isContainer = element.tagName === 'DIV';
               const hasNoChildren = element.childElementCount === 0;
               const hasManyChildren = element.childElementCount > 1;
               const properties = [
-                hasNoChildren &&
+                isContainer &&
+                  hasNoChildren &&
                   `height: 0px;
                   padding-left: calc(${debugSize} * 2);\n  padding-right: calc(${debugSize} * 2);
                   padding-top: calc(${debugSize} * 2);\n  padding-bottom: calc(${debugSize} * 2);`,
@@ -185,7 +187,7 @@ export const Canvas: React.FunctionComponent<CanvasProps> = ({
               // console.log(
               //   element,
               //   '\nHAS\n',
-              //   { width, height, marginTop, marginRight, marginBottom, marginLeft },
+              //   { isContainer, hasNoChildren, marginTop, marginRight, marginBottom, marginLeft },
               //   '\nGETS\n',
               //   properties,
               // );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The issue was that after Drag and Drop an image has no height in a build mode. Thus the image is not showing. The issue was caused by this PR [14384](https://github.com/microsoft/fluentui/pull/14384). This PR is fixing the issue.