### PR TITLE
allow consumers of FloatingPeopleSuggestions to use the onRenderSuggestion property

### DIFF
--- a/change/@uifabric-experiments-2020-09-10-13-58-06-rendersugfix.json
+++ b/change/@uifabric-experiments-2020-09-10-13-58-06-rendersugfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "allow FloatingPeopleSuggestions onRenderSuggestions property to be used",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T20:58:06.205Z"
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.tsx
@@ -15,7 +15,10 @@ export const FloatingPeopleSuggestions = (props: IFloatingPeopleSuggestionsProps
 
   return (
     <>
-      <BaseFloatingSuggestions {...props} onRenderSuggestion={renderSuggestionItem} />
+      <BaseFloatingSuggestions
+        {...props}
+        onRenderSuggestion={props.onRenderSuggestion ? props.onRenderSuggestion : renderSuggestionItem}
+      />
     </>
   );
 };

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingPeopleSuggestions.types.ts
@@ -1,5 +1,4 @@
 import { IBaseFloatingSuggestionsProps } from '../FloatingSuggestions.types';
-import { Omit } from '@uifabric/utilities';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 
-export type IFloatingPeopleSuggestionsProps = Omit<IBaseFloatingSuggestionsProps<IPersonaProps>, 'onRenderSuggestion'>;
+export type IFloatingPeopleSuggestionsProps = IBaseFloatingSuggestionsProps<IPersonaProps>;

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { ExampleCard, IComponentDemoPageProps, ComponentPage, PropertiesTableSet } from '@uifabric/example-app-base';
 import { FloatingPeopleSuggestionsExample } from './examples/FloatingPeopleSuggestions.Example';
-
 const FloatingPeoplePickerSuggestionsExampleCode = require('!raw-loader!./examples/FloatingPeopleSuggestions.Example') as string;
+import { FloatingPeopleSuggestionsCustomRenderExample } from './examples/FloatingPeopleSuggestions.CustomRender.Example';
+const FloatingPeoplePickerSuggestionsCustomRenderExampleCode = require('!raw-loader!./examples/FloatingPeopleSuggestions.CustomRender.Example') as string;
 
 export class FloatingSuggestionPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
