### PR TITLE
Add missing ref prop typing

### DIFF
--- a/change/@fluentui-react-checkbox-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-checkbox-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:36:31.365Z"
+}

--- a/change/@fluentui-react-checkbox-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-checkbox-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add missing ref prop typing.",
   "packageName": "@fluentui/react-checkbox",
   "email": "xgao@microsoft.com",

--- a/change/@fluentui-react-link-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-link-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add missing ref prop typing.",
   "packageName": "@fluentui/react-link",
   "email": "xgao@microsoft.com",

--- a/change/@fluentui-react-link-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-link-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-link",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:36:39.376Z"
+}

--- a/change/@fluentui-react-next-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-next-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:36:46.296Z"
+}

--- a/change/@fluentui-react-slider-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-slider-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-slider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:36:53.058Z"
+}

--- a/change/@fluentui-react-slider-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-slider-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add missing ref prop typing.",
   "packageName": "@fluentui/react-slider",
   "email": "xgao@microsoft.com",

--- a/change/@fluentui-react-tabs-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-tabs-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-tabs",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:37:01.696Z"
+}

--- a/change/@fluentui-react-tabs-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-tabs-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add missing ref prop typing.",
   "packageName": "@fluentui/react-tabs",
   "email": "xgao@microsoft.com",

--- a/change/@fluentui-react-toggle-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-toggle-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add missing ref prop typing.",
+  "packageName": "@fluentui/react-toggle",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-15T00:37:05.302Z"
+}

--- a/change/@fluentui-react-toggle-2020-09-14-17-37-05-xgao-fix-ref-typing.json
+++ b/change/@fluentui-react-toggle-2020-09-14-17-37-05-xgao-fix-ref-typing.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Add missing ref prop typing.",
   "packageName": "@fluentui/react-toggle",
   "email": "xgao@microsoft.com",

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -27,7 +27,7 @@ export interface ICheckbox {
 }
 
 // @public
-export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement> {
+export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement>, React.RefAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -47,7 +47,6 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
     label?: string;
     onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
     onRenderLabel?: IRenderFunction<ICheckboxProps>;
-    ref?: React.Ref<HTMLDivElement>;
     styles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
     theme?: ITheme;
 }

--- a/packages/react-checkbox/etc/react-checkbox.api.md
+++ b/packages/react-checkbox/etc/react-checkbox.api.md
@@ -14,10 +14,10 @@ import { ITheme } from '@uifabric/styling';
 import * as React from 'react';
 
 // @public (undocumented)
-export const Checkbox: React.FunctionComponent<ICheckboxProps & React.RefAttributes<HTMLDivElement>>;
+export const Checkbox: React.FunctionComponent<ICheckboxProps>;
 
 // @public (undocumented)
-export const CheckboxBase: React.ForwardRefExoticComponent<ICheckboxProps & React.RefAttributes<HTMLDivElement>>;
+export const CheckboxBase: React.FunctionComponent<ICheckboxProps>;
 
 // @public
 export interface ICheckbox {
@@ -47,6 +47,7 @@ export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement |
     label?: string;
     onChange?: (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, checked?: boolean) => void;
     onRenderLabel?: IRenderFunction<ICheckboxProps>;
+    ref?: React.Ref<HTMLDivElement>;
     styles?: IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>;
     theme?: ITheme;
 }

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.base.tsx
@@ -6,130 +6,132 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
 const getClassNames = classNamesFunction<ICheckboxStyleProps, ICheckboxStyles>();
 
