### PR TITLE
fix(Menu): set active item using children API

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -242,6 +242,14 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
       [actualProps, setActiveIndex],
     );
 
+    const handleSelect = React.useCallback(
+      (e, itemProps) => {
+        const { index } = itemProps;
+        setActiveIndex(e, index);
+      },
+      [setActiveIndex],
+    );
+
     const handleItemOverrides = (predefinedProps: MenuItemProps): MenuItemProps => ({
       onActiveChanged: (e, props) => {
         const { index, active } = props;
@@ -291,7 +299,8 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
 
     const childProps: MenuContextValue = {
       activeIndex: +activeIndex,
-      onItemSelect: handleClick,
+      onItemClick: handleClick,
+      onItemSelect: handleSelect,
       variables,
 
       slotProps: {

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -244,7 +244,6 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
 
     const handleItemOverrides = (predefinedProps: MenuItemProps): MenuItemProps => ({
       onClick: (e, itemProps) => {
-        handleClick(e, itemProps);
         _.invoke(predefinedProps, 'onClick', e, itemProps);
       },
       onActiveChanged: (e, props) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -243,8 +243,7 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
     );
 
     const handleSelect = React.useCallback(
-      (e, itemProps) => {
-        const { index } = itemProps;
+      (e, index) => {
         setActiveIndex(e, index);
       },
       [setActiveIndex],

--- a/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/Menu.tsx
@@ -243,9 +243,6 @@ export const Menu = compose<'ul', MenuProps, MenuStylesProps, {}, {}>(
     );
 
     const handleItemOverrides = (predefinedProps: MenuItemProps): MenuItemProps => ({
-      onClick: (e, itemProps) => {
-        _.invoke(predefinedProps, 'onClick', e, itemProps);
-      },
       onActiveChanged: (e, props) => {
         const { index, active } = props;
         if (active) {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -482,6 +482,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       },
       onClick: (e: React.MouseEvent) => {
         handleClick(e);
+        _.invoke(predefinedProps, 'onClick', e, props);
       },
       ...(on === 'hover' && {
         onMouseEnter: e => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -340,7 +340,8 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
+      _.invoke(props, 'onClick', e, props);
+      _.invoke(parentProps, 'onItemSelect', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {
@@ -481,7 +482,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       },
       onClick: (e: React.MouseEvent) => {
         handleClick(e);
-        _.invoke(predefinedProps, 'onClick', e, props);
+        // _.invoke(predefinedProps, 'onClick', e, props);
       },
       ...(on === 'hover' && {
         onMouseEnter: e => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -482,7 +482,6 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       },
       onClick: (e: React.MouseEvent) => {
         handleClick(e);
-        // _.invoke(predefinedProps, 'onClick', e, props);
       },
       ...(on === 'hover' && {
         onMouseEnter: e => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -412,7 +412,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
             setWhatInputSource(context.target, 'mouse');
             trySetMenuOpen(true, e);
             _.invoke(props, 'onMouseEnter', e, props);
-            _.invoke(parentProps, 'onItemSelect', e, props);
+            _.invoke(parentProps, 'onItemSelect', e, props.index);
           },
           onMouseLeave: e => {
             trySetMenuOpen(false, e);
@@ -490,7 +490,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
           setWhatInputSource(context.target, 'mouse');
           trySetMenuOpen(true, e);
           _.invoke(predefinedProps, 'onMouseEnter', e, props);
-          _.invoke(parentProps, 'onItemSelect', e, props);
+          _.invoke(parentProps, 'onItemSelect', e, props.index);
         },
         onMouseLeave: e => {
           trySetMenuOpen(false, e);

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -188,6 +188,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
 
     const parentProps = (useContextSelectors(MenuContext, {
       active: v => v.activeIndex === inputProps.index,
+      onItemClick: v => v.onItemClick,
       onItemSelect: v => v.onItemSelect,
       variables: v => v.variables,
       menuSlot: v => v.slots.menu,
@@ -341,7 +342,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       performClick(e);
 
       _.invoke(props, 'onClick', e, props);
-      _.invoke(parentProps, 'onItemSelect', e, props);
+      _.invoke(parentProps, 'onItemClick', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Menu/MenuItem.tsx
@@ -340,7 +340,7 @@ export const MenuItem = compose<'a', MenuItemProps, MenuItemStylesProps, {}, {}>
       }
       performClick(e);
 
-      _.invoke(props, 'onClick', e, props);
+      _.invoke({ onClick: parentProps.onItemSelect, ...props }, 'onClick', e, props);
     };
 
     const handleBlur = (e: React.FocusEvent) => {

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -8,7 +8,7 @@ export type MenuContextValue = {
   activeIndex: number;
   variables: ComponentVariablesInput;
   onItemClick: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
-  onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
+  onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
 
   slotProps: {
     item: Record<string, any>;

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -7,6 +7,7 @@ import { MenuItemProps } from './MenuItem';
 export type MenuContextValue = {
   activeIndex: number;
   variables: ComponentVariablesInput;
+  onItemClick: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
   onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
 
   slotProps: {
@@ -24,7 +25,7 @@ export type MenuContextValue = {
   };
 };
 
-export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemSelect'> & {
+export type MenuItemSubscribedValue = Pick<MenuContextValue, 'variables' | 'onItemClick' | 'onItemSelect'> & {
   slotProps: MenuContextValue['slotProps']['item'];
   accessibility: MenuContextValue['behaviors']['item'];
   menuSlot: MenuContextValue['slots']['menu'];
@@ -40,6 +41,7 @@ export const MenuContext = createContext<MenuContextValue>(
   {
     activeIndex: -1,
     variables: {},
+    onItemClick: null,
     onItemSelect: null,
     slotProps: {
       item: {},

--- a/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
+++ b/packages/fluentui/react-northstar/src/components/Menu/menuContext.ts
@@ -2,11 +2,12 @@ import { createContext } from '@fluentui/react-context-selector';
 import { ComponentVariablesInput } from '@fluentui/styles';
 import * as React from 'react';
 import { Accessibility } from '@fluentui/accessibility';
+import { MenuItemProps } from './MenuItem';
 
 export type MenuContextValue = {
   activeIndex: number;
   variables: ComponentVariablesInput;
-  onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemIndex: number) => void;
+  onItemSelect: (e: React.KeyboardEvent | React.MouseEvent, itemProps: MenuItemProps) => void;
 
   slotProps: {
     item: Record<string, any>;

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
@@ -278,7 +278,7 @@ describe('Menu', () => {
       });
     });
 
-    describe('chidlren API', () => {
+    describe('children', () => {
       it('should should select items', () => {
         const onActiveIndexChange = jest.fn();
         const wrapper = mountWithProvider(

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/Menu-test.tsx
@@ -277,5 +277,34 @@ describe('Menu', () => {
         });
       });
     });
+
+    describe('chidlren API', () => {
+      it('should should select items', () => {
+        const onActiveIndexChange = jest.fn();
+        const wrapper = mountWithProvider(
+          <Menu defaultActiveIndex={0} onActiveIndexChange={onActiveIndexChange}>
+            <Menu.Item index={0}>
+              <Menu.ItemContent>Editorials</Menu.ItemContent>
+            </Menu.Item>
+            <Menu.Item index={1}>
+              <Menu.ItemContent>Reviews</Menu.ItemContent>
+            </Menu.Item>
+            <Menu.Item index={2}>
+              <Menu.ItemContent>Upcoming Events</Menu.ItemContent>
+            </Menu.Item>
+          </Menu>,
+        );
+
+        wrapper
+          .find('MenuItem')
+          .at(1)
+          .simulate('click');
+
+        expect(onActiveIndexChange).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'click' }),
+          expect.objectContaining({ activeIndex: 1 }),
+        );
+      });
+    });
   });
 });

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
@@ -68,6 +68,15 @@ describe('MenuItem', () => {
     expect(menuItem.text()).toBe('Home');
   });
 
+  it('Wrapper onClick must be called', () => {
+    const onClick = jest.fn();
+    const menuItem = mountWithProviderAndGetComponent(MenuItem, <MenuItem wrapper={{ onClick }}>Home</MenuItem>);
+
+    menuItem.simulate('click');
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
   describe('accessibility', () => {
     handlesAccessibility(MenuItem, { defaultRootRole: 'presentation', usesWrapperSlot: true });
     handlesAccessibility(MenuItem, { defaultRootRole: 'menuitem', partSelector: 'a' });

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
@@ -7,7 +7,7 @@ import {
   getRenderedAttribute,
   implementsShorthandProp,
 } from 'test/specs/commonTests';
-import { mountWithProviderAndGetComponent, sharedIsConformant } from 'test/utils';
+import { mountWithProviderAndGetComponent, sharedIsConformant, mountWithProvider } from 'test/utils';
 import { MenuItem } from 'src/components/Menu/MenuItem';
 import { Menu } from 'src/components/Menu/Menu';
 import { MenuItemWrapper, menuItemWrapperClassName } from 'src/components/Menu/MenuItemWrapper';

--- a/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Menu/MenuItem-test.tsx
@@ -68,13 +68,14 @@ describe('MenuItem', () => {
     expect(menuItem.text()).toBe('Home');
   });
 
-  it('Wrapper onClick must be called', () => {
-    const onClick = jest.fn();
-    const menuItem = mountWithProviderAndGetComponent(MenuItem, <MenuItem wrapper={{ onClick }}>Home</MenuItem>);
+  describe('wrapper', () => {
+    it('onClick should be called', () => {
+      const onClick = jest.fn();
+      const wrapper = mountWithProvider(<MenuItem wrapper={{ onClick }}>Home</MenuItem>);
 
-    menuItem.simulate('click');
-
-    expect(onClick).toHaveBeenCalled();
+      wrapper.find('MenuItemWrapper').simulate('click');
+      expect(onClick).toHaveBeenCalled();
+    });
   });
 
   describe('accessibility', () => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fix `Menu` not setting active item when using children API and prevent calling 2 `onClick`

#### Focus areas to test

(optional)
