### PR TITLE
Reveal Passsword button

### DIFF
--- a/change/@fluentui-react-examples-2020-10-01-11-21-15-secureTextField.json
+++ b/change/@fluentui-react-examples-2020-10-01-11-21-15-secureTextField.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding reveal password functionality to TextField",
+  "packageName": "@fluentui/react-examples",
+  "email": "jrhutch@live.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-01T15:21:15.435Z"
+}

--- a/change/office-ui-fabric-react-2020-09-14-09-47-51-secureTextField.json
+++ b/change/office-ui-fabric-react-2020-09-14-09-47-51-secureTextField.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add 'Reveal Password' button to Textfield",
+  "packageName": "office-ui-fabric-react",
+  "email": "jehutchi@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T13:47:51.049Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8053,6 +8053,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     autoAdjustHeight?: boolean;
     autoComplete?: string;
     borderless?: boolean;
+    canRevealPassword?: boolean;
     className?: string;
     componentRef?: IRefObject<ITextField>;
     defaultValue?: string;
@@ -8105,6 +8106,7 @@ export interface ITextFieldSnapshot {
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
     isFocused?: boolean;
+    type: string;
     uncontrolledValue: string | undefined;
 }
 
@@ -8114,6 +8116,7 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> & Pi
     hasIcon?: boolean;
     hasLabel?: boolean;
     focused?: boolean;
+    hasRevealButton?: boolean;
 };
 
 // @public (undocumented)
