### PR TITLE
feat(UI builder): Integrated the screen reader message computation script into UI Builder

### DIFF
--- a/packages/fluentui/react-builder/src/components/Canvas.tsx
+++ b/packages/fluentui/react-builder/src/components/Canvas.tsx
@@ -9,7 +9,7 @@ import { DebugFrame } from './DebugFrame';
 import { DropSelector } from './DropSelector';
 import { ReaderText } from './ReaderText';
 
-const showNarration = false;
+const showNarration = true;
 
 export type CanvasProps = {
   draggingElement: JSONTreeElement;

--- a/packages/fluentui/react-builder/src/components/MessageComputer.tsx
+++ b/packages/fluentui/react-builder/src/components/MessageComputer.tsx
@@ -1,0 +1,247 @@
+/*
+ TODO:
+* Add the missing and not so obvious attributes (e.g. "aria-haspopup" or "aria-expanded") for the already defined roles (e.g. "menuitem" or "checkbox") according to the specification.
+* With JAWS, in the case of the element with the "listbox" role, differentiate between having and not having the aria-multiselectable="true" attribute. If this attribute is present, then aria-selected="false" on the child elements with the role "option" behave differently than if it is not present. Specifically, if aria-multiselectable="true" is present, the aria-selected="false" causes the narration of "not selected", but if present, having the aria-selected attribute makes no difference to the narration. 
+ * What about the "disabled" state?
+ */
+import SRMC from './SRMC-Definitions';
+import './SRMC-Rules-Win_JAWS';
+
+export default class MessageComputer {
+  private computedMessageParts: { [key: string]: string } = {
+    value: '',
+    name: '',
+    description: '',
+    type: '',
+    state: '',
+    position: '',
+    usage: '',
+  };
+
+  // Asynchronously computes and returns the complete screen reader message for the given element and platform.
+  async computeMessage(element: HTMLElement, platform: string): Promise<string> {
+    let definitionName = this.getDefinitionName(element, platform, 'stateRules');
+
+    // Determine and save the usage string
+    this.computedMessageParts.usage = '';
+    const usages = SRMC.usageStrings[platform][definitionName];
+    if (usages) {
+      // Begin if 1
+      if (usages['[default]']) {
+        // Begin if 2
+        this.computedMessageParts.usage = usages['[default]'];
+      } // End if 2
+      for (let usageName in usages) {
+        // Begin for 1
+        const split = usageName.split('=');
+        const state = split[0];
+        const stateValue = split[1];
+        const stateAndValueMatch = element.getAttribute(state) === stateValue;
+        const checkedDOMPropAndValueMatch =
+          state === 'checked' && (element as HTMLInputElement).checked.toString() === stateValue;
+        if (stateAndValueMatch || checkedDOMPropAndValueMatch) {
+          // Begin if 2
+          this.computedMessageParts.usage = usages[usageName];
+        } // End if 2
+      } // End for 1
+    } // End if 1
+
+    // compute the element's accessible description
+    let computedDescription = '';
+
+    // First, handle some special case conditions
+    let value;
+    if (definitionName === 'textarea') {
+      // Begin if 1
+      value = (element as HTMLTextAreaElement).value.trim();
+    } // End if 1
+    if (definitionName === 'textarea' && platform === 'Win/JAWS' && value) {
+      // Begin if 1
+      computedDescription = SRMC.stateStrings['Win/JAWS']['textarea']['[extra1]'];
+    } else {
+      // else if 1
+      const describedby = element.getAttribute('aria-describedby');
+      let descElement;
+      if (describedby) {
+        // Begin if 2
+        const computedDescriptionArr = [];
+        const describedbyArr = describedby.split(/\s+/);
+        for (let i = 0; i < describedbyArr.length; i++) {
+          // Begin for 1
+          descElement = document.getElementById(describedbyArr[i]);
+          if (descElement) {
+            // Begin if 3
+            computedDescriptionArr.push(descElement.textContent);
+          } // End if 3
+        } // End for 1
+        computedDescription = computedDescriptionArr.join('');
+      } // End if 2
+    } // End if 1
+
+    // Save the computed accessible description
+    this.computedMessageParts.description = computedDescription;
+
+    // Retrieve the computed accessibility properties
+    const node = await (window as any).getComputedAccessibleNode(element);
+
+    // Compute and save the element's accessible name
+    const computedName = node.name;
+    this.computedMessageParts.name = computedName;
+
+    // If present, set the element's title as the accessible description if conditions are met
+    let title = element.getAttribute('title');
+    if (title && computedName !== title && !this.computedMessageParts.description) {
+      // Begin if 1
+      this.computedMessageParts.description = title;
+    } // End if 1
+
+    // Retrieve the element's value and save it
+    this.computedMessageParts.value = node.valueText;
+
+    // Add an unspecified position in set
+    const positionRoles = ['role=menuitem', 'role=menuitemcheckbox', 'role=menuitemradio', 'role=tab', 'role=option'];
+    if (positionRoles.includes(definitionName)) {
+      // Begin if 1
+      this.computedMessageParts.position = '[X of Y]';
+    } // End if 1
+
+    // Compute the element's type and state
+    this.computedMessageParts.type = '[' + node.role + ']';
+    this.computedMessageParts.state = '';
+    const rules = SRMC.stateRules[platform][definitionName];
+    if (rules) {
+      // Begin if 1
+      rulesLoop: for (let i = 0; i < rules.length; i++) {
+        // Begin for 1
+        const rule = rules[i];
+        const possibleStates = SRMC.possibleStates[definitionName];
+        for (let j = 0; j < possibleStates.length; j++) {
+          // Begin for 2
+          const possibleState = possibleStates[j];
+          const stateValue = element.getAttribute(possibleState);
+          const elementHasState =
+            stateValue !== null && (stateValue !== 'false' || !SRMC.falseMeansOmitted.includes(possibleState));
+          const elementHasCheckedProp = (element as HTMLInputElement).checked !== undefined;
+          const elementHasStateOrCheckedProp = elementHasState || elementHasCheckedProp;
+          const combinationHasState = rule.combination.includes(possibleState);
+          if (elementHasStateOrCheckedProp !== combinationHasState) {
+            // Begin if 2
+            continue rulesLoop;
+          } //End if 2
+        } // End for 2
+
+        // Retrieve and save the element's type
+        this.computedMessageParts.type = rule.elementType;
+
+        // Compute and save the element's state
+        const computedStateArr = [];
+        let order;
+        if (rule.combination.length <= 1 && !rule.order) {
+          // Begin if 2
+          order = rule.combination;
+        } else {
+          // else if 2
+          order = rule.order;
+        } // End if 2
+        for (let j = 0; j < order.length; j++) {
+          // Begin for 2
+          const state = order[j];
+          let stateValue;
+          if (state === 'checked') {
+            // Begin if 2
+            stateValue = (element as HTMLInputElement).checked;
+          } else {
+            // else if 2
+            stateValue = element.getAttribute(state) || 'false';
+          } // End if 2
+          const strings = SRMC.stateStrings[platform][definitionName];
+          const statePart = strings[state + '=' + stateValue] || strings[state + '='];
+          if (statePart) {
+            // Begin if 2
+            computedStateArr.push(statePart);
+          } // End if 2
+        } // End for 2
+        const computedState = computedStateArr.join(SRMC.STATE_PART_SEPARATOR);
+        this.computedMessageParts.state = computedState;
+        break;
+      } // End for 1
+    } // End if 1
+    definitionName = this.getDefinitionName(element, platform, 'readingOrder');
+    const computedMessage = this.composeMessageFromParts(definitionName, platform);
+    return computedMessage;
+  } // End computeMessage
+
+  // Returns the definition name based on the given DOM element, platform and definition type.
+  getDefinitionName(element: HTMLElement, platform: string, definitionType: string): string {
+    // Determine the definitions source by the definition type
+    let definitions;
+    if (definitionType === 'readingOrder') {
+      // Begin if 1
+      definitions = SRMC.readingOrder[platform];
+    } else if (definitionType === 'stateRules') {
+      // else if 1
+      definitions = SRMC.stateRules[platform];
+    } // End if 1
+
+    // Determine the definition name
+    let definitionName = '[default]';
+    const role = element.getAttribute('role');
+    let testName = 'role=' + role;
+    let definition = definitions[testName];
+    if (role && definition) {
+      // Begin if 1
+      // The definition name is determined by the "role" attribute and the definition exists
+      if (typeof definition === 'string') {
+        // Begin if 2
+        // The definition is a reference to another definition
+        definitionName = definition;
+      } else {
+        // else if 2
+        // The definition is a regular definition (not a reference to another definition)
+        definitionName = testName;
+      } // End if 2
+    } else {
+      // Else if 1
+      // The definition name is determined by the element's tag name
+      testName = element.tagName.toLowerCase();
+
+      // In the case of the <input> element, the definition name is further determined by the element's "type" attribute
+      if (testName === 'input') {
+        // Begin if 2
+        testName += ':' + element.getAttribute('type');
+      } // End if 2
+      definition = definitions[testName];
+      if (definition) {
+        // Begin if 2
+        // The definition exists
+        if (typeof definition === 'string') {
+          // Begin if 3
+          // The definition is a reference to another definition
+          definitionName = definition;
+        } else {
+          // else if 3
+          // The definition is a regular definition (not a reference to another definition)
+          definitionName = testName;
+        } // End if 3
+      } // End if 2
+    } // End if 1
+    return definitionName;
+  } // End getDefinitionName
+
+  // Composes and returns the complete screen reader message according to the values of all the computed message parts in the correct order and based on the given definition name and platform.
+  composeMessageFromParts(definitionName: string, platform: string): string {
+    const readingOrder = SRMC.readingOrder[platform][definitionName];
+    const computedMessageArr = [];
+    for (let i = 0; i < readingOrder.length; i++) {
+      // Begin for 1
+      const partName = readingOrder[i];
+      const partValue = this.computedMessageParts[partName];
+      if (partValue) {
+        // Begin if 1
+        computedMessageArr.push(partValue);
+      } // End if 1
+    } // End for 1
+    const computedMessage = computedMessageArr.join(SRMC.PART_SEPARATOR);
+    return computedMessage;
+  } // End composeMessageFromParts
+} // End MessageComputer

--- a/packages/fluentui/react-builder/src/components/ReaderText.tsx
+++ b/packages/fluentui/react-builder/src/components/ReaderText.tsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { Alert, Ref } from '@fluentui/react-northstar';
+import MessageComputer from './MessageComputer';
+
+const mc: Messagecomputer = new MessageComputer();
 
 export type ReaderTextProps = {
   selector: string;
@@ -11,8 +14,10 @@ export const ReaderText: React.FunctionComponent<ReaderTextProps> = ({ selector 
 
   React.useEffect(() => {
     if (ref.current) {
-      const t = ref.current.ownerDocument.querySelector(selector)?.textContent;
-      setText(`Narration: ${t}`);
+      const element = ref.current.ownerDocument.querySelector(selector);
+      mc.computeMessage(element, 'Win/JAWS').then(message => {
+        setText(`Narration: ${message}`);
+      });
     }
   }, [setText, ref, selector]);
 

--- a/packages/fluentui/react-builder/src/components/SRMC-Definitions.tsx
+++ b/packages/fluentui/react-builder/src/components/SRMC-Definitions.tsx
@@ -1,0 +1,222 @@
+const SRMC: { [key: string]: any } = {
+  PART_SEPARATOR: ' ',
+  STATE_PART_SEPARATOR: ' ',
+
+  // Element type strings for each platform
+  typeStrings: {
+    'Win/JAWS': {
+      toggleButton: 'Toggle button',
+      textInput: 'Edit',
+      button: 'Button',
+      checkboxInput: 'check box',
+      radioInput: 'radio button',
+      combobox: 'edit combo',
+      textarea: 'Edit',
+      link: 'Link',
+      menuitem: '',
+      menuitemcheckbox: '',
+      menuitemradio: '',
+      select: 'Combo box',
+      switch: 'Switch',
+      tab: 'Tab',
+      option: '',
+    }, // End Win/JAWS
+  }, // End typeStrings
+
+  // Element state strings for each platform and definition name
+  stateStrings: {
+    'Win/JAWS': {
+      button: {
+        'aria-expanded=true': 'expanded',
+        'aria-expanded=false': 'collapsed',
+        'aria-haspopup=true': 'menu',
+        'aria-haspopup=menu': 'menu',
+        'aria-haspopup=listbox': 'menu',
+        'aria-haspopup=tree': 'menu',
+        'aria-haspopup=grid': 'menu',
+        'aria-haspopup=dialog': 'menu',
+        'aria-haspopup=': '',
+        'aria-pressed=true': 'Pressed',
+        'aria-pressed=false': '',
+      }, // End button
+      'input:text': {
+        'aria-invalid=true': 'invalid entry',
+        'aria-required=true': 'Required',
+      }, // End input:text
+      'input:checkbox': {
+        'checked=true': 'checked',
+        'checked=false': 'not checked',
+        'aria-required=true': 'Required',
+      }, // End input:checkbox
+      'role=checkbox': {
+        'aria-checked=true': 'checked',
+        'aria-checked=false': 'not checked',
+        'aria-checked=mixed': 'partially checked',
+        'aria-required=true': 'Required',
+      }, // End role=checkbox
+      'input:radio': {
+        'checked=true': 'checked',
+        'checked=false': 'not checked',
+        'aria-required=true': 'Required',
+      }, // End input:radio
+      'role=radio': {
+        'aria-checked=true': 'checked',
+        'aria-checked=false': 'not checked',
+        'aria-required=true': 'Required',
+      }, // End role=radio
+      'role=combobox': {
+        'aria-invalid=true': 'invalid entry',
+        'aria-required=true': 'Required',
+      }, // End role=combobox
+      textarea: {
+        'aria-invalid=true': 'invalid entry',
+        'aria-required=true': 'Required',
+        '[extra1]': 'Contains text',
+      }, // End textarea
+      a: {
+        'aria-expanded=true': 'expanded',
+        'aria-expanded=false': 'collapsed',
+        'aria-haspopup=true': 'Has Popup menu',
+        'aria-haspopup=menu': 'Has Popup menu',
+        'aria-haspopup=listbox': 'Has Popup listbox',
+        'aria-haspopup=tree': 'Has Popup tree',
+        'aria-haspopup=grid': 'Has Popup grid',
+        'aria-haspopup=dialog': 'Has Popup dialog',
+        'aria-haspopup=': '',
+      }, // End a
+      'role=menuitem': {
+        'aria-haspopup=true': 'submenu',
+        'aria-haspopup=menu': 'submenu',
+        'aria-haspopup=listbox': 'submenu',
+        'aria-haspopup=tree': 'submenu',
+        'aria-haspopup=grid': 'submenu',
+        'aria-haspopup=dialog': 'submenu',
+        'aria-haspopup=': '',
+      }, // End role=menuitem
+      'role=menuitemcheckbox': {
+        'aria-checked=true': 'checked',
+        'aria-checked=false': 'not checked',
+      }, // End role=menuitemcheckbox
+      'role=menuitemradio': {
+        'aria-checked=true': 'checked',
+        'aria-checked=false': 'not checked',
+      }, // End role=menuitemradio
+      select: {
+        'aria-invalid=true': 'invalid entry',
+        'aria-required=true': 'Required',
+      }, // End select
+      'role=switch': {
+        'aria-checked=true': 'Pressed On',
+        'aria-checked=false': 'Off',
+      }, // End role=switch
+      'role=tab': {
+        'aria-selected=true': 'Selected',
+        'aria-selected=false': '',
+      }, // End role=tab
+      'role=option': {}, // End role=option
+    }, // End Win/JAWS
+  }, // End stateStrings
+
+  // Element usage strings for each platform and definition name
+  usageStrings: {
+    'Win/JAWS': {
+      button: {
+        '[default]': 'To activate press Enter.',
+        'aria-pressed=true': 'To toggle the state press spacebar.',
+        'aria-pressed=false': 'To toggle the state press spacebar.',
+      }, // End button
+      'input:text': {
+        '[default]': 'Type in text.',
+      }, // End input:text
+      'input:checkbox': {
+        '[default]': 'To check press Spacebar.',
+        'checked=true': 'To clear checkmark press Spacebar.',
+      }, // End input:checkbox
+      'role=checkbox': {
+        '[default]': 'To check press Spacebar.',
+        'aria-checked=true': 'To clear checkmark press Spacebar.',
+      }, // End role=checkbox
+      'input:radio': {
+        '[default]': 'To change the selection press Up or Down Arrow.',
+      }, // End input:radio
+      'role=radio': {
+        '[default]': 'To change the selection press Up or Down Arrow.',
+      }, // End role=radio
+      'role=combobox': {
+        '[default]': 'To set the value use the Arrow keys or type the value.',
+      }, // End role=combobox
+      textarea: {
+        '[default]': 'Type in text.',
+      }, // End textarea
+      'role=menuitem': {
+        '[default]': 'To move through items press up or down arrow.',
+      }, // End role=menuitem
+      'role=menuitemcheckbox': {
+        '[default]': 'To move through items press up or down arrow.',
+      }, // End role=menuitemcheckbox
+      'role=menuitemradio': {
+        '[default]': 'To move through items press up or down arrow.',
+      }, // End role=menuitemradio
+      select: {
+        '[default]': 'To change the selection use the Arrow keys.',
+      }, // End select
+      'role=switch': {
+        '[default]': '',
+      }, // End role=switch
+      'role=tab': {
+        '[default]': 'To activate tab page press Spacebar.',
+        'aria-selected=true': '',
+      }, // End role=switch
+      'role=option': {
+        '[default]': 'To move to an item press the Arrow keys.',
+      }, // End role=option
+    }, // End Win/JAWS
+  }, // End usageStrings
+
+  // State attributes of which "false" value means the attribute is omitted
+  falseMeansOmitted: ['aria-haspopup', 'aria-invalid', 'aria-required'], // End falseMeansOmitted
+
+  // Rules for the message type and state computation based on the element state attributes combination (the definitions for each platform are stored in a separate file)
+  stateRules: {
+    'Win/JAWS': {},
+  }, // End stateRules
+
+  // Computed message parts reading order for each platform and definition name
+  readingOrder: {
+    'Win/JAWS': {
+      '[default]': ['name', 'type', 'state', 'description', 'usage'],
+      'input:text': ['name', 'type', 'state', 'value', 'description', 'usage'],
+      'role=combobox': 'input:text',
+      textarea: 'input:text',
+      a: ['name', 'state', 'type', 'description', 'usage'],
+      'role=menuitem': ['name', 'type', 'state', 'position', 'description', 'usage'],
+      'role=menuitemcheckbox': 'role=menuitem',
+      'role=menuitemradio': 'role=menuitem',
+      select: 'input:text',
+      'role=tab': 'role=menuitem',
+      'role=option': 'role=menuitem',
+    }, // End Win/JAWS
+  }, // End readingOrder
+
+  // Possible state attributes for each definition name
+  possibleStates: {
+    button: ['aria-expanded', 'aria-haspopup', 'aria-pressed'],
+    'input:text': ['aria-invalid', 'aria-required'],
+    'input:checkbox': ['checked', 'aria-required'],
+    'role=checkbox': ['aria-checked', 'aria-required'],
+    'input:radio': ['checked', 'aria-required'],
+    'role=radio': ['aria-checked', 'aria-required'],
+    'role=combobox': ['aria-invalid', 'aria-required'],
+    textarea: ['aria-invalid', 'aria-required'],
+    a: ['aria-expanded', 'aria-haspopup', 'aria-pressed'],
+    'role=menuitem': ['aria-haspopup'],
+    'role=menuitemcheckbox': ['aria-checked'],
+    'role=menuitemradio': ['aria-checked'],
+    select: ['aria-invalid', 'aria-required'],
+    'role=switch': ['aria-checked'],
+    'role=option': [],
+    'role=tab': ['aria-selected'],
+  }, // End possibleStates
+};
+
+export default SRMC;

--- a/packages/fluentui/react-builder/src/components/SRMC-Rules-Win_JAWS.tsx
+++ b/packages/fluentui/react-builder/src/components/SRMC-Rules-Win_JAWS.tsx
@@ -1,0 +1,277 @@
+import SRMC from './SRMC-Definitions';
+
+SRMC.stateRules['Win/JAWS'] = {
+  button: [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].button,
+    },
+    {
+      combination: ['aria-expanded'],
+      elementType: SRMC.typeStrings['Win/JAWS'].button,
+    },
+    {
+      combination: ['aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].button,
+    },
+    {
+      combination: ['aria-pressed'],
+      elementType: SRMC.typeStrings['Win/JAWS'].toggleButton,
+    },
+    {
+      combination: ['aria-expanded', 'aria-haspopup'],
+      order: ['aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].button,
+    },
+    {
+      combination: ['aria-expanded', 'aria-pressed'],
+      order: ['aria-pressed'],
+      elementType: SRMC.typeStrings['Win/JAWS'].toggleButton,
+    },
+    {
+      combination: ['aria-haspopup', 'aria-pressed'],
+      order: ['aria-pressed', 'aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].toggleButton,
+    },
+    {
+      combination: ['aria-expanded', 'aria-haspopup', 'aria-pressed'],
+      order: ['aria-pressed', 'aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].toggleButton,
+    },
+  ], // End button
+  'role=button': 'button',
+  'input:text': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].textInput,
+    },
+    {
+      combination: ['aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textInput,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textInput,
+    },
+    {
+      combination: ['aria-invalid', 'aria-required'],
+      order: ['aria-required', 'aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textInput,
+    },
+  ], // End input:text
+  'input:checkbox': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['checked', 'aria-required'],
+      order: ['checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+  ], // End input:checkbox
+  'role=checkbox': [
+    {
+      combination: [],
+      order: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['aria-required'],
+      order: ['aria-checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+    {
+      combination: ['aria-checked', 'aria-required'],
+      order: ['aria-checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].checkboxInput,
+    },
+  ], // End role=checkbox
+  'input:radio': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['checked', 'aria-required'],
+      order: ['checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+  ], // End input:radio
+  'role=radio': [
+    {
+      combination: [],
+      order: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['aria-required'],
+      order: ['aria-checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+    {
+      combination: ['aria-checked', 'aria-required'],
+      order: ['aria-checked', 'aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].radioInput,
+    },
+  ], // End role=radio
+  'role=combobox': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].combobox,
+    },
+    {
+      combination: ['aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].combobox,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].combobox,
+    },
+    {
+      combination: ['aria-invalid', 'aria-required'],
+      order: ['aria-required', 'aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].combobox,
+    },
+  ], // End role=combobox
+  textarea: [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].textarea,
+    },
+    {
+      combination: ['aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textarea,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textarea,
+    },
+    {
+      combination: ['aria-invalid', 'aria-required'],
+      order: ['aria-required', 'aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].textarea,
+    },
+  ], // End textarea
+  a: [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].link,
+    },
+    {
+      combination: ['aria-expanded'],
+      elementType: SRMC.typeStrings['Win/JAWS'].link,
+    },
+    {
+      combination: ['aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].link,
+    },
+    {
+      combination: ['aria-expanded', 'aria-haspopup'],
+      order: ['aria-expanded', 'aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].link,
+    },
+  ], // End a
+  'role=menuitem': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitem,
+    },
+    {
+      combination: ['aria-haspopup'],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitem,
+    },
+  ], // End role=menuitem
+  'role=menuitemcheckbox': [
+    {
+      combination: [],
+      order: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitemcheckbox,
+    },
+    {
+      combination: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitemcheckbox,
+    },
+  ], // End role=menuitemcheckbox
+  'role=menuitemradio': [
+    {
+      combination: [],
+      order: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitemradio,
+    },
+    {
+      combination: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].menuitemradio,
+    },
+  ], // End role=menuitemradio
+  select: [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].select,
+    },
+    {
+      combination: ['aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].select,
+    },
+    {
+      combination: ['aria-required'],
+      elementType: SRMC.typeStrings['Win/JAWS'].select,
+    },
+    {
+      combination: ['aria-invalid', 'aria-required'],
+      order: ['aria-required', 'aria-invalid'],
+      elementType: SRMC.typeStrings['Win/JAWS'].select,
+    },
+  ], // End select
+  'role=switch': [
+    {
+      combination: [],
+      order: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].switch,
+    },
+    {
+      combination: ['aria-checked'],
+      elementType: SRMC.typeStrings['Win/JAWS'].switch,
+    },
+  ], // End role=switch
+  'role=tab': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].tab,
+    },
+    {
+      combination: ['aria-selected'],
+      elementType: SRMC.typeStrings['Win/JAWS'].tab,
+    },
+  ], // End role=tab
+  'role=option': [
+    {
+      combination: [],
+      elementType: SRMC.typeStrings['Win/JAWS'].option,
+    },
+  ], // End role=option
+};


### PR DESCRIPTION
#### Description of changes
This is the first integration of the screen reader message computation code into the Ui builder. When user selects a component added to the canvas, this narration appears below the canvas. The narration tells exactly what a screen reader would announce upon focusing the element.

So far not all element types are supported by the computation, only the most important ones, namely:

* &lt;button&gt;
* <textarea>
* <input type="text">
* <input type="checkbox"> and role="checkbox"
* <input type="radio"> and role="radio"
* role="menuitem"
* role="option"