-export const CheckboxBase = React.forwardRef((props: ICheckboxProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-  const {
-    disabled,
-    inputProps,
-    name,
-    ariaLabel,
-    ariaLabelledBy,
-    ariaDescribedBy,
-    ariaPositionInSet,
-    ariaSetSize,
-    title,
-    label,
-    checkmarkIconProps,
-    styles,
-    theme,
-    className,
-    boxSide = 'start',
-  } = props;
-
-  const id = useId('checkbox-', props.id);
-
-  const rootRef = React.useRef<HTMLDivElement | null>(null);
-  const mergedRootRefs: React.Ref<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
-  const inputRef = React.useRef<HTMLInputElement>(null);
-
-  const [isChecked, setIsChecked] = useControllableValue(props.checked, props.defaultChecked, props.onChange);
-  const [isIndeterminate, setIsIndeterminate] = useControllableValue(props.indeterminate, props.defaultIndeterminate);
-
-  useFocusRects(rootRef);
-  useDebugWarning(props);
-  useComponentRef(props, isChecked, isIndeterminate, inputRef);
-
-  const classNames = getClassNames(styles!, {
-    theme: theme!,
-    className,
-    disabled,
-    indeterminate: isIndeterminate,
-    checked: isChecked,
-    reversed: boxSide !== 'start',
-    isUsingCustomLabelRender: !!props.onRenderLabel,
-  });
-
-  const onChange = (ev: React.ChangeEvent<HTMLElement>): void => {
-    if (isIndeterminate) {
-      // If indeterminate, clicking the checkbox *only* removes the indeterminate state (or if
-      // controlled, lets the consumer know to change it by calling onChange). It doesn't
-      // change the checked state.
-      setIsChecked(!!isChecked, ev);
-      setIsIndeterminate(false);
-    } else {
-      setIsChecked(!isChecked, ev);
-    }
-  };
-
-  const defaultLabelRenderer = React.useCallback(
-    (checkboxProps?: ICheckboxProps): JSX.Element | null => {
-      if (!checkboxProps) {
-        return null;
-      }
-      return checkboxProps.label ? (
-        <span aria-hidden="true" className={classNames.text} title={checkboxProps.title}>
-          {checkboxProps.label}
-        </span>
-      ) : null;
-    },
-    [classNames.text],
-  );
-
-  const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
-
-  const ariaChecked: React.InputHTMLAttributes<HTMLInputElement>['aria-checked'] = isIndeterminate
-    ? 'mixed'
-    : isChecked
-    ? 'true'
-    : 'false';
-
-  const slotProps = {
-    root: {
-      className: classNames.root,
-      title,
-      ref: mergedRootRefs,
-    },
-    input: {
-      className: classNames.input,
-      type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
-      ...inputProps,
-      ref: inputRef,
-      checked: !!isChecked,
+export const CheckboxBase: React.FunctionComponent<ICheckboxProps> = React.forwardRef<HTMLDivElement, ICheckboxProps>(
+  (props, forwardedRef) => {
+    const {
       disabled,
+      inputProps,
       name,
-      id,
+      ariaLabel,
+      ariaLabelledBy,
+      ariaDescribedBy,
+      ariaPositionInSet,
+      ariaSetSize,
       title,
-      onChange,
-      'data-ktp-execute-target': true,
-      'aria-disabled': disabled,
-      'aria-label': ariaLabel || label,
-      'aria-labelledby': ariaLabelledBy,
-      'aria-describedby': ariaDescribedBy,
-      'aria-posinset': ariaPositionInSet,
-      'aria-setsize': ariaSetSize,
-      'aria-checked': ariaChecked,
-    },
-    checkbox: {
-      className: classNames.checkbox,
-      'data-ktp-target': true,
-    },
-    container: {
-      className: classNames.label,
-      htmlFor: id,
-    },
-  };
+      label,
+      checkmarkIconProps,
+      styles,
+      theme,
+      className,
+      boxSide = 'start',
+    } = props;
 
-  return (
-    <div {...slotProps.root}>
-      <input {...slotProps.input} />
-      <label {...slotProps.container}>
-        <div {...slotProps.checkbox}>
-          <Icon iconName="CheckMark" {...checkmarkIconProps} className={classNames.checkmark} />
-        </div>
-        {onRenderLabel(props, defaultLabelRenderer)}
-      </label>
-    </div>
-  );
-});
+    const id = useId('checkbox-', props.id);
+
+    const rootRef = React.useRef<HTMLDivElement | null>(null);
+    const mergedRootRefs: React.Ref<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    const [isChecked, setIsChecked] = useControllableValue(props.checked, props.defaultChecked, props.onChange);
+    const [isIndeterminate, setIsIndeterminate] = useControllableValue(props.indeterminate, props.defaultIndeterminate);
+
+    useFocusRects(rootRef);
+    useDebugWarning(props);
+    useComponentRef(props, isChecked, isIndeterminate, inputRef);
+
+    const classNames = getClassNames(styles!, {
+      theme: theme!,
+      className,
+      disabled,
+      indeterminate: isIndeterminate,
+      checked: isChecked,
+      reversed: boxSide !== 'start',
+      isUsingCustomLabelRender: !!props.onRenderLabel,
+    });
+
+    const onChange = (ev: React.ChangeEvent<HTMLElement>): void => {
+      if (isIndeterminate) {
+        // If indeterminate, clicking the checkbox *only* removes the indeterminate state (or if
+        // controlled, lets the consumer know to change it by calling onChange). It doesn't
+        // change the checked state.
+        setIsChecked(!!isChecked, ev);
+        setIsIndeterminate(false);
+      } else {
+        setIsChecked(!isChecked, ev);
+      }
+    };
+
+    const defaultLabelRenderer = React.useCallback(
+      (checkboxProps?: ICheckboxProps): JSX.Element | null => {
+        if (!checkboxProps) {
+          return null;
+        }
+        return checkboxProps.label ? (
+          <span aria-hidden="true" className={classNames.text} title={checkboxProps.title}>
+            {checkboxProps.label}
+          </span>
+        ) : null;
+      },
+      [classNames.text],
+    );
+
+    const onRenderLabel = props.onRenderLabel || defaultLabelRenderer;
+
+    const ariaChecked: React.InputHTMLAttributes<HTMLInputElement>['aria-checked'] = isIndeterminate
+      ? 'mixed'
+      : isChecked
+      ? 'true'
+      : 'false';
+
+    const slotProps = {
+      root: {
+        className: classNames.root,
+        title,
+        ref: mergedRootRefs,
+      },
+      input: {
+        className: classNames.input,
+        type: 'checkbox' as React.InputHTMLAttributes<HTMLInputElement>['type'],
+        ...inputProps,
+        ref: inputRef,
+        checked: !!isChecked,
+        disabled,
+        name,
+        id,
+        title,
+        onChange,
+        'data-ktp-execute-target': true,
+        'aria-disabled': disabled,
+        'aria-label': ariaLabel || label,
+        'aria-labelledby': ariaLabelledBy,
+        'aria-describedby': ariaDescribedBy,
+        'aria-posinset': ariaPositionInSet,
+        'aria-setsize': ariaSetSize,
+        'aria-checked': ariaChecked,
+      },
+      checkbox: {
+        className: classNames.checkbox,
+        'data-ktp-target': true,
+      },
+      container: {
+        className: classNames.label,
+        htmlFor: id,
+      },
+    };
+
+    return (
+      <div {...slotProps.root}>
+        <input {...slotProps.input} />
+        <label {...slotProps.container}>
+          <div {...slotProps.checkbox}>
+            <Icon iconName="CheckMark" {...checkmarkIconProps} className={classNames.checkmark} />
+          </div>
+          {onRenderLabel(props, defaultLabelRenderer)}
+        </label>
+      </div>
+    );
+  },
+);
 
 CheckboxBase.displayName = 'CheckboxBase';
 

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.tsx
@@ -4,8 +4,8 @@ import { CheckboxBase } from './Checkbox.base';
 import { getStyles } from './Checkbox.styles';
 import { ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
 
-export const Checkbox = styled<
-  ICheckboxProps & React.RefAttributes<HTMLDivElement>,
+export const Checkbox: React.FunctionComponent<ICheckboxProps> = styled<
+  ICheckboxProps,
   ICheckboxStyleProps,
   ICheckboxStyles
 >(CheckboxBase, getStyles, undefined, { scope: 'Checkbox' });

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -27,6 +27,11 @@ export interface ICheckbox {
  */
 export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement> {
   /**
+   * Ref that is forwarded to the root element.
+   */
+  ref?: React.Ref<HTMLDivElement>;
+
+  /**
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */

--- a/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
+++ b/packages/react-checkbox/src/components/Checkbox/Checkbox.types.ts
@@ -25,12 +25,9 @@ export interface ICheckbox {
  * Checkbox properties.
  * {@docCategory Checkbox}
  */
-export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement> {
-  /**
-   * Ref that is forwarded to the root element.
-   */
-  ref?: React.Ref<HTMLDivElement>;
-
+export interface ICheckboxProps
+  extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the ICheckbox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-checkbox/src/next/Checkbox.tsx
+++ b/packages/react-checkbox/src/next/Checkbox.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { compose, ComposeOptions } from '@fluentui/react-compose';
 import { CheckMarkIcon } from '@fluentui/react-icons';
 import { CheckboxBase } from './Checkbox.base';
@@ -12,4 +13,7 @@ const composeOptions: ComposeOptions = {
   },
 };
 
-export const Checkbox = compose<'div', ICheckboxProps, {}, ICheckboxProps, {}>(CheckboxBase, composeOptions);
+export const Checkbox: React.FunctionComponent<ICheckboxProps> = compose<'div', ICheckboxProps, {}, ICheckboxProps, {}>(
+  CheckboxBase,
+  composeOptions,
+);

--- a/packages/react-checkbox/src/next/Checkbox.types.ts
+++ b/packages/react-checkbox/src/next/Checkbox.types.ts
@@ -28,6 +28,11 @@ export interface ICheckbox {
  */
 export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement> {
   /**
+   * Ref that is forwarded to the root element.
+   */
+  ref?: React.Ref<HTMLElement>;
+
+  /**
    * Render the root element as another type.
    */
   as?: React.ElementType;

--- a/packages/react-checkbox/src/next/Checkbox.types.ts
+++ b/packages/react-checkbox/src/next/Checkbox.types.ts
@@ -26,12 +26,9 @@ export interface ICheckbox {
  * Checkbox properties.
  * {@docCategory Checkbox}
  */
-export interface ICheckboxProps extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement> {
-  /**
-   * Ref that is forwarded to the root element.
-   */
-  ref?: React.Ref<HTMLElement>;
-
+export interface ICheckboxProps
+  extends React.ButtonHTMLAttributes<HTMLElement | HTMLInputElement>,
+    React.RefAttributes<HTMLElement> {
   /**
    * Render the root element as another type.
    */

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -68,6 +68,7 @@ export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTML
     disabled?: boolean;
     // @deprecated
     keytipProps?: IKeytipProps;
+    ref?: React.Ref<HTMLElement>;
     styles?: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles>;
     theme?: ITheme;
 }
@@ -98,7 +99,7 @@ export interface ILinkStyles {
 export const Link: React.FunctionComponent<ILinkProps>;
 
 // @public (undocumented)
-export const LinkBase: React.ForwardRefExoticComponent<Pick<ILinkProps, string | number> & React.RefAttributes<HTMLElement>>;
+export const LinkBase: React.FunctionComponent<ILinkProps>;
 
 // @public (undocumented)
 export type LinkSlotProps = {

--- a/packages/react-link/etc/react-link.api.md
+++ b/packages/react-link/etc/react-link.api.md
@@ -63,12 +63,11 @@ export interface ILinkOptions {
 }
 
 // @public (undocumented)
-export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement> {
+export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>, React.RefAttributes<HTMLElement> {
     componentRef?: IRefObject<ILink>;
     disabled?: boolean;
     // @deprecated
     keytipProps?: IKeytipProps;
-    ref?: React.Ref<HTMLElement>;
     styles?: IStyleFunctionOrObject<ILinkStyleProps, ILinkStyles>;
     theme?: ITheme;
 }

--- a/packages/react-link/src/components/Link/Link.base.tsx
+++ b/packages/react-link/src/components/Link/Link.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ILinkProps } from './Link.types';
 import { useLink } from './useLink';
 
-export const LinkBase = React.forwardRef((props: ILinkProps, ref: React.Ref<HTMLElement>) => {
+export const LinkBase: React.FunctionComponent<ILinkProps> = React.forwardRef<HTMLElement, ILinkProps>((props, ref) => {
   const { slots, slotProps } = useLink(props, ref);
 
   return <slots.root {...slotProps.root} />;

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -53,6 +53,11 @@ export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
  */
 export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement> {
   /**
+   * Ref that is forwarded to the root element.
+   */
+  ref?: React.Ref<HTMLElement>;
+
+  /**
    * Optional callback to access the ILink interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */

--- a/packages/react-link/src/components/Link/Link.types.ts
+++ b/packages/react-link/src/components/Link/Link.types.ts
@@ -51,12 +51,9 @@ export interface ILinkHTMLAttributes<T> extends React.HTMLAttributes<T> {
 /**
  * {@docCategory Link}
  */
-export interface ILinkProps extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement> {
-  /**
-   * Ref that is forwarded to the root element.
-   */
-  ref?: React.Ref<HTMLElement>;
-
+export interface ILinkProps
+  extends ILinkHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLElement>,
+    React.RefAttributes<HTMLElement> {
   /**
    * Optional callback to access the ILink interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -110,13 +110,13 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
 }
 
 // @public (undocumented)
-export const ButtonGrid: import("react").ForwardRefExoticComponent<IButtonGridProps & import("react").RefAttributes<HTMLElement>>;
+export const ButtonGrid: React.FunctionComponent<IButtonGridProps>;
 
 // @public (undocumented)
 export const ButtonGridCell: <T, P extends IButtonGridCellProps<T>>(props: IButtonGridCellProps<T>) => JSX.Element;
 
 // @public (undocumented)
-export const Callout: React.ForwardRefExoticComponent<ICalloutProps & React.RefAttributes<HTMLDivElement>>;
+export const Callout: React.FunctionComponent<ICalloutProps>;
 
 // @public
 export function canAnyMenuItemsCheck(items: IContextualMenuItem[]): boolean;
@@ -128,7 +128,7 @@ export const Coachmark: React.FunctionComponent<ICoachmarkProps>;
 export const COACHMARK_ATTRIBUTE_NAME = "data-coachmarkid";
 
 // @public (undocumented)
-export const CoachmarkBase: React.ForwardRefExoticComponent<ICoachmarkProps & React.RefAttributes<HTMLDivElement>>;
+export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps>;
 
 // @public (undocumented)
 export const ColorPickerGridCell: React.FunctionComponent<IColorPickerGridCellProps>;
@@ -205,7 +205,7 @@ export { DirectionalHint }
 export const Dropdown: React.FunctionComponent<IDropdownProps>;
 
 // @public (undocumented)
-export const DropdownBase: React.ForwardRefExoticComponent<IDropdownProps & React.RefAttributes<HTMLDivElement>>;
+export const DropdownBase: React.FunctionComponent<IDropdownProps>;
 
 export { DropdownMenuItemType }
 
@@ -222,7 +222,7 @@ export class ExtendedSelectedItem extends React.Component<ISelectedPeopleItemPro
 export const Fabric: React.FunctionComponent<IFabricProps>;
 
 // @public (undocumented)
-export const FabricBase: React.ForwardRefExoticComponent<IFabricProps & React.RefAttributes<HTMLDivElement>>;
+export const FabricBase: React.FunctionComponent<IFabricProps>;
 
 // @public
 export const FocusTrapCallout: React.FunctionComponent<IFocusTrapCalloutProps>;
@@ -337,7 +337,7 @@ export interface IButtonGridCellProps<T> {
 }
 
 // @public (undocumented)
-export interface IButtonGridProps extends React.TableHTMLAttributes<HTMLTableElement> {
+export interface IButtonGridProps extends React.TableHTMLAttributes<HTMLTableElement>, React.RefAttributes<HTMLElement> {
     ariaPosInSet?: number;
     ariaSetSize?: number;
     columnCount: number;
@@ -391,7 +391,7 @@ export interface ICalloutContentStyles {
 }
 
 // @public (undocumented)
-export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     alignTargetEdge?: boolean;
     ariaDescribedBy?: string;
     ariaLabel?: string;
@@ -449,7 +449,7 @@ export interface ICoachmark {
 }
 
 // @public
-export interface ICoachmarkProps {
+export interface ICoachmarkProps extends React.RefAttributes<HTMLDivElement> {
     ariaAlertText?: string;
     ariaDescribedBy?: string;
     ariaDescribedByText?: string;
@@ -970,7 +970,7 @@ export interface IDropdownOption extends ISelectableOption {
 }
 
 // @public (undocumented)
-export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement> {
+export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     defaultSelectedKeys?: string[] | number[];
     dropdownWidth?: number;
     // @deprecated
@@ -1088,7 +1088,7 @@ export interface IExtendedPersonaProps extends IPersonaProps {
 }
 
 // @public (undocumented)
-export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     applyTheme?: boolean;
     applyThemeToBody?: boolean;
     as?: React.ElementType;
@@ -1148,7 +1148,7 @@ export interface IImage {
 }
 
 // @public (undocumented)
-export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement>, React.RefAttributes<HTMLImageElement> {
     className?: string;
     coverStyle?: ImageCoverStyle;
     // @deprecated
@@ -1210,7 +1210,7 @@ export interface ILine extends IShimmerElement {
 export const Image: React.FunctionComponent<IImageProps>;
 
 // @public (undocumented)
-export const ImageBase: React.ForwardRefExoticComponent<IImageProps & React.RefAttributes<HTMLImageElement>>;
+export const ImageBase: React.FunctionComponent<IImageProps>;
 
 // @public
 export enum ImageCoverStyle {
@@ -1494,7 +1494,7 @@ export interface IPersonaProps extends IPersonaSharedProps {
 }
 
 // @public (undocumented)
-export interface IPersonaSharedProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPersonaSharedProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     allowPhoneInitials?: boolean;
     coinProps?: IPersonaCoinProps;
     coinSize?: number;
@@ -1566,7 +1566,7 @@ export interface IPersonaStyles {
 }
 
 // @public (undocumented)
-export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -1586,7 +1586,7 @@ export interface IPositioningContainer {
 }
 
 // @public (undocumented)
-export interface IPositioningContainerProps extends IBaseProps<IPositioningContainer> {
+export interface IPositioningContainerProps extends IBaseProps<IPositioningContainer>, React.RefAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaLabelledBy?: string;
@@ -1627,7 +1627,7 @@ export interface IRating {
 }
 
 // @public
-export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     allowZeroStars?: boolean;
     ariaLabelFormat?: string;
     componentRef?: IRefObject<IRating>;
@@ -1690,7 +1690,7 @@ export interface IResizeGroup {
 }
 
 // @public (undocumented)
-export interface IResizeGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IResizeGroupProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<IResizeGroup>;
     data: any;
@@ -1730,7 +1730,7 @@ export interface ISearchBox {
 }
 
 // @public (undocumented)
-export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElement>, React.RefAttributes<HTMLDivElement> {
     ariaLabel?: string;
     className?: string;
     clearButtonProps?: IButtonProps_2;
@@ -1947,7 +1947,7 @@ export interface IShimmerLineStyles {
 }
 
 // @public
-export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
+export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement>, React.RefAttributes<HTMLElement> {
     ariaLabel?: string;
     className?: string;
     customElementsGroup?: React.ReactNode;
@@ -2052,7 +2052,7 @@ export interface ISpinButtonStyles {
 }
 
 // @public (undocumented)
-export interface ISwatchColorPickerProps {
+export interface ISwatchColorPickerProps extends React.RefAttributes<HTMLElement> {
     ariaPosInSet?: number;
     ariaSetSize?: number;
     cellBorderWidth?: number;
@@ -2258,19 +2258,19 @@ export class ModalBase extends React.Component<IModalProps, IDialogState> implem
 export const OverflowSet: React.FunctionComponent<IOverflowSetProps>;
 
 // @public (undocumented)
-export const OverflowSetBase: React.ForwardRefExoticComponent<Pick<IOverflowSetProps, "vertical" | "key" | "items" | "styles" | "className" | "role" | "componentRef" | "onRenderItem" | "overflowSide" | "overflowItems" | "onRenderOverflowButton" | "keytipSequences" | "itemSubMenuProvider"> & React.RefAttributes<HTMLDivElement>>;
+export const OverflowSetBase: React.FunctionComponent<IOverflowSetProps>;
 
 // @public
 export const Persona: React.FunctionComponent<IPersonaProps>;
 
 // @public
-export const PersonaBase: React.ForwardRefExoticComponent<IPersonaProps & React.RefAttributes<HTMLDivElement>>;
+export const PersonaBase: React.FunctionComponent<IPersonaProps>;
 
 // @public
 export const PersonaCoin: React.FunctionComponent<IPersonaCoinProps>;
 
 // @public
-export const PersonaCoinBase: React.ForwardRefExoticComponent<IPersonaCoinProps & React.RefAttributes<HTMLDivElement>>;
+export const PersonaCoinBase: React.FunctionComponent<IPersonaCoinProps>;
 
 // @public (undocumented)
 export enum PersonaInitialsColor {
@@ -2424,10 +2424,10 @@ export namespace personaSize {
 }
 
 // @public
-export const Popup: React.ForwardRefExoticComponent<IPopupProps & React.RefAttributes<HTMLDivElement>>;
+export const Popup: React.FunctionComponent<IPopupProps>;
 
 // @public (undocumented)
-export const PositioningContainer: React.ForwardRefExoticComponent<IPositioningContainerProps & React.RefAttributes<HTMLDivElement>>;
+export const PositioningContainer: React.FunctionComponent<IPositioningContainerProps>;
 
 // @public (undocumented)
 export const presenceBoolean: (presence: PersonaPresence) => {
@@ -2443,7 +2443,7 @@ export const presenceBoolean: (presence: PersonaPresence) => {
 export const Rating: React.FunctionComponent<IRatingProps>;
 
 // @public (undocumented)
-export const RatingBase: React.ForwardRefExoticComponent<IRatingProps & React.RefAttributes<HTMLDivElement>>;
+export const RatingBase: React.FunctionComponent<IRatingProps>;
 
 // @public (undocumented)
 export enum RatingSize {
@@ -2454,10 +2454,10 @@ export enum RatingSize {
 }
 
 // @public (undocumented)
-export const ResizeGroup: import("react").ForwardRefExoticComponent<import("./ResizeGroup.types").IResizeGroupProps & import("react").RefAttributes<HTMLDivElement>>;
+export const ResizeGroup: import("react").FunctionComponent<import("./ResizeGroup.types").IResizeGroupProps>;
 
 // @public (undocumented)
-export const ResizeGroupBase: React.ForwardRefExoticComponent<IResizeGroupProps & React.RefAttributes<HTMLDivElement>>;
+export const ResizeGroupBase: React.FunctionComponent<IResizeGroupProps>;
 
 // @public (undocumented)
 export enum ResizeGroupDirection {
@@ -2473,7 +2473,7 @@ export { ResponsiveMode }
 export const SearchBox: React.FunctionComponent<ISearchBoxProps>;
 
 // @public (undocumented)
-export const SearchBoxBase: React.ForwardRefExoticComponent<ISearchBoxProps & React.RefAttributes<HTMLDivElement>>;
+export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps>;
 
 // @public
 export class SelectedPeopleList extends BasePeopleSelectedItemsList {
@@ -2487,7 +2487,7 @@ export class SelectedPeopleList extends BasePeopleSelectedItemsList {
 export const Shimmer: React.FunctionComponent<IShimmerProps>;
 
 // @public (undocumented)
-export const ShimmerBase: React.ForwardRefExoticComponent<IShimmerProps & React.RefAttributes<HTMLDivElement>>;
+export const ShimmerBase: React.FunctionComponent<IShimmerProps>;
 
 // @public (undocumented)
 export const ShimmerCircle: React.FunctionComponent<IShimmerCircleProps>;
@@ -2555,7 +2555,7 @@ export const SpinButton: React.FunctionComponent<ISpinButtonProps>;
 export const SwatchColorPicker: React.FunctionComponent<ISwatchColorPickerProps>;
 
 // @public (undocumented)
-export const SwatchColorPickerBase: React.ForwardRefExoticComponent<ISwatchColorPickerProps & React.RefAttributes<HTMLElement>>;
+export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerProps>;
 
 export { Target }
 

--- a/packages/react-next/src/components/Callout/Callout.tsx
+++ b/packages/react-next/src/components/Callout/Callout.tsx
@@ -3,8 +3,8 @@ import { ICalloutProps } from './Callout.types';
 import { CalloutContent } from './CalloutContent';
 import { Layer } from '../../Layer';
 
-export const Callout = React.forwardRef(
-  ({ layerProps, doNotLayer, ...rest }: ICalloutProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const Callout: React.FunctionComponent<ICalloutProps> = React.forwardRef<HTMLDivElement, ICalloutProps>(
+  ({ layerProps, doNotLayer, ...rest }, forwardedRef) => {
     const content = <CalloutContent {...rest} ref={forwardedRef} />;
     return doNotLayer ? content : <Layer {...layerProps}>{content}</Layer>;
   },

--- a/packages/react-next/src/components/Callout/Callout.types.ts
+++ b/packages/react-next/src/components/Callout/Callout.types.ts
@@ -11,7 +11,7 @@ export { Target };
 /**
  * {@docCategory Callout}
  */
-export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * The target that the Callout should try to position itself based on.
    * It can be either an Element a querySelector string of a valid Element

--- a/packages/react-next/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/react-next/src/components/Callout/CalloutContent.base.tsx
@@ -379,8 +379,8 @@ function useDismissHandlers(
   return mouseDownHandlers;
 }
 
-export const CalloutContentBase = React.memo(
-  React.forwardRef((propsWithoutDefaults: ICalloutProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const CalloutContentBase: React.FunctionComponent<ICalloutProps> = React.memo(
+  React.forwardRef<HTMLDivElement, ICalloutProps>((propsWithoutDefaults, forwardedRef) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
     const {

--- a/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -62,97 +62,98 @@ function useDebugWarnings(props: IChoiceGroupProps) {
 /**
  * {@docCategory ChoiceGroup}
  */
-export const ChoiceGroupBase: React.FunctionComponent = React.forwardRef(
-  (props: IChoiceGroupProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const {
-      className,
-      theme,
-      styles,
-      options = [],
-      label,
-      required,
-      disabled,
-      name,
-      defaultSelectedKey,
-      componentRef,
-      onChange,
-    } = props;
-    const id = useId('ChoiceGroup');
-    const labelId = useId('ChoiceGroupLabel');
+export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React.forwardRef<
+  HTMLDivElement,
+  IChoiceGroupProps
+>((props, forwardedRef) => {
+  const {
+    className,
+    theme,
+    styles,
+    options = [],
+    label,
+    required,
+    disabled,
+    name,
+    defaultSelectedKey,
+    componentRef,
+    onChange,
+  } = props;
+  const id = useId('ChoiceGroup');
+  const labelId = useId('ChoiceGroupLabel');
 
-    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties, [
-      'onChange',
-      'className',
-      'required',
-    ]);
+  const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties, [
+    'onChange',
+    'className',
+    'required',
+  ]);
 
-    const classNames = getClassNames(styles!, {
-      theme: theme!,
-      className,
-      optionsContainIconOrImage: options.some(option => !!(option.iconProps || option.imageSrc)),
-    });
+  const classNames = getClassNames(styles!, {
+    theme: theme!,
+    className,
+    optionsContainIconOrImage: options.some(option => !!(option.iconProps || option.imageSrc)),
+  });
 
-    const ariaLabelledBy = props.ariaLabelledBy || (label ? labelId : props['aria-labelledby']);
+  const ariaLabelledBy = props.ariaLabelledBy || (label ? labelId : props['aria-labelledby']);
 
-    const [keyChecked, setKeyChecked] = useControllableValue(props.selectedKey, defaultSelectedKey);
-    const [keyFocused, setKeyFocused] = React.useState<string | number>();
+  const [keyChecked, setKeyChecked] = useControllableValue(props.selectedKey, defaultSelectedKey);
+  const [keyFocused, setKeyFocused] = React.useState<string | number>();
 
-    useDebugWarnings(props);
-    useComponentRef(options, keyChecked, id, componentRef);
+  useDebugWarnings(props);
+  useComponentRef(options, keyChecked, id, componentRef);
 
-    const onFocus = React.useCallback((ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOptionProps) => {
-      setKeyFocused(option.itemKey);
-    }, []);
+  const onFocus = React.useCallback((ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOptionProps) => {
+    setKeyFocused(option.itemKey);
+  }, []);
 
-    const onBlur = React.useCallback((ev: React.FocusEvent<HTMLElement>) => {
-      setKeyFocused(undefined);
-    }, []);
+  const onBlur = React.useCallback((ev: React.FocusEvent<HTMLElement>) => {
+    setKeyFocused(undefined);
+  }, []);
 
-    const onOptionChange = React.useCallback(
-      (evt: React.FormEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOptionProps) => {
-        setKeyChecked(option.itemKey);
+  const onOptionChange = React.useCallback(
+    (evt: React.FormEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOptionProps) => {
+      setKeyChecked(option.itemKey);
 
-        if (onChange) {
-          onChange(
-            evt,
-            find(options || [], (value: IChoiceGroupOption) => value.key === option.itemKey),
-          );
-        }
-      },
-      [onChange, options, setKeyChecked],
-    );
+      if (onChange) {
+        onChange(
+          evt,
+          find(options || [], (value: IChoiceGroupOption) => value.key === option.itemKey),
+        );
+      }
+    },
+    [onChange, options, setKeyChecked],
+  );
 
-    return (
-      <div className={classNames.root} {...divProps} ref={forwardedRef}>
-        <div role="radiogroup" {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}>
-          {label && (
-            <Label className={classNames.label} required={required} id={labelId} disabled={disabled}>
-              {label}
-            </Label>
-          )}
-          <div className={classNames.flexContainer}>
-            {options.map((option: IChoiceGroupOption) => {
-              return (
-                <ChoiceGroupOption
-                  key={option.key}
-                  itemKey={option.key}
-                  onBlur={onBlur}
-                  onFocus={onFocus}
-                  onChange={onOptionChange}
-                  {...option}
-                  focused={option.key === keyFocused}
-                  checked={option.key === keyChecked}
-                  disabled={option.disabled || disabled}
-                  id={getOptionId(option, id)}
-                  labelId={option.labelId || `${labelId}-${option.key}`}
-                  name={name || id}
-                  required={required}
-                />
-              );
-            })}
-          </div>
+  return (
+    <div className={classNames.root} {...divProps} ref={forwardedRef}>
+      <div role="radiogroup" {...(ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy })}>
+        {label && (
+          <Label className={classNames.label} required={required} id={labelId} disabled={disabled}>
+            {label}
+          </Label>
+        )}
+        <div className={classNames.flexContainer}>
+          {options.map((option: IChoiceGroupOption) => {
+            return (
+              <ChoiceGroupOption
+                key={option.key}
+                itemKey={option.key}
+                onBlur={onBlur}
+                onFocus={onFocus}
+                onChange={onOptionChange}
+                {...option}
+                focused={option.key === keyFocused}
+                checked={option.key === keyChecked}
+                disabled={option.disabled || disabled}
+                id={getOptionId(option, id)}
+                labelId={option.labelId || `${labelId}-${option.key}`}
+                name={name || id}
+                required={required}
+              />
+            );
+          })}
         </div>
       </div>
-    );
-  },
-);
+    </div>
+  );
+});

--- a/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react-next/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -23,7 +23,9 @@ export interface IChoiceGroup {
 /**
  * {@docCategory ChoiceGroup}
  */
-export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement | HTMLInputElement> {
+export interface IChoiceGroupProps
+  extends React.InputHTMLAttributes<HTMLElement | HTMLInputElement>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IChoiceGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/src/components/Coachmark/Beak/Beak.tsx
+++ b/packages/react-next/src/components/Coachmark/Beak/Beak.tsx
@@ -8,71 +8,73 @@ import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning'
 export const BEAK_HEIGHT = 10;
 export const BEAK_WIDTH = 18;
 
-export const Beak = React.forwardRef((props: IBeakProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-  const { left, top, bottom, right, color, direction = RectangleEdge.top } = props;
+export const Beak: React.FunctionComponent<IBeakProps> = React.forwardRef<HTMLDivElement, IBeakProps>(
+  (props, forwardedRef) => {
+    const { left, top, bottom, right, color, direction = RectangleEdge.top } = props;
 
-  let svgHeight: number;
-  let svgWidth: number;
+    let svgHeight: number;
+    let svgWidth: number;
 
-  if (direction === RectangleEdge.top || direction === RectangleEdge.bottom) {
-    svgHeight = BEAK_HEIGHT;
-    svgWidth = BEAK_WIDTH;
-  } else {
-    svgHeight = BEAK_WIDTH;
-    svgWidth = BEAK_HEIGHT;
-  }
+    if (direction === RectangleEdge.top || direction === RectangleEdge.bottom) {
+      svgHeight = BEAK_HEIGHT;
+      svgWidth = BEAK_WIDTH;
+    } else {
+      svgHeight = BEAK_WIDTH;
+      svgWidth = BEAK_HEIGHT;
+    }
 
-  let pointOne: string;
-  let pointTwo: string;
-  let pointThree: string;
-  let transform: string;
+    let pointOne: string;
+    let pointTwo: string;
+    let pointThree: string;
+    let transform: string;
 
-  switch (direction) {
-    case RectangleEdge.top:
-    default:
-      pointOne = `${BEAK_WIDTH / 2}, 0`;
-      pointTwo = `${BEAK_WIDTH}, ${BEAK_HEIGHT}`;
-      pointThree = `0, ${BEAK_HEIGHT}`;
-      transform = 'translateY(-100%)';
-      break;
-    case RectangleEdge.right:
-      pointOne = `0, 0`;
-      pointTwo = `${BEAK_HEIGHT}, ${BEAK_HEIGHT}`;
-      pointThree = `0, ${BEAK_WIDTH}`;
-      transform = 'translateX(100%)';
-      break;
-    case RectangleEdge.bottom:
-      pointOne = `0, 0`;
-      pointTwo = `${BEAK_WIDTH}, 0`;
-      pointThree = `${BEAK_WIDTH / 2}, ${BEAK_HEIGHT}`;
-      transform = 'translateY(100%)';
-      break;
-    case RectangleEdge.left:
-      pointOne = `${BEAK_HEIGHT}, 0`;
-      pointTwo = `0, ${BEAK_HEIGHT}`;
-      pointThree = `${BEAK_HEIGHT}, ${BEAK_WIDTH}`;
-      transform = 'translateX(-100%)';
-      break;
-  }
+    switch (direction) {
+      case RectangleEdge.top:
+      default:
+        pointOne = `${BEAK_WIDTH / 2}, 0`;
+        pointTwo = `${BEAK_WIDTH}, ${BEAK_HEIGHT}`;
+        pointThree = `0, ${BEAK_HEIGHT}`;
+        transform = 'translateY(-100%)';
+        break;
+      case RectangleEdge.right:
+        pointOne = `0, 0`;
+        pointTwo = `${BEAK_HEIGHT}, ${BEAK_HEIGHT}`;
+        pointThree = `0, ${BEAK_WIDTH}`;
+        transform = 'translateX(100%)';
+        break;
+      case RectangleEdge.bottom:
+        pointOne = `0, 0`;
+        pointTwo = `${BEAK_WIDTH}, 0`;
+        pointThree = `${BEAK_WIDTH / 2}, ${BEAK_HEIGHT}`;
+        transform = 'translateY(100%)';
+        break;
+      case RectangleEdge.left:
+        pointOne = `${BEAK_HEIGHT}, 0`;
+        pointTwo = `0, ${BEAK_HEIGHT}`;
+        pointThree = `${BEAK_HEIGHT}, ${BEAK_WIDTH}`;
+        transform = 'translateX(-100%)';
+        break;
+    }
 
-  const getClassNames = classNamesFunction<IBeakStylesProps, IBeakStyles>();
-  const classNames = getClassNames(getStyles, {
-    left,
-    top,
-    bottom,
-    right,
-    height: `${svgHeight}px`,
-    width: `${svgWidth}px`,
-    transform: transform,
-    color,
-  });
+    const getClassNames = classNamesFunction<IBeakStylesProps, IBeakStyles>();
+    const classNames = getClassNames(getStyles, {
+      left,
+      top,
+      bottom,
+      right,
+      height: `${svgHeight}px`,
+      width: `${svgWidth}px`,
+      transform: transform,
+      color,
+    });
 
-  return (
-    <div className={classNames.root} role="presentation" ref={forwardedRef}>
-      <svg height={svgHeight} width={svgWidth} className={classNames.beak}>
-        <polygon points={pointOne + ' ' + pointTwo + ' ' + pointThree} />
-      </svg>
-    </div>
-  );
-});
+    return (
+      <div className={classNames.root} role="presentation" ref={forwardedRef}>
+        <svg height={svgHeight} width={svgWidth} className={classNames.beak}>
+          <polygon points={pointOne + ' ' + pointTwo + ' ' + pointThree} />
+        </svg>
+      </div>
+    );
+  },
+);
 Beak.displayName = 'Beak';

--- a/packages/react-next/src/components/Coachmark/Beak/Beak.types.ts
+++ b/packages/react-next/src/components/Coachmark/Beak/Beak.types.ts
@@ -1,6 +1,7 @@
+import * as React from 'react';
 import { RectangleEdge } from 'office-ui-fabric-react/lib/utilities/positioning';
 
-export interface IBeakProps {
+export interface IBeakProps extends React.RefAttributes<HTMLDivElement> {
   /**
    * Beak width.
    * @defaultvalue 18

--- a/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/react-next/src/components/Coachmark/Coachmark.base.tsx
@@ -401,126 +401,128 @@ function useDeprecationWarning(props: ICoachmarkProps) {
 }
 
 const COMPONENT_NAME = 'CoachmarkBase';
-export const CoachmarkBase = React.forwardRef(
-  (propsWithoutDefaults: ICoachmarkProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    const entityInnerHostElementRef = React.useRef<HTMLDivElement | null>(null);
-    const translateAnimationContainer = React.useRef<HTMLDivElement | null>(null);
+export const CoachmarkBase: React.FunctionComponent<ICoachmarkProps> = React.forwardRef<
+  HTMLDivElement,
+  ICoachmarkProps
+>((propsWithoutDefaults, forwardedRef) => {
+  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    const [targetAlignment, targetPosition, onPositioned] = usePositionedData();
-    const [isCollapsed, openCoachmark] = useCollapsedState(props, entityInnerHostElementRef);
-    const [beakPositioningProps, transformOrigin] = useBeakPosition(props, targetAlignment, targetPosition);
-    const [isMeasuring, entityInnerHostRect] = useEntityHostMeasurements(props, entityInnerHostElementRef);
-    const alertText = useAriaAlert(props);
-    const entityHost = useAutoFocus(props);
+  const entityInnerHostElementRef = React.useRef<HTMLDivElement | null>(null);
+  const translateAnimationContainer = React.useRef<HTMLDivElement | null>(null);
 
-    useListeners(props, translateAnimationContainer, openCoachmark);
-    useComponentRef(props);
-    useProximityHandlers(props, translateAnimationContainer, openCoachmark);
-    useDeprecationWarning(props);
+  const [targetAlignment, targetPosition, onPositioned] = usePositionedData();
+  const [isCollapsed, openCoachmark] = useCollapsedState(props, entityInnerHostElementRef);
+  const [beakPositioningProps, transformOrigin] = useBeakPosition(props, targetAlignment, targetPosition);
+  const [isMeasuring, entityInnerHostRect] = useEntityHostMeasurements(props, entityInnerHostElementRef);
+  const alertText = useAriaAlert(props);
+  const entityHost = useAutoFocus(props);
 
-    const {
-      beaconColorOne,
-      beaconColorTwo,
-      children,
-      target,
-      color,
-      positioningContainerProps,
-      ariaDescribedBy,
-      ariaDescribedByText,
-      ariaLabelledBy,
-      ariaLabelledByText,
-      ariaAlertText,
-      delayBeforeCoachmarkAnimation,
-      styles,
-      theme,
-      className,
-      persistentBeak,
-    } = props;
+  useListeners(props, translateAnimationContainer, openCoachmark);
+  useComponentRef(props);
+  useProximityHandlers(props, translateAnimationContainer, openCoachmark);
+  useDeprecationWarning(props);
 
-    // Defaulting the main background before passing it to the styles because it is used for `Beak` too.
-    let defaultColor = color;
-    if (!defaultColor && theme) {
-      defaultColor = theme.semanticColors.primaryButtonBackground;
-    }
+  const {
+    beaconColorOne,
+    beaconColorTwo,
+    children,
+    target,
+    color,
+    positioningContainerProps,
+    ariaDescribedBy,
+    ariaDescribedByText,
+    ariaLabelledBy,
+    ariaLabelledByText,
+    ariaAlertText,
+    delayBeforeCoachmarkAnimation,
+    styles,
+    theme,
+    className,
+    persistentBeak,
+  } = props;
 
-    const classNames = getClassNames(styles, {
-      theme,
-      beaconColorOne,
-      beaconColorTwo,
-      className,
-      isCollapsed,
-      isMeasuring,
-      color: defaultColor,
-      transformOrigin,
-      entityHostHeight: entityInnerHostRect.height === undefined ? undefined : `${entityInnerHostRect.height}px`,
-      entityHostWidth: entityInnerHostRect.width === undefined ? undefined : `${entityInnerHostRect.width}px`,
-      width: `${COACHMARK_WIDTH}px`,
-      height: `${COACHMARK_HEIGHT}px`,
-      delayBeforeCoachmarkAnimation: `${delayBeforeCoachmarkAnimation}ms`,
-    });
+  // Defaulting the main background before passing it to the styles because it is used for `Beak` too.
+  let defaultColor = color;
+  if (!defaultColor && theme) {
+    defaultColor = theme.semanticColors.primaryButtonBackground;
+  }
 
-    const finalHeight: number | undefined = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;
+  const classNames = getClassNames(styles, {
+    theme,
+    beaconColorOne,
+    beaconColorTwo,
+    className,
+    isCollapsed,
+    isMeasuring,
+    color: defaultColor,
+    transformOrigin,
+    entityHostHeight: entityInnerHostRect.height === undefined ? undefined : `${entityInnerHostRect.height}px`,
+    entityHostWidth: entityInnerHostRect.width === undefined ? undefined : `${entityInnerHostRect.width}px`,
+    width: `${COACHMARK_WIDTH}px`,
+    height: `${COACHMARK_HEIGHT}px`,
+    delayBeforeCoachmarkAnimation: `${delayBeforeCoachmarkAnimation}ms`,
+  });
 
-    return (
-      <PositioningContainer
-        target={target}
-        offsetFromTarget={BEAK_HEIGHT}
-        finalHeight={finalHeight}
-        ref={forwardedRef}
-        onPositioned={onPositioned}
-        bounds={getBounds(props)}
-        {...positioningContainerProps}
-      >
-        <div className={classNames.root}>
-          {ariaAlertText && (
-            <div className={classNames.ariaContainer} role="alert" aria-hidden={!isCollapsed}>
-              {alertText}
-            </div>
-          )}
-          <div className={classNames.pulsingBeacon} />
-          <div className={classNames.translateAnimationContainer} ref={translateAnimationContainer}>
-            <div className={classNames.scaleAnimationLayer}>
-              <div className={classNames.rotateAnimationLayer}>
-                {(isCollapsed || persistentBeak) && <Beak {...beakPositioningProps} color={defaultColor} />}
-                <div
-                  className={classNames.entityHost}
-                  ref={entityHost}
-                  tabIndex={-1}
-                  data-is-focusable={true}
-                  role="dialog"
-                  aria-labelledby={ariaLabelledBy}
-                  aria-describedby={ariaDescribedBy}
-                >
-                  {isCollapsed && [
-                    ariaLabelledBy && (
-                      <p id={ariaLabelledBy} key={0} className={classNames.ariaContainer}>
-                        {ariaLabelledByText}
-                      </p>
-                    ),
-                    ariaDescribedBy && (
-                      <p id={ariaDescribedBy} key={1} className={classNames.ariaContainer}>
-                        {ariaDescribedByText}
-                      </p>
-                    ),
-                  ]}
-                  <FocusTrapZone isClickableOutsideFocusTrap={true} forceFocusInsideTrap={false}>
-                    <div className={classNames.entityInnerHost} ref={entityInnerHostElementRef}>
-                      <div className={classNames.childrenContainer} aria-hidden={isCollapsed}>
-                        {children}
-                      </div>
+  const finalHeight: number | undefined = isCollapsed ? COACHMARK_HEIGHT : entityInnerHostRect.height;
+
+  return (
+    <PositioningContainer
+      target={target}
+      offsetFromTarget={BEAK_HEIGHT}
+      finalHeight={finalHeight}
+      ref={forwardedRef}
+      onPositioned={onPositioned}
+      bounds={getBounds(props)}
+      {...positioningContainerProps}
+    >
+      <div className={classNames.root}>
+        {ariaAlertText && (
+          <div className={classNames.ariaContainer} role="alert" aria-hidden={!isCollapsed}>
+            {alertText}
+          </div>
+        )}
+        <div className={classNames.pulsingBeacon} />
+        <div className={classNames.translateAnimationContainer} ref={translateAnimationContainer}>
+          <div className={classNames.scaleAnimationLayer}>
+            <div className={classNames.rotateAnimationLayer}>
+              {(isCollapsed || persistentBeak) && <Beak {...beakPositioningProps} color={defaultColor} />}
+              <div
+                className={classNames.entityHost}
+                ref={entityHost}
+                tabIndex={-1}
+                data-is-focusable={true}
+                role="dialog"
+                aria-labelledby={ariaLabelledBy}
+                aria-describedby={ariaDescribedBy}
+              >
+                {isCollapsed && [
+                  ariaLabelledBy && (
+                    <p id={ariaLabelledBy} key={0} className={classNames.ariaContainer}>
+                      {ariaLabelledByText}
+                    </p>
+                  ),
+                  ariaDescribedBy && (
+                    <p id={ariaDescribedBy} key={1} className={classNames.ariaContainer}>
+                      {ariaDescribedByText}
+                    </p>
+                  ),
+                ]}
+                <FocusTrapZone isClickableOutsideFocusTrap={true} forceFocusInsideTrap={false}>
+                  <div className={classNames.entityInnerHost} ref={entityInnerHostElementRef}>
+                    <div className={classNames.childrenContainer} aria-hidden={isCollapsed}>
+                      {children}
                     </div>
-                  </FocusTrapZone>
-                </div>
+                  </div>
+                </FocusTrapZone>
               </div>
             </div>
           </div>
         </div>
-      </PositioningContainer>
-    );
-  },
-);
+      </div>
+    </PositioningContainer>
+  );
+});
 CoachmarkBase.displayName = COMPONENT_NAME;
 
 function getBounds({ isPositionForced, positioningContainerProps }: ICoachmarkProps): IRectangle | undefined {

--- a/packages/react-next/src/components/Coachmark/Coachmark.types.ts
+++ b/packages/react-next/src/components/Coachmark/Coachmark.types.ts
@@ -18,7 +18,7 @@ export interface ICoachmark {
  * Coachmark component props
  * {@docCategory Coachmark}
  */
-export interface ICoachmarkProps {
+export interface ICoachmarkProps extends React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the ICoachmark interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -283,81 +283,82 @@ export function useHeightOffset(
   return heightOffset;
 }
 
-export const PositioningContainer = React.forwardRef(
-  (propsWithoutDefaults: IPositioningContainerProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+export const PositioningContainer: React.FunctionComponent<IPositioningContainerProps> = React.forwardRef<
+  HTMLDivElement,
+  IPositioningContainerProps
+>((propsWithoutDefaults, forwardedRef) => {
+  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    // @TODO rename to reflect the name of this class
-    const contentHost = React.useRef<HTMLDivElement>(null);
-    /**
-     * The primary positioned div.
-     */
-    const positionedHost = React.useRef<HTMLDivElement>(null);
-    const rootRef = useMergedRefs(forwardedRef, positionedHost);
+  // @TODO rename to reflect the name of this class
+  const contentHost = React.useRef<HTMLDivElement>(null);
+  /**
+   * The primary positioned div.
+   */
+  const positionedHost = React.useRef<HTMLDivElement>(null);
+  const rootRef = useMergedRefs(forwardedRef, positionedHost);
 
-    const [targetRef, targetWindow] = useTarget(props.target, positionedHost);
-    const getCachedBounds = useCachedBounds(props, targetWindow);
-    const [positions, updateAsyncPosition] = usePositionState(
-      props,
-      positionedHost,
-      contentHost,
-      targetRef,
-      getCachedBounds,
-    );
-    const getCachedMaxHeight = useMaxHeight(props, targetRef, getCachedBounds);
-    const heightOffset = useHeightOffset(props, contentHost);
+  const [targetRef, targetWindow] = useTarget(props.target, positionedHost);
+  const getCachedBounds = useCachedBounds(props, targetWindow);
+  const [positions, updateAsyncPosition] = usePositionState(
+    props,
+    positionedHost,
+    contentHost,
+    targetRef,
+    getCachedBounds,
+  );
+  const getCachedMaxHeight = useMaxHeight(props, targetRef, getCachedBounds);
+  const heightOffset = useHeightOffset(props, contentHost);
 
-    useSetInitialFocus(props, contentHost, positions);
-    useAutoDismissEvents(props, positionedHost, targetWindow, targetRef, positions, updateAsyncPosition);
+  useSetInitialFocus(props, contentHost, positions);
+  useAutoDismissEvents(props, positionedHost, targetWindow, targetRef, positions, updateAsyncPosition);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on initial render
-    React.useEffect(() => props.onLayerMounted?.(), []);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- should only run on initial render
+  React.useEffect(() => props.onLayerMounted?.(), []);
 
-    // If there is no target window then we are likely in server side rendering and we should not render anything.
-    if (!targetWindow) {
-      return null;
-    }
+  // If there is no target window then we are likely in server side rendering and we should not render anything.
+  if (!targetWindow) {
+    return null;
+  }
 
-    const { className, positioningContainerWidth, positioningContainerMaxHeight, children } = props;
+  const { className, positioningContainerWidth, positioningContainerMaxHeight, children } = props;
 
-    const styles = getClassNames();
+  const styles = getClassNames();
 
-    const directionalClassName =
-      positions && positions.targetEdge ? AnimationClassNames[SLIDE_ANIMATIONS[positions.targetEdge]] : '';
+  const directionalClassName =
+    positions && positions.targetEdge ? AnimationClassNames[SLIDE_ANIMATIONS[positions.targetEdge]] : '';
 
-    const getContentMaxHeight: number = getCachedMaxHeight() + heightOffset!;
-    const contentMaxHeight: number =
-      positioningContainerMaxHeight! && positioningContainerMaxHeight! > getContentMaxHeight
-        ? getContentMaxHeight
-        : positioningContainerMaxHeight!;
-    const content = (
-      <div ref={rootRef} className={css('ms-PositioningContainer', styles.container)}>
-        <div
-          className={mergeStyles(
-            'ms-PositioningContainer-layerHost',
-            styles.root,
-            className,
-            directionalClassName,
-            !!positioningContainerWidth && { width: positioningContainerWidth },
-          )}
-          style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
-          // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
-          // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
-          tabIndex={-1}
-          ref={contentHost}
-        >
-          {children}
-          {
-            // @TODO apply to the content container
-            contentMaxHeight
-          }
-        </div>
+  const getContentMaxHeight: number = getCachedMaxHeight() + heightOffset!;
+  const contentMaxHeight: number =
+    positioningContainerMaxHeight! && positioningContainerMaxHeight! > getContentMaxHeight
+      ? getContentMaxHeight
+      : positioningContainerMaxHeight!;
+  const content = (
+    <div ref={rootRef} className={css('ms-PositioningContainer', styles.container)}>
+      <div
+        className={mergeStyles(
+          'ms-PositioningContainer-layerHost',
+          styles.root,
+          className,
+          directionalClassName,
+          !!positioningContainerWidth && { width: positioningContainerWidth },
+        )}
+        style={positions ? positions.elementPosition : OFF_SCREEN_STYLE}
+        // Safari and Firefox on Mac OS requires this to back-stop click events so focus remains in the Callout.
+        // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#Clicking_and_focus
+        tabIndex={-1}
+        ref={contentHost}
+      >
+        {children}
+        {
+          // @TODO apply to the content container
+          contentMaxHeight
+        }
       </div>
-    );
+    </div>
+  );
 
-    return props.doNotLayer ? content : <Layer>{content}</Layer>;
-  },
-);
+  return props.doNotLayer ? content : <Layer>{content}</Layer>;
+});
 PositioningContainer.displayName = 'PositioningContainer';
 
 function arePositionsEqual(positions: IPositionedData, newPosition: IPositionedData): boolean {

--- a/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
+++ b/packages/react-next/src/components/Coachmark/PositioningContainer/PositioningContainer.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { DirectionalHint } from '../../../common/DirectionalHint';
 import { IRefObject, IBaseProps, Point, IRectangle } from '../../../Utilities';
 import { IPositionedData } from 'office-ui-fabric-react/lib/utilities/positioning';
@@ -11,11 +12,14 @@ export interface IPositioningContainer {}
 /**
  * {@docCategory Coachmark}
  */
-export interface IPositioningContainerProps extends IBaseProps<IPositioningContainer> {
+export interface IPositioningContainerProps
+  extends IBaseProps<IPositioningContainer>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * All props for your component are to be defined here.
    */
   componentRef?: IRefObject<IPositioningContainer>;
+
   /**
    * The target that the positioningContainer should try to position itself based on.
    * It can be either an HTMLElement a querySelector string of a valid HTMLElement

--- a/packages/react-next/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/react-next/src/components/Dropdown/Dropdown.base.tsx
@@ -54,7 +54,7 @@ import { useMergedRefs, usePrevious } from '@uifabric/react-hooks';
 const getClassNames = classNamesFunction<IDropdownStyleProps, IDropdownStyles>();
 
 /** Internal only props interface to support mixing in responsive mode */
-interface IDropdownInternalProps extends IDropdownProps, IWithResponsiveModeState {
+interface IDropdownInternalProps extends Omit<IDropdownProps, 'ref'>, IWithResponsiveModeState {
   hoisted: {
     rootRef: React.Ref<HTMLDivElement>;
     selectedIndices: number[];
@@ -159,8 +159,8 @@ function useSelectedItemsState({
   return [selectedIndices, setSelectedIndices] as const;
 }
 
-export const DropdownBase = React.forwardRef(
-  (propsWithoutDefaults: IDropdownProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const DropdownBase: React.FunctionComponent<IDropdownProps> = React.forwardRef<HTMLDivElement, IDropdownProps>(
+  (propsWithoutDefaults, forwardedRef) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
     const rootRef = React.useRef<HTMLDivElement>(null);
@@ -171,7 +171,7 @@ export const DropdownBase = React.forwardRef(
 
     return (
       <DropdownInternal
-        {...props}
+        {...(props as Omit<IDropdownProps, 'ref'>)}
         responsiveMode={responsiveMode}
         hoisted={{ rootRef: mergedRootRef, selectedIndices, setSelectedIndices }}
       />

--- a/packages/react-next/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/react-next/src/components/Dropdown/Dropdown.types.ts
@@ -29,7 +29,9 @@ export interface IDropdown {
 /**
  * {@docCategory Dropdown}
  */
-export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement> {
+export interface IDropdownProps
+  extends ISelectableDroppableTextProps<IDropdown, HTMLDivElement>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * Input placeholder text. Displayed until option is selected.
    * @deprecated Use `placeholder`

--- a/packages/react-next/src/components/Fabric/Fabric.base.tsx
+++ b/packages/react-next/src/components/Fabric/Fabric.base.tsx
@@ -32,21 +32,23 @@ const getDir = ({ theme, dir }: IFabricProps) => {
   };
 };
 
-export const FabricBase = React.forwardRef((props: IFabricProps, ref: React.Ref<HTMLDivElement>) => {
-  const { className, theme, applyTheme, applyThemeToBody, styles } = props;
+export const FabricBase: React.FunctionComponent<IFabricProps> = React.forwardRef<HTMLDivElement, IFabricProps>(
+  (props, ref) => {
+    const { className, theme, applyTheme, applyThemeToBody, styles } = props;
 
-  const classNames = getClassNames(styles, {
-    theme: theme!,
-    applyTheme: applyTheme,
-    className,
-  });
+    const classNames = getClassNames(styles, {
+      theme: theme!,
+      applyTheme: applyTheme,
+      className,
+    });
 
-  const rootElement = React.useRef<HTMLDivElement | null>(null);
-  useApplyThemeToBody(applyThemeToBody, classNames, rootElement);
-  useFocusRects(rootElement);
+    const rootElement = React.useRef<HTMLDivElement | null>(null);
+    useApplyThemeToBody(applyThemeToBody, classNames, rootElement);
+    useFocusRects(rootElement);
 
-  return <>{useRenderedContent(props, classNames, rootElement, ref)}</>;
-});
+    return <>{useRenderedContent(props, classNames, rootElement, ref)}</>;
+  },
+);
 FabricBase.displayName = 'FabricBase';
 
 function useRenderedContent(

--- a/packages/react-next/src/components/Fabric/Fabric.types.ts
+++ b/packages/react-next/src/components/Fabric/Fabric.types.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
-export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   componentRef?: IRefObject<{}>;
 
   /**

--- a/packages/react-next/src/components/Image/Image.base.tsx
+++ b/packages/react-next/src/components/Image/Image.base.tsx
@@ -74,68 +74,70 @@ function useLoadState(
   return [loadState, onImageLoaded, onImageError] as const;
 }
 
-export const ImageBase = React.forwardRef((props: IImageProps, forwardedRef: React.Ref<HTMLImageElement>) => {
-  const frameElement = React.useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
-  const imageElement = React.useRef<HTMLImageElement>() as React.RefObject<HTMLImageElement>;
-  const [loadState, onImageLoaded, onImageError] = useLoadState(props, imageElement);
+export const ImageBase: React.FunctionComponent<IImageProps> = React.forwardRef<HTMLImageElement, IImageProps>(
+  (props, forwardedRef) => {
+    const frameElement = React.useRef<HTMLDivElement>() as React.RefObject<HTMLDivElement>;
+    const imageElement = React.useRef<HTMLImageElement>() as React.RefObject<HTMLImageElement>;
+    const [loadState, onImageLoaded, onImageError] = useLoadState(props, imageElement);
 
-  const imageProps = getNativeProps<React.ImgHTMLAttributes<HTMLImageElement>>(props, imgProperties, [
-    'width',
-    'height',
-  ]);
-  const {
-    src,
-    alt,
-    width,
-    height,
-    shouldFadeIn = true,
-    shouldStartVisible,
-    className,
-    imageFit,
-    role,
-    maximizeFrame,
-    styles,
-    theme,
-  } = props;
-  const coverStyle = useCoverStyle(props, loadState, imageElement, frameElement);
-  const classNames = getClassNames(styles!, {
-    theme: theme!,
-    className,
-    width,
-    height,
-    maximizeFrame,
-    shouldFadeIn,
-    shouldStartVisible,
-    isLoaded:
-      loadState === ImageLoadState.loaded || (loadState === ImageLoadState.notLoaded && props.shouldStartVisible),
-    isLandscape: coverStyle === ImageCoverStyle.landscape,
-    isCenter: imageFit === ImageFit.center,
-    isCenterContain: imageFit === ImageFit.centerContain,
-    isCenterCover: imageFit === ImageFit.centerCover,
-    isContain: imageFit === ImageFit.contain,
-    isCover: imageFit === ImageFit.cover,
-    isNone: imageFit === ImageFit.none,
-    isError: loadState === ImageLoadState.error,
-    isNotImageFit: imageFit === undefined,
-  });
+    const imageProps = getNativeProps<React.ImgHTMLAttributes<HTMLImageElement>>(props, imgProperties, [
+      'width',
+      'height',
+    ]);
+    const {
+      src,
+      alt,
+      width,
+      height,
+      shouldFadeIn = true,
+      shouldStartVisible,
+      className,
+      imageFit,
+      role,
+      maximizeFrame,
+      styles,
+      theme,
+    } = props;
+    const coverStyle = useCoverStyle(props, loadState, imageElement, frameElement);
+    const classNames = getClassNames(styles!, {
+      theme: theme!,
+      className,
+      width,
+      height,
+      maximizeFrame,
+      shouldFadeIn,
+      shouldStartVisible,
+      isLoaded:
+        loadState === ImageLoadState.loaded || (loadState === ImageLoadState.notLoaded && props.shouldStartVisible),
+      isLandscape: coverStyle === ImageCoverStyle.landscape,
+      isCenter: imageFit === ImageFit.center,
+      isCenterContain: imageFit === ImageFit.centerContain,
+      isCenterCover: imageFit === ImageFit.centerCover,
+      isContain: imageFit === ImageFit.contain,
+      isCover: imageFit === ImageFit.cover,
+      isNone: imageFit === ImageFit.none,
+      isError: loadState === ImageLoadState.error,
+      isNotImageFit: imageFit === undefined,
+    });
 
-  // If image dimensions aren't specified, the natural size of the image is used.
-  return (
-    <div className={classNames.root} style={{ width: width, height: height }} ref={frameElement}>
-      <img
-        {...imageProps}
-        onLoad={onImageLoaded}
-        onError={onImageError}
-        key={KEY_PREFIX + props.src || ''}
-        className={classNames.image}
-        ref={useMergedRefs(imageElement, forwardedRef)}
-        src={src}
-        alt={alt}
-        role={role}
-      />
-    </div>
-  );
-});
+    // If image dimensions aren't specified, the natural size of the image is used.
+    return (
+      <div className={classNames.root} style={{ width: width, height: height }} ref={frameElement}>
+        <img
+          {...imageProps}
+          onLoad={onImageLoaded}
+          onError={onImageError}
+          key={KEY_PREFIX + props.src || ''}
+          className={classNames.image}
+          ref={useMergedRefs(imageElement, forwardedRef)}
+          src={src}
+          alt={alt}
+          role={role}
+        />
+      </div>
+    );
+  },
+);
 ImageBase.displayName = 'ImageBase';
 
 function useCoverStyle(

--- a/packages/react-next/src/components/Image/Image.types.ts
+++ b/packages/react-next/src/components/Image/Image.types.ts
@@ -10,7 +10,7 @@ export interface IImage {}
 /**
  * {@docCategory Image}
  */
-export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
+export interface IImageProps extends React.ImgHTMLAttributes<HTMLImageElement>, React.RefAttributes<HTMLImageElement> {
   /**
    * Call to provide customized styling that will layer on top of the variant rules
    */

--- a/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/react-next/src/components/OverflowSet/OverflowSet.base.tsx
@@ -35,7 +35,10 @@ const useComponentRef = (props: IOverflowSetProps, divContainer: React.RefObject
   );
 };
 
-export const OverflowSetBase = React.forwardRef((props: IOverflowSetProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const OverflowSetBase: React.FunctionComponent<IOverflowSetProps> = React.forwardRef<
+  HTMLDivElement,
+  IOverflowSetProps
+>((props, forwardedRef) => {
   const divContainer = React.useRef<HTMLDivElement>(null);
   const mergedRef = useMergedRefs(divContainer, forwardedRef);
   useComponentRef(props, divContainer);

--- a/packages/react-next/src/components/Persona/Persona.base.tsx
+++ b/packages/react-next/src/components/Persona/Persona.base.tsx
@@ -16,7 +16,7 @@ import {
   PersonaSize,
   IPersonaCoinProps,
 } from './Persona.types';
-import { useWarnings } from '@uifabric/react-hooks';
+import { useWarnings, useMergedRefs } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IPersonaStyleProps, IPersonaStyles>();
 
@@ -41,11 +41,13 @@ function useDebugWarnings(props: IPersonaProps) {
  * Persona with no default styles.
  * [Use the `styles` API to add your own styles.](https://github.com/microsoft/fluentui/wiki/Styling)
  */
-export const PersonaBase = React.forwardRef(
-  (propsWithoutDefaults: IPersonaProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const PersonaBase: React.FunctionComponent<IPersonaProps> = React.forwardRef<HTMLDivElement, IPersonaProps>(
+  (propsWithoutDefaults, forwardedRef) => {
     const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
     useDebugWarnings(props);
+    const rootRef = React.useRef<HTMLDivElement>(null);
+    const mergedRootRef = useMergedRefs(forwardedRef, rootRef);
 
     /**
      * Deprecation helper for getting text.
@@ -189,6 +191,7 @@ export const PersonaBase = React.forwardRef(
     return (
       <div
         {...divProps}
+        ref={mergedRootRef}
         className={classNames.root}
         style={coinSize ? { height: coinSize, minWidth: coinSize } : undefined}
       >

--- a/packages/react-next/src/components/Persona/Persona.types.ts
+++ b/packages/react-next/src/components/Persona/Persona.types.ts
@@ -12,7 +12,7 @@ export interface IPersona {}
 /**
  * {@docCategory Persona}
  */
-export interface IPersonaSharedProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPersonaSharedProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Primary text to display, usually the name of the person.
    */

--- a/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/react-next/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -66,102 +66,100 @@ function useImageLoadState({ onPhotoLoadingStateChange, imageUrl }: IPersonaCoin
  * PersonaCoin with no default styles.
  * [Use the `getStyles` API to add your own styles.](https://github.com/microsoft/fluentui/wiki/Styling)
  */
-export const PersonaCoinBase = React.forwardRef(
-  (propsWithoutDefaults: IPersonaCoinProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+export const PersonaCoinBase: React.FunctionComponent<IPersonaCoinProps> = React.forwardRef<
+  HTMLDivElement,
+  IPersonaCoinProps
+>((propsWithoutDefaults, forwardedRef) => {
+  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
 
-    useDebugWarnings(props);
+  useDebugWarnings(props);
 
-    const [imageLoadState, onLoadingStateChange] = useImageLoadState(props);
+  const [imageLoadState, onLoadingStateChange] = useImageLoadState(props);
 
-    const renderCoin = getCoinRenderer(onLoadingStateChange);
+  const renderCoin = getCoinRenderer(onLoadingStateChange);
 
-    const {
-      className,
-      coinProps,
-      showUnknownPersonaCoin,
-      coinSize,
-      styles,
-      imageUrl,
-      isOutOfOffice,
+  const {
+    className,
+    coinProps,
+    showUnknownPersonaCoin,
+    coinSize,
+    styles,
+    imageUrl,
+    isOutOfOffice,
+    // eslint-disable-next-line deprecation/deprecation
+    onRenderCoin = renderCoin,
+    // eslint-disable-next-line deprecation/deprecation
+    onRenderPersonaCoin = onRenderCoin,
+    onRenderInitials = renderPersonaCoinInitials,
+    presence,
+    presenceTitle,
+    presenceColors,
+    showInitialsUntilImageLoads,
+    theme,
+    size,
+  } = props;
+
+  const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
+  const divCoinProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(coinProps || {}, divProperties);
+  const coinSizeStyle = coinSize ? { width: coinSize, height: coinSize } : undefined;
+  const hideImage = showUnknownPersonaCoin;
+
+  const personaPresenceProps: IPersonaPresenceProps = {
+    coinSize,
+    isOutOfOffice,
+    presence,
+    presenceTitle,
+    presenceColors,
+    size,
+    theme,
+  };
+
+  // Use getStyles from props, or fall back to getStyles from styles file.
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    className: coinProps && coinProps.className ? coinProps.className : className,
+    size,
+    coinSize,
+    showUnknownPersonaCoin,
+  });
+
+  const shouldRenderInitials = Boolean(
+    imageLoadState !== ImageLoadState.loaded &&
+      ((showInitialsUntilImageLoads && imageUrl) || !imageUrl || imageLoadState === ImageLoadState.error || hideImage),
+  );
+
+  return (
+    <div role="presentation" {...divProps} className={classNames.coin} ref={forwardedRef}>
+      {// Render PersonaCoin if size is not size8. size10 and tiny need to removed after a deprecation cleanup.
       // eslint-disable-next-line deprecation/deprecation
-      onRenderCoin = renderCoin,
-      // eslint-disable-next-line deprecation/deprecation
-      onRenderPersonaCoin = onRenderCoin,
-      onRenderInitials = renderPersonaCoinInitials,
-      presence,
-      presenceTitle,
-      presenceColors,
-      showInitialsUntilImageLoads,
-      theme,
-      size,
-    } = props;
-
-    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
-    const divCoinProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(coinProps || {}, divProperties);
-    const coinSizeStyle = coinSize ? { width: coinSize, height: coinSize } : undefined;
-    const hideImage = showUnknownPersonaCoin;
-
-    const personaPresenceProps: IPersonaPresenceProps = {
-      coinSize,
-      isOutOfOffice,
-      presence,
-      presenceTitle,
-      presenceColors,
-      size,
-      theme,
-    };
-
-    // Use getStyles from props, or fall back to getStyles from styles file.
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      className: coinProps && coinProps.className ? coinProps.className : className,
-      size,
-      coinSize,
-      showUnknownPersonaCoin,
-    });
-
-    const shouldRenderInitials = Boolean(
-      imageLoadState !== ImageLoadState.loaded &&
-        ((showInitialsUntilImageLoads && imageUrl) ||
-          !imageUrl ||
-          imageLoadState === ImageLoadState.error ||
-          hideImage),
-    );
-
-    return (
-      <div role="presentation" {...divProps} className={classNames.coin} ref={forwardedRef}>
-        {// Render PersonaCoin if size is not size8. size10 and tiny need to removed after a deprecation cleanup.
-        // eslint-disable-next-line deprecation/deprecation
-        size !== PersonaSize.size8 && size !== PersonaSize.size10 && size !== PersonaSize.tiny ? (
-          <div role="presentation" {...divCoinProps} className={classNames.imageArea} style={coinSizeStyle}>
-            {shouldRenderInitials && (
-              <div
-                className={mergeStyles(
-                  classNames.initials,
-                  !showUnknownPersonaCoin && { backgroundColor: getPersonaInitialsColor(props) },
-                )}
-                style={coinSizeStyle}
-                aria-hidden="true"
-              >
-                {onRenderInitials(props, renderPersonaCoinInitials)}
-              </div>
-            )}
-            {!hideImage && onRenderPersonaCoin(props, renderCoin)}
-            <PersonaPresence {...personaPresenceProps} />
-          </div>
-        ) : // Otherwise, render just PersonaPresence.
-        props.presence ? (
+      size !== PersonaSize.size8 && size !== PersonaSize.size10 && size !== PersonaSize.tiny ? (
+        <div role="presentation" {...divCoinProps} className={classNames.imageArea} style={coinSizeStyle}>
+          {shouldRenderInitials && (
+            <div
+              className={mergeStyles(
+                classNames.initials,
+                !showUnknownPersonaCoin && { backgroundColor: getPersonaInitialsColor(props) },
+              )}
+              style={coinSizeStyle}
+              aria-hidden="true"
+            >
+              {onRenderInitials(props, renderPersonaCoinInitials)}
+            </div>
+          )}
+          {!hideImage && onRenderPersonaCoin(props, renderCoin)}
           <PersonaPresence {...personaPresenceProps} />
-        ) : (
-          // Just render Contact Icon if there isn't a Presence prop.
-          <Icon iconName="Contact" className={classNames.size10WithoutPresenceIcon} />
-        )}
-        {props.children}
-      </div>
-    );
-  },
-);
+        </div>
+      ) : // Otherwise, render just PersonaPresence.
+      props.presence ? (
+        <PersonaPresence {...personaPresenceProps} />
+      ) : (
+        // Just render Contact Icon if there isn't a Presence prop.
+        <Icon iconName="Contact" className={classNames.size10WithoutPresenceIcon} />
+      )}
+      {props.children}
+    </div>
+  );
+});
 PersonaCoinBase.displayName = 'PersonaCoinBase';
 
 const getCoinRenderer = (onLoadingStateChange: (loadState: ImageLoadState) => void) => ({

--- a/packages/react-next/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/react-next/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -9,6 +9,7 @@ import {
   PersonaSize,
 } from '../Persona.types';
 import { sizeBoolean } from '../PersonaConsts';
+import { useMergedRefs } from '@uifabric/react-hooks';
 
 const coinSizeFontScaleFactor = 6;
 const coinSizePresenceScaleFactor = 3;
@@ -25,73 +26,76 @@ const getClassNames = classNamesFunction<IPersonaPresenceStyleProps, IPersonaPre
  * PersonaPresence with no default styles.
  * [Use the `getStyles` API to add your own styles.](https://github.com/microsoft/fluentui/wiki/Styling)
  */
-export const PersonaPresenceBase = React.forwardRef(
-  (props: IPersonaPresenceProps, forwarededRef: React.Ref<HTMLDivElement>) => {
-    const {
-      coinSize,
-      isOutOfOffice,
-      styles, // Use getStyles from props.
-      presence,
-      theme,
-      presenceTitle,
-      presenceColors,
-    } = props;
-    const size = sizeBoolean(props.size as PersonaSize);
+export const PersonaPresenceBase: React.FunctionComponent<IPersonaPresenceProps> = React.forwardRef<
+  HTMLDivElement,
+  IPersonaPresenceProps
+>((props, forwardedRef) => {
+  const {
+    coinSize,
+    isOutOfOffice,
+    styles, // Use getStyles from props.
+    presence,
+    theme,
+    presenceTitle,
+    presenceColors,
+  } = props;
 
-    // Render Presence Icon if Persona is above size 32.
-    const renderIcon =
-      !(size.isSize8 || size.isSize10 || size.isSize16 || size.isSize24 || size.isSize28 || size.isSize32) &&
-      (coinSize ? coinSize > 32 : true);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const mergedRootRef = useMergedRefs(forwardedRef, rootRef);
 
-    const presenceHeightWidth: string = coinSize
-      ? coinSize / coinSizePresenceScaleFactor < presenceMaxSize
-        ? coinSize / coinSizePresenceScaleFactor + 'px'
-        : presenceMaxSize + 'px'
-      : '';
-    const presenceFontSize: string = coinSize
-      ? coinSize / coinSizeFontScaleFactor < presenceFontMaxSize
-        ? coinSize / coinSizeFontScaleFactor + 'px'
-        : presenceFontMaxSize + 'px'
-      : '';
-    const coinSizeWithPresenceIconStyle = coinSize
-      ? { fontSize: presenceFontSize, lineHeight: presenceHeightWidth }
-      : undefined;
-    const coinSizeWithPresenceStyle = coinSize
-      ? { width: presenceHeightWidth, height: presenceHeightWidth }
-      : undefined;
+  const size = sizeBoolean(props.size as PersonaSize);
 
-    // Use getStyles from props, or fall back to getStyles from styles file.
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      presence,
-      size: props.size,
-      isOutOfOffice,
-      presenceColors,
-    });
+  // Render Presence Icon if Persona is above size 32.
+  const renderIcon =
+    !(size.isSize8 || size.isSize10 || size.isSize16 || size.isSize24 || size.isSize28 || size.isSize32) &&
+    (coinSize ? coinSize > 32 : true);
 
-    if (presence === PersonaPresenceEnum.none) {
-      return null;
-    }
+  const presenceHeightWidth: string = coinSize
+    ? coinSize / coinSizePresenceScaleFactor < presenceMaxSize
+      ? coinSize / coinSizePresenceScaleFactor + 'px'
+      : presenceMaxSize + 'px'
+    : '';
+  const presenceFontSize: string = coinSize
+    ? coinSize / coinSizeFontScaleFactor < presenceFontMaxSize
+      ? coinSize / coinSizeFontScaleFactor + 'px'
+      : presenceFontMaxSize + 'px'
+    : '';
+  const coinSizeWithPresenceIconStyle = coinSize
+    ? { fontSize: presenceFontSize, lineHeight: presenceHeightWidth }
+    : undefined;
+  const coinSizeWithPresenceStyle = coinSize ? { width: presenceHeightWidth, height: presenceHeightWidth } : undefined;
 
-    return (
-      <div
-        role="presentation"
-        className={classNames.presence}
-        style={coinSizeWithPresenceStyle}
-        title={presenceTitle}
-        ref={forwarededRef}
-      >
-        {renderIcon && (
-          <Icon
-            className={classNames.presenceIcon}
-            iconName={determineIcon(props.presence, props.isOutOfOffice)}
-            style={coinSizeWithPresenceIconStyle}
-          />
-        )}
-      </div>
-    );
-  },
-);
+  // Use getStyles from props, or fall back to getStyles from styles file.
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    presence,
+    size: props.size,
+    isOutOfOffice,
+    presenceColors,
+  });
+
+  if (presence === PersonaPresenceEnum.none) {
+    return null;
+  }
+
+  return (
+    <div
+      role="presentation"
+      className={classNames.presence}
+      style={coinSizeWithPresenceStyle}
+      title={presenceTitle}
+      ref={mergedRootRef}
+    >
+      {renderIcon && (
+        <Icon
+          className={classNames.presenceIcon}
+          iconName={determineIcon(props.presence, props.isOutOfOffice)}
+          style={coinSizeWithPresenceIconStyle}
+        />
+      )}
+    </div>
+  );
+});
 PersonaPresenceBase.displayName = 'PersonaPresenceBase';
 
 function determineIcon(

--- a/packages/react-next/src/components/Popup/Popup.tsx
+++ b/packages/react-next/src/components/Popup/Popup.tsx
@@ -107,52 +107,54 @@ function useRestoreFocus(props: IPopupProps, root: React.RefObject<HTMLDivElemen
 /**
  * This adds accessibility to Dialog and Panel controls
  */
-export const Popup = React.forwardRef((props: IPopupProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-  // Default props
-  // eslint-disable-next-line deprecation/deprecation
-  props = { shouldRestoreFocus: true, ...props };
+export const Popup: React.FunctionComponent<IPopupProps> = React.forwardRef<HTMLDivElement, IPopupProps>(
+  (props, forwardedRef) => {
+    // Default props
+    // eslint-disable-next-line deprecation/deprecation
+    props = { shouldRestoreFocus: true, ...props };
 
-  const root = React.useRef<HTMLDivElement>();
-  const mergedRootRef = useMergedRefs(root, forwardedRef) as React.Ref<HTMLDivElement>;
+    const root = React.useRef<HTMLDivElement>();
+    const mergedRootRef = useMergedRefs(root, forwardedRef) as React.Ref<HTMLDivElement>;
 
-  useRestoreFocus(props, root);
+    useRestoreFocus(props, root);
 
-  const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style, children, onDismiss } = props;
-  const needsVerticalScrollBar = useScrollbarAsync(props, root);
+    const { role, className, ariaLabel, ariaLabelledBy, ariaDescribedBy, style, children, onDismiss } = props;
+    const needsVerticalScrollBar = useScrollbarAsync(props, root);
 
-  const onKeyDown = React.useCallback(
-    (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
-      // eslint-disable-next-line deprecation/deprecation
-      switch (ev.which) {
-        case KeyCodes.escape:
-          if (onDismiss) {
-            onDismiss(ev);
+    const onKeyDown = React.useCallback(
+      (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
+        // eslint-disable-next-line deprecation/deprecation
+        switch (ev.which) {
+          case KeyCodes.escape:
+            if (onDismiss) {
+              onDismiss(ev);
 
-            ev.preventDefault();
-            ev.stopPropagation();
-          }
+              ev.preventDefault();
+              ev.stopPropagation();
+            }
 
-          break;
-      }
-    },
-    [onDismiss],
-  );
+            break;
+        }
+      },
+      [onDismiss],
+    );
 
-  useOnEvent(getWindow(root.current), 'keydown', onKeyDown as (ev: Event) => void);
+    useOnEvent(getWindow(root.current), 'keydown', onKeyDown as (ev: Event) => void);
 
-  return (
-    <div
-      ref={mergedRootRef}
-      {...getNativeProps(props, divProperties)}
-      className={className}
-      role={role}
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
-      aria-describedby={ariaDescribedBy}
-      onKeyDown={onKeyDown}
-      style={{ overflowY: needsVerticalScrollBar ? 'scroll' : undefined, outline: 'none', ...style }}
-    >
-      {children}
-    </div>
-  );
-});
+    return (
+      <div
+        ref={mergedRootRef}
+        {...getNativeProps(props, divProperties)}
+        className={className}
+        role={role}
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        onKeyDown={onKeyDown}
+        style={{ overflowY: needsVerticalScrollBar ? 'scroll' : undefined, outline: 'none', ...style }}
+      >
+        {children}
+      </div>
+    );
+  },
+);

--- a/packages/react-next/src/components/Popup/Popup.types.ts
+++ b/packages/react-next/src/components/Popup/Popup.types.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 /**
  * {@docCategory Popup}
  */
-export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPopupProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Aria role for popup
    */

--- a/packages/react-next/src/components/Rating/Rating.base.tsx
+++ b/packages/react-next/src/components/Rating/Rating.base.tsx
@@ -78,113 +78,115 @@ const getStarId = (id: string, starNum: number) => {
   return `${id}-star-${starNum - 1}`;
 };
 
-export const RatingBase = React.forwardRef<HTMLDivElement, IRatingProps>((props, ref) => {
-  const id = useId('Rating');
-  const labelId = useId('RatingLabel');
-  const {
-    ariaLabelFormat,
-    disabled,
-    getAriaLabel,
-    styles,
-    // eslint-disable-next-line deprecation/deprecation
-    min: minFromProps = props.allowZeroStars ? 0 : 1,
-    max = 5,
-    readOnly,
-    size,
-    theme,
-    icon = 'FavoriteStarFill',
-    unselectedIcon = 'FavoriteStar',
-  } = props;
+export const RatingBase: React.FunctionComponent<IRatingProps> = React.forwardRef<HTMLDivElement, IRatingProps>(
+  (props, ref) => {
+    const id = useId('Rating');
+    const labelId = useId('RatingLabel');
+    const {
+      ariaLabelFormat,
+      disabled,
+      getAriaLabel,
+      styles,
+      // eslint-disable-next-line deprecation/deprecation
+      min: minFromProps = props.allowZeroStars ? 0 : 1,
+      max = 5,
+      readOnly,
+      size,
+      theme,
+      icon = 'FavoriteStarFill',
+      unselectedIcon = 'FavoriteStar',
+    } = props;
 
-  // Ensure min is >= 0 to avoid issues elsewhere
-  const min = Math.max(minFromProps, 0);
+    // Ensure min is >= 0 to avoid issues elsewhere
+    const min = Math.max(minFromProps, 0);
 
-  const [rating, setRating] = useControllableValue(props.rating, props.defaultRating, props.onChange);
-  /** Rating clamped within valid range. Will be `min` if `rating` is undefined. */
-  const displayRating = getClampedRating(rating, min, max);
+    const [rating, setRating] = useControllableValue(props.rating, props.defaultRating, props.onChange);
+    /** Rating clamped within valid range. Will be `min` if `rating` is undefined. */
+    const displayRating = getClampedRating(rating, min, max);
 
-  useDebugWarnings(props);
+    useDebugWarnings(props);
 
-  useComponentRef(props.componentRef, displayRating);
+    useComponentRef(props.componentRef, displayRating);
 
-  const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
 
-  const classNames = getClassNames(styles!, {
-    disabled,
-    readOnly,
-    theme: theme!,
-  });
+    const classNames = getClassNames(styles!, {
+      disabled,
+      readOnly,
+      theme: theme!,
+    });
 
-  const ariaLabel = getAriaLabel?.(displayRating, max);
+    const ariaLabel = getAriaLabel?.(displayRating, max);
 
-  const stars: JSX.Element[] = [];
+    const stars: JSX.Element[] = [];
 
-  for (let starNum = 1; starNum <= max; starNum++) {
-    const fillPercentage = getFillingPercentage(starNum, displayRating);
+    for (let starNum = 1; starNum <= max; starNum++) {
+      const fillPercentage = getFillingPercentage(starNum, displayRating);
 
-    const onSelectStar = (ev: React.SyntheticEvent<HTMLElement>): void => {
-      // Use the actual rating (not display value) here, to ensure that we update if the actual
-      // rating is undefined and the user clicks the first star.
-      if (rating === undefined || Math.ceil(rating) !== starNum) {
-        setRating(starNum, ev);
-      }
-    };
+      const onSelectStar = (ev: React.SyntheticEvent<HTMLElement>): void => {
+        // Use the actual rating (not display value) here, to ensure that we update if the actual
+        // rating is undefined and the user clicks the first star.
+        if (rating === undefined || Math.ceil(rating) !== starNum) {
+          setRating(starNum, ev);
+        }
+      };
 
-    stars.push(
-      <button
-        className={css(
-          classNames.ratingButton,
-          size === RatingSize.Large ? classNames.ratingStarIsLarge : classNames.ratingStarIsSmall,
-        )}
-        id={getStarId(id, starNum)}
-        key={starNum}
-        {...(starNum === Math.ceil(displayRating) && { 'data-is-current': true })}
-        onFocus={onSelectStar}
-        onClick={onSelectStar} // For Safari & Firefox on OSX
-        disabled={!!(disabled || readOnly)}
-        role="presentation"
-        type="button"
+      stars.push(
+        <button
+          className={css(
+            classNames.ratingButton,
+            size === RatingSize.Large ? classNames.ratingStarIsLarge : classNames.ratingStarIsSmall,
+          )}
+          id={getStarId(id, starNum)}
+          key={starNum}
+          {...(starNum === Math.ceil(displayRating) && { 'data-is-current': true })}
+          onFocus={onSelectStar}
+          onClick={onSelectStar} // For Safari & Firefox on OSX
+          disabled={!!(disabled || readOnly)}
+          role="presentation"
+          type="button"
+        >
+          <span id={`${labelId}-${starNum}`} className={classNames.labelText}>
+            {format(ariaLabelFormat || '', starNum, max)}
+          </span>
+          <RatingStar
+            fillPercentage={fillPercentage}
+            disabled={disabled}
+            classNames={classNames}
+            icon={fillPercentage > 0 ? icon : unselectedIcon}
+          />
+        </button>,
+      );
+    }
+
+    const rootSizeClass = size === RatingSize.Large ? classNames.rootIsLarge : classNames.rootIsSmall;
+
+    return (
+      <div
+        ref={ref}
+        className={css('ms-Rating-star', classNames.root, rootSizeClass)}
+        aria-label={!readOnly ? ariaLabel : ''}
+        id={id}
+        {...divProps}
       >
-        <span id={`${labelId}-${starNum}`} className={classNames.labelText}>
-          {format(ariaLabelFormat || '', starNum, max)}
-        </span>
-        <RatingStar
-          fillPercentage={fillPercentage}
-          disabled={disabled}
-          classNames={classNames}
-          icon={fillPercentage > 0 ? icon : unselectedIcon}
-        />
-      </button>,
+        <FocusZone
+          direction={FocusZoneDirection.horizontal}
+          className={css(classNames.ratingFocusZone, rootSizeClass)}
+          defaultActiveElement={'#' + getStarId(id, Math.ceil(displayRating))}
+          // When in read-only mode, we allow focus (per ARIA standards) and set up ARIA attributes to indicate element
+          // is read-only. https://www.w3.org/TR/wai-aria-1.1/#aria-readonly
+          {...(readOnly && {
+            allowFocusRoot: true,
+            disabled: true,
+            'aria-label': ariaLabel,
+            'aria-readonly': true,
+            'data-is-focusable': true,
+            tabIndex: 0,
+          })}
+        >
+          {stars}
+        </FocusZone>
+      </div>
     );
-  }
-
-  const rootSizeClass = size === RatingSize.Large ? classNames.rootIsLarge : classNames.rootIsSmall;
-
-  return (
-    <div
-      ref={ref}
-      className={css('ms-Rating-star', classNames.root, rootSizeClass)}
-      aria-label={!readOnly ? ariaLabel : ''}
-      id={id}
-      {...divProps}
-    >
-      <FocusZone
-        direction={FocusZoneDirection.horizontal}
-        className={css(classNames.ratingFocusZone, rootSizeClass)}
-        defaultActiveElement={'#' + getStarId(id, Math.ceil(displayRating))}
-        // When in read-only mode, we allow focus (per ARIA standards) and set up ARIA attributes to indicate element
-        // is read-only. https://www.w3.org/TR/wai-aria-1.1/#aria-readonly
-        {...(readOnly && {
-          allowFocusRoot: true,
-          disabled: true,
-          'aria-label': ariaLabel,
-          'aria-readonly': true,
-          'data-is-focusable': true,
-          tabIndex: 0,
-        })}
-      >
-        {stars}
-      </FocusZone>
-    </div>
-  );
-});
+  },
+);

--- a/packages/react-next/src/components/Rating/Rating.types.ts
+++ b/packages/react-next/src/components/Rating/Rating.types.ts
@@ -14,7 +14,7 @@ export interface IRating {
  * Rating component props.
  * {@docCategory Rating}
  */
-export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IRatingProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IRating interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/react-next/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -464,7 +464,10 @@ function useDebugWarnings(props: IResizeGroupProps) {
   }
 }
 
-export const ResizeGroupBase = React.forwardRef((props: IResizeGroupProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const ResizeGroupBase: React.FunctionComponent<IResizeGroupProps> = React.forwardRef<
+  HTMLDivElement,
+  IResizeGroupProps
+>((props, forwardedRef) => {
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   // The root div which is the container inside of which we are trying to fit content.
   const mergedRootRef = useMergedRefs(rootRef, forwardedRef);

--- a/packages/react-next/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/react-next/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -23,7 +23,7 @@ export interface IResizeGroup {
 /**
  * {@docCategory ResizeGroup}
  */
-export interface IResizeGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IResizeGroupProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IResizeGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/react-next/src/components/SearchBox/SearchBox.base.tsx
@@ -27,7 +27,10 @@ const useComponentRef = (
   );
 };
 
-export const SearchBoxBase = React.forwardRef((props: ISearchBoxProps, forwardedRef: React.Ref<HTMLDivElement>) => {
+export const SearchBoxBase: React.FunctionComponent<ISearchBoxProps> = React.forwardRef<
+  HTMLDivElement,
+  ISearchBoxProps
+>((props, forwardedRef) => {
   const [hasFocus, setHasFocus] = React.useState(false);
   const [value = '', setValue] = useControllableValue(props.value, props.defaultValue, props.onChange);
   const rootElementRef = React.useRef<HTMLDivElement>(null);

--- a/packages/react-next/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/react-next/src/components/SearchBox/SearchBox.types.ts
@@ -22,7 +22,9 @@ export interface ISearchBox {
 /**
  * {@docCategory SearchBox}
  */
-export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface ISearchBoxProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the ISearchBox interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-next/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/react-next/src/components/Shimmer/Shimmer.base.tsx
@@ -12,83 +12,85 @@ const getClassNames = classNamesFunction<IShimmerStyleProps, IShimmerStyles>();
 /**
  * {@docCategory Shimmer}
  */
-export const ShimmerBase = React.forwardRef<HTMLDivElement, IShimmerProps>((props, ref) => {
-  const {
-    styles,
-    shimmerElements,
-    children,
-    width,
-    className,
-    customElementsGroup,
-    theme,
-    ariaLabel,
-    shimmerColors,
-    isDataLoaded = false,
-  } = props;
+export const ShimmerBase: React.FunctionComponent<IShimmerProps> = React.forwardRef<HTMLDivElement, IShimmerProps>(
+  (props, ref) => {
+    const {
+      styles,
+      shimmerElements,
+      children,
+      width,
+      className,
+      customElementsGroup,
+      theme,
+      ariaLabel,
+      shimmerColors,
+      isDataLoaded = false,
+    } = props;
 
-  const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
+    const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(props, divProperties);
 
-  const classNames: { [key in keyof IShimmerStyles]: string } = getClassNames(styles!, {
-    theme: theme!,
-    isDataLoaded,
-    className,
-    transitionAnimationInterval: TRANSITION_ANIMATION_INTERVAL,
-    shimmerColor: shimmerColors && shimmerColors.shimmer,
-    shimmerWaveColor: shimmerColors && shimmerColors.shimmerWave,
-  });
+    const classNames: { [key in keyof IShimmerStyles]: string } = getClassNames(styles!, {
+      theme: theme!,
+      isDataLoaded,
+      className,
+      transitionAnimationInterval: TRANSITION_ANIMATION_INTERVAL,
+      shimmerColor: shimmerColors && shimmerColors.shimmer,
+      shimmerWaveColor: shimmerColors && shimmerColors.shimmerWave,
+    });
 
-  const internalState = useConst({
-    lastTimeoutId: 0,
-  });
+    const internalState = useConst({
+      lastTimeoutId: 0,
+    });
 
-  const { setTimeout, clearTimeout } = useSetTimeout();
+    const { setTimeout, clearTimeout } = useSetTimeout();
 
-  /**
-   * Flag for knowing when to remove the shimmerWrapper from the DOM.
-   */
-  const [contentLoaded, setContentLoaded] = React.useState(isDataLoaded);
+    /**
+     * Flag for knowing when to remove the shimmerWrapper from the DOM.
+     */
+    const [contentLoaded, setContentLoaded] = React.useState(isDataLoaded);
 
-  const divStyleProp = { width: width ? width : '100%' };
+    const divStyleProp = { width: width ? width : '100%' };
 
-  React.useEffect(() => {
-    if (isDataLoaded !== contentLoaded) {
-      if (isDataLoaded) {
-        internalState.lastTimeoutId = setTimeout(() => {
-          setContentLoaded(true);
-        }, TRANSITION_ANIMATION_INTERVAL);
+    React.useEffect(() => {
+      if (isDataLoaded !== contentLoaded) {
+        if (isDataLoaded) {
+          internalState.lastTimeoutId = setTimeout(() => {
+            setContentLoaded(true);
+          }, TRANSITION_ANIMATION_INTERVAL);
 
-        return () => clearTimeout(internalState.lastTimeoutId);
-      } else {
-        setContentLoaded(false);
+          return () => clearTimeout(internalState.lastTimeoutId);
+        } else {
+          setContentLoaded(false);
+        }
       }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Should only run when isDataLoaded changes.
-  }, [isDataLoaded]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- Should only run when isDataLoaded changes.
+    }, [isDataLoaded]);
 
-  return (
-    <div {...divProps} className={classNames.root} ref={ref}>
-      {!contentLoaded && (
-        <div style={divStyleProp} className={classNames.shimmerWrapper}>
-          <div className={classNames.shimmerGradient} />
-          {customElementsGroup ? (
-            customElementsGroup
-          ) : (
-            <ShimmerElementsGroup
-              shimmerElements={shimmerElements}
-              backgroundColor={shimmerColors && shimmerColors.background}
-            />
-          )}
-        </div>
-      )}
-      {children && <div className={classNames.dataWrapper}>{children}</div>}
-      {ariaLabel && !isDataLoaded && (
-        <div role="status" aria-live="polite">
-          <DelayedRender>
-            <div className={classNames.screenReaderText}>{ariaLabel}</div>
-          </DelayedRender>
-        </div>
-      )}
-    </div>
-  );
-});
+    return (
+      <div {...divProps} className={classNames.root} ref={ref}>
+        {!contentLoaded && (
+          <div style={divStyleProp} className={classNames.shimmerWrapper}>
+            <div className={classNames.shimmerGradient} />
+            {customElementsGroup ? (
+              customElementsGroup
+            ) : (
+              <ShimmerElementsGroup
+                shimmerElements={shimmerElements}
+                backgroundColor={shimmerColors && shimmerColors.background}
+              />
+            )}
+          </div>
+        )}
+        {children && <div className={classNames.dataWrapper}>{children}</div>}
+        {ariaLabel && !isDataLoaded && (
+          <div role="status" aria-live="polite">
+            <DelayedRender>
+              <div className={classNames.screenReaderText}>{ariaLabel}</div>
+            </DelayedRender>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 ShimmerBase.displayName = COMPONENT_NAME;

--- a/packages/react-next/src/components/Shimmer/Shimmer.types.ts
+++ b/packages/react-next/src/components/Shimmer/Shimmer.types.ts
@@ -6,7 +6,7 @@ import { IStyleFunctionOrObject } from '../../Utilities';
  * Shimmer component props.
  * {@docCategory Shimmer}
  */
-export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement> {
+export interface IShimmerProps extends React.AllHTMLAttributes<HTMLElement>, React.RefAttributes<HTMLElement> {
   /**
    * Sets the width value of the shimmer wave wrapper.
    * @defaultvalue 100%

--- a/packages/react-next/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/react-next/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -34,7 +34,10 @@ function useDebugWarnings(props: ISwatchColorPickerProps) {
   }
 }
 
-export const SwatchColorPickerBase = React.forwardRef<HTMLElement, ISwatchColorPickerProps>((props, ref) => {
+export const SwatchColorPickerBase: React.FunctionComponent<ISwatchColorPickerProps> = React.forwardRef<
+  HTMLElement,
+  ISwatchColorPickerProps
+>((props, ref) => {
   const defaultId = useId('swatchColorPicker');
   const id = props.id || defaultId;
 

--- a/packages/react-next/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/react-next/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -10,7 +10,7 @@ import {
 /**
  * {@docCategory SwatchColorPicker}
  */
-export interface ISwatchColorPickerProps {
+export interface ISwatchColorPickerProps extends React.RefAttributes<HTMLElement> {
   /**
    * Number of columns for the swatch color picker
    */

--- a/packages/react-next/src/components/TeachingBubble/TeachingBubble.base.tsx
+++ b/packages/react-next/src/components/TeachingBubble/TeachingBubble.base.tsx
@@ -35,53 +35,54 @@ const useComponentRef = (
   );
 };
 
-export const TeachingBubbleBase = React.forwardRef(
-  (props: ITeachingBubbleProps, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const rootElementRef = React.useRef<HTMLDivElement>(null);
-    const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
-    const {
-      calloutProps: setCalloutProps,
-      // eslint-disable-next-line deprecation/deprecation
-      targetElement,
-      onDismiss,
-      // eslint-disable-next-line deprecation/deprecation
-      hasCloseButton = props.hasCloseIcon,
-      isWide,
-      styles,
-      theme,
-      target,
-    } = props;
+export const TeachingBubbleBase: React.FunctionComponent<ITeachingBubbleProps> = React.forwardRef<
+  HTMLDivElement,
+  ITeachingBubbleProps
+>((props, forwardedRef) => {
+  const rootElementRef = React.useRef<HTMLDivElement>(null);
+  const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
+  const {
+    calloutProps: setCalloutProps,
+    // eslint-disable-next-line deprecation/deprecation
+    targetElement,
+    onDismiss,
+    // eslint-disable-next-line deprecation/deprecation
+    hasCloseButton = props.hasCloseIcon,
+    isWide,
+    styles,
+    theme,
+    target,
+  } = props;
 
-    const calloutProps = { ...defaultCalloutProps, ...setCalloutProps };
+  const calloutProps = { ...defaultCalloutProps, ...setCalloutProps };
 
-    const stylesProps: ITeachingBubbleStyleProps = {
-      theme: theme!,
-      isWide,
-      calloutProps: { ...calloutProps, theme: calloutProps.theme! },
-      hasCloseButton,
-    };
+  const stylesProps: ITeachingBubbleStyleProps = {
+    theme: theme!,
+    isWide,
+    calloutProps: { ...calloutProps, theme: calloutProps.theme! },
+    hasCloseButton,
+  };
 
-    const classNames = getClassNames(styles, stylesProps);
-    const calloutStyles = classNames.subComponentStyles
-      ? (classNames.subComponentStyles as ITeachingBubbleSubComponentStyles).callout
-      : undefined;
+  const classNames = getClassNames(styles, stylesProps);
+  const calloutStyles = classNames.subComponentStyles
+    ? (classNames.subComponentStyles as ITeachingBubbleSubComponentStyles).callout
+    : undefined;
 
-    useComponentRef(props.componentRef, rootElementRef);
+  useComponentRef(props.componentRef, rootElementRef);
 
-    return (
-      <Callout
-        target={target || targetElement}
-        onDismiss={onDismiss}
-        {...calloutProps}
-        className={classNames.root}
-        styles={calloutStyles}
-        hideOverflow
-      >
-        <div ref={mergedRootRef}>
-          <TeachingBubbleContent {...props} />
-        </div>
-      </Callout>
-    );
-  },
-);
+  return (
+    <Callout
+      target={target || targetElement}
+      onDismiss={onDismiss}
+      {...calloutProps}
+      className={classNames.root}
+      styles={calloutStyles}
+      hideOverflow
+    >
+      <div ref={mergedRootRef}>
+        <TeachingBubbleContent {...props} />
+      </div>
+    </Callout>
+  );
+});
 TeachingBubbleBase.displayName = COMPONENT_NAME;

--- a/packages/react-next/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/react-next/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -28,146 +28,147 @@ const useComponentRef = (
   );
 };
 
-export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleProps> = React.forwardRef(
-  (props, forwardedRef: React.Ref<HTMLDivElement>) => {
-    const rootElementRef = React.useRef<HTMLDivElement>(null);
-    const documentRef = useDocument();
-    const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
+export const TeachingBubbleContentBase: React.FunctionComponent<ITeachingBubbleProps> = React.forwardRef<
+  HTMLDivElement,
+  ITeachingBubbleProps
+>((props, forwardedRef) => {
+  const rootElementRef = React.useRef<HTMLDivElement>(null);
+  const documentRef = useDocument();
+  const mergedRootRef = useMergedRefs(rootElementRef, forwardedRef);
 
-    const {
-      illustrationImage,
-      primaryButtonProps,
-      secondaryButtonProps,
-      headline,
-      hasCondensedHeadline,
-      // eslint-disable-next-line deprecation/deprecation
-      hasCloseButton = props.hasCloseIcon,
-      onDismiss,
-      closeButtonAriaLabel,
-      hasSmallHeadline,
-      isWide,
-      styles,
-      theme,
-      ariaDescribedBy,
-      ariaLabelledBy,
-      footerContent: customFooterContent,
-      focusTrapZoneProps,
-    } = props;
+  const {
+    illustrationImage,
+    primaryButtonProps,
+    secondaryButtonProps,
+    headline,
+    hasCondensedHeadline,
+    // eslint-disable-next-line deprecation/deprecation
+    hasCloseButton = props.hasCloseIcon,
+    onDismiss,
+    closeButtonAriaLabel,
+    hasSmallHeadline,
+    isWide,
+    styles,
+    theme,
+    ariaDescribedBy,
+    ariaLabelledBy,
+    footerContent: customFooterContent,
+    focusTrapZoneProps,
+  } = props;
 
-    const classNames = getClassNames(styles, {
-      theme: theme!,
-      hasCondensedHeadline,
-      hasSmallHeadline,
-      hasCloseButton,
-      hasHeadline: !!headline,
-      isWide,
-      primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
-      secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined,
-    });
+  const classNames = getClassNames(styles, {
+    theme: theme!,
+    hasCondensedHeadline,
+    hasSmallHeadline,
+    hasCloseButton,
+    hasHeadline: !!headline,
+    isWide,
+    primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
+    secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined,
+  });
 
-    const onKeyDown = React.useCallback(
-      (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
-        if (onDismiss) {
-          // eslint-disable-next-line deprecation/deprecation
-          if (ev.which === KeyCodes.escape) {
-            onDismiss(ev);
-          }
+  const onKeyDown = React.useCallback(
+    (ev: React.KeyboardEvent<HTMLElement> | KeyboardEvent): void => {
+      if (onDismiss) {
+        // eslint-disable-next-line deprecation/deprecation
+        if (ev.which === KeyCodes.escape) {
+          onDismiss(ev);
         }
-      },
-      [onDismiss],
-    );
+      }
+    },
+    [onDismiss],
+  );
 
-    useOnEvent(documentRef, 'keydown', onKeyDown as (ev: Event) => void);
+  useOnEvent(documentRef, 'keydown', onKeyDown as (ev: Event) => void);
 
-    let imageContent: JSX.Element | undefined;
-    let headerContent: JSX.Element | undefined;
-    let bodyContent: JSX.Element | undefined;
-    let footerContent: JSX.Element | undefined;
-    let closeButton: JSX.Element | undefined;
+  let imageContent: JSX.Element | undefined;
+  let headerContent: JSX.Element | undefined;
+  let bodyContent: JSX.Element | undefined;
+  let footerContent: JSX.Element | undefined;
+  let closeButton: JSX.Element | undefined;
 
-    if (illustrationImage && illustrationImage.src) {
-      imageContent = (
-        <div className={classNames.imageContent}>
-          <Image
-            {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              ...(illustrationImage as any)
-            }
-          />
-        </div>
-      );
-    }
-
-    if (headline) {
-      const HeaderWrapperAs = typeof headline === 'string' ? 'p' : 'div';
-
-      headerContent = (
-        <div className={classNames.header}>
-          <HeaderWrapperAs role="heading" className={classNames.headline} id={ariaLabelledBy}>
-            {headline}
-          </HeaderWrapperAs>
-        </div>
-      );
-    }
-
-    if (props.children) {
-      const BodyContentWrapperAs = typeof props.children === 'string' ? 'p' : 'div';
-
-      bodyContent = (
-        <div className={classNames.body}>
-          <BodyContentWrapperAs className={classNames.subText} id={ariaDescribedBy}>
-            {props.children}
-          </BodyContentWrapperAs>
-        </div>
-      );
-    }
-
-    if (primaryButtonProps || secondaryButtonProps || customFooterContent) {
-      footerContent = (
-        <Stack className={classNames.footer} horizontal horizontalAlign={customFooterContent ? 'space-between' : 'end'}>
-          <Stack.Item align="center">{<span>{customFooterContent}</span>}</Stack.Item>
-          <Stack.Item>
-            {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
-            {primaryButtonProps && <PrimaryButton {...primaryButtonProps} className={classNames.primaryButton} />}
-          </Stack.Item>
-        </Stack>
-      );
-    }
-
-    if (hasCloseButton) {
-      closeButton = (
-        <IconButton
-          className={classNames.closeButton}
-          iconProps={{ iconName: 'Cancel' }}
-          title={closeButtonAriaLabel}
-          ariaLabel={closeButtonAriaLabel}
-          onClick={onDismiss}
+  if (illustrationImage && illustrationImage.src) {
+    imageContent = (
+      <div className={classNames.imageContent}>
+        <Image
+          {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ...(illustrationImage as any)
+          }
         />
-      );
-    }
-
-    useComponentRef(props.componentRef, rootElementRef);
-
-    return (
-      <div
-        className={classNames.content}
-        ref={mergedRootRef}
-        role={'dialog'}
-        tabIndex={-1}
-        aria-labelledby={ariaLabelledBy}
-        aria-describedby={ariaDescribedBy}
-        data-is-focusable
-      >
-        {imageContent}
-        <FocusTrapZone isClickableOutsideFocusTrap {...focusTrapZoneProps}>
-          <div className={classNames.bodyContent}>
-            {headerContent}
-            {bodyContent}
-            {footerContent}
-            {closeButton}
-          </div>
-        </FocusTrapZone>
       </div>
     );
-  },
-);
+  }
+
+  if (headline) {
+    const HeaderWrapperAs = typeof headline === 'string' ? 'p' : 'div';
+
+    headerContent = (
+      <div className={classNames.header}>
+        <HeaderWrapperAs role="heading" className={classNames.headline} id={ariaLabelledBy}>
+          {headline}
+        </HeaderWrapperAs>
+      </div>
+    );
+  }
+
+  if (props.children) {
+    const BodyContentWrapperAs = typeof props.children === 'string' ? 'p' : 'div';
+
+    bodyContent = (
+      <div className={classNames.body}>
+        <BodyContentWrapperAs className={classNames.subText} id={ariaDescribedBy}>
+          {props.children}
+        </BodyContentWrapperAs>
+      </div>
+    );
+  }
+
+  if (primaryButtonProps || secondaryButtonProps || customFooterContent) {
+    footerContent = (
+      <Stack className={classNames.footer} horizontal horizontalAlign={customFooterContent ? 'space-between' : 'end'}>
+        <Stack.Item align="center">{<span>{customFooterContent}</span>}</Stack.Item>
+        <Stack.Item>
+          {secondaryButtonProps && <DefaultButton {...secondaryButtonProps} className={classNames.secondaryButton} />}
+          {primaryButtonProps && <PrimaryButton {...primaryButtonProps} className={classNames.primaryButton} />}
+        </Stack.Item>
+      </Stack>
+    );
+  }
+
+  if (hasCloseButton) {
+    closeButton = (
+      <IconButton
+        className={classNames.closeButton}
+        iconProps={{ iconName: 'Cancel' }}
+        title={closeButtonAriaLabel}
+        ariaLabel={closeButtonAriaLabel}
+        onClick={onDismiss}
+      />
+    );
+  }
+
+  useComponentRef(props.componentRef, rootElementRef);
+
+  return (
+    <div
+      className={classNames.content}
+      ref={mergedRootRef}
+      role={'dialog'}
+      tabIndex={-1}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      data-is-focusable
+    >
+      {imageContent}
+      <FocusTrapZone isClickableOutsideFocusTrap {...focusTrapZoneProps}>
+        <div className={classNames.bodyContent}>
+          {headerContent}
+          {bodyContent}
+          {footerContent}
+          {closeButton}
+        </div>
+      </FocusTrapZone>
+    </div>
+  );
+});

--- a/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.base.tsx
+++ b/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.base.tsx
@@ -6,7 +6,10 @@ import { useId } from '@uifabric/react-hooks';
 
 const getClassNames = classNamesFunction<IButtonGridStyleProps, IButtonGridStyles>();
 
-export const ButtonGridBase = React.forwardRef<HTMLElement, IButtonGridProps>((props, ref) => {
+export const ButtonGridBase: React.FunctionComponent<IButtonGridProps> = React.forwardRef<
+  HTMLElement,
+  IButtonGridProps
+>((props, forwardedRef) => {
   const id = useId(undefined, props.id);
 
   const {
@@ -65,7 +68,7 @@ export const ButtonGridBase = React.forwardRef<HTMLElement, IButtonGridProps>((p
     content
   ) : (
     <FocusZone
-      elementRef={ref}
+      elementRef={forwardedRef}
       isCircularNavigation={props.shouldFocusCircularNavigate}
       className={classNames.focusedContainer}
       onBlur={props.onBlur}

--- a/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.tsx
+++ b/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.tsx
@@ -1,9 +1,12 @@
+import * as React from 'react';
 import { styled } from '../../Utilities';
 import { ButtonGridBase } from './ButtonGrid.base';
 import { IButtonGridProps, IButtonGridStyleProps, IButtonGridStyles } from './ButtonGrid.types';
 import { getStyles } from './ButtonGrid.styles';
 
-export const ButtonGrid = styled<IButtonGridProps, IButtonGridStyleProps, IButtonGridStyles, HTMLElement>(
-  ButtonGridBase,
-  getStyles,
-);
+export const ButtonGrid: React.FunctionComponent<IButtonGridProps> = styled<
+  IButtonGridProps,
+  IButtonGridStyleProps,
+  IButtonGridStyles,
+  HTMLElement
+>(ButtonGridBase, getStyles);

--- a/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.types.ts
+++ b/packages/react-next/src/utilities/ButtonGrid/ButtonGrid.types.ts
@@ -4,7 +4,9 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IButtonGrid {}
 
-export interface IButtonGridProps extends React.TableHTMLAttributes<HTMLTableElement> {
+export interface IButtonGridProps
+  extends React.TableHTMLAttributes<HTMLTableElement>,
+    React.RefAttributes<HTMLElement> {
   /**
    * Gets the component ref.
    */

--- a/packages/react-slider/etc/react-slider.api.md
+++ b/packages/react-slider/etc/react-slider.api.md
@@ -19,7 +19,7 @@ export interface ISlider {
 }
 
 // @public (undocumented)
-export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
+export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'>, React.RefAttributes<HTMLDivElement> {
     'aria-label'?: string;
     // @deprecated
     ariaLabel?: string;
@@ -35,7 +35,6 @@ export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
     onChange?: (value: number) => void;
     onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
     originFromZero?: boolean;
-    ref?: React.Ref<HTMLDivElement>;
     showValue?: boolean;
     snapToStep?: boolean;
     step?: number;

--- a/packages/react-slider/etc/react-slider.api.md
+++ b/packages/react-slider/etc/react-slider.api.md
@@ -35,6 +35,7 @@ export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
     onChange?: (value: number) => void;
     onChanged?: (event: MouseEvent | TouchEvent | KeyboardEvent, value: number) => void;
     originFromZero?: boolean;
+    ref?: React.Ref<HTMLDivElement>;
     showValue?: boolean;
     snapToStep?: boolean;
     step?: number;
@@ -74,7 +75,7 @@ export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
 export const Slider: React.FunctionComponent<ISliderProps>;
 
 // @public (undocumented)
-export const SliderBase: React.ForwardRefExoticComponent<ISliderProps & React.RefAttributes<HTMLDivElement>>;
+export const SliderBase: React.FunctionComponent<ISliderProps>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-slider/src/components/Slider/Slider.base.tsx
+++ b/packages/react-slider/src/components/Slider/Slider.base.tsx
@@ -8,37 +8,37 @@ import { useWarnings } from '@uifabric/react-hooks';
 const COMPONENT_NAME = 'SliderBase';
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
 
-export const SliderBase = React.forwardRef((props: ISliderProps, ref: React.Ref<HTMLDivElement>) => {
-  // Ensure that value is always a number and is clamped by min/max.
+export const SliderBase: React.FunctionComponent<ISliderProps> = React.forwardRef<HTMLDivElement, ISliderProps>(
+  (props, ref) => {
+    const slotProps = useSlider(props, ref);
 
-  const slotProps = useSlider(props, ref);
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
+      useWarnings({
+        name: COMPONENT_NAME,
+        props,
+        mutuallyExclusive: { value: 'defaultValue' },
+      });
+    }
 
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
-    useWarnings({
-      name: COMPONENT_NAME,
-      props,
-      mutuallyExclusive: { value: 'defaultValue' },
-    });
-  }
-
-  return (
-    <div {...slotProps.root}>
-      {slotProps && <Label {...slotProps.label} />}
-      <div {...slotProps.container}>
-        <div {...slotProps.sliderBox}>
-          <div {...slotProps.sliderLine}>
-            <span {...slotProps.thumb} />
-            {slotProps.zeroTick && <span {...slotProps.zeroTick} />}
-            <span {...slotProps.bottomInactiveTrack} />
-            <span {...slotProps.activeTrack} />
-            <span {...slotProps.topInactiveTrack} />
+    return (
+      <div {...slotProps.root}>
+        {slotProps && <Label {...slotProps.label} />}
+        <div {...slotProps.container}>
+          <div {...slotProps.sliderBox}>
+            <div {...slotProps.sliderLine}>
+              <span {...slotProps.thumb} />
+              {slotProps.zeroTick && <span {...slotProps.zeroTick} />}
+              <span {...slotProps.bottomInactiveTrack} />
+              <span {...slotProps.activeTrack} />
+              <span {...slotProps.topInactiveTrack} />
+            </div>
           </div>
+          {slotProps.valueLabel && <Label {...slotProps.valueLabel} />}
         </div>
-        {slotProps.valueLabel && <Label {...slotProps.valueLabel} />}
+        <FocusRects />
       </div>
-      <FocusRects />
-    </div>
-  ) as React.ReactElement<{}>;
-});
+    ) as React.ReactElement<{}>;
+  },
+);
 SliderBase.displayName = COMPONENT_NAME;

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -16,12 +16,9 @@ export interface ISlider {
 /**
  * {@docCategory Slider}
  */
-export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
-  /**
-   * Ref that is forwarded to the root element.
-   */
-  ref?: React.Ref<HTMLDivElement>;
-
+export interface ISliderProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'>,
+    React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the ISlider interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-slider/src/components/Slider/Slider.types.ts
+++ b/packages/react-slider/src/components/Slider/Slider.types.ts
@@ -18,6 +18,11 @@ export interface ISlider {
  */
 export interface ISliderProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue' | 'onChange'> {
   /**
+   * Ref that is forwarded to the root element.
+   */
+  ref?: React.Ref<HTMLDivElement>;
+
+  /**
    * Optional callback to access the ISlider interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */

--- a/packages/react-tabs/etc/react-tabs.api.md
+++ b/packages/react-tabs/etc/react-tabs.api.md
@@ -37,7 +37,7 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 // @public (undocumented)
-export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: React.RefObject<IPivot>;
     defaultSelectedKey?: string;

--- a/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
@@ -64,8 +64,8 @@ const isPivotItem = (item: React.ReactNode): item is PivotItem => {
   return ((item as React.ReactElement)?.type as React.ComponentType)?.name === PivotItem.name;
 };
 
-export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef(
-  (props: IPivotProps, ref: React.Ref<HTMLDivElement>) => {
+export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<HTMLDivElement, IPivotProps>(
+  (props, ref) => {
     const { componentRef, theme, linkSize, linkFormat, overflowBehavior } = props;
     const pivotId: string = useId('Pivot');
     let linkCollection = getLinkItems(props, pivotId);

--- a/packages/react-tabs/src/components/Pivot/Pivot.types.ts
+++ b/packages/react-tabs/src/components/Pivot/Pivot.types.ts
@@ -20,6 +20,11 @@ export interface IPivot {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
+   * Ref that is forwarded to the root element.
+   */
+  ref?: React.Ref<HTMLDivElement>;
+
+  /**
    * Optional callback to access the IPivot interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
    */

--- a/packages/react-tabs/src/components/Pivot/Pivot.types.ts
+++ b/packages/react-tabs/src/components/Pivot/Pivot.types.ts
@@ -18,12 +18,7 @@ export interface IPivot {
  * {@docCategory Pivot}
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Ref that is forwarded to the root element.
-   */
-  ref?: React.Ref<HTMLDivElement>;
-
+export interface IPivotProps extends React.HTMLAttributes<HTMLDivElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * Optional callback to access the IPivot interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-toggle/etc/react-toggle.api.md
+++ b/packages/react-toggle/etc/react-toggle.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { IComponentAs } from '@uifabric/utilities';
 import { IKeytipProps } from 'office-ui-fabric-react/lib/Keytip';
 import { IRefObject } from '@uifabric/utilities';
 import { IStyle } from '@uifabric/styling';
@@ -22,8 +23,9 @@ export interface IToggleOptions {
 }
 
 // @public
-export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
+export interface IToggleProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLElement> {
     ariaLabel?: string;
+    as?: IComponentAs<React.HTMLAttributes<HTMLElement>>;
     checked?: boolean;
     componentRef?: IRefObject<IToggle>;
     defaultChecked?: boolean;
@@ -76,10 +78,10 @@ export interface IToggleStyles {
 }
 
 // @public (undocumented)
-export const Toggle: React.FunctionComponent<IToggleProps & React.RefAttributes<HTMLDivElement>>;
+export const Toggle: React.FunctionComponent<IToggleProps>;
 
 // @public (undocumented)
-export const ToggleBase: React.ForwardRefExoticComponent<IToggleProps & React.RefAttributes<HTMLDivElement>>;
+export const ToggleBase: React.FunctionComponent<IToggleProps>;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
@@ -8,142 +8,145 @@ const getClassNames = classNamesFunction<IToggleStyleProps, IToggleStyles>();
 
 const COMPONENT_NAME = 'ToggleBase';
 
-export const ToggleBase = React.forwardRef((props: IToggleProps, ref: React.Ref<HTMLDivElement>) => {
-  const {
-    ariaLabel,
-    checked: controlledChecked,
-    className,
-    defaultChecked = false,
-    disabled,
-    inlineLabel,
-    label,
-    // eslint-disable-next-line deprecation/deprecation
-    offAriaLabel,
-    offText,
-    // eslint-disable-next-line deprecation/deprecation
-    onAriaLabel,
-    onChange,
-    onClick: onToggleClick,
-    onText,
-    role,
-    styles,
-    theme,
-  } = props;
+export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRef<HTMLElement, IToggleProps>(
+  (props, forwardedRef) => {
+    const {
+      as: RootType = 'div',
+      ariaLabel,
+      checked: controlledChecked,
+      className,
+      defaultChecked = false,
+      disabled,
+      inlineLabel,
+      label,
+      // eslint-disable-next-line deprecation/deprecation
+      offAriaLabel,
+      offText,
+      // eslint-disable-next-line deprecation/deprecation
+      onAriaLabel,
+      onChange,
+      onClick: onToggleClick,
+      onText,
+      role,
+      styles,
+      theme,
+    } = props;
 
-  const [checked, setChecked] = useControllableValue(controlledChecked, defaultChecked, onChange);
+    const [checked, setChecked] = useControllableValue(controlledChecked, defaultChecked, onChange);
 
-  const classNames = getClassNames(styles!, {
-    theme: theme!,
-    className,
-    disabled,
-    checked,
-    inlineLabel,
-    onOffMissing: !onText && !offText,
-  });
-  const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
-  const id = useId(COMPONENT_NAME, props.id);
-  const labelId = `${id}-label`;
-  const stateTextId = `${id}-stateText`;
-  const stateText = checked ? onText : offText;
-  const toggleNativeProps = getNativeProps<React.HTMLAttributes<HTMLButtonElement>>(props, inputProperties, [
-    'defaultChecked',
-  ]);
-
-  // The following properties take priority for what Narrator should read:
-  // 1. ariaLabel
-  // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
-  // 3. label AND stateText, if existent
-
-  let labelledById: string | undefined = undefined;
-  if (!ariaLabel && !badAriaLabel) {
-    if (label) {
-      labelledById = labelId;
-    }
-    if (stateText) {
-      labelledById = labelledById ? `${labelledById} ${stateTextId}` : stateTextId;
-    }
-  }
-
-  const toggleButton = React.useRef<HTMLButtonElement>(null);
-  useFocusRects(toggleButton);
-  useComponentRef(props, checked, toggleButton);
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
-    useWarnings({
-      name: COMPONENT_NAME,
-      props,
-      deprecations: {
-        offAriaLabel: undefined,
-        onAriaLabel: 'ariaLabel',
-        onChanged: 'onChange',
-      },
-      mutuallyExclusive: { checked: 'defaultChecked' },
+    const classNames = getClassNames(styles!, {
+      theme: theme!,
+      className,
+      disabled,
+      checked,
+      inlineLabel,
+      onOffMissing: !onText && !offText,
     });
-  }
+    const badAriaLabel = checked ? onAriaLabel : offAriaLabel;
+    const id = useId(COMPONENT_NAME, props.id);
+    const labelId = `${id}-label`;
+    const stateTextId = `${id}-stateText`;
+    const stateText = checked ? onText : offText;
+    const toggleNativeProps = getNativeProps<React.HTMLAttributes<HTMLButtonElement>>(props, inputProperties, [
+      'defaultChecked',
+    ]);
 
-  const onClick = (ev: React.MouseEvent<HTMLElement>) => {
-    if (!disabled) {
-      setChecked(!checked);
-      if (onToggleClick) {
-        onToggleClick(ev);
+    // The following properties take priority for what Narrator should read:
+    // 1. ariaLabel
+    // 2. onAriaLabel (if checked) or offAriaLabel (if not checked)
+    // 3. label AND stateText, if existent
+
+    let labelledById: string | undefined = undefined;
+    if (!ariaLabel && !badAriaLabel) {
+      if (label) {
+        labelledById = labelId;
+      }
+      if (stateText) {
+        labelledById = labelledById ? `${labelledById} ${stateTextId}` : stateTextId;
       }
     }
-  };
 
-  const slotProps = {
-    root: {
-      className: classNames.root,
-      hidden: toggleNativeProps.hidden,
-    },
-    label: {
-      children: label,
-      className: classNames.label,
-      htmlFor: id,
-      id: labelId,
-    },
-    container: {
-      className: classNames.container,
-    },
-    pill: {
-      ...toggleNativeProps,
-      'aria-disabled': disabled,
-      'aria-checked': checked,
-      'aria-label': ariaLabel ? ariaLabel : badAriaLabel,
-      'aria-labelledby': labelledById,
-      className: classNames.pill,
-      'data-is-focusable': true,
-      'data-ktp-target': true,
-      disabled: disabled,
-      id: id,
-      onClick: onClick,
-      ref: toggleButton,
-      role: role ? role : 'switch',
-      type: 'button' as React.ButtonHTMLAttributes<HTMLButtonElement>['type'],
-    },
-    thumb: {
-      className: classNames.thumb,
-    },
-    stateText: {
-      children: stateText,
-      className: classNames.text,
-      htmlFor: id,
-      id: stateTextId,
-    },
-  };
+    const toggleButton = React.useRef<HTMLButtonElement>(null);
+    useFocusRects(toggleButton);
+    useComponentRef(props, checked, toggleButton);
 
-  return (
-    <div ref={ref} {...slotProps.root}>
-      {label && <Label {...slotProps.label} />}
-      <div {...slotProps.container}>
-        <button {...slotProps.pill}>
-          <span {...slotProps.thumb} />
-        </button>
-        {((checked && onText) || offText) && <Label {...slotProps.stateText} />}
-      </div>
-    </div>
-  );
-});
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line react-hooks/rules-of-hooks -- build-time conditional
+      useWarnings({
+        name: COMPONENT_NAME,
+        props,
+        deprecations: {
+          offAriaLabel: undefined,
+          onAriaLabel: 'ariaLabel',
+          onChanged: 'onChange',
+        },
+        mutuallyExclusive: { checked: 'defaultChecked' },
+      });
+    }
+
+    const onClick = (ev: React.MouseEvent<HTMLElement>) => {
+      if (!disabled) {
+        setChecked(!checked);
+        if (onToggleClick) {
+          onToggleClick(ev);
+        }
+      }
+    };
+
+    const slotProps = {
+      root: {
+        className: classNames.root,
+        hidden: toggleNativeProps.hidden,
+      },
+      label: {
+        children: label,
+        className: classNames.label,
+        htmlFor: id,
+        id: labelId,
+      },
+      container: {
+        className: classNames.container,
+      },
+      pill: {
+        ...toggleNativeProps,
+        'aria-disabled': disabled,
+        'aria-checked': checked,
+        'aria-label': ariaLabel ? ariaLabel : badAriaLabel,
+        'aria-labelledby': labelledById,
+        className: classNames.pill,
+        'data-is-focusable': true,
+        'data-ktp-target': true,
+        disabled: disabled,
+        id: id,
+        onClick: onClick,
+        ref: toggleButton,
+        role: role ? role : 'switch',
+        type: 'button' as React.ButtonHTMLAttributes<HTMLButtonElement>['type'],
+      },
+      thumb: {
+        className: classNames.thumb,
+      },
+      stateText: {
+        children: stateText,
+        className: classNames.text,
+        htmlFor: id,
+        id: stateTextId,
+      },
+    };
+
+    return (
+      <RootType ref={forwardedRef as React.Ref<HTMLDivElement>} {...slotProps.root}>
+        {label && <Label {...slotProps.label} />}
+        <div {...slotProps.container}>
+          <button {...slotProps.pill}>
+            <span {...slotProps.thumb} />
+          </button>
+          {((checked && onText) || offText) && <Label {...slotProps.stateText} />}
+        </div>
+      </RootType>
+    );
+  },
+);
 
 ToggleBase.displayName = COMPONENT_NAME;
 

--- a/packages/react-toggle/src/components/Toggle/Toggle.tsx
+++ b/packages/react-toggle/src/components/Toggle/Toggle.tsx
@@ -4,7 +4,7 @@ import { ToggleBase } from './Toggle.base';
 import { getStyles } from './Toggle.styles';
 import { IToggleProps, IToggleStyleProps, IToggleStyles } from './Toggle.types';
 
-export const Toggle = styled<IToggleProps & React.RefAttributes<HTMLDivElement>, IToggleStyleProps, IToggleStyles>(
+export const Toggle: React.FunctionComponent<IToggleProps> = styled<IToggleProps, IToggleStyleProps, IToggleStyles>(
   ToggleBase,
   getStyles,
   undefined,

--- a/packages/react-toggle/src/components/Toggle/Toggle.types.ts
+++ b/packages/react-toggle/src/components/Toggle/Toggle.types.ts
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import { IStyle, ITheme } from '@uifabric/styling';
-import { IRefObject, IStyleFunctionOrObject } from '@uifabric/utilities';
+import { IRefObject, IStyleFunctionOrObject, IComponentAs } from '@uifabric/utilities';
 import { IKeytipProps } from 'office-ui-fabric-react/lib/Keytip';
 
 /**
@@ -16,7 +16,12 @@ export interface IToggle {
  * Toggle component props.
  * {@docCategory Toggle}
  */
-export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
+export interface IToggleProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLElement> {
+  /**
+   * Render the root element as another type.
+   */
+  as?: IComponentAs<React.HTMLAttributes<HTMLElement>>;
+
   /**
    * Optional callback to access the IToggle interface. Use this instead of ref for accessing
    * the public methods and properties of the component.

--- a/packages/react-toggle/src/next/Toggle.tsx
+++ b/packages/react-toggle/src/next/Toggle.tsx
@@ -53,7 +53,7 @@ const getStaticStyles = (props: IToggleStyleProps): Required<IToggleStyles> => {
   return getStaticStylesMemoized(theme!, className, checked, disabled, inlineLabel, onOffMissing);
 };
 
-export const Toggle = styled<IToggleProps & React.RefAttributes<HTMLDivElement>, IToggleStyleProps, IToggleStyles>(
+export const Toggle: React.FunctionComponent<IToggleProps> = styled<IToggleProps, IToggleStyleProps, IToggleStyles>(
   compose<'div', {}, {}, IToggleProps, IToggleProps>(ToggleBase, {
     slots: {
       label: Label,

--- a/packages/react-toggle/src/next/Toggle.types.ts
+++ b/packages/react-toggle/src/next/Toggle.types.ts
@@ -16,7 +16,7 @@ export interface IToggle {
  * Toggle component props.
  * {@docCategory Toggle}
  */
-export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
+export interface IToggleProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLElement> {
   /**
    * Render the root element as another type.
    */

--- a/packages/react-toggle/src/next/ToggleBase.tsx
+++ b/packages/react-toggle/src/next/ToggleBase.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { compose } from '@fluentui/react-compose';
-import { IToggleProps } from '../components/Toggle/Toggle.types';
+import { IToggleProps } from './Toggle.types';
 import { useToggle } from './useToggle';
 
 export const ToggleBase = compose<'div', IToggleProps, {}, IToggleProps, {}>(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #14974
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Add missing ref prop typing for v8 components
- Create and merge refs in Persona, PersonaPresence component
- Add missing `as` prop for `Link`
- Some refactoring related to typing:
     - Always assign `React.FunctionComponent<IComponentProps>` typing to Component and BaseComponent. that way the typing for these components is cleaner for consumer. 
     - Pass generic types to `forwardRef`

#### Focus areas to test

(optional)
