### PR TITLE
Renaming react-next SpinButton's internalState interface

### DIFF
--- a/change/@fluentui-react-next-2020-09-04-15-06-35-feat-renaming-SpinButton-internalState-interface.json
+++ b/change/@fluentui-react-next-2020-09-04-15-06-35-feat-renaming-SpinButton-internalState-interface.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-04T22:06:35.295Z"
+}

--- a/change/@fluentui-react-next-2020-09-04-15-06-35-feat-renaming-SpinButton-internalState-interface.json
+++ b/change/@fluentui-react-next-2020-09-04-15-06-35-feat-renaming-SpinButton-internalState-interface.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "packageName": "@fluentui/react-next",
-  "email": "czearing@outlook.com",
-  "dependentChangeType": "patch",
-  "date": "2020-09-04T22:06:35.295Z"
-}

--- a/change/@fluentui-react-next-2020-09-04-15-07-13-feat-renaming-SpinButton-internalState-interface.json
+++ b/change/@fluentui-react-next-2020-09-04-15-07-13-feat-renaming-SpinButton-internalState-interface.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Renaming SpinButton internalState interface.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-04T22:07:13.240Z"
+}

--- a/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
+++ b/packages/react-next/src/components/SpinButton/SpinButton.base.tsx
@@ -19,7 +19,7 @@ import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 import { KeytipData } from '../../KeytipData';
 import { useBoolean, useSetTimeout, useControllableValue, useWarnings } from '@uifabric/react-hooks';
 
-interface ISpinButtonState {
+interface ISpinButtonInternalState {
   inputId: string;
   labelId: string;
   lastValidValue: string;
@@ -114,7 +114,7 @@ export const SpinButtonBase = (props: ISpinButtonProps) => {
     initialValue = typeof min === 'number' ? String(min) : '0';
   }
 
-  const { current: internalState } = React.useRef<ISpinButtonState>({
+  const { current: internalState } = React.useRef<ISpinButtonInternalState>({
     inputId: getId('input'),
     labelId: getId('Label'),
     lastValidValue: initialValue,


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Renaming react-next `SpinButton's` ISpinButtonState interface to ISpinButtonInternalState to better reflect it's usage.
