### PR TITLE
fix(Menu+Carousel): prop 'active' not mapped to behavior

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
+- Fix `MenuItem` and `CarouselNavigationItem` to correctly map `active` prop to behavior @yuanboxue-amber ([#14970](https://github.com/microsoft/fluentui/pull/14970))
 - Fix default focused outline in Safari @yuanboxue-amber ([#14917](https://github.com/microsoft/fluentui/pull/14917))
 - Fix a warning when the `inverted` prop was used in `TextArea` @layershifter ([#14357](https://github.com/microsoft/fluentui/pull/14357))
 - Fix `Tree` component to correctly keep track of the `activeItemIds` @assuncaocharles ([#14507](https://github.com/microsoft/fluentui/pull/14507))

--- a/packages/fluentui/accessibility/src/behaviors/Tab/tabBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tab/tabBehavior.ts
@@ -44,7 +44,7 @@ export const tabBehavior: Accessibility<TabBehaviorProps> = props => ({
   },
 });
 
-type TabBehaviorProps = {
+export type TabBehaviorProps = {
   /** Indicates if tab is selected. */
   active?: boolean;
   /** Indicates if tab is disabled. */

--- a/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Carousel/CarouselNavigationItem.tsx
@@ -2,7 +2,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as customPropTypes from '@fluentui/react-proptypes';
 import * as _ from 'lodash';
-import { Accessibility, tabBehavior } from '@fluentui/accessibility';
+import { Accessibility, tabBehavior, TabBehaviorProps } from '@fluentui/accessibility';
 
 import {
   childrenExist,
@@ -35,7 +35,7 @@ export interface CarouselNavigationItemProps extends UIComponentProps, ChildrenC
   /**
    * Accessibility behavior if overridden by the user.
    */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<TabBehaviorProps>;
 
   /** A menu item can be active. */
   active?: boolean;
@@ -113,6 +113,9 @@ export const CarouselNavigationItem: ComponentWithAs<'li', CarouselNavigationIte
     actionHandlers: {
       performClick: event => !event.defaultPrevented && handleClick(event),
     },
+    mapPropsToBehavior: () => ({
+      active,
+    }),
   });
 
   const { classes, styles: resolvedStyles } = useStyles<CarouselNavigationItemStylesProps>(

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -265,6 +265,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
         hasMenu: !!menu,
         disabled,
         vertical,
+        active, // for tabBehavior
       }),
       rtl: context.rtl,
     });


### PR DESCRIPTION

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14537 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The original bug is reported on Menu: when a MenuItem is selected, screen-reader does not read 'selected'.
It's expected with Menu's default accessibility behavior, as there's no `aria-selected` mentioned for Menu in [aria practices](https://www.w3.org/TR/wai-aria-practices-1.1/examples/menubar/menubar-1/menubar-1.html)

Menu supports also `accessibility={tabListBehavior}`. And in this case, `aria-selected` should be true for selected item. But it is not.
The same problem happens to `CarouselNavigationItem`, whose default `accessibility` is `tabBehavior`.

This happens, because the `active` prop for `MenuItem/CarouselNavigationItem` is not passed to `tabBehavior`. Therefore aria-selected was not set to true for the active item.

#### Focus areas to test

(optional)
