### PR TITLE
fix(UI builder): Dragging selected components in canvas

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -65,6 +65,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fixed incorrect margin and padding after drag&drop (UI builder) @vyhnalekl ([#14384](https://github.com/microsoft/fluentui/pull/14384))
 - Add `Form.Datepicker` example with error message handler @pompomon ([#14820](https://github.com/microsoft/fluentui/pull/14820))
 - Fixed as prop in UI builder @vyhnalekl ([#14815](https://github.com/microsoft/fluentui/pull/14815))
+- Fixed dragging selected component in canvas UI builder @vyhnalekl ([#14894](https://github.com/microsoft/fluentui/pull/14894))
 
 <!--------------------------------[ v0.51.0 ]------------------------------- -->
 ## [v0.51.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.51.0) (2020-07-27)

--- a/packages/fluentui/react-builder/src/components/DebugFrame.tsx
+++ b/packages/fluentui/react-builder/src/components/DebugFrame.tsx
@@ -117,7 +117,7 @@ export const DebugFrame: React.FunctionComponent<DebugFrameProps> = ({
         userSelect: 'none',
       }}
     >
-      <div style={{ width: '100%', height: '100%' }} onMouseDown={handleMove} />
+      <div style={{ width: '100%', height: '100%' }} draggable={true} onDragStart={handleMove} />
       <div style={styles}>
         <span style={{ fontWeight: 'bold' }}>{componentName}</span>
         <LevelUpDebugButton onClick={handleGoToParent} />


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The issue was that previously the drag and drop in canvas started with `onClick` event. This was not user friendly, thus the event was changed to `onDragStart`.