@@ -8124,6 +8127,9 @@ export interface ITextFieldStyles {
     fieldGroup: IStyle;
     icon: IStyle;
     prefix: IStyle;
+    revealButton: IStyle;
+    revealIcon: IStyle;
+    revealSpan: IStyle;
     root: IStyle;
     subComponentStyles: ITextFieldSubComponentStyles;
     suffix: IStyle;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { IProcessedStyleSet } from '../../Styling';
 import { Label, ILabelStyleProps, ILabelStyles } from '../../Label';
-import { IconButton, IButtonProps } from '../../Button';
-import { Icon } from '../../Icon';
+import { Icon, IIconProps } from '../../Icon';
 import {
   Async,
   DelayedRender,
@@ -60,7 +59,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     resizable: true,
     deferredValidationTime: 200,
     validateOnLoad: true,
-    showRevealPassword: true,
+    canRevealPassword: true,
   };
 
   /** Fallback ID if none is provided in props. Access proper value via `this._id`. */
@@ -79,8 +78,9 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
   private _isPassword = false;
   private _showRevealButton = false;
-  private _revealButtonProps: IButtonProps = { iconProps: { iconName: 'RedEye' } };
-  private _hideButtonProps: IButtonProps = { iconProps: { iconName: 'Hide' } };
+  private _revealIconProps: IIconProps = { iconName: 'RedEye' };
+  private _hideIconProps: IIconProps = { iconName: 'Hide' };
+
   public constructor(props: ITextFieldProps) {
     super(props);
 
@@ -241,11 +241,14 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {multiline ? this._renderTextArea() : this._renderInput()}
             {iconProps && <Icon className={this._classNames.icon} {...iconProps} />}
             {this._isPassword && this._showRevealButton && (
-              <IconButton
-                className={this._classNames.revealButton}
-                onClick={this._onRevealButtonClick}
-                {...(this.state.type === 'password' ? this._revealButtonProps : this._hideButtonProps)}
-              />
+              <button className={this._classNames.revealButton} onClick={this._onRevealButtonClick}>
+                <span className={this._classNames.revealSpan} data-automationid="splitbuttonprimary">
+                  <Icon
+                    className={this._classNames.revealIcon}
+                    {...(this.state.type === 'password' ? this._revealIconProps : this._hideIconProps)}
+                  />
+                </span>
+              </button>
             )}
             {(suffix !== undefined || this.props.onRenderSuffix) && (
               <div className={this._classNames.suffix}>{onRenderSuffix(this.props, this._onRenderSuffix)}</div>
@@ -602,7 +605,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       return false;
     }
 
-    if (this.props.showRevealPassword) {
+    if (this.props.canRevealPassword) {
       const userAgent = window.navigator.userAgent;
 
       // CHROME

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -59,7 +59,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     resizable: true,
     deferredValidationTime: 200,
     validateOnLoad: true,
-    canRevealPassword: true,
+    canRevealPassword: false,
   };
 
   /** Fallback ID if none is provided in props. Access proper value via `this._id`. */
@@ -608,24 +608,17 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     if (this.props.canRevealPassword) {
       const userAgent = window.navigator.userAgent;
 
-      // CHROME
-      const isChrome = /Chrome/.test(userAgent) && !/Edg\//.test(userAgent);
+      //IE
+      const isIE = /rv:11.0/.test(userAgent);
 
-      // FIREFOX
-      const isFirefox = /Firefox/.test(userAgent);
+      //Edge
+      //Chromium Edge
+      const isEdge = /Edg/.test(userAgent);
 
-      // SAFARI
-      const isSafari = /Safari/.test(userAgent) && !/Chrome/.test(userAgent);
-
-      // OPERA
-      const isOpera = /Opera/.test(userAgent);
-
-      // Jest test framework
-      const isJest = /jsdom/.test(userAgent);
-
-      if (isChrome || isFirefox || isSafari || isOpera || isJest) {
-        return true;
+      if (isIE || isEdge) {
+        return false;
       }
+      return true;
     }
     return false;
   };

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -22,6 +22,7 @@ const globalClassNames = {
   prefix: 'ms-TextField-prefix',
   suffix: 'ms-TextField-suffix',
   wrapper: 'ms-TextField-wrapper',
+  reveal: 'ms-TextField-reveal',
 
   multiline: 'ms-TextField--multiline',
   borderless: 'ms-TextField--borderless',
@@ -79,6 +80,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     hasErrorMessage,
     inputClassName,
     autoAdjustHeight,
+    hasRevealButton,
   } = props;
 
   const { semanticColors, effects, fonts } = theme;
@@ -336,9 +338,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         autoAdjustHeight && {
           overflow: 'hidden',
         },
-      hasIcon && {
-        paddingRight: 24,
-      },
+      hasIcon &&
+        !hasRevealButton && {
+          paddingRight: 24,
+        },
       multiline &&
         hasIcon && {
           paddingRight: 40,
@@ -416,5 +419,14 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     subComponentStyles: {
       label: getLabelStyles(props),
     },
+    revealButton: [
+      classNames.reveal,
+      {
+        height: 30,
+      },
+      hasIcon && {
+        marginRight: 28,
+      },
+    ],
   };
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -83,7 +83,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     hasRevealButton,
   } = props;
 
-  const { semanticColors, effects, fonts } = theme;
+  const { semanticColors, effects, fonts, palette } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
@@ -421,11 +421,50 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     },
     revealButton: [
       classNames.reveal,
+      'ms-Button',
+      'ms-Button--icon',
       {
         height: 30,
+        width: 32,
+        border: 'none',
+        padding: '0px 4px',
+        backgroundColor: 'transparent',
+        color: semanticColors.link,
+        selectors: {
+          ':hover': {
+            outline: 0,
+            color: palette.themeDarkAlt,
+            backgroundColor: palette.neutralLighter,
+            selectors: {
+              [HighContrastSelector]: {
+                borderColor: 'Highlight',
+                color: 'Highlight',
+              },
+            },
+          },
+          ':focus': { outline: 0 },
+        },
       },
       hasIcon && {
         marginRight: 28,
+      },
+    ],
+    revealSpan: [
+      {
+        display: 'flex',
+        height: '100%',
+        alignItems: 'center',
+      },
+    ],
+    revealIcon: [
+      {
+        margin: '0px 4px',
+        pointerEvents: 'none',
+        bottom: 6,
+        right: 8,
+        top: 'auto',
+        fontSize: IconFontSizes.medium,
+        lineHeight: 18,
       },
     ],
   };

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -230,6 +230,31 @@ describe('TextField basic props', () => {
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
   });
 
+  it('should render reveal password button', () => {
+    const component = renderer.create(<TextField type="password" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should not render reveal password button if showRevealPassword=false', () => {
+    const component = renderer.create(<TextField type="password" showRevealPassword={false} />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('should toggle reveal password on reveal button click', () => {
+    wrapper = mount(<TextField type="password" />);
+    const input = wrapper.find('input');
+    const reveal = wrapper.find('button');
+
+    input.simulate('input', mockEvent('Password123$'));
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
+    reveal.simulate('click');
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('text');
+    reveal.simulate('click');
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
+  });
+
   it('should not give an aria-labelledby if no label is provided', () => {
     wrapper = mount(<TextField />);
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -230,8 +230,8 @@ describe('TextField basic props', () => {
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
   });
 
-  it('should render reveal password button', () => {
-    const component = renderer.create(<TextField type="password" />);
+  it('should render reveal password button if showRevealPassword=true', () => {
+    const component = renderer.create(<TextField type="password" canRevealPassword={true} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -242,8 +242,14 @@ describe('TextField basic props', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('should not render reveal password button if showRevealPassword is not set', () => {
+    const component = renderer.create(<TextField type="password" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('should toggle reveal password on reveal button click', () => {
-    wrapper = mount(<TextField type="password" />);
+    wrapper = mount(<TextField type="password" canRevealPassword={true} />);
     const input = wrapper.find('input');
     const reveal = wrapper.find('button');
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -237,7 +237,7 @@ describe('TextField basic props', () => {
   });
 
   it('should not render reveal password button if showRevealPassword=false', () => {
-    const component = renderer.create(<TextField type="password" showRevealPassword={false} />);
+    const component = renderer.create(<TextField type="password" canRevealPassword={false} />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -252,6 +252,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   autoComplete?: string;
 
   /**
+   * Whether to show the reveal password button for input type 'password'
+   * @defaultvalue true
+   */
+  showRevealPassword?: boolean;
+
+  /**
    * @deprecated Only used by `MaskedTextField`, which now has a separate `IMaskedTextFieldProps` interface.
    */
   mask?: string;
@@ -291,6 +297,8 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> &
     hasLabel?: boolean;
     /** Element has focus. */
     focused?: boolean;
+    /** Element has a peek button for Passwords */
+    hasRevealButton?: boolean;
   };
 
 /**
@@ -358,6 +366,11 @@ export interface ITextFieldStyles {
    * Styling for subcomponents.
    */
   subComponentStyles: ITextFieldSubComponentStyles;
+
+  /**
+   * Styling for Password Peek Button
+   */
+  revealButton: IStyle;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -255,7 +255,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * Whether to show the reveal password button for input type 'password'
    * @defaultvalue true
    */
-  showRevealPassword?: boolean;
+  canRevealPassword?: boolean;
 
   /**
    * @deprecated Only used by `MaskedTextField`, which now has a separate `IMaskedTextFieldProps` interface.
@@ -368,9 +368,19 @@ export interface ITextFieldStyles {
   subComponentStyles: ITextFieldSubComponentStyles;
 
   /**
-   * Styling for Password Peek Button
+   * Styling for reveal password button
    */
   revealButton: IStyle;
+
+  /**
+   * Styling for reveal password span
+   */
+  revealSpan: IStyle;
+
+  /**
+   * Styling for reveal password icon
+   */
+  revealIcon: IStyle;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,5 +1,160 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextField basic props should not render reveal password button if showRevealPassword is not set 1`] = `
+<div
+  className=
+      ms-TextField
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          @media screen and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
+    >
+      <input
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: 0px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        type="password"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TextField basic props should not render reveal password button if showRevealPassword=false 1`] = `
 <div
   className=
@@ -155,7 +310,7 @@ exports[`TextField basic props should not render reveal password button if showR
 </div>
 `;
 
-exports[`TextField basic props should render reveal password button 1`] = `
+exports[`TextField basic props should render reveal password button if showRevealPassword=true 1`] = `
 <div
   className=
       ms-TextField

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -307,127 +307,68 @@ exports[`TextField basic props should render reveal password button 1`] = `
       />
       <button
         className=
+            ms-TextField-reveal
             ms-Button
             ms-Button--icon
-            ms-TextField-reveal
             {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
               background-color: transparent;
-              border-radius: 2px;
               border: none;
-              box-sizing: border-box;
               color: #0078d4;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
               height: 30px;
-              outline: transparent;
-              padding-bottom: 0;
+              padding-bottom: 0px;
               padding-left: 4px;
               padding-right: 4px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
+              padding-top: 0px;
               width: 32px;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 1px solid transparent;
-              bottom: 2px;
-              content: "";
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: absolute;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
             }
             &:hover {
               background-color: #f3f2f1;
               color: #106ebe;
+              outline: 0px;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
               color: Highlight;
             }
-            &:active {
-              background-color: #edebe9;
-              color: #005a9e;
+            &:focus {
+              outline: 0px;
             }
-        data-is-focusable={true}
         onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        type="button"
       >
         <span
           className=
-              ms-Button-flexContainer
+
               {
                 align-items: center;
                 display: flex;
-                flex-wrap: nowrap;
                 height: 100%;
-                justify-content: center;
               }
           data-automationid="splitbuttonprimary"
         >
           <i
             aria-hidden={true}
             className=
-                ms-Icon
-                ms-Button-icon
-                {
-                  display: inline-block;
-                }
+
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
+                  bottom: 6px;
+                  display: inline-block;
                   font-family: "FabricMDL2Icons-1";
+                  font-size: 16px;
                   font-style: normal;
                   font-weight: normal;
-                  speak: none;
-                }
-                {
-                  flex-shrink: 0;
-                  font-size: 16px;
-                  height: 16px;
-                  line-height: 16px;
-                  margin-bottom: 0;
+                  line-height: 18px;
+                  margin-bottom: 0px;
                   margin-left: 4px;
                   margin-right: 4px;
-                  margin-top: 0;
-                  text-align: center;
+                  margin-top: 0px;
+                  pointer-events: none;
+                  right: 8px;
+                  speak: none;
+                  top: auto;
                 }
             data-icon-name="RedEye"
-            role="presentation"
-            style={
-              Object {
-                "fontFamily": "\\"FabricMDL2Icons-1\\"",
-              }
-            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,5 +1,443 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TextField basic props should not render reveal password button if showRevealPassword=false 1`] = `
+<div
+  className=
+      ms-TextField
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          @media screen and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
+    >
+      <input
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: 0px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        type="password"
+        value=""
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextField basic props should render reveal password button 1`] = `
+<div
+  className=
+      ms-TextField
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          @media screen and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
+    >
+      <input
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: 0px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        type="password"
+        value=""
+      />
+      <button
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-TextField-reveal
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #0078d4;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: relative;
+              text-align: center;
+              text-decoration: none;
+              user-select: none;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #106ebe;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #005a9e;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons-1";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                }
+            data-icon-name="RedEye"
+            role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-1\\"",
+              }
+            }
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TextField snapshots renders correctly 1`] = `
 <div
   className=

--- a/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
@@ -26,7 +26,7 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
-        <TextField label="Secure Text" type="password" />
+        <TextField label="Password with Reveal Button" type="password" canRevealPassword={true} />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
@@ -26,6 +26,7 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
+        <TextField label="Secure Text" type="password" />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -1930,6 +1930,316 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         </div>
       </div>
     </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField30"
+          id="TextFieldLabel32"
+        >
+          Secure Text
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
+              @media screen and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel32"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            id="TextField30"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            type="password"
+            value=""
+          />
+          <button
+            className=
+                ms-Button
+                ms-Button--icon
+                ms-TextField-reveal
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  border-radius: 2px;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 30px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  width: 32px;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  color: #106ebe;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:active {
+                  background-color: #edebe9;
+                  color: #005a9e;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Icon
+                    ms-Button-icon
+                    {
+                      display: inline-block;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      font-family: "FabricMDL2Icons-1";
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    {
+                      flex-shrink: 0;
+                      font-size: 16px;
+                      height: 16px;
+                      line-height: 16px;
+                      margin-bottom: 0;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0;
+                      text-align: center;
+                    }
+                data-icon-name="RedEye"
+                role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-1\\"",
+                  }
+                }
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -2111,127 +2111,68 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           />
           <button
             className=
+                ms-TextField-reveal
                 ms-Button
                 ms-Button--icon
-                ms-TextField-reveal
                 {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
                   background-color: transparent;
-                  border-radius: 2px;
                   border: none;
-                  box-sizing: border-box;
                   color: #0078d4;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
                   height: 30px;
-                  outline: transparent;
-                  padding-bottom: 0;
+                  padding-bottom: 0px;
                   padding-left: 4px;
                   padding-right: 4px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
+                  padding-top: 0px;
                   width: 32px;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 1px solid transparent;
-                  bottom: 2px;
-                  content: "";
-                  left: 2px;
-                  outline: 1px solid #605e5c;
-                  position: absolute;
-                  right: 2px;
-                  top: 2px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
                 }
                 &:hover {
                   background-color: #f3f2f1;
                   color: #106ebe;
+                  outline: 0px;
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                   color: Highlight;
                 }
-                &:active {
-                  background-color: #edebe9;
-                  color: #005a9e;
+                &:focus {
+                  outline: 0px;
                 }
-            data-is-focusable={true}
             onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            type="button"
           >
             <span
               className=
-                  ms-Button-flexContainer
+
                   {
                     align-items: center;
                     display: flex;
-                    flex-wrap: nowrap;
                     height: 100%;
-                    justify-content: center;
                   }
               data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}
                 className=
-                    ms-Icon
-                    ms-Button-icon
-                    {
-                      display: inline-block;
-                    }
+
                     {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
+                      bottom: 6px;
+                      display: inline-block;
                       font-family: "FabricMDL2Icons-1";
+                      font-size: 16px;
                       font-style: normal;
                       font-weight: normal;
-                      speak: none;
-                    }
-                    {
-                      flex-shrink: 0;
-                      font-size: 16px;
-                      height: 16px;
-                      line-height: 16px;
-                      margin-bottom: 0;
+                      line-height: 18px;
+                      margin-bottom: 0px;
                       margin-left: 4px;
                       margin-right: 4px;
-                      margin-top: 0;
-                      text-align: center;
+                      margin-top: 0px;
+                      pointer-events: none;
+                      right: 8px;
+                      speak: none;
+                      top: auto;
                     }
                 data-icon-name="RedEye"
-                role="presentation"
-                style={
-                  Object {
-                    "fontFamily": "\\"FabricMDL2Icons-1\\"",
-                  }
-                }
               >
                 
               </i>

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -1982,7 +1982,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           htmlFor="TextField30"
           id="TextFieldLabel32"
         >
-          Secure Text
+          Password with Reveal Button
         </label>
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15333
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add reveal password button for browsers that don't have native reveal password (Chrome, Firefox, Safari and Opera)

#### Focus areas to test

I don't have a Mac, so it still needs to be verified on Safari.

### Other notes
Currently defaults to enable the reveal functionality with the ability to turn it off if it's not desired. It also always allows reveal, we may want to only allow revealing if the user has typed everything that is in the textfield (don't allow reveal of auto-entered passwords).