### PR TITLE
Fix useKeytipRef() function adding keytip sequence value multiple times

### DIFF
--- a/change/office-ui-fabric-react-2020-09-17-18-11-24-fixUseKeytipRef.json
+++ b/change/office-ui-fabric-react-2020-09-17-18-11-24-fixUseKeytipRef.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix bug in useKeytipRef function",
+  "packageName": "office-ui-fabric-react",
+  "email": "kinhln@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-18T01:11:24.705Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9388,6 +9388,9 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps>;
 // @public
 export function sequencesToID(keySequences: string[]): string;
 
+// @public (undocumented)
+export function setAttribute(element: HTMLElement | null, attributeName: string, attributeValue: string | undefined, append?: boolean): void;
+
 // @public
 export enum Shade {
     // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9388,9 +9388,6 @@ export const SeparatorBase: React.FunctionComponent<ISeparatorProps>;
 // @public
 export function sequencesToID(keySequences: string[]): string;
 
-// @public (undocumented)
-export function setAttribute(element: HTMLElement | null, attributeName: string, attributeValue: string | undefined, append?: boolean): void;
-
 // @public
 export enum Shade {
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/KeytipData/index.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/index.ts
@@ -1,3 +1,3 @@
 export * from './KeytipData';
 export { KeytipDataOptions } from './KeytipData.types';
-export * from './useKeytipRef';
+export { useKeytipRef } from './useKeytipRef';

--- a/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipRef.test.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipRef.test.ts
@@ -1,0 +1,15 @@
+import { setAttribute } from './useKeytipRef';
+
+describe('useKeytipRef tests', () => {
+  it('setAttribute does not add attribute value multiple times', () => {
+    // Arrange
+    const element: HTMLElement = document.createElement('div');
+
+    // Act
+    setAttribute(element, 'aria-describedby', 'h-f-f', true);
+    setAttribute(element, 'aria-describedby', 'h-f-f', true);
+
+    // Assert
+    expect(element.getAttribute('aria-describedby')).toEqual('h-f-f');
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipRef.ts
+++ b/packages/office-ui-fabric-react/src/components/KeytipData/useKeytipRef.ts
@@ -29,7 +29,7 @@ export function useKeytipRef<TElement extends HTMLElement = HTMLElement>(
   return contentRef;
 }
 
-function setAttribute(
+export function setAttribute(
   element: HTMLElement | null,
   attributeName: string,
   attributeValue: string | undefined,
@@ -39,7 +39,7 @@ function setAttribute(
     let value = attributeValue;
     if (append) {
       const currentValue = element.getAttribute(attributeName);
-      if (currentValue && currentValue.indexOf(attributeName) === -1) {
+      if (currentValue && currentValue.indexOf(attributeValue) === -1) {
         value = `${currentValue} ${attributeValue}`;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15112 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There's a bug in the `setAttribute()` function which fails to check if the incoming value already exists in the affected attribute.

#### Focus areas to test

Unit test