@@ -3,7 +3,7 @@ import { ExampleCard, IComponentDemoPageProps, ComponentPage, PropertiesTableSet
 import { FloatingPeopleSuggestionsExample } from './examples/FloatingPeopleSuggestions.Example';
 const FloatingPeoplePickerSuggestionsExampleCode = require('!raw-loader!./examples/FloatingPeopleSuggestions.Example') as string;
 import { FloatingPeopleSuggestionsCustomRenderExample } from './examples/FloatingPeopleSuggestions.CustomRender.Example';
-const FloatingPeoplePickerSuggestionsCustomRenderExampleCode = require('!raw-loader!./examples/FloatingPeopleSuggestions.CustomRender.Example') as string;
+const FloatingPeoplePickerSuggestionsCustomRenderCode = require('!raw-loader!./examples/FloatingPeopleSuggestions.CustomRender.Example') as string;
 
 export class FloatingSuggestionPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -15,6 +15,9 @@ export class FloatingSuggestionPage extends React.Component<IComponentDemoPagePr
           <div>
             <ExampleCard title="Basic" isOptIn={true} code={FloatingPeoplePickerSuggestionsExampleCode}>
               <FloatingPeopleSuggestionsExample />
+            </ExampleCard>
+            <ExampleCard title="Basic" isOptIn={true} code={FloatingPeoplePickerSuggestionsCustomRenderCode}>
+              <FloatingPeopleSuggestionsCustomRenderExample />
             </ExampleCard>
           </div>
         }

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/examples/FloatingPeopleSuggestions.CustomRender.Example.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingPeopleSuggestions/examples/FloatingPeopleSuggestions.CustomRender.Example.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import {
+  IFloatingSuggestionItemProps,
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+  IFloatingSuggestionOnRenderItemProps,
+} from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
+import { mru } from '@uifabric/example-data';
+import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
+import { css, classNamesFunction } from '@uifabric/experiments/lib/Utilities';
+
+const _suggestions = [
+  {
+    key: '1',
+    id: '1',
+    displayText: 'Suggestion 1',
+    item: mru[0],
+    isSelected: true,
+    showRemoveButton: true,
+  },
+  {
+    key: '2',
+    id: '2',
+    displayText: 'Suggestion 2',
+    item: mru[1],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '3',
+    id: '3',
+    displayText: 'Suggestion 3',
+    item: mru[2],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '4',
+    id: '4',
+    displayText: 'Suggestion 4',
+    item: mru[3],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '5',
+    id: '5',
+    displayText: 'Suggestion 5',
+    item: mru[4],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+] as IFloatingSuggestionItem<IPersonaProps>[];
+
+import { getGlobalClassNames, getTheme, IStyle } from '@uifabric/styling';
+
+interface ISuggestionItemExampleStylesProps {}
+interface ISuggestionItemExampleStyles {
+  persona: IStyle;
+  personaContent: IStyle;
+}
+
+const GlobalClassNames = {
+  root: 'ms-FloatingPeopleSuggestions-SuggestionItemDefault-persona',
+  callout: 'ms-FloatingPeopleSuggestions-SuggestionItemDefault-personaContent',
+};
+
+const getStyles = (props: ISuggestionItemExampleStylesProps): ISuggestionItemExampleStyles => {
+  const theme = getTheme();
+
+  if (!theme) {
+    throw new Error('theme is undefined or null in Editing item getStyles function.');
+  }
+
+  // const { semanticColors } = theme;
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    persona: [
+      classNames.root,
+      {
+        width: '100%',
+        selectors: {
+          ['.ms-Persona-detail']: {
+            minHeight: '40px',
+          },
+        },
+      },
+    ],
+    personaContent: [
+      classNames.callout,
+      {
+        display: 'flex',
+        width: '100%',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '7px 12px',
+      },
+    ],
+  };
+};
+
+export const FloatingPeopleSuggestionsCustomRenderExample = (): JSX.Element => {
+  const [peopleSuggestions, setPeopleSuggestions] = React.useState<IFloatingSuggestionItemProps<IPersonaProps>[]>([
+    ..._suggestions,
+  ]);
+
+  const _onSuggestionSelected = (
+    ev: React.MouseEvent<HTMLElement, MouseEvent>,
+    item: IFloatingSuggestionItemProps<IPersonaProps>,
+  ) => {
+    _markSuggestionSelected(item);
+  };
+
+  const _onSuggestionRemoved = (
+    ev: React.MouseEvent<HTMLElement, MouseEvent>,
+    suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
+  ) => {
+    setPeopleSuggestions(suggestions => {
+      const modifiedSuggestions = suggestions.filter(item => item.id !== suggestionToRemove.id);
+      return modifiedSuggestions;
+    });
+  };
+
+  const _markSuggestionSelected = (selectedSuggestion: IFloatingSuggestionItemProps<IPersonaProps>) => {
+    setPeopleSuggestions(suggestions => {
+      const modifiedSuggestions = suggestions.map(suggestion =>
+        suggestion.id === selectedSuggestion.id
+          ? { ...suggestion, isSelected: true }
+          : { ...suggestion, isSelected: false },
+      );
+      return modifiedSuggestions;
+    });
+  };
+
+  const renderSuggestionItem = React.useCallback(
+    (suggestionItemProps: IFloatingSuggestionOnRenderItemProps<IPersonaProps>): JSX.Element => {
+      const getClassNames = classNamesFunction<ISuggestionItemExampleStylesProps, ISuggestionItemExampleStyles>();
+      const classNames = getClassNames(getStyles);
+      return (
+        <div className={css('ms-PeoplePicker-personaContent', classNames.personaContent)}>
+          <div>
+            {suggestionItemProps.item.text} ({suggestionItemProps.item.secondaryText})
+          </div>
+        </div>
+      );
+    },
+    [],
+  );
+
+  return (
+    <>
+      <FloatingPeopleSuggestions
+        suggestions={[...peopleSuggestions]}
+        isSuggestionsVisible={true}
+        targetElement={null}
+        /* eslint-disable react/jsx-no-bind */
+        onSuggestionSelected={_onSuggestionSelected}
+        onRemoveSuggestion={_onSuggestionRemoved}
+        /* eslint-enable react/jsx-no-bind */
+        suggestionsHeaderText={'People suggestions'}
+        noResultsFoundText={'No suggestions'}
+        onFloatingSuggestionsDismiss={undefined}
+        showSuggestionRemoveButton={true}
+        onRenderSuggestion={renderSuggestionItem}
+      />
+    </>
+  );
+};

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -255,7 +255,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     if (!composing) {
       // update query string
       setQueryString(value);
-      !isSuggestionsVisible ? showPicker(true) : null;
+      !isSuggestionsShown ? showPicker(true) : null;
       onInputChange ? onInputChange(value) : null;
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

IFloatingPeopleSuggestionsProps was omitting the IBaseFloatingSuggestionsProps onRenderSuggestion property, instead rendering its own default item. Users (us) may want to override how the items are rendered, so I'm removing that omission. Listing this as a patch, because that property was always optional, so now it's using the old default if the property isn't specified, so there should be no change in behavior for users.

I added an example that overrides onRenderSuggestions
