### PR TITLE
Revert "fix(Tree): always show selectable indicator (#14916)"

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Tree/Usage/TreeMultiselectExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Tree/Usage/TreeMultiselectExample.shorthand.tsx
@@ -75,7 +75,7 @@ const items = [
     title: 'House Targaryen',
     selectionIndicator: {
       children: (Component, { expanded, selected, ...props }) => {
-        return <Text {...props} content={selected ? 'unselect all' : 'select all'} />;
+        return <Text {...props} content={expanded && (selected ? 'unselect all' : 'select all')} />;
       },
     },
     selectableParent: true,

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -240,20 +240,12 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
 
   const setSelectedItemIds = React.useCallback(
     (e: React.SyntheticEvent, updateSelectedItemIds: (currSelectedItemIds: string[]) => string[]) => {
-      setSelectedItemIdsState(prevSelectedItemIds => {
-        // This is a hack to make it work with useAutoControlled since it's not keeping track of
-        // the controlled state in the first interaction breaking the expected behavior
-        // Remove this once the useAutoControle is fixed and the prevState will be stable
-        // see https://github.com/microsoft/fluentui/issues/14509
-        const nextSelectedItemIds = updateSelectedItemIds(stableProps.current.selectedItemIds || prevSelectedItemIds);
-
-        _.invoke(stableProps.current, 'onSelectedItemIdsChange', e, {
-          ...stableProps.current,
-          selectedItemIds: nextSelectedItemIds,
-        });
-
-        return nextSelectedItemIds;
+      _.invoke(stableProps.current, 'onSelectedItemIdsChange', e, {
+        ...stableProps.current,
+        selectedItemIds: updateSelectedItemIds,
       });
+
+      setSelectedItemIdsState(updateSelectedItemIds);
     },
     [stableProps, setSelectedItemIdsState],
   );
@@ -308,17 +300,18 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
   const onTitleClick = React.useCallback(
     (e: React.SyntheticEvent, treeItemProps: TreeItemProps, executeSelection: boolean = false) => {
       const treeItemHasSubtree = hasSubtree(treeItemProps);
+
       if (!treeItemProps) {
         return;
       }
 
-      if (treeItemHasSubtree && e.target === e.currentTarget && !executeSelection) {
+      if (treeItemHasSubtree && !executeSelection && e.target === e.currentTarget) {
         expandItems(e, treeItemProps);
       }
 
       if (treeItemProps.selectable) {
         // parent must be selectable and expanded in order to procced with selection, otherwise return
-        if (treeItemHasSubtree && !treeItemProps.selectableParent) {
+        if (treeItemHasSubtree && !(treeItemProps.selectableParent && treeItemProps.expanded)) {
           return;
         }
 

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -172,7 +172,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
       ...(selectableParent && !_.isEmpty(selectionIndicator) && { expanded }),
       ...getA11Props('indicator', {
         className: treeTitleSlotClassNames.indicator,
-        ...(((selectable && !hasSubtree) || selectableParent) &&
+        ...(((selectable && !hasSubtree) || (selectableParent && expanded)) &&
           _.isEmpty(selectionIndicator) && {
             styles: resolvedStyles.selectionIndicator,
           }),

--- a/packages/fluentui/react-northstar/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react-northstar/src/components/Tree/utils/index.ts
@@ -59,14 +59,14 @@ export const getSiblings = (items: any[], itemId: string): any[] => {
 
 export const processItemsForSelection = (treeItemProps: TreeItemProps, selectedItemIds: string[]) => {
   const treeItemHasSubtree = hasSubtree(treeItemProps);
-  const isSelectableParent = treeItemHasSubtree && treeItemProps.selectableParent;
+  const isExpandedSelectableParent = treeItemHasSubtree && treeItemProps.selectableParent && treeItemProps.expanded;
 
   let nextSelectedItemIds = selectedItemIds;
 
   // push all tree items under particular parent into selection array
   // not parent itself, therefore not procced with selection
 
-  if (isSelectableParent) {
+  if (isExpandedSelectableParent) {
     if (isAllGroupChecked(treeItemProps.items as TreeItemProps[], selectedItemIds)) {
       const selectedItems = getAllSelectableChildrenId(treeItemProps.items as TreeItemProps[]);
       nextSelectedItemIds = selectedItemIds.filter(id => selectedItems.indexOf(id) === -1);


### PR DESCRIPTION
This reverts commit d6ed67d374f9d03068c8b114120d090ffb0e5395.

#### Description of changes

The fix doesn't match with what is specified on the design, I am reverting it till the proper solution can be defined. What we had in master tho also didn't match the specified in the design spec so I am opening #15133 that matches the design spec but having it as Draft while designers decide how to approach the select indictor in the `Tree` regarding [`WCAG Guideline 1.3`](https://www.w3.org/TR/2008/WD-UNDERSTANDING-WCAG20-20081103/content-structure-separation.html)

FYI @jurokapsiar @kolaps33 @pompomon 

#### Focus areas to test

(optional)
