### PR TITLE
Add control to the set of keys which dismiss the tooltip

### DIFF
--- a/change/office-ui-fabric-react-2020-09-11-12-42-50-control-dismisses-tooltip.json
+++ b/change/office-ui-fabric-react-2020-09-11-12-42-50-control-dismisses-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add control to the set of keys which dismiss the tooltip",
+  "packageName": "office-ui-fabric-react",
+  "email": "artber@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T16:42:50.503Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -223,7 +223,7 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
   };
 
   private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    if (ev.which === KeyCodes.escape) {
+    if (ev.which === KeyCodes.escape || ev.ctrlKey) {
       this._hideTooltip();
       ev.stopPropagation();
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #14987 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Office tooltips in general support dismissal on ctrl; this change ensures the same is true for Fluent UI tooltips.

#### Focus areas to test

- Any tooltip that can be dismissed via escape should be dismissable via control (right and left).
- Control key events should not propagate to parent elements.
- Focus should not change when control is invoked.


