### PR TITLE
Export getMenuStyles from ContextualMenu

### DIFF
--- a/change/office-ui-fabric-react-2020-09-09-16-05-30-anpablo-fluentuxexport.json
+++ b/change/office-ui-fabric-react-2020-09-09-16-05-30-anpablo-fluentuxexport.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export getMenuItemStyles from ContextualMenu",
+  "packageName": "office-ui-fabric-react",
+  "email": "anpablo@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-09T23:05:30.683Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1320,6 +1320,9 @@ export const getMeasurementCache: () => {
     addMeasurementToCache: (data: any, measurement: number) => void;
 };
 
+// @public (undocumented)
+export const getMenuItemStyles: (theme: ITheme) => IMenuItemStyles;
+
 // @public
 export const getNextResizeGroupStateProvider: (measurementCache?: {
     getCachedMeasurement: (data: any) => number | undefined;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/index.ts
@@ -4,3 +4,4 @@ export * from './ContextualMenu.types';
 export * from './ContextualMenuItem';
 export * from './ContextualMenuItem.base';
 export * from './ContextualMenuItem.types';
+export { getMenuItemStyles } from './ContextualMenu.cnstyles';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Export getMenuStyles from ContextualMenu to avoid needing to use deep import path
