### PR TITLE
Support StrictMode in DetailsList component hierarchy

### DIFF
--- a/change/office-ui-fabric-react-2020-09-10-12-35-55-list-strict-mode.json
+++ b/change/office-ui-fabric-react-2020-09-10-12-35-55-list-strict-mode.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Support StrictMode in DetailsList hierarchy",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T19:35:55.800Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -923,6 +923,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     // (undocumented)
     forceUpdate(): void;
     // (undocumented)
+    static getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
+    // (undocumented)
     getStartItemIndexInView(): number;
     // (undocumented)
     protected _onRenderRow: (props: IDetailsRowProps, defaultRender?: IRenderFunction<IDetailsRowProps> | undefined) => JSX.Element;
@@ -930,9 +932,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     render(): JSX.Element;
     // (undocumented)
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: IDetailsListProps): void;
-}
+    }
 
 // @public (undocumented)
 export enum DetailsListLayoutMode {
@@ -954,6 +954,8 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     componentWillUnmount(): void;
     // (undocumented)
     focus(forceIntoFirstElement?: boolean): boolean;
+    // (undocumented)
+    static getDerivedStateFromProps(nextProps: IDetailsRowBaseProps, previousState: IDetailsRowState): IDetailsRowState;
     measureCell(index: number, onMeasureDone: (width: number) => void): void;
     // (undocumented)
     protected _onRenderCheck(props: IDetailsRowCheckProps): JSX.Element;
@@ -961,8 +963,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     render(): JSX.Element;
     // (undocumented)
     shouldComponentUpdate(nextProps: IDetailsRowBaseProps, nextState: IDetailsRowState): boolean;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: IDetailsRowBaseProps): void;
     }
 
 // @public (undocumented)
@@ -1373,6 +1373,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     // (undocumented)
     forceUpdate(): void;
     // (undocumented)
+    static getDerivedStateFromProps(nextProps: IGroupedListProps, previousState: IGroupedListState): IGroupedListState;
+    // (undocumented)
     getStartItemIndexInView(): number;
     // (undocumented)
     render(): JSX.Element;
@@ -1380,8 +1382,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     toggleCollapseAll(allCollapsed: boolean): void;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: IGroupedListProps): void;
     }
 
 // @public (undocumented)
