### PR TITLE
FocusZone: Adding forceAlignment attribute to focusElement to set focus alignment according to the element provided

### DIFF
--- a/change/@fluentui-react-focus-2020-09-04-13-19-52-focusZoneFocusElementForceAlignment.json
+++ b/change/@fluentui-react-focus-2020-09-04-13-19-52-focusZoneFocusElementForceAlignment.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "FocusZone: Adding forceAlignment attribute to focusElement to set focus aligment according to the element provided.",
+  "packageName": "@fluentui/react-focus",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-04T20:19:52.045Z"
+}

--- a/change/@fluentui-react-focus-2020-09-04-13-19-52-focusZoneFocusElementForceAlignment.json
+++ b/change/@fluentui-react-focus-2020-09-04-13-19-52-focusZoneFocusElementForceAlignment.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "FocusZone: Adding forceAlignment attribute to focusElement to set focus aligment according to the element provided.",
+  "comment": "FocusZone: Adding forceAlignment attribute to focusElement to set focus alignment according to the element provided.",
   "packageName": "@fluentui/react-focus",
   "email": "humbertomakotomorimoto@gmail.com",
   "dependentChangeType": "patch",

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -40,6 +40,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Add `shouldFocusFirstElementWhenReceivedFocus` prop, which forces focus to first element when container receives focus @sophieH29 ([#469](https://github.com/stardust-ui/react/pull/469))
 - Handle keyDownCapture based on `shouldHandleKeyDownCapture` prop @sophieH29 ([#563](https://github.com/stardust-ui/react/pull/563))
 - Add `bidirectionalDomOrder` direction allowing arrow keys navigation following DOM order @sophieH29 ([#1637](https://github.com/stardust-ui/react/pull/1647))
+- FocusZone: Adding `forceAlignment` attribute to `focusElement` to set focus aligment according to the element provided @khmakoto ([#14911](https://github.com/microsoft/fluentui/pull/14911))
 
 ### Upgrade `FocusZone` to the latest version from `fabric-ui` @sophieH29 ([#1772](https://github.com/stardust-ui/react/pull/1772))
 - Restore focus on removing item ([OfficeDev/office-ui-fabric-react#7818](https://github.com/OfficeDev/office-ui-fabric-react/pull/7818))

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -40,7 +40,7 @@ This is a list of changes made to this Stardust copy of FocusZone in comparison 
 - Add `shouldFocusFirstElementWhenReceivedFocus` prop, which forces focus to first element when container receives focus @sophieH29 ([#469](https://github.com/stardust-ui/react/pull/469))
 - Handle keyDownCapture based on `shouldHandleKeyDownCapture` prop @sophieH29 ([#563](https://github.com/stardust-ui/react/pull/563))
 - Add `bidirectionalDomOrder` direction allowing arrow keys navigation following DOM order @sophieH29 ([#1637](https://github.com/stardust-ui/react/pull/1647))
-- FocusZone: Adding `forceAlignment` attribute to `focusElement` to set focus aligment according to the element provided @khmakoto ([#14911](https://github.com/microsoft/fluentui/pull/14911))
+- FocusZone: Adding `forceAlignment` attribute to `focusElement` to set focus alignment according to the element provided @khmakoto ([#14911](https://github.com/microsoft/fluentui/pull/14911))
 
 ### Upgrade `FocusZone` to the latest version from `fabric-ui` @sophieH29 ([#1772](https://github.com/stardust-ui/react/pull/1772))
 - Restore focus on removing item ([OfficeDev/office-ui-fabric-react#7818](https://github.com/OfficeDev/office-ui-fabric-react/pull/7818))

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -338,7 +338,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus aligment will be set according to the element provided.
+   * @param forceAlignment If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -338,7 +338,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus alignment will be set according to the element provided.
+   * @param forceAlignment - If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -338,9 +338,10 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
+   * @param forceAlignment If true, focus aligment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focusElement(element: HTMLElement): boolean {
+  focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {
     const { shouldReceiveFocus } = this.props;
 
     if (shouldReceiveFocus && !shouldReceiveFocus(element)) {
@@ -348,7 +349,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
     }
 
     if (element) {
-      this.setActiveElement(element);
+      this.setActiveElement(element, forceAlignment);
       if (this._activeElement) {
         this._activeElement.focus();
       }
@@ -514,7 +515,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
     }
   };
 
-  setActiveElement(element: HTMLElement, forceAlignemnt?: boolean): void {
+  setActiveElement(element: HTMLElement, forceAlignment?: boolean): void {
     const previousActiveElement = this._activeElement;
 
     this._activeElement = element;
@@ -528,7 +529,7 @@ export class FocusZone extends React.Component<FocusZoneProps> implements IFocus
     }
 
     if (this._activeElement) {
-      if (!this._focusAlignment || forceAlignemnt) {
+      if (!this._focusAlignment || forceAlignment) {
         this.setFocusAlignment(element, true, true);
       }
 

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -25,7 +25,7 @@ export interface IFocusZone {
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus alignment will be set according to the element provided.
+   * @param forceAlignment - If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -25,9 +25,10 @@ export interface IFocusZone {
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
+   * @param forceAlignment If true, focus aligment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focusElement(childElement?: HTMLElement): boolean;
+  focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;
 }
 
 // Heads up! Keep in sync with packages/accessibility/src/focusZone/types.ts

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts
@@ -25,7 +25,7 @@ export interface IFocusZone {
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus aligment will be set according to the element provided.
+   * @param forceAlignment If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;

--- a/packages/react-focus/etc/react-focus.api.md
+++ b/packages/react-focus/etc/react-focus.api.md
@@ -20,7 +20,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // (undocumented)
     static defaultProps: IFocusZoneProps;
     focus(forceIntoFirstElement?: boolean): boolean;
-    focusElement(element: HTMLElement): boolean;
+    focusElement(element: HTMLElement, forceAlignment?: boolean): boolean;
     focusLast(): boolean;
     static getOuterZones(): number;
     // (undocumented)
@@ -49,7 +49,7 @@ export type FocusZoneTabbableElements = typeof FocusZoneTabbableElements[keyof t
 // @public
 export interface IFocusZone {
     focus(forceIntoFirstElement?: boolean): boolean;
-    focusElement(childElement?: HTMLElement): boolean;
+    focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;
     focusLast(): boolean;
     setFocusAlignment(point: Point): void;
 }

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -337,7 +337,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus alignment will be set according to the element provided.
+   * @param forceAlignment - If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   public focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -337,9 +337,10 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
+   * @param forceAlignment If true, focus aligment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  public focusElement(element: HTMLElement): boolean {
+  public focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {
     // eslint-disable-next-line deprecation/deprecation
     const { onBeforeFocus, shouldReceiveFocus } = this.props;
 
@@ -349,7 +350,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     if (element) {
       // when we Set focus to a specific child, we should recalculate the alignment depend on its position
-      this._setActiveElement(element);
+      this._setActiveElement(element, forceAlignment);
       if (this._activeElement) {
         this._activeElement.focus();
       }

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -337,7 +337,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param element - The child element within the zone to focus.
-   * @param forceAlignment If true, focus aligment will be set according to the element provided.
+   * @param forceAlignment If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   public focusElement(element: HTMLElement, forceAlignment?: boolean): boolean {

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -349,7 +349,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     }
 
     if (element) {
-      // when we Set focus to a specific child, we should recalculate the alignment depend on its position
+      // when we set focus to a specific child, we should recalculate the alignment depending on its position.
       this._setActiveElement(element, forceAlignment);
       if (this._activeElement) {
         this._activeElement.focus();

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -25,10 +25,11 @@ export interface IFocusZone {
    * Sets focus to a specific child element within the zone. This can be used in conjunction with
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
-   * @param element - The child element within the zone to focus.
+   * @param childElement - The child element within the zone to focus.
+   * @param forceAlignment If true, focus aligment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
-  focusElement(childElement?: HTMLElement): boolean;
+  focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;
 
   /**
    * Forces horizontal alignment in the context of vertical arrowing to use specific point as the reference, rather

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -26,7 +26,7 @@ export interface IFocusZone {
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param childElement - The child element within the zone to focus.
-   * @param forceAlignment If true, focus alignment will be set according to the element provided.
+   * @param forceAlignment - If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;

--- a/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.types.ts
@@ -26,7 +26,7 @@ export interface IFocusZone {
    * shouldReceiveFocus to create delayed focus scenarios (like animate the scroll position to the correct
    * location and then focus.)
    * @param childElement - The child element within the zone to focus.
-   * @param forceAlignment If true, focus aligment will be set according to the element provided.
+   * @param forceAlignment If true, focus alignment will be set according to the element provided.
    * @returns True if focus could be set to an active element, false if no operation was taken.
    */
   focusElement(childElement?: HTMLElement, forceAlignment?: boolean): boolean;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds a second optional `forceAlignment` parameter into the imperative `focusElement` function to allow the user to set the focus alignment according to the element they provide via the `element` parameter.

#### Focus areas to test

(optional)
