### PR TITLE
Drag and drop fixes

### DIFF
--- a/change/@uifabric-experiments-2020-09-14-09-37-00-dndfixes.json
+++ b/change/@uifabric-experiments-2020-09-14-09-37-00-dndfixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Drag and drop fixes",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-14T16:37:00.383Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -155,7 +155,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragEnd = (item?: any, event?: DragEvent): void => {
-    if (event && event.dataTransfer?.dropEffect == 'move') {
+    if (event && event.dataTransfer?.dropEffect === 'move') {
       const itemstoRemove = focusedItemIndices.includes(draggedIndex)
         ? (getSelectedItems() as T[])
         : [selectedItems[draggedIndex]];

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -150,6 +150,12 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragEnd = (item?: any, event?: DragEvent): void => {
+    if (event && event.dataTransfer?.dropEffect == 'move') {
+      const itemstoRemove = focusedItemIndices.includes(draggedIndex)
+        ? (getSelectedItems() as T[])
+        : [selectedItems[draggedIndex]];
+      _onRemoveSelectedItems(itemstoRemove);
+    }
     setDraggedIndex(-1);
     if (event) {
       const dataList = event?.dataTransfer?.items;

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -155,18 +155,18 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragEnd = (item?: any, event?: DragEvent): void => {
-    if (event && event.dataTransfer?.dropEffect === 'move') {
-      const itemstoRemove = focusedItemIndices.includes(draggedIndex)
-        ? (getSelectedItems() as T[])
-        : [selectedItems[draggedIndex]];
-      _onRemoveSelectedItems(itemstoRemove);
-    }
-    setDraggedIndex(-1);
     if (event) {
-      const dataList = event?.dataTransfer?.items;
+      if (event.dataTransfer?.dropEffect === 'move') {
+        const itemsToRemove = focusedItemIndices.includes(draggedIndex)
+          ? (getSelectedItems() as T[])
+          : [selectedItems[draggedIndex]];
+        _onRemoveSelectedItems(itemsToRemove);
+      }
       // Clear any remaining drag data
+      const dataList = event?.dataTransfer?.items;
       dataList?.clear();
     }
+    setDraggedIndex(-1);
   };
 
   const defaultDragDropEvents: IDragDropEvents = {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -19,6 +19,7 @@ import { useSelectedItems } from './hooks/useSelectedItems';
 import { IFloatingSuggestionItemProps } from '../../FloatingSuggestionsComposite';
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from '@uifabric/merge-styles';
+import { IDragDropContext } from 'office-ui-fabric-react/lib/utilities/dragdrop/interfaces';
 
 export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.Element => {
   const getClassNames = classNamesFunction<IUnifiedPickerStyleProps, IUnifiedPickerStyles>();
@@ -110,6 +111,10 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     dropItemsAt(insertIndex, newItems, indicesToRemove);
   };
 
+  const _canDrop = (dropContext?: IDragDropContext, dragContext?: IDragDropContext): boolean => {
+    return dropContext!.index != draggedIndex;
+  };
+
   const _onDrop = (item?: any, event?: DragEvent): void => {
     const insertIndex = selectedItems.indexOf(item);
     let isDropHandled = false;
@@ -165,7 +170,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const defaultDragDropEvents: IDragDropEvents = {
-    canDrop: () => true,
+    canDrop: _canDrop,
     canDrag: () => true,
     onDragEnter: _onDragEnter,
     onDragLeave: () => undefined,

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -112,7 +112,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _canDrop = (dropContext?: IDragDropContext, dragContext?: IDragDropContext): boolean => {
-    return dropContext!.index != draggedIndex;
+    return !focusedItemIndices.includes(dropContext!.index);
   };
 
   const _onDrop = (item?: any, event?: DragEvent): void => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Check on drop that we are not dropping over the selected items. Previously we were not checking and this was causing items to be duplicated when dropped over themselves
- Remove items when they were successfully dropped into another well

Tested that the move works with single and multiple items. Also tested that drag and drop within wells is unaffected.