### PR TITLE
Deprecate useConstCallback

### DIFF
--- a/change/@fluentui-react-next-2020-09-10-16-58-53-constcallback.json
+++ b/change/@fluentui-react-next-2020-09-10-16-58-53-constcallback.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Remove useConstCallback usage",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T23:58:53.184Z"
+}

--- a/change/@uifabric-date-time-2020-09-10-16-58-53-constcallback.json
+++ b/change/@uifabric-date-time-2020-09-10-16-58-53-constcallback.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove useConstCallback usage",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T23:58:39.684Z"
+}

--- a/change/@uifabric-react-hooks-2020-09-10-16-58-53-constcallback.json
+++ b/change/@uifabric-react-hooks-2020-09-10-16-58-53-constcallback.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Deprecate useConstCallback",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T23:58:50.082Z"
+}

--- a/change/office-ui-fabric-react-2020-09-10-16-58-53-constcallback.json
+++ b/change/office-ui-fabric-react-2020-09-10-16-58-53-constcallback.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove useConstCallback usage",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-10T23:58:47.066Z"
+}

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -16,7 +16,7 @@ import { defaultIconStrings, defaultDateTimeFormatterCallbacks } from '../Calend
 import { css, getRTL, classNamesFunction, KeyCodes, format, getPropsWithDefaults } from '@uifabric/utilities';
 import { ICalendarYear, ICalendarYearRange } from '../CalendarYear/CalendarYear.types';
 import { CalendarYear } from '../CalendarYear/CalendarYear';
-import { usePrevious, useConstCallback } from '@uifabric/react-hooks';
+import { usePrevious } from '@uifabric/react-hooks';
 
 const MONTHS_PER_ROW = 4;
 
