### PR TITLE
Don't remove item in onDragEnd if their removal (rearrangement) has already been handled

### DIFF
--- a/change/@uifabric-experiments-2020-09-17-10-40-52-movedeletefix.json
+++ b/change/@uifabric-experiments-2020-09-17-10-40-52-movedeletefix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Don't remove dropped items if they've already been moved within the same well",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-17T17:40:52.551Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -109,6 +109,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       props.selectedItemsListProps.dropItemsAt(insertIndex, newItems, indicesToRemove);
     }
     dropItemsAt(insertIndex, newItems, indicesToRemove);
+    unselectAll();
   };
 
   const _canDrop = (dropContext?: IDragDropContext, dragContext?: IDragDropContext): boolean => {
@@ -156,7 +157,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
 
   const _onDragEnd = (item?: any, event?: DragEvent): void => {
     if (event) {
-      if (event.dataTransfer?.dropEffect === 'move') {
+      // If we have a move event, and we still have selected items (indicating that we
+      // haven't already moved items within the well) we should remove the item(s)
+      if (event.dataTransfer?.dropEffect === 'move' && focusedItemIndices.length > 0) {
         const itemsToRemove = focusedItemIndices.includes(draggedIndex)
           ? (getSelectedItems() as T[])
           : [selectedItems[draggedIndex]];


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
When we drop items, unselect all items.
In onDragEnd, if there are no selected items, don't remove anything. This way we don't delete an item after already having properly rearranged the well (if it was dropped within the same well)

