### PR TITLE
fix(GroupedList): forceUpdate was not propagating to sub-groups

### DIFF
--- a/change/office-ui-fabric-react-2020-09-09-05-36-09-fix-grouped-list-force-update.json
+++ b/change/office-ui-fabric-react-2020-09-09-05-36-09-fix-grouped-list-force-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "GroupedList: Fixed forceListUpdate was not propagating to subgroups",
+  "packageName": "office-ui-fabric-react",
+  "email": "marwankhalili@hotmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T03:36:09.946Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -313,26 +313,17 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     return ev.which === getRTLSafeKeyCode(KeyCodes.right);
   };
 
-  private _forceListUpdates(groups?: IGroup[]): void {
-    groups = groups || this.state.groups;
-
-    const groupCount = groups ? groups.length : 1;
-
+  private _forceListUpdates(): void {
     if (this._list.current) {
       this._list.current.forceUpdate();
+    }
 
-      for (let i = 0; i < groupCount; i++) {
-        const group = this._list.current.pageRefs['group_' + String(i)] as GroupedListSection;
-        if (group) {
-          group.forceListUpdate();
-        }
-      }
-    } else {
-      const group = this._groupRefs['group_' + String(0)];
+    Object.keys(this._groupRefs).forEach(refKey => {
+      const group = this._groupRefs[refKey];
       if (group) {
         group.forceListUpdate();
       }
-    }
+    });
   }
 
   private _onToggleSummarize = (group: IGroup): void => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -278,29 +278,16 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
   }
 
   public forceListUpdate() {
-    const { group } = this.props;
-
     if (this._list.current) {
       this._list.current.forceUpdate();
+    }
 
-      if (group && group.children && group.children.length > 0) {
-        const subGroupCount = group.children.length;
-
-        for (let i = 0; i < subGroupCount; i++) {
-          const subGroup = this._list.current.pageRefs['subGroup_' + String(i)] as GroupedListSection;
-
-          if (subGroup) {
-            subGroup.forceListUpdate();
-          }
-        }
-      }
-    } else {
-      const subGroup = this._subGroupRefs['subGroup_' + String(0)];
-
+    Object.keys(this._subGroupRefs).forEach(refKey => {
+      const subGroup = this._subGroupRefs[refKey];
       if (subGroup) {
         subGroup.forceListUpdate();
       }
-    }
+    });
   }
 
   private _onRenderGroupHeader = (props: IGroupHeaderProps): JSX.Element => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14589
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes expand / collapse functionality not working for sub-groups since v7.125.0.

- GroupedList's `_forceListUpdates` will now iterate over `this._groupRefs` and call `forceListUpdate()` on every GroupedListSection component. The optional function parameter in `_forceListUpdates` has been removed since it was not being used in any function calls and a proper implementation was missing.

- GroupedListSection's `forceListUpdate` will now iterate over `this._subGroupRefs` and call `forceListUpdate()` on every GroupedListSection component.
