### PR TITLE
fix(RadioGroup): remove the input from inside the RadioGroupItem

### DIFF
--- a/packages/fluentui/docs/src/examples/components/RadioGroup/Types/RadioGroupExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/RadioGroup/Types/RadioGroupExample.shorthand.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Divider, RadioGroup, Input, Text } from '@fluentui/react-northstar';
+import { Divider, RadioGroup } from '@fluentui/react-northstar';
 
 class RadioGroupVerticalExample extends React.Component {
   state = { selectedValue: '', inputTabIndex: '-1' };
@@ -28,17 +28,6 @@ class RadioGroupVerticalExample extends React.Component {
         label: 'Prosciutto',
         value: 'prosciutto',
         disabled: true,
-      },
-      {
-        name: 'pizza',
-        key: 'Custom',
-        label: (
-          <Text>
-            Choose your own <Input input={{ tabIndex: this.state.inputTabIndex }} inline placeholder="flavour" />
-          </Text>
-        ),
-        value: 'custom',
-        'aria-label': 'Press Tab to change flavour',
       },
     ];
   }

--- a/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/RadioGroupCustomExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/RadioGroupCustomExample.shorthand.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import { Divider, RadioGroup, Input } from '@fluentui/react-northstar';
+
+class RadioGroupCustomExample extends React.Component {
+  state = { selectedValue: '', inputTabIndex: '-1' };
+
+  render() {
+    const { selectedValue } = this.state;
+    return (
+      <div>
+        The selected value is: {selectedValue}
+        <Divider />
+        <RadioGroup
+          checkedValue={selectedValue}
+          defaultCheckedValue="capricciosa"
+          items={this.getItems()}
+          onCheckedValueChange={this.handleChange}
+        />
+      </div>
+    );
+  }
+
+  getItems() {
+    return [
+      { name: 'pizza', key: 'Capricciosa', label: 'Capricciosa', value: 'capricciosa' },
+      {
+        name: 'pizza',
+        key: 'Prosciutto',
+        label: 'Prosciutto',
+        value: 'prosciutto',
+        disabled: true,
+      },
+      {
+        name: 'pizza',
+        key: 'Custom',
+        label: 'Choose your own',
+        children: (Component, { key, ...props }) => {
+          return (
+            <div
+              key={key}
+              style={{
+                display: 'inline-flex',
+              }}
+            >
+              <Component {...props} />
+              <Input
+                onFocus={() => {
+                  this.setState({ selectedValue: 'custom' });
+                }}
+                input={{ tabIndex: this.state.inputTabIndex }}
+                inline
+                placeholder="flavour"
+              />
+            </div>
+          );
+        },
+        value: 'custom',
+        'aria-label': 'Press Tab to change flavour',
+      },
+    ];
+  }
+
+  handleChange = (e, props) =>
+    this.setState({ selectedValue: props.value, inputTabIndex: props.value === 'custom' ? '0' : '-1' });
+}
+
+export default RadioGroupCustomExample;

--- a/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/RadioGroupCustomVerticalExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/RadioGroupCustomVerticalExample.shorthand.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { Divider, RadioGroup } from '@fluentui/react-northstar';
+import { Divider, RadioGroup, Input } from '@fluentui/react-northstar';
 
-class RadioGroupVerticalExample extends React.Component {
+class RadioGroupCustomVerticalExample extends React.Component {
   state = { selectedValue: '', inputTabIndex: '-1' };
 
   render() {
@@ -41,6 +41,33 @@ class RadioGroupVerticalExample extends React.Component {
         label: 'Pepperoni',
         value: 'pepperoni',
       },
+      {
+        name: 'pizza',
+        key: 'Custom',
+        label: 'Choose your own',
+        children: (Component, { key, ...props }) => {
+          return (
+            <div
+              key={key}
+              style={{
+                display: 'inline-flex',
+              }}
+            >
+              <Component {...props} />
+              <Input
+                onFocus={() => {
+                  this.setState({ selectedValue: 'custom' });
+                }}
+                input={{ tabIndex: this.state.inputTabIndex }}
+                inline
+                placeholder="flavour"
+              />
+            </div>
+          );
+        },
+        value: 'custom',
+        'aria-label': 'Press Tab to change flavour',
+      },
     ];
   }
 
@@ -48,4 +75,4 @@ class RadioGroupVerticalExample extends React.Component {
     this.setState({ selectedValue: props.value, inputTabIndex: props.value === 'custom' ? '0' : '-1' });
 }
 
-export default RadioGroupVerticalExample;
+export default RadioGroupCustomVerticalExample;

--- a/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/RadioGroup/Variants/index.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
+import ExampleSection from '../../../../components/ComponentDoc/ExampleSection';
+
+const Variants = () => (
+  <ExampleSection title="Variants">
+    <ComponentExample
+      title="Radio Group Custom"
+      description="A radio group can have custom items"
+      examplePath="components/RadioGroup/Variants/RadioGroupCustomExample"
+    />
+    <ComponentExample
+      title="Radio Group Custom"
+      description="A radio group can have custom items"
+      examplePath="components/RadioGroup/Variants/RadioGroupCustomVerticalExample"
+    />
+  </ExampleSection>
+);
+
+export default Variants;

--- a/packages/fluentui/docs/src/examples/components/RadioGroup/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/RadioGroup/index.tsx
@@ -3,11 +3,13 @@ import * as React from 'react';
 import Rtl from './Rtl';
 import Types from './Types';
 import Item from './Item';
+import Variants from './Variants';
 
 const RadioGroupExamples = () => (
   <>
     <Types />
     <Item />
+    <Variants />
     <Rtl />
   </>
 );


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Radio Group and Vertical Radio Group examples in @fluentui/react-northstar integrate Radio and Input in an incorrect way, as the Input has to be a sibling of the Radio, not its child to allow better screen reader experience.

This PR removes inputs from the basic examples and add "Custom radio item" example hat uses `children` callback to render the input next to the radio.

#### Focus areas to test

(optional)