@@ -3733,6 +3733,8 @@ export interface IDetailsListState {
     // (undocumented)
     focusedItemIndex: number;
     // (undocumented)
+    getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
+    // (undocumented)
     isCollapsed?: boolean;
     // (undocumented)
     isSizing?: boolean;
@@ -5046,6 +5048,8 @@ export interface IGroupedListState {
     groups?: IGroup[];
     // (undocumented)
     lastSelectionMode?: SelectionMode;
+    // (undocumented)
+    version: {};
 }
 
 // @public (undocumented)
@@ -5665,6 +5669,8 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
 
 // @public (undocumented)
 export interface IListState<T = any> {
+    // (undocumented)
+    getDerivedStateFromProps(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
     // (undocumented)
     isScrolling?: boolean;
     measureVersion?: number;
@@ -8535,6 +8541,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
+    componentDidUpdate(): void;
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: {
@@ -8546,6 +8554,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     // (undocumented)
     forceUpdate(): void;
     // (undocumented)
+    static getDerivedStateFromProps<T = any>(nextProps: IListProps<T>, previousState: IListState<T>): IListState<T>;
+    // (undocumented)
     getStartItemIndexInView(measureItem?: (itemIndex: number) => number): number;
     getTotalListHeight(): number;
     // (undocumented)
@@ -8555,8 +8565,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: IListProps<T>): void;
     }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -63,6 +63,7 @@ export interface IDetailsListState {
    * A unique object used to force-update the List when it changes.
    */
   version: {};
+  getDerivedStateFromProps(nextProps: IDetailsListProps, previousState: IDetailsListState): IDetailsListState;
 }
 
 const MIN_COLUMN_WIDTH = 100; // this is the global min width
@@ -684,6 +685,13 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     [key: string]: IColumn;
   };
 
+  public static getDerivedStateFromProps(
+    nextProps: IDetailsListProps,
+    previousState: IDetailsListState,
+  ): IDetailsListState {
+    return previousState.getDerivedStateFromProps(nextProps, previousState);
+  }
+
   constructor(props: IDetailsListProps) {
     super(props);
 
@@ -696,11 +704,12 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     this.state = {
       focusedItemIndex: -1,
       lastWidth: 0,
-      adjustedColumns: this._getAdjustedColumns(props),
+      adjustedColumns: this._getAdjustedColumns(props, undefined),
       isSizing: false,
       isCollapsed: props.groupProps && props.groupProps.isAllGroupsCollapsed,
       isSomeGroupExpanded: props.groupProps && !props.groupProps.isAllGroupsCollapsed,
       version: {},
+      getDerivedStateFromProps: this._getDerivedStateFromProps,
     };
 
     this._selection =
@@ -765,6 +774,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
   }
 
   public componentDidUpdate(prevProps: IDetailsListProps, prevState: IDetailsListState) {
+    this._notifyColumnsResized();
+
     if (this._initialFocusedIndex !== undefined) {
       const item = this.props.items[this._initialFocusedIndex];
       if (item) {
@@ -800,83 +811,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     }
     if (this.props.onDidUpdate) {
       this.props.onDidUpdate(this);
-    }
-  }
-
-  public UNSAFE_componentWillReceiveProps(newProps: IDetailsListProps): void {
-    const {
-      checkboxVisibility,
-      items,
-      setKey,
-      selectionMode = this._selection.mode,
-      columns,
-      viewport,
-      compact,
-      dragDropEvents,
-    } = this.props;
-    const { isAllGroupsCollapsed = undefined } = this.props.groupProps || {};
-    const newViewportWidth = (newProps.viewport && newProps.viewport.width) || 0;
-    const oldViewportWidth = (viewport && viewport.width) || 0;
-    const shouldResetSelection = newProps.setKey !== setKey || newProps.setKey === undefined;
-    let shouldForceUpdates = false;
-
-    if (newProps.layoutMode !== this.props.layoutMode) {
-      shouldForceUpdates = true;
-    }
-
-    if (shouldResetSelection) {
-      this._initialFocusedIndex = newProps.initialFocusedIndex;
-      // reset focusedItemIndex when setKey changes
-      this.setState({
-        focusedItemIndex: this._initialFocusedIndex !== undefined ? this._initialFocusedIndex : -1,
-      });
-    }
-
-    if (!this.props.disableSelectionZone && newProps.items !== items) {
-      this._selection.setItems(newProps.items, shouldResetSelection);
-    }
-
-    if (
-      newProps.checkboxVisibility !== checkboxVisibility ||
-      newProps.columns !== columns ||
-      newViewportWidth !== oldViewportWidth ||
-      newProps.compact !== compact
-    ) {
-      shouldForceUpdates = true;
-    }
-
-    this._adjustColumns(newProps, true);
-
-    if (newProps.selectionMode !== selectionMode) {
-      shouldForceUpdates = true;
-    }
-
-    if (
-      isAllGroupsCollapsed === undefined &&
-      newProps.groupProps &&
-      newProps.groupProps.isAllGroupsCollapsed !== undefined
-    ) {
-      this.setState({
-        isCollapsed: newProps.groupProps.isAllGroupsCollapsed,
-        isSomeGroupExpanded: !newProps.groupProps.isAllGroupsCollapsed,
-      });
-    }
-
-    if (newProps.dragDropEvents !== dragDropEvents) {
-      this._dragDropHelper && this._dragDropHelper.dispose();
-      this._dragDropHelper = newProps.dragDropEvents
-        ? new DragDropHelper({
-            selection: this._selection,
-            minimumPixelsForDrag: newProps.minimumPixelsForDrag,
-          })
-        : undefined;
-      shouldForceUpdates = true;
-    }
-
-    if (shouldForceUpdates) {
-      this.setState({
-        version: {},
-      });
     }
   }
 
@@ -917,6 +851,97 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     defaultRender?: IRenderFunction<IDetailsRowProps>,
   ): JSX.Element => {
     return <DetailsRow {...props} />;
+  };
+
+  private _getDerivedStateFromProps = (
+    nextProps: IDetailsListProps,
+    previousState: IDetailsListState,
+  ): IDetailsListState => {
+    const {
+      checkboxVisibility,
+      items,
+      setKey,
+      selectionMode = this._selection.mode,
+      columns,
+      viewport,
+      compact,
+      dragDropEvents,
+    } = this.props;
+
+    const { isAllGroupsCollapsed = undefined } = this.props.groupProps || {};
+    const newViewportWidth = (nextProps.viewport && nextProps.viewport.width) || 0;
+    const oldViewportWidth = (viewport && viewport.width) || 0;
+    const shouldResetSelection = nextProps.setKey !== setKey || nextProps.setKey === undefined;
+    let shouldForceUpdates = false;
+
+    if (nextProps.layoutMode !== this.props.layoutMode) {
+      shouldForceUpdates = true;
+    }
+
+    let nextState = previousState;
+
+    if (shouldResetSelection) {
+      this._initialFocusedIndex = nextProps.initialFocusedIndex;
+      // reset focusedItemIndex when setKey changes
+      nextState = {
+        ...nextState,
+        focusedItemIndex: this._initialFocusedIndex !== undefined ? this._initialFocusedIndex : -1,
+      };
+    }
+
+    if (!this.props.disableSelectionZone && nextProps.items !== items) {
+      this._selection.setItems(nextProps.items, shouldResetSelection);
+    }
+
+    if (
+      nextProps.checkboxVisibility !== checkboxVisibility ||
+      nextProps.columns !== columns ||
+      newViewportWidth !== oldViewportWidth ||
+      nextProps.compact !== compact
+    ) {
+      shouldForceUpdates = true;
+    }
+
+    nextState = {
+      ...nextState,
+      ...this._adjustColumns(nextProps, nextState, true),
+    };
+
+    if (nextProps.selectionMode !== selectionMode) {
+      shouldForceUpdates = true;
+    }
+
+    if (
+      isAllGroupsCollapsed === undefined &&
+      nextProps.groupProps &&
+      nextProps.groupProps.isAllGroupsCollapsed !== undefined
+    ) {
+      nextState = {
+        ...nextState,
+        isCollapsed: nextProps.groupProps.isAllGroupsCollapsed,
+        isSomeGroupExpanded: !nextProps.groupProps.isAllGroupsCollapsed,
+      };
+    }
+
+    if (nextProps.dragDropEvents !== dragDropEvents) {
+      this._dragDropHelper && this._dragDropHelper.dispose();
+      this._dragDropHelper = nextProps.dragDropEvents
+        ? new DragDropHelper({
+            selection: this._selection,
+            minimumPixelsForDrag: nextProps.minimumPixelsForDrag,
+          })
+        : undefined;
+      shouldForceUpdates = true;
+    }
+
+    if (shouldForceUpdates) {
+      nextState = {
+        ...nextState,
+        version: {},
+      };
+    }
+
+    return nextState;
   };
 
   private _onGroupExpandStateChanged = (isSomeGroupExpanded: boolean): void => {
@@ -1008,25 +1033,27 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     });
   }
 