@@ -46,13 +46,13 @@ function useFocusLogic({ componentRef }: ICalendarMonthProps) {
   const calendarYearRef = React.useRef<ICalendarYear>(null);
   const focusOnUpdate = React.useRef(false);
 
-  const focus = useConstCallback(() => {
+  const focus = React.useCallback(() => {
     if (calendarYearRef.current) {
       calendarYearRef.current.focus();
     } else if (navigatedMonthRef.current) {
       navigatedMonthRef.current.focus();
     }
-  });
+  }, []);
 
   React.useImperativeHandle(componentRef, () => ({ focus }), [focus]);
 

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Announced } from 'office-ui-fabric-react/lib/Announced';
-import { useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 import { DetailsList, DetailsListLayoutMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { Selection } from 'office-ui-fabric-react/lib/Selection';
 import { Text } from 'office-ui-fabric-react/lib/Text';
@@ -35,13 +35,13 @@ export const AnnouncedBulkOperationsExample: React.FunctionComponent = () => {
   );
   const [deletedCount, setDeletedCount] = React.useState<number>(0);
 
-  const onDelete = useConstCallback(() => {
+  const onDelete = React.useCallback(() => {
     setDeletedCount(selection.count);
     setItems(prevItems => {
       const selectedIndices = selection.getSelectedIndices();
       return prevItems.filter((item, i) => selectedIndices.indexOf(i) === -1);
     });
-  });
+  }, [selection]);
 
   return (
     <Stack tokens={stackTokens}>

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.QuickActions.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.QuickActions.Example.tsx
@@ -11,7 +11,7 @@ import { IconButton, PrimaryButton, IButtonStyles } from 'office-ui-fabric-react
 import { Dialog, DialogFooter } from 'office-ui-fabric-react/lib/Dialog';
 import { TextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
 import { createArray } from 'office-ui-fabric-react/lib/Utilities';
-import { useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 
 const iconButtonStyles: Partial<IButtonStyles> = { root: { float: 'right', height: 'inherit' } };
 
@@ -34,26 +34,37 @@ export const AnnouncedQuickActionsExample: React.FunctionComponent = () => {
   const [dialogContent, setDialogContent] = React.useState<JSX.Element | undefined>(undefined);
   const [announced, setAnnounced] = React.useState<JSX.Element | undefined>(undefined);
 
-  const deleteItem = useConstCallback((index: number): void => {
+  const deleteItem = React.useCallback((index: number): void => {
     setItems(prevItems => prevItems.filter((item, i) => i !== index));
     setAnnounced(<Announced message="Item deleted" aria-live="assertive" />);
-  });
+  }, []);
 
-  const renameItem = useConstCallback((item: IExampleItem, index: number): void => {
+  const renameItem = React.useCallback((item: IExampleItem, index: number): void => {
+    const updateItemName = () => {
+      if (textField && textField.current) {
+        setItems(prevItems => {
+          const renamedItems = [...prevItems];
+          renamedItems[index] = { ...prevItems[index], name: textField.current?.value || renamedItems[index].name };
+          return renamedItems;
+        });
+        setDialogContent(undefined);
+        setAnnounced(<Announced message="Item renamed" aria-live="assertive" />);
+      }
+    };
+
     setDialogContent(
       <>
         <TextField componentRef={textField} label="Rename" defaultValue={item.name} />
         <DialogFooter>
           <PrimaryButton
             // eslint-disable-next-line react/jsx-no-bind
-            onClick={() => updateItemName(index)}
+            onClick={updateItemName}
             text="Save"
           />
         </DialogFooter>
       </>,
     );
-    return;
-  });
+  }, []);
 
   const columns = useConst((): IColumn[] => [
     {
@@ -91,21 +102,9 @@ export const AnnouncedQuickActionsExample: React.FunctionComponent = () => {
     },
   ]);
 
-  const updateItemName = useConstCallback((index: number) => {
-    if (textField && textField.current) {
-      setItems(prevItems => {
-        const renamedItems = [...prevItems];
-        renamedItems[index] = { ...prevItems[index], name: textField.current?.value || renamedItems[index].name };
-        return renamedItems;
-      });
-      setDialogContent(undefined);
-      setAnnounced(<Announced message="Item renamed" aria-live="assertive" />);
-    }
-  });
-
-  const closeRenameDialog = useConstCallback((): void => {
+  const closeRenameDialog = React.useCallback((): void => {
     setDialogContent(undefined);
-  });
+  }, []);
 
   return (
     <>

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.SearchResults.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.SearchResults.Example.tsx
@@ -3,7 +3,6 @@ import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { TagPicker, ITag, IInputProps, IBasePickerSuggestionsProps } from 'office-ui-fabric-react/lib/Pickers';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { IStackTokens, Stack } from 'office-ui-fabric-react/lib/Stack';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 const inputProps: IInputProps = {
   'aria-label': 'Tag Picker',
@@ -47,7 +46,7 @@ export const AnnouncedSearchResultsExample: React.FunctionComponent = () => {
   const [hasFilterText, setHasFilterText] = React.useState(false);
   const [suggestionCount, setSuggestionCount] = React.useState(0);
 
-  const onFilterChanged = useConstCallback((filterText: string, tagList: ITag[]): ITag[] => {
+  const onFilterChanged = React.useCallback((filterText: string, tagList: ITag[]): ITag[] => {
     setHasFilterText(!!filterText);
     const filteredTags = filterText
       ? _testTags
@@ -56,7 +55,7 @@ export const AnnouncedSearchResultsExample: React.FunctionComponent = () => {
       : [];
     setSuggestionCount(filteredTags.length);
     return filteredTags;
-  });
+  }, []);
 
   return (
     <Stack tokens={stackTokens}>

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/examples/ColorPicker.Basic.Example.tsx
@@ -11,7 +11,6 @@ import {
   updateA,
 } from 'office-ui-fabric-react/lib/index';
 import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 const white = getColorFromString('#ffffff')!;
 
@@ -20,8 +19,8 @@ export const ColorPickerBasicExample: React.FunctionComponent = () => {
   const [showPreview, setShowPreview] = React.useState(true);
   const [alphaType, setAlphaType] = React.useState<IColorPickerProps['alphaType']>('alpha');
 
-  const updateColor = useConstCallback((ev: any, colorObj: IColor) => setColor(colorObj));
-  const onShowPreviewClick = useConstCallback((ev: any, checked?: boolean) => setShowPreview(!!checked));
+  const updateColor = React.useCallback((ev: any, colorObj: IColor) => setColor(colorObj), []);
+  const onShowPreviewClick = React.useCallback((ev: any, checked?: boolean) => setShowPreview(!!checked), []);
   const onAlphaTypeChange = React.useCallback(
     (ev: any, option: IChoiceGroupOption = alphaOptions[0]) => {
       if (option.key === 'none') {

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.Lazy.Example.tsx
@@ -1,39 +1,34 @@
 import * as React from 'react';
 import { CommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
 import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 export const CommandBarLazyExample: React.FunctionComponent = () => {
   const [menuItems, setMenuItems] = React.useState<ICommandBarItemProps[] | undefined>(undefined);
 
   const timeoutRef = React.useRef<number | null>();
 
-  const onMenuDismissed = useConstCallback(() => {
-    setMenuItems(undefined);
-  });
-
-  const loadItems = useConstCallback(() => {
-    const itemCount = Math.floor(Math.random() * 5) + 1;
-
-    const newMenuItems: ICommandBarItemProps[] = [];
-
-    for (let i = 0; i < itemCount; i++) {
-      newMenuItems.push({
-        key: `sub-item-${i}`,
-        name: `Item ${i}`,
-      });
-    }
-
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-    }
-
-    timeoutRef.current = (setTimeout(() => {
-      setMenuItems(newMenuItems);
-    }, 2000) as unknown) as number;
-  });
-
   const items = React.useMemo((): ICommandBarItemProps[] => {
+    const loadItems = () => {
+      const itemCount = Math.floor(Math.random() * 5) + 1;
+
+      const newMenuItems: ICommandBarItemProps[] = [];
+
+      for (let i = 0; i < itemCount; i++) {
+        newMenuItems.push({
+          key: `sub-item-${i}`,
+          name: `Item ${i}`,
+        });
+      }
+
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = (setTimeout(() => {
+        setMenuItems(newMenuItems);
+      }, 2000) as unknown) as number;
+    };
+
     return [
       {
         key: 'a',
@@ -58,11 +53,11 @@ export const CommandBarLazyExample: React.FunctionComponent = () => {
               ]
             : [],
           onMenuOpened: loadItems,
-          onMenuDismissed: onMenuDismissed,
+          onMenuDismissed: () => setMenuItems(undefined),
         },
       },
     ];
-  }, [menuItems, loadItems, onMenuDismissed]);
+  }, [menuItems]);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 export const ContextualMenuBasicExample: React.FunctionComponent = () => {
   const linkRef = React.useRef(null);
-  const [showContextualMenu, setShowContextualMenu] = React.useState(false);
-  const onShowContextualMenu = useConstCallback(() => setShowContextualMenu(true));
-  const onHideContextualMenu = useConstCallback(() => setShowContextualMenu(false));
+  const [showContextualMenu, { setTrue: onShowContextualMenu, setFalse: onHideContextualMenu }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConstCallback, useConst } from '@uifabric/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { ISearchBoxStyles, SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -9,11 +9,11 @@ import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = () => {
   const [items, setItems] = React.useState(menuItems);
 
-  const onAbort = useConstCallback(() => {
+  const onAbort = React.useCallback(() => {
     setItems(menuItems);
-  });
+  }, []);
 
-  const onChange = useConstCallback((ev: React.ChangeEvent<HTMLInputElement>, newValue: string) => {
+  const onChange = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>, newValue: string) => {
     const filteredItems = menuItems.filter(
       item => item.text && item.text.toLowerCase().indexOf(newValue.toLowerCase()) !== -1,
     );
@@ -31,9 +31,9 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
     }
 
     setItems(filteredItems);
-  });
+  }, []);
 
-  const renderMenuList = useConstCallback(
+  const renderMenuList = React.useCallback(
     (menuListProps: IContextualMenuListProps, defaultRender: IRenderFunction<IContextualMenuListProps>) => {
       return (
         <div>
@@ -50,6 +50,7 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
         </div>
       );
     },
+    [onAbort, onChange],
   );
 
   const menuProps = useConst(() => ({

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useConstCallback } from '@uifabric/react-hooks';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox, ICheckboxStyles } from 'office-ui-fabric-react/lib/Checkbox';
 import {
@@ -39,24 +38,26 @@ export const ContextualMenuDirectionalExample: React.FunctionComponent = () => {
     DirectionalHint.bottomLeftEdge,
   );
 
-  const onShowBeakChange = useConstCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
+  const onShowBeakChange = React.useCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
     setIsBeakVisible(isVisible);
-  });
+  }, []);
 
-  const onUseRtlHintChange = useConstCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
+  const onUseRtlHintChange = React.useCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
     setUseDirectionalHintForRTL(isVisible);
-  });
+  }, []);
 
-  const onDirectionalChanged = useConstCallback(
+  const onDirectionalChanged = React.useCallback(
     (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
       setDirectionalHint(option.key as DirectionalHint);
     },
+    [],
   );
 
-  const onDirectionalRtlChanged = useConstCallback(
+  const onDirectionalRtlChanged = React.useCallback(
     (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
       setDirectionalHintForRTL(option.key as DirectionalHint);
     },
+    [],
   );
 
   const menuProps: IContextualMenuProps = React.useMemo(

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useConst, useBoolean } from '@uifabric/react-hooks';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
 import {
@@ -14,10 +14,7 @@ import * as stylesImport from './ContextualMenuExample.scss';
 const styles: any = stylesImport;
 
 export const ContextualMenuIconExample: React.FunctionComponent = () => {
-  const [showCallout, setShowCallout] = React.useState(false);
-
-  const onShowCallout = useConstCallback(() => setShowCallout(true));
-  const onHideCallout = useConstCallback(() => setShowCallout(false));
+  const [showCallout, { setTrue: onShowCallout, setFalse: onHideCallout }] = useBoolean(false);
 
   const menuItems: IContextualMenuItem[] = useConst([
     {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useConstCallback } from '@uifabric/react-hooks';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { IContextualMenuProps, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { TextField, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
@@ -19,10 +18,11 @@ export interface IContextualMenuSubmenuExampleState {
 export const ContextualMenuSubmenuExample: React.FunctionComponent = () => {
   const [hoverDelay, setHoverDelay] = React.useState(250);
 
-  const onHoverDelayChanged = useConstCallback(
+  const onHoverDelayChanged = React.useCallback(
     (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string) => {
       setHoverDelay(Number(newValue) || 0);
     },
+    [],
   );
 
   const menuProps: IContextualMenuProps = React.useMemo(

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
@@ -4,7 +4,7 @@ import { List } from 'office-ui-fabric-react/lib/List';
 import { IRectangle } from 'office-ui-fabric-react/lib/Utilities';
 import { ITheme, getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
-import { useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 
 const theme: ITheme = getTheme();
 const { palette, fonts } = theme;
@@ -68,15 +68,15 @@ export const ListGridExample: React.FunctionComponent = () => {
   const columnCount = React.useRef(0);
   const rowHeight = React.useRef(0);
 
-  const getItemCountForPage = useConstCallback((itemIndex: number, surfaceRect: IRectangle) => {
+  const getItemCountForPage = React.useCallback((itemIndex: number, surfaceRect: IRectangle) => {
     if (itemIndex === 0) {
       columnCount.current = Math.ceil(surfaceRect.width / MAX_ROW_HEIGHT);
       rowHeight.current = Math.floor(surfaceRect.width / columnCount.current);
     }
     return columnCount.current * ROWS_PER_PAGE;
-  });
+  }, []);
 
-  const onRenderCell = useConstCallback((item: IExampleItem, index: number | undefined) => {
+  const onRenderCell = React.useCallback((item: IExampleItem, index: number | undefined) => {
     return (
       <div
         className={classNames.listGridExampleTile}
@@ -93,13 +93,14 @@ export const ListGridExample: React.FunctionComponent = () => {
         </div>
       </div>
     );
-  });
+  }, []);
 
-  const getPageHeight = useConstCallback((): number => {
+  const getPageHeight = React.useCallback((): number => {
     return rowHeight.current * ROWS_PER_PAGE;
-  });
+  }, []);
 
   const items = useConst(() => createListItems(5000));
+
   return (
     <FocusZone>
       <List

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Basic.Example.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 export const PanelBasicExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.ConfirmDismiss.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.ConfirmDismiss.Example.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 const explanation = 'When this panel is closed, a confirmation dialog will appear.';
 const dialogContentProps = {
@@ -18,20 +17,20 @@ export const PanelConfirmDismissExample: React.FunctionComponent = () => {
   const [isPanelOpen, setIsPanelOpen] = React.useState(false);
   const [isDialogVisible, setIsDialogVisible] = React.useState(false);
 
-  const openPanel = useConstCallback(() => setIsPanelOpen(true));
-  const onDismiss = useConstCallback((ev?: React.SyntheticEvent) => {
+  const openPanel = React.useCallback(() => setIsPanelOpen(true), []);
+  const onDismiss = React.useCallback((ev?: React.SyntheticEvent) => {
     if (ev) {
       // Instead of closing the panel immediately, cancel that action and show a dialog
       ev.preventDefault();
       setIsDialogVisible(true);
     }
-  });
+  }, []);
 
-  const hideDialog = useConstCallback(() => setIsDialogVisible(false));
-  const hideDialogAndPanel = useConstCallback(() => {
+  const hideDialog = React.useCallback(() => setIsDialogVisible(false), []);
+  const hideDialogAndPanel = React.useCallback(() => {
     setIsPanelOpen(false);
     setIsDialogVisible(false);
-  });
+  }, []);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Controlled.Example.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 export const PanelControlledExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Footer.Example.tsx
@@ -1,26 +1,26 @@
 import * as React from 'react';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const buttonStyles = { root: { marginRight: 8 } };
 
 export const PanelFooterExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   // This panel doesn't actually save anything; the buttons are just an example of what
   // someone might want to render in a panel footer.
-  const onRenderFooterContent = useConstCallback(() => (
-    <div>
-      <PrimaryButton onClick={dismissPanel} styles={buttonStyles}>
-        Save
-      </PrimaryButton>
-      <DefaultButton onClick={dismissPanel}>Cancel</DefaultButton>
-    </div>
-  ));
+  const onRenderFooterContent = React.useCallback(
+    () => (
+      <div>
+        <PrimaryButton onClick={dismissPanel} styles={buttonStyles}>
+          Save
+        </PrimaryButton>
+        <DefaultButton onClick={dismissPanel}>Cancel</DefaultButton>
+      </div>
+    ),
+    [dismissPanel],
+  );
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HandleDismissTarget.Example.tsx
@@ -1,36 +1,36 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const explanation =
   'This example demonstrates detecting whether a panel was dismissed using the close button ' +
   'or using "light dismiss" (a click outside the panel area).';
 
 export const PanelHandleDismissTargetExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const onDismiss = React.useCallback(
+    (ev?: React.SyntheticEvent<HTMLElement>) => {
+      if (!ev) {
+        console.log('Panel dismissed.');
+        return;
+      }
 
-  const onDismiss = useConstCallback((ev?: React.SyntheticEvent<HTMLElement>) => {
-    if (!ev) {
-      console.log('Panel dismissed.');
-      return;
-    }
-
-    // Demonstrates how to do different things depending on how which element dismissed the panel
-    console.log('Close button clicked or light dismissed.');
-    // eslint-disable-next-line deprecation/deprecation
-    const srcElement = ev.nativeEvent.srcElement as Element | null;
-    if (srcElement && srcElement.className.indexOf('ms-Button-icon') !== -1) {
-      console.log('Close button clicked.');
-    }
-    if (srcElement && srcElement.className.indexOf('ms-Overlay') !== -1) {
-      console.log('Light dismissed.');
-    }
-    dismissPanel();
-  });
+      // Demonstrates how to do different things depending on how which element dismissed the panel
+      console.log('Close button clicked or light dismissed.');
+      // eslint-disable-next-line deprecation/deprecation
+      const srcElement = ev.nativeEvent.srcElement as Element | null;
+      if (srcElement && srcElement.className.indexOf('ms-Button-icon') !== -1) {
+        console.log('Close button clicked.');
+      }
+      if (srcElement && srcElement.className.indexOf('ms-Overlay') !== -1) {
+        console.log('Light dismissed.');
+      }
+      dismissPanel();
+    },
+    [dismissPanel],
+  );
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HiddenOnDismiss.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.HiddenOnDismiss.Example.tsx
@@ -2,17 +2,14 @@ import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const contentExplanation =
   'Try typing something in this text field, closing the panel, and re-opening the panel. ' +
   " The text field's contents should still be here when the panel re-opens.";
 
 export const PanelHiddenOnDismissExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismiss.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismiss.Example.tsx
@@ -1,17 +1,14 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const explanation =
   'This panel uses "light dismiss" behavior: it can be closed by clicking or tapping ' +
   'the area outside the panel (or using the close button as usual).';
 
 export const PanelLightDismissExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const explanation =
   'If this panel is closed using light dismiss (clicking outside the panel), a confirmation dialog will appear.';
@@ -16,20 +16,20 @@ const dialogModalProps = {
 };
 
 export const PanelLightDismissCustomExample: React.FunctionComponent = () => {
-  const [isPanelOpen, setIsPanelOpen] = React.useState(false);
-  const [isDialogVisible, setIsDialogVisible] = React.useState(false);
+  const [isPanelOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
+  const [isDialogVisible, { setTrue: showDialog, setFalse: hideDialog }] = useBoolean(false);
 
-  const openPanel = useConstCallback(() => setIsPanelOpen(true));
-  const dismissPanel = useConstCallback(() => setIsPanelOpen(false));
-  const showDialog = useConstCallback(() => setIsDialogVisible(true));
-  const hideDialog = useConstCallback(ev => {
-    ev.preventDefault();
-    setIsDialogVisible(false);
-  });
-  const hideDialogAndPanel = useConstCallback(() => {
-    setIsPanelOpen(false);
-    setIsDialogVisible(false);
-  });
+  const onHideDialog = React.useCallback(
+    ev => {
+      ev.preventDefault();
+      hideDialog();
+    },
+    [hideDialog],
+  );
+  const onHideDialogAndPanel = React.useCallback(() => {
+    dismissPanel();
+    hideDialog();
+  }, [dismissPanel, hideDialog]);
 
   return (
     <div>
@@ -51,13 +51,13 @@ export const PanelLightDismissCustomExample: React.FunctionComponent = () => {
       </Panel>
       <Dialog
         hidden={!isDialogVisible}
-        onDismiss={hideDialog}
+        onDismiss={onHideDialog}
         dialogContentProps={dialogContentProps}
         modalProps={dialogModalProps}
       >
         <DialogFooter>
-          <PrimaryButton onClick={hideDialogAndPanel} text="Yes" />
-          <DefaultButton onClick={hideDialog} text="No" />
+          <PrimaryButton onClick={onHideDialogAndPanel} text="Yes" />
+          <DefaultButton onClick={onHideDialog} text="No" />
         </DialogFooter>
       </Dialog>
     </div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Navigation.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Navigation.Example.tsx
@@ -3,7 +3,7 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
 import { IRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const explanation =
   'This panel has custom content in the navigation region (the part at the top which normally ' +
@@ -12,23 +12,23 @@ const explanation =
 const searchboxStyles = { root: { margin: '5px', height: 'auto', width: '100%' } };
 
 export const PanelNavigationExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
-
-  const onRenderNavigationContent: IRenderFunction<IPanelProps> = useConstCallback((props, defaultRender) => (
-    <>
-      <SearchBox
-        placeholder="Search here..."
-        styles={searchboxStyles}
-        ariaLabel="Sample search box. Does not actually search anything."
-      />
-      {// This custom navigation still renders the close button (defaultRender).
-      // If you don't use defaultRender, be sure to provide some other way to close the panel.
-      defaultRender!(props)}
-    </>
-  ));
+  const onRenderNavigationContent: IRenderFunction<IPanelProps> = React.useCallback(
+    (props, defaultRender) => (
+      <>
+        <SearchBox
+          placeholder="Search here..."
+          styles={searchboxStyles}
+          ariaLabel="Sample search box. Does not actually search anything."
+        />
+        {// This custom navigation still renders the close button (defaultRender).
+        // If you don't use defaultRender, be sure to provide some other way to close the panel.
+        defaultRender!(props)}
+      </>
+    ),
+    [],
+  );
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.NonModal.Example.tsx
@@ -1,16 +1,13 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel } from 'office-ui-fabric-react/lib/Panel';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 const explanation =
   "This panel is non-modal: even when it's open, it allows interacting with content outside the panel.";
 
 export const PanelNonModalExample: React.FunctionComponent = () => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
@@ -3,15 +3,12 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 // The panel type and description are passed in by the PanelSizesExample component (later in this file)
 const PanelExample: React.FunctionComponent<{ panelType: PanelType; description: string }> = props => {
   const { description, panelType } = props;
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const openPanel = useConstCallback(() => setIsOpen(true));
-  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const [isOpen, { setTrue: openPanel, setFalse: dismissPanel }] = useBoolean(false);
 
   const a = 'aeiou'.indexOf(description[0]) === -1 ? 'a' : 'an'; // grammar...
 
@@ -54,7 +51,7 @@ const firstPStyle = { marginTop: 0 };
 
 export const PanelSizesExample: React.FunctionComponent = () => {
   const [option, setOption] = React.useState<IDropdownOption>(options[0]);
-  const updateOption = useConstCallback((ev: any, opt: IDropdownOption) => setOption(opt));
+  const updateOption = React.useCallback((ev: any, opt: IDropdownOption) => setOption(opt), []);
 
   const description = option.text.toLowerCase().replace(' (default)', '');
   return (

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
 import { IColumn, buildColumns, SelectionMode, Toggle, IListProps } from 'office-ui-fabric-react/lib/index';
 import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList';
-import { useSetInterval, useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useSetInterval, useConst } from '@uifabric/react-hooks';
 
 interface IShimmerApplicationExampleState {
   lastIntervalId: number;
@@ -92,22 +92,25 @@ export const ShimmerApplicationExample: React.FunctionComponent = () => {
 
   const { setInterval, clearInterval } = useSetInterval();
 
-  const loadMoreItems = (): void => {
-    state.visibleCount = Math.min(exampleItems.length, state.visibleCount + 2);
+  const onLoadData = React.useCallback(
+    (ev: React.MouseEvent<HTMLElement>, checked: boolean): void => {
+      const loadMoreItems = (): void => {
+        state.visibleCount = Math.min(exampleItems.length, state.visibleCount + 2);
 
-    setItems(exampleItems.map((current, index) => (index < state.visibleCount ? current : null)) as IExampleItem[]);
-  };
+        setItems(exampleItems.map((current, index) => (index < state.visibleCount ? current : null)) as IExampleItem[]);
+      };
 
-  const onLoadData = useConstCallback((ev: React.MouseEvent<HTMLElement>, checked: boolean): void => {
-    state.visibleCount = 0;
-    if (checked) {
-      loadMoreItems();
-      state.lastIntervalId = setInterval(loadMoreItems, INTERVAL_DELAY);
-    } else {
-      setItems(undefined);
-      clearInterval(state.lastIntervalId);
-    }
-  });
+      state.visibleCount = 0;
+      if (checked) {
+        loadMoreItems();
+        state.lastIntervalId = setInterval(loadMoreItems, INTERVAL_DELAY);
+      } else {
+        setItems(undefined);
+        clearInterval(state.lastIntervalId);
+      }
+    },
+    [clearInterval, setInterval, state],
+  );
 
   return (
     <>

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { TextField, ITextFieldStyles } from 'office-ui-fabric-react/lib/TextField';
 import { Stack } from 'office-ui-fabric-react/lib/Stack';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 const textFieldStyles: Partial<ITextFieldStyles> = { fieldGroup: { width: 300 } };
 const narrowTextFieldStyles: Partial<ITextFieldStyles> = { fieldGroup: { width: 100 } };
@@ -10,18 +9,21 @@ const stackTokens = { childrenGap: 15 };
 export const TextFieldControlledExample: React.FunctionComponent = () => {
   const [firstTextFieldValue, setFirstTextFieldValue] = React.useState('');
   const [secondTextFieldValue, setSecondTextFieldValue] = React.useState('');
-  const onChangeFirstTextFieldValue = useConstCallback(
+  const onChangeFirstTextFieldValue = React.useCallback(
     (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
       setFirstTextFieldValue(newValue || '');
     },
+    [],
   );
-  const onChangeSecondTextFieldValue = useConstCallback(
+  const onChangeSecondTextFieldValue = React.useCallback(
     (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
       if (!newValue || newValue.length <= 5) {
         setSecondTextFieldValue(newValue || '');
       }
     },
+    [],
   );
+
   return (
     <Stack tokens={stackTokens}>
       <TextField

--- a/packages/react-hooks/README.md
+++ b/packages/react-hooks/README.md
@@ -6,7 +6,6 @@ Helpful hooks not provided by React itself. These hooks were built for use in Fl
 
 - [useBoolean](#useboolean) - Return a boolean value and callbacks for setting it to true or false, or toggling
 - [useConst](#useconst) - Initialize and return a value that's always constant
-- [useConstCallback](#useconstcallback) - Like `useConst` but for functions
 - [useControllableValue](#usecontrollablevalue) - Manage the current value for a component that could be either controlled or uncontrolled
 - [useForceUpdate](#useforceupdate) - Force a function component to update
 - [useId](#useid) - Get a globally unique ID
@@ -45,8 +44,8 @@ const MyComponent = () => {
   const [value, { setTrue: showDialog, setFalse: hideDialog, toggle: toggleDialogVisible }] = useBoolean(false);
   // ^^^ Instead of:
   // const [isDialogVisible, setIsDialogVisible] = React.useState(false);
-  // const showDialog = useConstCallback(() => setIsDialogVisible(true));
-  // const hideDialog = useConstCallback(() => setIsDialogVisible(false));
+  // const showDialog = React.useCallback(() => setIsDialogVisible(true), []);
+  // const hideDialog = React.useCallback(() => setIsDialogVisible(false), []);
   // const toggleDialogVisible = isDialogVisible ? setFalse : setTrue;
 
   // ... code that shows a dialog when a button is clicked ...
@@ -64,8 +63,6 @@ Hook to initialize and return a constant value. Unlike `React.useMemo`, this wil
 Its one parameter is the initial value, or a function to get the initial value. Similar to `useState`, only the first value/function passed in is respected.
 
 If the value should ever change based on dependencies, use `React.useMemo` instead.
-
-If the value itself is a function, consider using [`useConstCallback`](#useconstcallback) instead.
 
 ### Example
 
@@ -88,20 +85,6 @@ According to the [React docs](https://reactjs.org/docs/hooks-reference.html#usem
 > **You may rely on `useMemo` as a performance optimization, not as a semantic guarantee.** In the future, React may choose to “forget” some previously memoized values and recalculate them on next render, e.g. to free memory for offscreen components. Write your code so that it still works without `useMemo` — and then add it to optimize performance.
 
 In cases where the value **must** never change, the recommended workaround is to store it with `useRef`, but refs are more awkward to initialize and don't enforce or even communicate that the value should be immutable. An alternative workaround is `const [value] = useState(initializer)`, but this is semantically wrong and more costly under the hood.
-
-## useConstCallback
-
-```ts
-function useConstCallback<T extends (...args: any[]) => any>(callback: T): T;
-```
-
-Hook to ensure a callback function always has the same identity. Unlike `React.useCallback`, this is guaranteed to always return the same value.
-
-Its one parameter is the callback. Similar to `useState`, only the first value/function passed in is respected.
-
-If the callback should ever change based on dependencies, use `React.useCallback` instead.
-
-`useConstCallback(fn)` has the same behavior as `useConst(() => fn)`.
 
 ## useControllableValue
 
@@ -336,3 +319,11 @@ The following types of warnings are supported (see typings for details on how to
   - The component is attempting to switch between controlled and uncontrolled
 
 Note that all warnings except `controlledUsage` will only be shown on first render. New `controlledUsage` warnings may be shown later based on prop changes. All warnings are shown synchronously during render (not wrapped in `useEffect`) for easier tracing/debugging.
+
+## Deprecated hooks
+
+### useConstCallback
+
+This hook was intended for creating callbacks which have no dependencies, and therefore never need to change. It works fine if everyone using it is extremely mindful of how closures work, but that's not a safe assumption--so in practice, usage of this hook tends to result in bugs like unintentionally capturing the first value of a prop and not respecting updates (when updates should be respected).
+
+If absolutely necessary, you can imitate `useConstCallback`'s behavior with `useConst`: `const myCallback = useConst(() => () => { /* callback body */ })`. (The extra function wrapper is necessary to prevent the callback itself from being interpreted as an initializer.)

--- a/packages/react-hooks/etc/react-hooks.api.md
+++ b/packages/react-hooks/etc/react-hooks.api.md
@@ -49,7 +49,7 @@ export function useBoolean(initialState: boolean): [boolean, IUseBooleanCallback
 // @public
 export function useConst<T>(initialValue: T | (() => T)): T;
 
-// @public
+// @public @deprecated (undocumented)
 export function useConstCallback<T extends (...args: any[]) => any>(callback: T): T;
 
 // @public

--- a/packages/react-hooks/src/useBoolean.ts
+++ b/packages/react-hooks/src/useBoolean.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConstCallback } from './useConstCallback';
+import { useConst } from './useConst';
 
 /** Updater callbacks returned by `useBoolean`. */
 export interface IUseBooleanCallbacks {
@@ -24,15 +24,15 @@ export function useBoolean(initialState: boolean): [boolean, IUseBooleanCallback
   // constant identity, which overall is probably better for consumers' perf.
   const valueRef = React.useRef(value);
 
-  const setTrue = useConstCallback(() => {
+  const setTrue = useConst(() => () => {
     setValue(true);
     valueRef.current = true;
   });
-  const setFalse = useConstCallback(() => {
+  const setFalse = useConst(() => () => {
     setValue(false);
     valueRef.current = false;
   });
-  const toggle = useConstCallback(() => (valueRef.current ? setFalse() : setTrue()));
+  const toggle = useConst(() => () => (valueRef.current ? setFalse() : setTrue()));
 
   return [value, { setTrue, setFalse, toggle }];
 }

--- a/packages/react-hooks/src/useConst.ts
+++ b/packages/react-hooks/src/useConst.ts
@@ -7,8 +7,6 @@ import * as React from 'react';
  *
  * If the value should ever change based on dependencies, use `React.useMemo` instead.
  *
- * If the value itself is a function, consider using `useConstCallback` instead.
- *
  * @param initialValue - Initial value, or function to get the initial value. Similar to `useState`,
  * only the value/function passed in the first time this is called is respected.
  * @returns The value. The identity of this value will always be the same.

--- a/packages/react-hooks/src/useConstCallback.test.tsx
+++ b/packages/react-hooks/src/useConstCallback.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable deprecation/deprecation */
 import * as React from 'react';
 import { mount } from 'enzyme';
 import { useConstCallback } from './useConstCallback';

--- a/packages/react-hooks/src/useConstCallback.ts
+++ b/packages/react-hooks/src/useConstCallback.ts
@@ -1,13 +1,8 @@
 import * as React from 'react';
 
 /**
- * Hook to ensure a callback function always has the same identity.
- * Unlike `React.useCallback`, this is guaranteed to always return the same value.
- *
- * If the callback should ever change based on dependencies, use `React.useCallback` instead.
- *
- * @param callback - The callback. Only the first value passed is respected.
- * @returns The callback. The identity of this callback will always be the same.
+ * @deprecated Deprecated due to potential for misuse (see package readme).
+ * Use `React.useCallback` instead.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useConstCallback<T extends (...args: any[]) => any>(callback: T): T {

--- a/packages/react-hooks/src/useControllableValue.ts
+++ b/packages/react-hooks/src/useControllableValue.ts
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useConst } from './useConst';
-import { useConstCallback } from './useConstCallback';
 
 export type ChangeCallback<
   TElement extends HTMLElement,
@@ -58,7 +57,7 @@ export function useControllableValue<
 
   // To match the behavior of the setter returned by React.useState, this callback's identity
   // should never change. This means it MUST NOT directly reference variables that can change.
-  const setValueOrCallOnChange = useConstCallback((update: React.SetStateAction<TValue | undefined>, ev?: TEvent) => {
+  const setValueOrCallOnChange = useConst(() => (update: React.SetStateAction<TValue | undefined>, ev?: TEvent) => {
     // Assuming here that TValue is not a function, because a controllable value will typically
     // be something a user can enter as input
     const newValue = typeof update === 'function' ? (update as Function)(valueRef.current) : update;

--- a/packages/react-hooks/src/useForceUpdate.ts
+++ b/packages/react-hooks/src/useForceUpdate.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { useConstCallback } from './useConstCallback';
+import { useConst } from './useConst';
 
 /**
  * Hook to force update a function component by updating a dummy state.
  */
 export function useForceUpdate(): () => void {
   const [, setValue] = React.useState(0);
-  const forceUpdate = useConstCallback(() => setValue(value => ++value));
+  const forceUpdate = useConst(() => () => setValue(value => ++value));
   return forceUpdate;
 }

--- a/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -10,7 +10,7 @@ import {
 } from './ChoiceGroup.types';
 import { IChoiceGroupOptionProps } from './ChoiceGroupOption/ChoiceGroupOption.types';
 import { ChoiceGroupOption } from './ChoiceGroupOption/index';
-import { useId, useControllableValue, useWarnings, useConstCallback } from '@uifabric/react-hooks';
+import { useId, useControllableValue, useWarnings } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IChoiceGroupStyleProps, IChoiceGroupStyles>();
 
@@ -100,13 +100,13 @@ export const ChoiceGroupBase: React.FunctionComponent = React.forwardRef(
     useDebugWarnings(props);
     useComponentRef(options, keyChecked, id, componentRef);
 
-    const onFocus = useConstCallback((ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOptionProps) => {
+    const onFocus = React.useCallback((ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOptionProps) => {
       setKeyFocused(option.itemKey);
-    });
+    }, []);
 
-    const onBlur = useConstCallback((ev: React.FocusEvent<HTMLElement>) => {
+    const onBlur = React.useCallback((ev: React.FocusEvent<HTMLElement>) => {
       setKeyFocused(undefined);
-    });
+    }, []);
 
     const onOptionChange = React.useCallback(
       (evt: React.FormEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOptionProps) => {

--- a/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -1,12 +1,10 @@
 import * as React from 'react';
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from '@fluentui/react-next/lib/ContextualMenu';
-import { useConstCallback } from '@uifabric/react-hooks';
+import { useBoolean } from '@uifabric/react-hooks';
 
 export const ContextualMenuBasicExample: React.FunctionComponent = () => {
   const linkRef = React.useRef(null);
-  const [showContextualMenu, setShowContextualMenu] = React.useState(false);
-  const onShowContextualMenu = useConstCallback(() => setShowContextualMenu(true));
-  const onHideContextualMenu = useConstCallback(() => setShowContextualMenu(false));
+  const [showContextualMenu, { setTrue: onShowContextualMenu, setFalse: onHideContextualMenu }] = useBoolean(false);
 
   return (
     <div>

--- a/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
+++ b/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.CustomMenuList.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConstCallback, useConst } from '@uifabric/react-hooks';
+import { useConst } from '@uifabric/react-hooks';
 import { DefaultButton } from '@fluentui/react-next/lib/compat/Button';
 import { ISearchBoxStyles, SearchBox } from '@fluentui/react-next/lib/SearchBox';
 import { Icon } from '@fluentui/react-next/lib/Icon';
@@ -9,11 +9,11 @@ import { IRenderFunction } from '@fluentui/react-next/lib/Utilities';
 export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = () => {
   const [items, setItems] = React.useState(menuItems);
 
-  const onAbort = useConstCallback(() => {
+  const onAbort = React.useCallback(() => {
     setItems(menuItems);
-  });
+  }, []);
 
-  const onChange = useConstCallback((ev: React.ChangeEvent<HTMLInputElement>, newValue: string) => {
+  const onChange = React.useCallback((ev: React.ChangeEvent<HTMLInputElement>, newValue: string) => {
     const filteredItems = menuItems.filter(
       item => item.text && item.text.toLowerCase().indexOf(newValue.toLowerCase()) !== -1,
     );
@@ -31,9 +31,9 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
     }
 
     setItems(filteredItems);
-  });
+  }, []);
 
-  const renderMenuList = useConstCallback(
+  const renderMenuList = React.useCallback(
     (menuListProps: IContextualMenuListProps, defaultRender: IRenderFunction<IContextualMenuListProps>) => {
       return (
         <div>
@@ -50,6 +50,7 @@ export const ContextualMenuWithCustomMenuListExample: React.FunctionComponent = 
         </div>
       );
     },
+    [onAbort, onChange],
   );
 
   const menuProps = useConst(() => ({

--- a/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
+++ b/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Directional.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useConstCallback } from '@uifabric/react-hooks';
 import { DefaultButton } from '@fluentui/react-next/lib/compat/Button';
 import { Checkbox, ICheckboxStyles } from '@fluentui/react-next/lib/Checkbox';
 import {
@@ -39,24 +38,26 @@ export const ContextualMenuDirectionalExample: React.FunctionComponent = () => {
     DirectionalHint.bottomLeftEdge,
   );
 
-  const onShowBeakChange = useConstCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
+  const onShowBeakChange = React.useCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
     setIsBeakVisible(isVisible);
-  });
+  }, []);
 
-  const onUseRtlHintChange = useConstCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
+  const onUseRtlHintChange = React.useCallback((event: React.FormEvent<HTMLElement>, isVisible: boolean): void => {
     setUseDirectionalHintForRTL(isVisible);
-  });
+  }, []);
 
-  const onDirectionalChanged = useConstCallback(
+  const onDirectionalChanged = React.useCallback(
     (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
       setDirectionalHint(option.key as DirectionalHint);
     },
+    [],
   );
 
-  const onDirectionalRtlChanged = useConstCallback(
+  const onDirectionalRtlChanged = React.useCallback(
     (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
       setDirectionalHintForRTL(option.key as DirectionalHint);
     },
+    [],
   );
 
   const menuProps: IContextualMenuProps = React.useMemo(

--- a/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
+++ b/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useConst, useBoolean } from '@uifabric/react-hooks';
 import { DefaultButton } from '@fluentui/react-next/lib/compat/Button';
 import { Callout } from '@fluentui/react-next/lib/Callout';
 import {
@@ -14,10 +14,7 @@ import * as stylesImport from './ContextualMenuExample.scss';
 const styles = stylesImport;
 
 export const ContextualMenuIconExample: React.FunctionComponent = () => {
-  const [showCallout, setShowCallout] = React.useState(false);
-
-  const onShowCallout = useConstCallback(() => setShowCallout(true));
-  const onHideCallout = useConstCallback(() => setShowCallout(false));
+  const [showCallout, { setTrue: onShowCallout, setFalse: onHideCallout }] = useBoolean(false);
 
   const menuItems: IContextualMenuItem[] = useConst([
     {

--- a/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
+++ b/packages/react-next/src/components/ContextualMenu/examples/ContextualMenu.Submenu.Example.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { useConstCallback } from '@uifabric/react-hooks';
 import { DefaultButton } from '@fluentui/react-next/lib/compat/Button';
 import { IContextualMenuProps, IContextualMenuItem } from '@fluentui/react-next/lib/ContextualMenu';
 import { TextField, ITextFieldStyles } from '@fluentui/react-next/lib/TextField';
@@ -19,10 +18,11 @@ export interface IContextualMenuSubmenuExampleState {
 export const ContextualMenuSubmenuExample: React.FunctionComponent = () => {
   const [hoverDelay, setHoverDelay] = React.useState(250);
 
-  const onHoverDelayChanged = useConstCallback(
+  const onHoverDelayChanged = React.useCallback(
     (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string) => {
       setHoverDelay(Number(newValue) || 0);
     },
+    [],
   );
 
   const menuProps: IContextualMenuProps = React.useMemo(

--- a/packages/react-next/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/react-next/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
 import { IColumn, buildColumns, SelectionMode, Toggle, IListProps, ShimmeredDetailsList } from '@fluentui/react-next';
-import { useSetInterval, useConst, useConstCallback } from '@uifabric/react-hooks';
+import { useSetInterval, useConst } from '@uifabric/react-hooks';
 
 interface IShimmerApplicationExampleState {
   lastIntervalId: number;
@@ -91,22 +91,25 @@ export const ShimmerApplicationExample: React.FunctionComponent = () => {
 
   const { setInterval, clearInterval } = useSetInterval();
 
-  const loadMoreItems = (): void => {
-    state.visibleCount = Math.min(exampleItems.length, state.visibleCount + 2);
+  const onLoadData = React.useCallback(
+    (ev: React.MouseEvent<HTMLElement>, checked: boolean): void => {
+      const loadMoreItems = (): void => {
+        state.visibleCount = Math.min(exampleItems.length, state.visibleCount + 2);
 
-    setItems(exampleItems.map((current, index) => (index < state.visibleCount ? current : null)) as IExampleItem[]);
-  };
+        setItems(exampleItems.map((current, index) => (index < state.visibleCount ? current : null)) as IExampleItem[]);
+      };
 
-  const onLoadData = useConstCallback((ev: React.MouseEvent<HTMLElement>, checked: boolean): void => {
-    state.visibleCount = 0;
-    if (checked) {
-      loadMoreItems();
-      state.lastIntervalId = setInterval(loadMoreItems, INTERVAL_DELAY);
-    } else {
-      setItems(undefined);
-      clearInterval(state.lastIntervalId);
-    }
-  });
+      state.visibleCount = 0;
+      if (checked) {
+        loadMoreItems();
+        state.lastIntervalId = setInterval(loadMoreItems, INTERVAL_DELAY);
+      } else {
+        setItems(undefined);
+        clearInterval(state.lastIntervalId);
+      }
+    },
+    [clearInterval, setInterval, state],
+  );
 
   return (
     <>

--- a/packages/react-next/src/components/TextField/examples/TextField.Controlled.Example.tsx
+++ b/packages/react-next/src/components/TextField/examples/TextField.Controlled.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { TextField, ITextFieldStyles } from '@fluentui/react-next/lib/TextField';
 import { Stack } from '@fluentui/react-next/lib/Stack';
-import { useConstCallback } from '@uifabric/react-hooks';
 
 const textFieldStyles: Partial<ITextFieldStyles> = { fieldGroup: { width: 300 } };
 const narrowTextFieldStyles: Partial<ITextFieldStyles> = { fieldGroup: { width: 100 } };
@@ -10,18 +9,21 @@ const stackTokens = { childrenGap: 15 };
 export const TextFieldControlledExample: React.FunctionComponent = () => {
   const [firstTextFieldValue, setFirstTextFieldValue] = React.useState('');
   const [secondTextFieldValue, setSecondTextFieldValue] = React.useState('');
-  const onChangeFirstTextFieldValue = useConstCallback(
+  const onChangeFirstTextFieldValue = React.useCallback(
     (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
       setFirstTextFieldValue(newValue || '');
     },
+    [],
   );
-  const onChangeSecondTextFieldValue = useConstCallback(
+  const onChangeSecondTextFieldValue = React.useCallback(
     (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
       if (!newValue || newValue.length <= 5) {
         setSecondTextFieldValue(newValue || '');
       }
     },
+    [],
   );
+
   return (
     <Stack tokens={stackTokens}>
       <TextField


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14580
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I thought `useConstCallback` would be a good idea, but turns out it's easy to misuse and create bugs related to stale captured values. So this PR deprecates it and removes all usage in the repo.