### PR TITLE
Charting: Removing trailing zero's from ticks of axis

### DIFF
--- a/change/@uifabric-charting-2020-09-09-21-37-39-user-v-jasha-trailingZerosIssue.json
+++ b/change/@uifabric-charting-2020-09-09-21-37-39-user-v-jasha-trailingZerosIssue.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Insiginificant trailing zeros removed from ticks",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T16:07:39.001Z"
+}

--- a/change/@uifabric-charting-2020-09-09-21-37-39-user-v-jasha-trailingZerosIssue.json
+++ b/change/@uifabric-charting-2020-09-09-21-37-39-user-v-jasha-trailingZerosIssue.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Insiginificant trailing zeros removed from ticks",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.om",
   "dependentChangeType": "patch",
   "date": "2020-09-09T16:07:39.001Z"
 }

--- a/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
+++ b/packages/charting/src/components/GroupedVerticalBarChart/GroupedVerticalBarChart.base.tsx
@@ -539,7 +539,7 @@ export class GroupedVerticalBarChartBase extends React.Component<
     const axis = this._isRtl ? d3AxisRight(yAxisScale) : d3AxisLeft(yAxisScale);
     const yAxis = axis
       .tickPadding(5)
-      .tickFormat(d3Format('.2s'))
+      .tickFormat(d3Format('.2~s'))
       .tickValues(domains);
 
     this._showYAxisGridLines &&

--- a/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalBarChart/VerticalBarChart.base.tsx
@@ -252,7 +252,7 @@ export class VerticalBarChartBase extends React.Component<IVerticalBarChartProps
     const yAxis = axis
       .tickPadding(5)
       .tickValues(domains)
-      .tickFormat(d3Format('.2s'))
+      .tickFormat(d3Format('.2~s'))
       .tickSizeInner(-(this.state.containerWidth - this.margins.left - this.margins.right));
     return yAxis;
   }

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -204,7 +204,7 @@ export function createYAxis(yAxisParams: IYAxisParams, isRtl: boolean) {
     .tickPadding(tickPadding)
     .tickValues(domainValues)
     .tickSizeInner(-(containerWidth - margins.left! - margins.right!));
-  yAxisTickFormat ? yAxis.tickFormat(yAxisTickFormat) : yAxis.tickFormat(d3Format('.2s'));
+  yAxisTickFormat ? yAxis.tickFormat(yAxisTickFormat) : yAxis.tickFormat(d3Format('.2~s'));
   yAxisElement
     ? d3Select(yAxisElement)
         .call(yAxis)


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

By adding d3.tickformat('.2s'), If we have integers, it is showing extra 0's like (8.0 or 0.0). 
As we can't remove tickFormat for one tick in axis, removing insignificant zero's from ticks. To achieve this added d3.tickFormat('.2~s'). By this, we can achieve SI units to the ticks and non zero's ticks.

#### Focus areas to test

Area chart, Line chart, Vertical stacked bar chart, Vertical bar chart, Grouped vertical bar chart.

### Line chart examples of all the cases
#### small values (integers)
![image](https://user-images.githubusercontent.com/20105532/92625290-17910000-f2e6-11ea-991a-dfd53e71363e.png)

#### Example 1 - 1k
[{ x: new Date('2018/01/06'), y: 1880 },
 { x: new Date('2018/01/16'), y: 1890 },
 { x: new Date('2018/01/20'), y: 1870 }]
![image](https://user-images.githubusercontent.com/20105532/92625500-5d4dc880-f2e6-11ea-80d9-997f83388db5.png)

#### Example 2 - 2k
data: [
          { x: new Date('2018/01/06'), y: 2830 },
          { x: new Date('2018/01/16'), y: 2860 },
          { x: new Date('2018/01/20'), y: 2870 },
]
![image](https://user-images.githubusercontent.com/20105532/92625780-ba497e80-f2e6-11ea-86b7-ec92ebcbcacc.png)

#### Example 3 
 data: [
          { x: new Date('2018/01/06'), y: 28300 },
          { x: new Date('2018/01/16'), y: 20860 },
          { x: new Date('2018/01/20'), y: 28070 },
]
![image](https://user-images.githubusercontent.com/20105532/92626044-07c5eb80-f2e7-11ea-915e-8db087c61a4a.png)

#### Example 4
data: [
          { x: new Date('2018/01/06'), y: 28300 },
          { x: new Date('2018/01/16'), y: 30860 },
          { x: new Date('2018/01/20'), y: 98070 },
]
![image](https://user-images.githubusercontent.com/20105532/92626200-3a6fe400-f2e7-11ea-93af-9f3682f8e575.png)

#### Example 5
data: [
          { x: new Date('2018/01/06'), y: 2830000 },
          { x: new Date('2018/01/16'), y: 3086000 },
          { x: new Date('2018/01/20'), y: 9807000 },
]
![image](https://user-images.githubusercontent.com/20105532/92626414-80c54300-f2e7-11ea-807b-62ba92ba5e6e.png)

#### Example 6
 data: [
          { x: new Date('2018/01/06'), y: 283000000 },
          { x: new Date('2018/01/16'), y: 308600000 },
          { x: new Date('2018/01/20'), y: 980700000 },
]
![image](https://user-images.githubusercontent.com/20105532/92626537-a7837980-f2e7-11ea-9135-4988acb72b5a.png)

#### Example 7
data: [
          { x: new Date('2018/01/06'), y: 28300000000 },
          { x: new Date('2018/01/16'), y: 30860000000 },
          { x: new Date('2018/01/20'), y: 98070000000 },
]
![image](https://user-images.githubusercontent.com/20105532/92626723-f03b3280-f2e7-11ea-8063-a22ecaf3a5d8.png)

#### Example 8
data: [
          { x: new Date('2018/01/06'), y: 2830000000000 },
          { x: new Date('2018/01/16'), y: 3086000000000 },
          { x: new Date('2018/01/20'), y: 9807000000000 },
]
![image](https://user-images.githubusercontent.com/20105532/92626852-21b3fe00-f2e8-11ea-985d-422164391bc6.png)

#### Example 9
data: [
          { x: new Date('2018/01/06'), y: 2830000000000000 },
          { x: new Date('2018/01/16'), y: 3086000000000000 },
          { x: new Date('2018/01/20'), y: 9807000000000000 },
]
![image](https://user-images.githubusercontent.com/20105532/92626949-4b6d2500-f2e8-11ea-82c7-c7718e7d53fe.png)


#### Test link: 