-  private _adjustColumns(newProps: IDetailsListProps, forceUpdate?: boolean, resizingColumnIndex?: number): void {
-    const adjustedColumns = this._getAdjustedColumns(newProps, forceUpdate, resizingColumnIndex);
+  private _adjustColumns(
+    newProps: IDetailsListProps,
+    previousState: IDetailsListState,
+    forceUpdate?: boolean,
+    resizingColumnIndex?: number,
+  ): IDetailsListState {
+    const adjustedColumns = this._getAdjustedColumns(newProps, previousState, forceUpdate, resizingColumnIndex);
     const { viewport } = this.props;
     const viewportWidth = viewport && viewport.width ? viewport.width : 0;
 
-    if (adjustedColumns) {
-      this.setState(
-        {
-          adjustedColumns: adjustedColumns,
-          lastWidth: viewportWidth,
-        },
-        this._notifyColumnsResized,
-      );
-    }
+    return {
+      ...previousState,
+      adjustedColumns: adjustedColumns,
+      lastWidth: viewportWidth,
+    };
   }
 
   /** Returns adjusted columns, given the viewport size and layout mode. */
   private _getAdjustedColumns(
     newProps: IDetailsListProps,
+    previousState: IDetailsListState | undefined,
     forceUpdate?: boolean,
     resizingColumnIndex?: number,
   ): IColumn[] {
@@ -1035,8 +1062,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     let { columns: newColumns } = newProps;
 
     const columns = this.props ? this.props.columns : [];
-    const lastWidth = this.state ? this.state.lastWidth : -1;
-    const lastSelectionMode = this.state ? this.state.lastSelectionMode : undefined;
+    const lastWidth = previousState ? previousState.lastWidth : -1;
+    const lastSelectionMode = previousState ? previousState.lastSelectionMode : undefined;
 
     if (
       !forceUpdate &&
@@ -1044,7 +1071,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       lastSelectionMode === selectionMode &&
       (!columns || newColumns === columns)
     ) {
-      return [];
+      return newColumns || [];
     }
 
     newColumns = newColumns || buildColumns(newItems, true);
@@ -1192,9 +1219,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
 
     this._rememberCalculatedWidth(resizingColumn, newCalculatedWidth);
 
-    this._adjustColumns(this.props, true, resizingColumnIndex);
-
     this.setState({
+      ...this._adjustColumns(this.props, this.state, true, resizingColumnIndex),
       version: {},
     });
   };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -57,6 +57,16 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
   private _classNames: IProcessedStyleSet<IDetailsRowStyles>;
   private _rowClassNames: IDetailsRowFieldsProps['rowClassNames'];
 
+  public static getDerivedStateFromProps(
+    nextProps: IDetailsRowBaseProps,
+    previousState: IDetailsRowState,
+  ): IDetailsRowState {
+    return {
+      ...previousState,
+      selectionState: getSelectionState(nextProps),
+    };
+  }
+
   constructor(props: IDetailsRowBaseProps) {
     super(props);
 
@@ -64,14 +74,13 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     this._events = new EventGroup(this);
 
     this.state = {
-      selectionState: this._getSelectionState(props),
+      selectionState: getSelectionState(props),
       columnMeasureInfo: undefined,
       isDropping: false,
     };
 
     this._droppingClassNames = '';
   }
-
   public componentDidMount(): void {
     const { dragDropHelper, selection, item, onDidMount } = this.props;
 
@@ -150,15 +159,9 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     this._events.dispose();
   }
 
-  public UNSAFE_componentWillReceiveProps(newProps: IDetailsRowBaseProps): void {
-    this.setState({
-      selectionState: this._getSelectionState(newProps),
-    });
-  }
-
   public shouldComponentUpdate(nextProps: IDetailsRowBaseProps, nextState: IDetailsRowState): boolean {
     if (this.props.useReducedRowRenderer) {
-      const newSelectionState = this._getSelectionState(nextProps);
+      const newSelectionState = getSelectionState(nextProps);
       if (this.state.selectionState.isSelected !== newSelectionState.isSelected) {
         return true;
       }
@@ -368,17 +371,8 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     return <DetailsRowCheck {...props} />;
   }
 
-  private _getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState {
-    const { itemIndex, selection } = props;
-
-    return {
-      isSelected: !!selection?.isIndexSelected(itemIndex),
-      isSelectionModal: !!selection?.isModal?.(),
-    };
-  }
-
   private _onSelectionChanged = (): void => {
-    const selectionState = this._getSelectionState(this.props);
+    const selectionState = getSelectionState(this.props);
 
     if (!shallowCompare(selectionState, this.state.selectionState)) {
       this.setState({
@@ -431,5 +425,14 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     if (isDropping !== newValue) {
       this.setState({ isDropping: newValue });
     }
+  };
+}
+
+function getSelectionState(props: IDetailsRowBaseProps): IDetailsRowSelectionState {
+  const { itemIndex, selection } = props;
+
+  return {
+    isSelected: !!selection?.isIndexSelected(itemIndex),
+    isSelectionModal: !!selection?.isModal?.(),
   };
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -27,6 +27,25 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
 
   private _classNames: IProcessedStyleSet<IGroupHeaderStyles>;
 
+  public static getDerivedStateFromProps(
+    nextProps: IGroupHeaderProps,
+    previousState: IGroupHeaderState,
+  ): IGroupHeaderState {
+    if (nextProps.group) {
+      const newCollapsed = nextProps.group.isCollapsed;
+      const isGroupLoading = nextProps.isGroupLoading;
+      const newLoadingVisible = !newCollapsed && isGroupLoading && isGroupLoading(nextProps.group);
+
+      return {
+        ...previousState,
+        isCollapsed: newCollapsed || false,
+        isLoadingVisible: newLoadingVisible || false,
+      };
+    }
+
+    return previousState;
+  }
+
   constructor(props: IGroupHeaderProps) {
     super(props);
 
@@ -34,19 +53,6 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       isCollapsed: (this.props.group && this.props.group.isCollapsed) as boolean,
       isLoadingVisible: false,
     };
-  }
-
-  public UNSAFE_componentWillReceiveProps(newProps: IGroupHeaderProps): void {
-    if (newProps.group) {
-      const newCollapsed = newProps.group.isCollapsed;
-      const isGroupLoading = newProps.isGroupLoading;
-      const newLoadingVisible = !newCollapsed && isGroupLoading && isGroupLoading(newProps.group);
-
-      this.setState({
-        isCollapsed: newCollapsed || false,
-        isLoadingVisible: newLoadingVisible || false,
-      });
-    }
   }
 
   public render(): JSX.Element | null {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -23,6 +23,7 @@ const { rowHeight: ROW_HEIGHT, compactRowHeight: COMPACT_ROW_HEIGHT } = DEFAULT_
 export interface IGroupedListState {
   lastSelectionMode?: SelectionMode;
   groups?: IGroup[];
+  version: {};
 }
 
 export class GroupedListBase extends React.Component<IGroupedListProps, IGroupedListState> implements IGroupedList {
@@ -41,6 +42,45 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _groupRefs: Record<string, GroupedListSection | null> = {};
 
+  public static getDerivedStateFromProps(
+    nextProps: IGroupedListProps,
+    previousState: IGroupedListState,
+  ): IGroupedListState {
+    let nextState = previousState;
+
+    const { listProps: { version = undefined } = {} } = nextProps;
+
+    if (version) {
+      nextState = {
+        ...nextState,
+        version,
+      };
+    }
+
+    const { groups, selectionMode, compact } = nextProps;
+    let shouldForceUpdates = false;
+
+    if (nextProps.groups !== groups) {
+      nextState = {
+        ...nextState,
+        groups: nextProps.groups,
+      };
+    }
+
+    if (nextProps.selectionMode !== selectionMode || nextProps.compact !== compact) {
+      shouldForceUpdates = true;
+    }
+
+    if (shouldForceUpdates) {
+      nextState = {
+        ...nextState,
+        version: {},
+      };
+    }
+
+    return nextState;
+  }
+
   constructor(props: IGroupedListProps) {
     super(props);
 
@@ -48,8 +88,11 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     this._isSomeGroupExpanded = this._computeIsSomeGroupExpanded(props.groups);
 
+    const { listProps: { version = {} } = {} } = props;
+
     this.state = {
       groups: props.groups,
+      version,
     };
   }
 
@@ -63,24 +106,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     return this._list.current!.getStartItemIndexInView() || 0;
   }
 
-  public UNSAFE_componentWillReceiveProps(newProps: IGroupedListProps): void {
-    const { groups, selectionMode, compact } = this.props;
-    let shouldForceUpdates = false;
-
-    if (newProps.groups !== groups) {
-      this.setState({ groups: newProps.groups });
-      shouldForceUpdates = true;
-    }
-
-    if (newProps.selectionMode !== selectionMode || newProps.compact !== compact) {
-      shouldForceUpdates = true;
-    }
-
-    if (shouldForceUpdates) {
-      this._forceListUpdates();
-    }
-  }
-
   public componentDidMount() {
     const { groupProps, groups = [] } = this.props;
 
@@ -90,24 +115,13 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   public render(): JSX.Element {
-    const {
-      className,
-      usePageCache,
-      onShouldVirtualize,
-      theme,
-      styles,
-      compact,
-      listProps = {},
-      focusZoneProps = {},
-    } = this.props;
-    const { groups } = this.state;
+    const { className, usePageCache, onShouldVirtualize, theme, styles, compact, focusZoneProps = {} } = this.props;
+    const { groups, version } = this.state;
     this._classNames = getClassNames(styles, {
       theme: theme!,
       className,
       compact: compact,
     });
-
-    const { version } = listProps;
 
     const { shouldEnterInnerZone = this._isInnerZoneKeystroke } = focusZoneProps;
 
@@ -203,6 +217,11 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
       return null;
     }
 
+    const finalListProps: IListProps = {
+      ...(listProps || {}),
+      version: this.state.version,
+    };
+
     return (
       <GroupedListSection
         ref={ref => (this._groupRefs['group_' + groupIndex] = ref)}
@@ -217,7 +236,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
         groupNestingDepth={groupNestingDepth}
         groupProps={groupProps}
         headerProps={headerProps}
-        listProps={listProps}
+        listProps={finalListProps}
         items={items}
         onRenderCell={onRenderCell}
         onRenderGroupHeader={groupProps!.onRenderHeader}


### PR DESCRIPTION
#### Description of changes

Updated `DetailsList`, `GroupedList`, `GroupHeader`, and `List` so they comply with the requirements of `StrictMode`: namely, they no longer implement `UNSAFE_componentWillReceiveProps` and now use `getDerivedStateFromProps`.
It's important to note that this change only seeks *minimal compliance*. The components aren't guaranteed to work perfectly in concurrent mode, because they still rely on a lot of class fields to maintain state, and the implementations of `getDerivedStateFromProps` still delegate logic back to the class instance, by shuttling a bound method into the component state (this pattern was leveraged by `react-redux` before they fully moved to Hooks).

Where needed, the logic in each component has been converted so helper functions that operate on state will return the new state instead of calling `setState`. Multiple calls to `setState` now simply aggregate a new state, and usage of the `setState` post-update callback has been replaced with `componentDidUpdate`.

#### Focus areas to test

The typical logic which breaks when updating these components:
1. Resizing a column in a grouped list. This appears to be working.
2. Virtual scrolling. Appears to be working.
3. Virtual scrolling within groups. Appears to be working.
4. General rendering of the DetailsList. Appears to be working.

Fixes #14296, fixes #14295, fixes #14291