### PR TITLE
Use new button in SpinButton

### DIFF
--- a/packages/office-ui-fabric-react/.storybook/preview.js
+++ b/packages/office-ui-fabric-react/.storybook/preview.js
@@ -4,10 +4,12 @@ import { configure, addParameters, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import { withPerformance } from 'storybook-addon-performance';
 import { withKeytipLayer } from './decorators';
+import { withThemeProvider } from '@fluentui/storybook';
 
 addDecorator(withA11y());
 addDecorator(withPerformance);
 addDecorator(withKeytipLayer);
+addDecorator(withThemeProvider);
 
 addParameters({
   a11y: {

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.0",
+    "@fluentui/storybook": "0.4.12",
     "@types/chalk": "^2.0.0",
     "@types/enzyme": "3.10.3",
     "@types/enzyme-adapter-react-16": "1.0.3",
@@ -68,6 +69,8 @@
   "dependencies": {
     "@fluentui/react-focus": "^7.16.0",
     "@fluentui/react-icons": "^0.3.0",
+    "@fluentui/react-button": "0.12.5",
+    "@fluentui/react-theme-provider": "0.11.3",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/date-time-utilities": "^7.8.0",
     "@uifabric/foundation": "^7.9.0",

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { IconButton } from '../../Button';
+//import { IconButton } from '../../Button';
+import { Button } from '@fluentui/react-button';
 import { Label } from '../../Label';
 import { Icon } from '../../Icon';
 import {
@@ -139,9 +140,9 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
       max,
       labelPosition,
       iconProps,
-      incrementButtonIcon,
+      //incrementButtonIcon,
       incrementButtonAriaLabel,
-      decrementButtonIcon,
+      //decrementButtonIcon,
       decrementButtonAriaLabel,
       ariaLabel,
       ariaDescribedBy,
@@ -240,31 +241,33 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
                 {...inputProps}
               />
               <span className={classNames.arrowBox}>
-                <IconButton
+                <Button
+                  iconOnly
                   styles={getArrowButtonStyles(theme!, true, customUpArrowButtonStyles)}
                   className={'ms-UpButton'}
                   checked={keyboardSpinDirection === KeyboardSpinDirection.up}
                   disabled={disabled}
-                  iconProps={incrementButtonIcon}
+                  icon={<Icon iconName="ChevronUpSmall" />}
                   onMouseDown={this._onIncrementMouseDown}
                   onMouseLeave={this._stop}
                   onMouseUp={this._stop}
                   tabIndex={-1}
-                  ariaLabel={incrementButtonAriaLabel}
+                  aria-label={incrementButtonAriaLabel}
                   data-is-focusable={false}
                   {...iconButtonProps}
                 />
-                <IconButton
+                <Button
+                  iconOnly
                   styles={getArrowButtonStyles(theme!, false, customDownArrowButtonStyles)}
                   className={'ms-DownButton'}
                   checked={keyboardSpinDirection === KeyboardSpinDirection.down}
                   disabled={disabled}
-                  iconProps={decrementButtonIcon}
+                  icon={<Icon iconName="ChevronDownSmall" />}
                   onMouseDown={this._onDecrementMouseDown}
                   onMouseLeave={this._stop}
                   onMouseUp={this._stop}
                   tabIndex={-1}
-                  ariaLabel={decrementButtonAriaLabel}
+                  aria-label={decrementButtonAriaLabel}
                   data-is-focusable={false}
                   {...iconButtonProps}
                 />

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -6,7 +6,8 @@ import { KeyboardSpinDirection } from './SpinButton';
 import { IButtonStyles } from '../../Button';
 import { IKeytipProps } from '../../Keytip';
 import { IRefObject } from '../../Utilities';
-import { IButtonProps } from '../Button/Button.types';
+//import { IButtonProps } from '../Button/Button.types';
+import { ButtonProps } from '@fluentui/react-button';
 
 /**
  * {@docCategory SpinButton}
@@ -252,7 +253,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Additional props for the up and down arrow buttons.
    */
-  iconButtonProps?: IButtonProps;
+  iconButtonProps?: ButtonProps;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #14673 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR integrates new button in SpinButton component. It updates IconButton from oufr to Button from react-button, and changes the type of iconButtonProps from IButtonProps to ButtonProps

#### Focus areas to test

(optional)
