### PR TITLE
fix: elementContains should behave like .contains()

### DIFF
--- a/change/@fluentui-dom-utilities-2020-09-17-14-01-18-fix-el-contains.json
+++ b/change/@fluentui-dom-utilities-2020-09-17-14-01-18-fix-el-contains.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: elementContains should behave like .contains()",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "olfedias@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-17T12:01:17.999Z"
+}

--- a/packages/dom-utilities/src/elementContains.ts
+++ b/packages/dom-utilities/src/elementContains.ts
@@ -15,17 +15,21 @@ export function elementContains(
 
   if (parent && child) {
     if (allowVirtualParents) {
-      isContained = false;
+      if (parent === child) {
+        isContained = true;
+      } else {
+        isContained = false;
 
-      while (child) {
-        const nextParent: HTMLElement | null = getParent(child);
+        while (child) {
+          const nextParent: HTMLElement | null = getParent(child);
 
-        if (nextParent === parent) {
-          isContained = true;
-          break;
+          if (nextParent === parent) {
+            isContained = true;
+            break;
+          }
+
+          child = nextParent;
         }
-
-        child = nextParent;
       }
     } else if (parent.contains) {
       isContained = parent.contains(child);

--- a/packages/dom-utilities/src/index.test.ts
+++ b/packages/dom-utilities/src/index.test.ts
@@ -15,6 +15,11 @@ describe('elementContains', () => {
     expect(elementContains(parentDiv, childDiv)).toEqual(true);
   });
 
+  it('can find itself', () => {
+    expect(elementContains(childDiv, childDiv)).toEqual(true);
+    expect(elementContains(childDiv, childDiv, false)).toEqual(true);
+  });
+
   it('can return false on an unattached child', () => {
     expect(elementContains(parentDiv, unattachedDiv)).toEqual(false);
   });


### PR DESCRIPTION
This PR fixes `elementContains()` to behave like `.contains()`:

```tsx
const a = document.createElement('div')
a.contains(a) // true
```