### PR TITLE
Allow consumers to use the onClick input property

### DIFF
--- a/change/@uifabric-experiments-2020-09-11-14-56-34-passinputthrough.json
+++ b/change/@uifabric-experiments-2020-09-11-14-56-34-passinputthrough.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "allow consumers of the UPP to use the onClick input property",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-11T21:56:34.854Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -247,9 +247,12 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       props.inputProps.onFocus(ev as React.FocusEvent<HTMLInputElement>);
     }
   };
-  const _onInputClick = () => {
+  const _onInputClick = (ev: React.MouseEvent<HTMLInputElement | Autofill>) => {
     unselectAll();
     showPicker(true);
+    if (props.inputProps && props.inputProps.onClick) {
+      props.inputProps.onClick(ev as React.MouseEvent<HTMLInputElement>);
+    }
   };
   const _onInputChange = (value: string, composing?: boolean) => {
     if (!composing) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Calling the props onClick function as well in our internal onClick function so that consumers can use it.

I tested this worked by adding logging to the example.
