### PR TITLE
Mapping .classifier file extension to SharePoint filetype icon

### DIFF
--- a/change/@uifabric-file-type-icons-2020-09-22-12-04-57-caperez-classifier_filetype_icon.json
+++ b/change/@uifabric-file-type-icons-2020-09-22-12-04-57-caperez-classifier_filetype_icon.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "updating filetype mapping to support classifier, list and listitem",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T19:04:57.501Z"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -286,6 +286,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['lnk', 'link', 'url', 'website', 'webloc'],
   },
   linkedfolder: {},
+  listitem: {},
   officescript: {
     extensions: ['osts'],
   },

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -253,9 +253,6 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['vcf'],
   },
   /*  css: {},  not broken out yet, snapping to 'code' for now */
-  classifier: {
-    extensions: ['classifier'],
-  },
   csv: {
     extensions: ['csv'],
   },
@@ -405,7 +402,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['pub'],
   },
   spo: {
-    extensions: ['aspx'],
+    extensions: ['aspx', 'classifier'],
   },
   sponews: {},
   spreadsheet: {

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -5,7 +5,7 @@ import { FileTypeIconMap } from './FileTypeIconMap';
 const PNG_SUFFIX = '_png';
 const SVG_SUFFIX = '_svg';
 
-const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200821.001/assets/item-types/';
+const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200921.001/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: File extension had generic icon
- [x] Include a change request file using `$ yarn change`

#### Focus areas to test

Test file-type-icons package
