### PR TITLE
Removing unused eslint-disable rules from picker files

### DIFF
--- a/change/@fluentui-react-next-2020-09-16-18-20-55-fix-removing-unused-eslint-disables-from-picker.json
+++ b/change/@fluentui-react-next-2020-09-16-18-20-55-fix-removing-unused-eslint-disables-from-picker.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Removing unused eslint-disable rules from Picker files.",
+  "packageName": "@fluentui/react-next",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-17T01:20:55.364Z"
+}

--- a/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -8,8 +8,8 @@ import { IBaseFloatingPickerProps, BaseFloatingPicker } from '../../FloatingPick
 import { BaseSelectedItemsList, IBaseSelectedItemsListProps } from '../../SelectedItemsList';
 import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { Selection, SelectionMode, SelectionZone } from '../../Selection';
-/* eslint-disable */
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const styles: any = stylesImport;
 
 export interface IBaseExtendedPickerState<T> {
@@ -39,6 +39,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     this.state = {
       queryString: '',
       // TODO: determine whether this can be removed
+      // eslint-disable-next-line react/no-unused-state
       suggestionItems: this.props.suggestionItems ? (this.props.suggestionItems as T[]) : null,
       selectedItems: this.props.defaultSelectedItems
         ? (this.props.defaultSelectedItems as T[])
@@ -260,7 +261,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     const queryString = this.state.queryString;
     if (currentRenderedQueryString === undefined || currentRenderedQueryString === queryString) {
       const processedItem: T | PromiseLike<T> | null = this.props.onItemSelected
-        ? (this.props.onItemSelected as any)(item)
+        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (this.props.onItemSelected as any)(item)
         : item;
 
       if (processedItem === null) {

--- a/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -52,6 +52,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     this.selectedItemsListProps = this.props.selectedItemsListProps;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public get items(): any {
     return this.state.selectedItems ?? this.selectedItemsList.current?.items ?? null;
   }

--- a/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/react-next/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -39,7 +39,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>>
     this.state = {
       queryString: '',
       // TODO: determine whether this can be removed
-      // eslint-disable-next-line react/no-unused-state
       suggestionItems: this.props.suggestionItems ? (this.props.suggestionItems as T[]) : null,
       selectedItems: this.props.defaultSelectedItems
         ? (this.props.defaultSelectedItems as T[])

--- a/packages/react-next/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/react-next/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -8,7 +8,8 @@ import { ISuggestionModel } from '../../Pickers';
 import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsControl } from './Suggestions/SuggestionsControl';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
-/* eslint-disable */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const styles: any = stylesImport;
 
 export interface IBaseFloatingPickerState {
@@ -49,6 +50,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>>
     return this.state.queryString;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public get suggestions(): any[] {
     return this.suggestionStore.suggestions;
   }

--- a/packages/react-next/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
+++ b/packages/react-next/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SelectedItemDefault.tsx
@@ -4,8 +4,8 @@ import { Persona, PersonaSize, PersonaPresence } from '../../../../Persona';
 import { IPeoplePickerItemProps } from '../../../../ExtendedPicker';
 import { IconButton } from '../../../../compat/Button';
 import * as stylesImport from './PickerItemsDefault.scss';
-/* eslint-disable */
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const styles: any = stylesImport;
 
 export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element = (
@@ -40,7 +40,8 @@ export const SelectedItemDefault: (props: IPeoplePickerItemProps) => JSX.Element
         <Persona
           {...item}
           presence={item.presence !== undefined ? item.presence : PersonaPresence.none}
-          size={PersonaSize.size28} // eslint-disable-line deprecation/deprecation
+          // eslint-disable-next-line deprecation/deprecation
+          size={PersonaSize.size28}
         />
       </div>
       <IconButton

--- a/packages/react-next/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
+++ b/packages/react-next/src/components/FloatingPicker/PeoplePicker/examples/FloatingPeoplePicker.Basic.Example.tsx
@@ -9,7 +9,6 @@ import {
 import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 import { people } from '@uifabric/example-data';
 import { useConst } from '@uifabric/react-hooks';
-/* eslint-disable */
 
 const searchBoxWrapperStyling = { width: 208 };
 
@@ -56,6 +55,7 @@ export const FloatingPeoplePickerTypesExample: React.FunctionComponent = () => {
     }
   };
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onRemoveSuggestion = (item: any): void => {
     const itemIndex = peopleList.indexOf(item);
     if (itemIndex >= 0) {

--- a/packages/react-next/src/components/FloatingPicker/Suggestions/SuggestionsStore.ts
+++ b/packages/react-next/src/components/FloatingPicker/Suggestions/SuggestionsStore.ts
@@ -1,6 +1,5 @@
 import { ISuggestionModel, ITag } from '../../../Pickers';
 import { IPersonaProps } from '../../../Persona';
-/* eslint-disable */
 
 export type SuggestionsStoreOptions<T> = {
   getAriaLabel?: (item: T) => string;
@@ -53,9 +52,11 @@ export class SuggestionsStore<T> {
         ariaLabel:
           this.getAriaLabel !== undefined
             ? this.getAriaLabel(suggestion)
-            : ((suggestion as any) as ITag).name ||
+            : // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              ((suggestion as any) as ITag).name ||
               (<IPersonaProps>suggestion).text ||
-              (<IPersonaProps>suggestion).primaryText, // eslint-disable-line deprecation/deprecation
+              // eslint-disable-next-line deprecation/deprecation
+              (<IPersonaProps>suggestion).primaryText,
       };
     }
   };


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Removing unused eslint-disable rules from `BaseExtendedPicker.tsx`, `BaseFloatingPicker.tsx`, `SelectedItemDefault.tsx`, `FloatingPeoplePicker.Basic.Example.tsx.` and `SuggestionsStore.ts`

