### PR TITLE
chore(Datepicker): Add minHeight for calendar popup

### DIFF
--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerCalendarStyles.ts
@@ -6,7 +6,7 @@ export const datepickerCalendarStyles: ComponentSlotStylesPrepared<
   DatepickerCalendarStylesProps,
   DatepickerVariables
 > = {
-  root: (): ICSSInJSStyle => {
-    return {};
-  },
+  root: ({ variables: v }): ICSSInJSStyle => ({
+    minHeight: v.calendarMinHeight,
+  }),
 };

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Datepicker/datepickerVariables.ts
@@ -24,6 +24,8 @@ export interface DatepickerVariables {
   calendarHeaderPaddingBottom: string;
   calendarHeaderLabelPaddingLeft: string;
   calendarHeaderLabelFontWeight;
+
+  calendarMinHeight: string;
 }
 
 export const datepickerVariables = (siteVars): DatepickerVariables => ({
@@ -50,4 +52,6 @@ export const datepickerVariables = (siteVars): DatepickerVariables => ({
   calendarHeaderPaddingBottom: pxToRem(5),
   calendarHeaderLabelPaddingLeft: pxToRem(10),
   calendarHeaderLabelFontWeight: siteVars.fontWeightBold,
+
+  calendarMinHeight: pxToRem(266),
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Add `minHeight` to `DatepickerCalendar` to prevent popup jumping