### PR TITLE
Upload demo images to CDN

### DIFF
--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -45,7 +45,7 @@ steps:
     workingDirectory: apps/perf-test
     displayName: Perf Test
 
-  - task: AzureUpload@1
+  - task: AzureUpload@2
     displayName: Upload Perf Test Result to PR deploy site (Fluent)
     inputs:
       SourcePath: 'packages/fluentui/perf-test/dist'
@@ -54,7 +54,7 @@ steps:
       ContainerName: '$web'
       BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test/fluentui'
 
-  - task: AzureUpload@1
+  - task: AzureUpload@2
     displayName: Upload Perf Test Result to PR deploy site
     inputs:
       SourcePath: 'apps/perf-test/dist'

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -34,7 +34,7 @@ steps:
       NODE_ENV=production yarn build:fluentui:docs
     displayName: yarn build:fluentui:docs
 
-  - task: AzureUpload@1
+  - task: AzureUpload@2
     displayName: Upload docs site
     inputs:
       SourcePath: 'packages/fluentui/docs/dist'

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -136,7 +136,7 @@ steps:
       yarn workspace @uifabric/build just generate-package-manifest
     displayName: 'Generates a package manifest'
 
-  - task: AzureUpload@1
+  - task: AzureUpload@2
     displayName: Upload Package Manifest
     inputs:
       SourcePath: 'package-manifest.json'
@@ -144,3 +144,4 @@ steps:
       storage: fabricweb
       ContainerName: 'fabric'
       BlobPrefix: 'package-manifest/latest'
+      Gzip: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
 
       - task: AzureUpload@2
         displayName: Upload demo images (master)
-        # condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
         inputs:
           azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
           BlobPrefix: 'assets'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: Build-PR-$(Build.BuildNumber)
 
-      - task: AzureUpload@1
+      - task: AzureUpload@2
         displayName: Upload PR deploy site
         inputs:
           SourcePath: 'apps/pr-deploy-site/dist'
@@ -98,6 +98,17 @@ jobs:
           storage: fabricweb
           ContainerName: '$web'
           BlobPrefix: '$(deployBasePath)'
+
+      - task: AzureUpload@2
+        displayName: Upload demo images (master)
+        # condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')
+        inputs:
+          azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+          BlobPrefix: 'assets'
+          CacheControl: 'public, max-age=600000'
+          ContainerName: 'fabric-website' # this container has a CDN
+          SourcePath: 'packages/fluentui/docs/src/public'
+          storage: fabricweb
 
   - job: ScreenerFluent
     workspace:


### PR DESCRIPTION
Upload images used in screener and other places to our CDN that we use for the website (http://fabricweb.azureedge.net/fabric-website/*). This will make them load faster than if we uploaded them to normal blob storages, which can be important for getting correct results in screener tests.

For testing purposes I have the images uploading as part of the PR build, but before check-in I plan to change it so the images upload **only on master builds** (mainly to avoid accidental changes). This means that if you want to use a new image, you'll have to check it in separately first, but that shouldn't be a big issue since it won't happen very often.

Also update other upload tasks to use the new AzureUpload task which gzips things. This should make the PR deploy site load faster.