### PR TITLE
Making fluid button screener tests take 100% of the width to properly test for fluid styling

### DIFF
--- a/apps/vr-tests/src/stories/ButtonNext.stories.tsx
+++ b/apps/vr-tests/src/stories/ButtonNext.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '@fluentui/react-button';
 import { AddIcon } from '@fluentui/react-icons';
 import { TeamsTheme } from '@fluentui/react-theme-provider';
 import { withThemeProvider } from '@fluentui/storybook';
-import { FabricDecorator } from '../utilities';
+import { FabricDecorator, FabricDecoratorFullWidth } from '../utilities';
 
 storiesOf('Button Next', module)
   .addDecorator(FabricDecorator)
@@ -305,7 +305,7 @@ storiesOf('Button Next - Icon only', module)
   ));
 
 storiesOf('Button Next - Fluid', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFullWidth)
   .addDecorator(withThemeProvider)
   .addDecorator(story => (
     <Screener


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR changes the use of `FabricDecorator` to `FabricDecoratorFullWidth` in the fluid button visual regression tests to account for fluid styling taking the full width of its container.

#### Focus areas to test

(optional)
