### PR TITLE
docs: serve images from CDN for N* docs

### DIFF
--- a/packages/fluentui/docs/README.md
+++ b/packages/fluentui/docs/README.md
@@ -1,0 +1,7 @@
+## FAQ
+
+### I want to add an image to use it in examples. How I can do this?
+
+Please create a separate PR and put it into `packages/fluentui/docs/src/public` directory. Once that PR will be merged it will be available at CDN. For example, `packages/fluentui/docs/src/public/images/fluent-ui-logo.png` is available on CDN as [https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png](https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png).
+
+Once an image that was added on CDN will be available it can be used in examples.

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentDocLinks.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentDocLinks.tsx
@@ -27,7 +27,11 @@ export default class ComponentDocLinks extends React.PureComponent<any, any> {
         }}
       >
         <>
-          <Image src="public/images/github.png" width="16px" height="16px" />
+          <Image
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/github.png"
+            width="16px"
+            height="16px"
+          />
           <code>
             <a
               style={{ color: 'rgba(0,0,0,.4)' }}

--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentExample/ComponentExample.tsx
@@ -355,7 +355,13 @@ class ComponentExample extends React.Component<ComponentExampleProps, ComponentE
       },
       {
         disabled: currentCodeLanguage !== 'ts',
-        icon: <Image src="public/images/github.png" width="16px" height="16px" />,
+        icon: (
+          <Image
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/github.png"
+            width="16px"
+            height="16px"
+          />
+        ),
         content: 'Edit',
         href: ghEditHref,
         rel: 'noopener noreferrer',

--- a/packages/fluentui/docs/src/components/Logo/Logo.tsx
+++ b/packages/fluentui/docs/src/components/Logo/Logo.tsx
@@ -6,7 +6,10 @@ export type LogoProps = ImageProps & {
 };
 
 const Logo: React.SFC<LogoProps> = ({ flavor, ...props }) => (
-  <Image {...props} src={`public/images/fluent-ui-logo${flavor ? `-${flavor}` : ''}.png`} />
+  <Image
+    {...props}
+    src={`https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo${flavor ? `-${flavor}` : ''}.png`}
+  />
 );
 
 export default Logo;

--- a/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
+++ b/packages/fluentui/docs/src/components/Sidebar/Sidebar.tsx
@@ -520,7 +520,12 @@ const Sidebar: React.FC<RouteComponentProps & SidebarProps> = props => {
         <a href={config.repoURL} target="_blank" rel="noopener noreferrer" style={topItemTheme}>
           <Box>
             GitHub
-            <Image src="public/images/github.png" width="20px" height="20px" styles={{ float: 'right' }} />
+            <Image
+              src="https://fabricweb.azureedge.net/fabric-website/assets/images/github.png"
+              width="20px"
+              height="20px"
+              styles={{ float: 'right' }}
+            />
           </Box>
         </a>
         <NavLink to="/builder" exact style={topItemTheme} activeStyle={{ fontWeight: 'bold' }}>

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleImage.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleImage.shorthand.tsx
@@ -3,8 +3,8 @@ import { Avatar } from '@fluentui/react-northstar';
 
 const AvatarExampleImageShorthand = () => (
   <>
-    <Avatar image="public/images/avatar/small/matt.jpg" />
-    <Avatar image="public/images/avatar/large/jerry.png" />
+    <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" />
+    <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jerry.png" />
   </>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSize.shorthand.tsx
@@ -19,15 +19,26 @@ const AvatarExampleSizeShorthand = () => (
       <React.Fragment key={size}>
         <strong>{size}</strong>
         <div>
-          <Avatar size={size} image="public/images/avatar/small/matt.jpg" status={statusProps} />
+          <Avatar
+            size={size}
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+            status={statusProps}
+          />
           &emsp;
           <Avatar size={size} name="John Doe" status={statusProps} />
           &emsp;
-          <Avatar size={size} image="public/images/avatar/small/matt.jpg" />
+          <Avatar
+            size={size}
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          />
           &emsp;
           <Avatar size={size} icon={<UserFriendsIcon />} />
           &emsp;
-          <Avatar size={size} image="public/images/avatar/small/matt.jpg" square />
+          <Avatar
+            size={size}
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+            square
+          />
         </div>
       </React.Fragment>
     ))}

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSquare.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleSquare.shorthand.tsx
@@ -5,7 +5,7 @@ import { AcceptIcon } from '@fluentui/react-icons-northstar';
 const AvatarExampleSquare = () => (
   <div>
     <Avatar
-      image="public/images/avatar/small/matt.jpg"
+      image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
       square
       status={{ color: 'green', icon: <AcceptIcon />, title: 'Available' }}
     />

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleStatus.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleStatus.shorthand.tsx
@@ -5,13 +5,19 @@ import { AcceptIcon } from '@fluentui/react-icons-northstar';
 const AvatarExampleStatusShorthand = () => (
   <div>
     <Avatar
-      image="public/images/avatar/small/matt.jpg"
+      image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
       status={{ color: 'green', icon: <AcceptIcon />, title: 'Available' }}
     />
     &emsp;
-    <Avatar image="public/images/avatar/small/matt.jpg" status={{ color: 'red', title: 'Busy' }} />
+    <Avatar
+      image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+      status={{ color: 'red', title: 'Busy' }}
+    />
     &emsp;
-    <Avatar image="public/images/avatar/small/matt.jpg" status={{ color: 'grey', title: 'Offline' }} />
+    <Avatar
+      image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+      status={{ color: 'grey', title: 'Offline' }}
+    />
     &emsp;
   </div>
 );

--- a/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Avatar/Variations/AvatarExampleStatusCustomization.shorthand.tsx
@@ -4,7 +4,10 @@ import { AcceptIcon } from '@fluentui/react-icons-northstar';
 
 const defaultAvatar = (
   <Avatar
-    image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+    image={{
+      src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+      alt: 'Profile picture of Matt',
+    }}
     status={{
       color: 'green',
       icon: <AcceptIcon />,
@@ -27,7 +30,10 @@ const AvatarExampleStatusCustomizationShorthand = () => (
     <Text content="Status can receive variables." />
     {defaultAvatar}
     <Avatar
-      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      image={{
+        src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+        alt: 'Profile picture of Matt',
+      }}
       status={{
         color: 'green',
         icon: <AcceptIcon />,
@@ -38,7 +44,10 @@ const AvatarExampleStatusCustomizationShorthand = () => (
     <Text content="Avatar and its status are proportionate (share the same size value) by default." />
     {defaultAvatar}
     <Avatar
-      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      image={{
+        src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+        alt: 'Profile picture of Matt',
+      }}
       size="larger"
       status={{
         color: 'green',
@@ -49,7 +58,10 @@ const AvatarExampleStatusCustomizationShorthand = () => (
     <Text content="Status can have different size for the same avatar size." />
     {defaultAvatar}
     <Avatar
-      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      image={{
+        src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+        alt: 'Profile picture of Matt',
+      }}
       status={{
         color: 'green',
         icon: <AcceptIcon />,
@@ -60,7 +72,10 @@ const AvatarExampleStatusCustomizationShorthand = () => (
     <Text content="Status can have same size for different avatar sizes." />
     {defaultAvatar}
     <Avatar
-      image={{ src: 'public/images/avatar/small/matt.jpg', alt: 'Profile picture of Matt' }}
+      image={{
+        src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+        alt: 'Profile picture of Matt',
+      }}
       size="larger"
       status={{
         color: 'green',

--- a/packages/fluentui/docs/src/examples/components/Card/Slots/CardExampleBody.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Slots/CardExampleBody.tsx
@@ -5,7 +5,7 @@ const CardExampleBody = () => (
   <Card aria-roledescription="card with image and text">
     <Card.Body fitted>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         <Text content="Citizens of distant epochs muse about at the edge of forever hearts of the..." />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Slots/CardExampleHeader.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Slots/CardExampleHeader.tsx
@@ -5,7 +5,12 @@ const CardExampleHeader = () => (
   <Card aria-roledescription="card avatar">
     <Card.Header fitted>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Title goes here" weight="bold" />
           <Text content="Secondary line" size="small" />

--- a/packages/fluentui/docs/src/examples/components/Card/Slots/CardExamplePreview.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Slots/CardExamplePreview.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 const CardExamplePreview = () => (
   <Card compact aria-roledescription="image card">
     <Card.Preview fitted>
-      <Image fluid src="public/images/wireframe/square-image.png" />
+      <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
     </Card.Preview>
   </Card>
 );

--- a/packages/fluentui/docs/src/examples/components/Card/States/CardExampleDisabled.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/States/CardExampleDisabled.tsx
@@ -16,7 +16,7 @@ const CardExampleDisabled = () => {
         <Text content={`Card was clicked ${clickCount} times.`} weight="bold" />
       </Card.Header>
       <Card.Body>
-        <Image src="public/images/wireframe/square-image.png" />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
       </Card.Body>
     </Card>
   );

--- a/packages/fluentui/docs/src/examples/components/Card/States/CardExampleSelected.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/States/CardExampleSelected.tsx
@@ -7,7 +7,7 @@ const CardExampleSelected = () => (
       <Text content="Selected card" weight="bold" />
     </Card.Header>
     <Card.Body>
-      <Image src="public/images/wireframe/square-image.png" />
+      <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
     </Card.Body>
   </Card>
 );

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleContextMenu.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleContextMenu.tsx
@@ -12,7 +12,7 @@ const CardExampleContextMenu = () => (
           <Text content={`Software developer`} temporary />
         </Card.Header>
         <Card.Body>
-          <Image src="public/images/wireframe/square-image.png" />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         </Card.Body>
       </Card>
     }

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleExpandable.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleExpandable.tsx
@@ -7,7 +7,7 @@ const CardExampleExpandable = () => {
       <Card.Header>
         <Flex gap="gap.small">
           <Avatar
-            image="public/images/avatar/small/matt.jpg"
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
@@ -20,7 +20,7 @@ const CardExampleExpandable = () => {
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
           <Card.ExpandableBox>
             <Text content="Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum." />
           </Card.ExpandableBox>

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleFocusable.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleFocusable.tsx
@@ -14,7 +14,7 @@ const CardExampleFocusable = () => {
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         </Flex>
       </Card.Body>
     </Card>

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleFocusableGrid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleFocusableGrid.tsx
@@ -28,7 +28,7 @@ const ClickableCard: React.FC<ClickableCardProps> = ({ index }) => {
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         </Flex>
       </Card.Body>
     </Card>

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleSelectableGrid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleSelectableGrid.tsx
@@ -47,7 +47,7 @@ const SelectableCard: React.FC<SelectableCardProps> = ({ title, index, selected,
 
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         </Flex>
       </Card.Body>
     </Card>

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleSimple.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleSimple.tsx
@@ -6,7 +6,12 @@ const CardExampleSimple = () => (
   <Card aria-roledescription="card with avatar, image and action buttons">
     <Card.Header>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Title goes here" weight="bold" />
           <Text content="Secondary line" size="small" />
@@ -15,7 +20,7 @@ const CardExampleSimple = () => (
     </Card.Header>
     <Card.Body>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         <Text content="Citizens of distant epochs muse about at the edge of forever hearts of the..." />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleWithPreview.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Usage/CardExampleWithPreview.tsx
@@ -8,7 +8,7 @@ const CardExampleWithPreview = () => (
       <Checkbox aria-label="test checkbox" />
     </Card.TopControls>
     <Card.Preview>
-      <Image fluid src="public/images/wireframe/square-image.png" />
+      <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
     </Card.Preview>
     <Card.Header fitted>
       <Flex padding="padding.medium">

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleCentered.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleCentered.tsx
@@ -6,14 +6,19 @@ const CardExampleCentered = () => (
   <Card centered aria-roledescription="card with avatar, image and action buttons">
     <Card.Header>
       <Flex gap="gap.small" column hAlign="center">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Text content="Title goes here" weight="bold" />
         <Text content="Secondary line" size="small" />
       </Flex>
     </Card.Header>
     <Card.Body>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
         <Text content="Citizens of distant epochs muse about at the edge of forever hearts of the..." align="center" />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleElevated.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleElevated.tsx
@@ -5,7 +5,12 @@ const CardExampleElevated = () => (
   <Card aria-roledescription="card with avatar, image and text" elevated>
     <Card.Header>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Elevated card" weight="bold" />
           <Text content="Secondary line" size="small" />
@@ -14,7 +19,7 @@ const CardExampleElevated = () => (
     </Card.Header>
     <Card.Body>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" fluid />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
         <Text content="Content text" />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleFluid.tsx
@@ -6,7 +6,12 @@ const CardExample = () => (
   <Card fluid aria-roledescription="card with avatar, image and action buttons">
     <Card.Header>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Fluid card" weight="bold" />
           <Text content="Secondary line" size="small" />

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleHorizontal.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleHorizontal.tsx
@@ -5,7 +5,10 @@ import { DownloadIcon, MoreIcon } from '@fluentui/react-icons-northstar';
 const CardExampleHorizontal = () => (
   <Card compact horizontal aria-roledescription="card with a preview image, text and action buttons">
     <Card.Preview horizontal>
-      <Image style={{ height: '115px', width: '115px' }} src="public/images/wireframe/square-image.png" />
+      <Image
+        style={{ height: '115px', width: '115px' }}
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png"
+      />
     </Card.Preview>
     <Card.Column>
       <Card.Header>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleInverted.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleInverted.tsx
@@ -5,7 +5,12 @@ const CardExampleInverted = () => (
   <Card aria-roledescription="card with avatar, image and text" inverted>
     <Card.Header>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Inverted card" weight="bold" />
           <Text content="For lighter background" size="small" />
@@ -14,7 +19,7 @@ const CardExampleInverted = () => (
     </Card.Header>
     <Card.Body>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" fluid />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
         <Text content="Content text" />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleQuiet.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleQuiet.tsx
@@ -5,7 +5,12 @@ const CardExampleQuiet = () => (
   <Card aria-roledescription="card with avatar, image and text" quiet>
     <Card.Header>
       <Flex gap="gap.small">
-        <Avatar image="public/images/avatar/small/matt.jpg" label="Copy bandwidth" name="Evie yundt" status="unknown" />
+        <Avatar
+          image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+          label="Copy bandwidth"
+          name="Evie yundt"
+          status="unknown"
+        />
         <Flex column>
           <Text content="Quiet card" weight="bold" />
           <Text content="Secondary line" size="small" />
@@ -14,7 +19,7 @@ const CardExampleQuiet = () => (
     </Card.Header>
     <Card.Body>
       <Flex column gap="gap.small">
-        <Image src="public/images/wireframe/square-image.png" fluid />
+        <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
         <Text content="Content text" />
       </Flex>
     </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
+++ b/packages/fluentui/docs/src/examples/components/Card/Variations/CardExampleSize.tsx
@@ -7,7 +7,7 @@ const CardExampleSize = () => (
       <Card.Header>
         <Flex gap="gap.small">
           <Avatar
-            image="public/images/avatar/small/matt.jpg"
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
@@ -20,7 +20,7 @@ const CardExampleSize = () => (
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
           <Text content="Content text" />
         </Flex>
       </Card.Body>
@@ -30,7 +30,7 @@ const CardExampleSize = () => (
       <Card.Header>
         <Flex gap="gap.small">
           <Avatar
-            image="public/images/avatar/small/matt.jpg"
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
@@ -43,7 +43,7 @@ const CardExampleSize = () => (
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
           <Text content="Content text" />
         </Flex>
       </Card.Body>
@@ -53,7 +53,7 @@ const CardExampleSize = () => (
       <Card.Header>
         <Flex gap="gap.small">
           <Avatar
-            image="public/images/avatar/small/matt.jpg"
+            image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
             label="Copy bandwidth"
             name="Evie yundt"
             status="unknown"
@@ -66,7 +66,7 @@ const CardExampleSize = () => (
       </Card.Header>
       <Card.Body>
         <Flex column gap="gap.small">
-          <Image src="public/images/wireframe/square-image.png" fluid />
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" fluid />
           <Text content="Content text" />
         </Flex>
       </Card.Body>

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.shorthand.tsx
@@ -11,25 +11,49 @@ const carouselItems = [
   {
     key: 'ade',
     id: 'ade',
-    content: <Image src="public/images/avatar/large/ade.jpg" fluid alt={imageAltTags.ade} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
     'aria-label': imageAltTags.ade,
   },
   {
     key: 'elliot',
     id: 'elliot',
-    content: <Image src="public/images/avatar/large/elliot.jpg" fluid alt={imageAltTags.elliot} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
     'aria-label': imageAltTags.elliot,
   },
   {
     key: 'kristy',
     id: 'kristy',
-    content: <Image src="public/images/avatar/large/kristy.png" fluid alt={imageAltTags.kristy} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
+        fluid
+        alt={imageAltTags.kristy}
+      />
+    ),
     'aria-label': imageAltTags.kristy,
   },
   {
     key: 'nan',
     id: 'nan',
-    content: <Image src="public/images/avatar/large/nan.jpg" fluid alt={imageAltTags.nan} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
+        fluid
+        alt={imageAltTags.nan}
+      />
+    ),
     'aria-label': imageAltTags.nan,
   },
 ];

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.shorthand.tsx
@@ -4,19 +4,43 @@ import { Carousel, Image } from '@fluentui/react-northstar';
 const carouselItems = [
   {
     key: 'ade',
-    content: <Image src="public/images/avatar/large/ade.jpg" fluid alt={'Portrait of Ade'} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+        fluid
+        alt={'Portrait of Ade'}
+      />
+    ),
   },
   {
     key: 'elliot',
-    content: <Image src="public/images/avatar/large/elliot.jpg" fluid alt={'Portrait of Elliot'} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+        fluid
+        alt={'Portrait of Elliot'}
+      />
+    ),
   },
   {
     key: 'kristy',
-    content: <Image src="public/images/avatar/large/kristy.png" fluid alt={'Portrait of Kristy'} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
+        fluid
+        alt={'Portrait of Kristy'}
+      />
+    ),
   },
   {
     key: 'nan',
-    content: <Image src="public/images/avatar/large/nan.jpg" fluid alt={'Portrait of Nan'} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
+        fluid
+        alt={'Portrait of Nan'}
+      />
+    ),
   },
 ];
 

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.shorthand.tsx
@@ -11,22 +11,46 @@ const carouselItems = [
   {
     key: 'ade',
     id: 'ade',
-    content: <Image src="public/images/avatar/large/ade.jpg" fluid alt={imageAltTags.ade} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
   },
   {
     key: 'elliot',
     id: 'elliot',
-    content: <Image src="public/images/avatar/large/elliot.jpg" fluid alt={imageAltTags.elliot} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
   },
   {
     key: 'kristy',
     id: 'kristy',
-    content: <Image src="public/images/avatar/large/kristy.png" fluid alt={imageAltTags.kristy} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
+        fluid
+        alt={imageAltTags.kristy}
+      />
+    ),
   },
   {
     key: 'nan',
     id: 'nan',
-    content: <Image src="public/images/avatar/large/nan.jpg" fluid alt={imageAltTags.nan} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
+        fluid
+        alt={imageAltTags.nan}
+      />
+    ),
   },
 ];
 

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselExampleWithFocusableElements.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselExampleWithFocusableElements.tsx
@@ -60,7 +60,12 @@ const carouselItems = [
     content: (
       <div>
         <Flex gap="gap.medium">
-          <Image styles={imageStyles} src="public/images/avatar/large/ade.jpg" fluid alt={imageAltTags.ade} />
+          <Image
+            styles={imageStyles}
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+            fluid
+            alt={imageAltTags.ade}
+          />
           {carouselTextContent}
         </Flex>
         <Button content="Open" styles={buttonStyles} />
@@ -74,7 +79,12 @@ const carouselItems = [
     content: (
       <div>
         <Flex gap="gap.medium">
-          <Image styles={imageStyles} src="public/images/avatar/large/elliot.jpg" fluid alt={imageAltTags.elliot} />
+          <Image
+            styles={imageStyles}
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+            fluid
+            alt={imageAltTags.elliot}
+          />
           {carouselTextContent}
         </Flex>
         {carouselToolbarContent}
@@ -88,7 +98,12 @@ const carouselItems = [
     content: (
       <div>
         <Flex gap="gap.medium">
-          <Image styles={imageStyles} src="public/images/avatar/large/kristy.png" fluid alt={imageAltTags.kristy} />
+          <Image
+            styles={imageStyles}
+            src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
+            fluid
+            alt={imageAltTags.kristy}
+          />
           {carouselTextContent}
         </Flex>
         <Flex gap="gap.medium" styles={buttonStyles}>

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselThumbnailsExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselThumbnailsExample.shorthand.tsx
@@ -11,43 +11,115 @@ const carouselItems = [
   {
     key: 'ade',
     id: 'ade',
-    content: <Image src="public/images/avatar/large/ade.jpg" fluid alt={imageAltTags.ade} />,
-    thumbnail: <Image src="public/images/avatar/small/ade.jpg" fluid alt={imageAltTags.ade} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
     'aria-label': imageAltTags.ade,
   },
   {
     key: 'elliot',
     id: 'elliot',
-    content: <Image src="public/images/avatar/large/elliot.jpg" fluid alt={imageAltTags.elliot} />,
-    thumbnail: <Image src="public/images/avatar/small/elliot.jpg" fluid alt={imageAltTags.elliot} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
     'aria-label': imageAltTags.elliot,
   },
   {
     key: 'molly',
     id: 'molly',
-    content: <Image src="public/images/avatar/large/molly.png" fluid alt={imageAltTags.molly} />,
-    thumbnail: <Image src="public/images/avatar/small/molly.png" fluid alt={imageAltTags.molly} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
+        fluid
+        alt={imageAltTags.molly}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/molly.png"
+        fluid
+        alt={imageAltTags.molly}
+      />
+    ),
     'aria-label': imageAltTags.molly,
   },
   {
     key: 'nan',
     id: 'nan',
-    content: <Image src="public/images/avatar/large/nan.jpg" fluid alt={imageAltTags.nan} />,
-    thumbnail: <Image src="public/images/avatar/small/nan.jpg" fluid alt={imageAltTags.nan} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
+        fluid
+        alt={imageAltTags.nan}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nan.jpg"
+        fluid
+        alt={imageAltTags.nan}
+      />
+    ),
     'aria-label': imageAltTags.nan,
   },
   {
     key: 'elliot1',
     id: 'elliot1',
-    content: <Image src="public/images/avatar/large/elliot.jpg" fluid alt={imageAltTags.elliot} />,
-    thumbnail: <Image src="public/images/avatar/small/elliot.jpg" fluid alt={imageAltTags.elliot} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/elliot.jpg"
+        fluid
+        alt={imageAltTags.elliot}
+      />
+    ),
     'aria-label': imageAltTags.elliot,
   },
   {
     key: 'ade1',
     id: 'ade1',
-    content: <Image src="public/images/avatar/large/ade.jpg" fluid alt={imageAltTags.ade} />,
-    thumbnail: <Image src="public/images/avatar/small/ade.jpg" fluid alt={imageAltTags.ade} />,
+    content: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
+    thumbnail: (
+      <Image
+        src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg"
+        fluid
+        alt={imageAltTags.ade}
+      />
+    ),
     'aria-label': imageAltTags.ade,
   },
 ];

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleActions.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleActions.shorthand.tsx
@@ -34,7 +34,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+    gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
     message: <Chat.Message actionMenu={actionMenu} content="Hi" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />,
     key: 'message-3',
   },

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleHeader.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleHeader.shorthand.tsx
@@ -31,7 +31,7 @@ const items: ChatProps['items'] = [
     ),
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+    gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
     message: (
       <Chat.Message
         reactionGroup={reactions}

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleHeaderOverride.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleHeaderOverride.shorthand.tsx
@@ -44,7 +44,7 @@ const items: ChatProps['items'] = [
     ),
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+    gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
     message: (
       <Chat.Message
         reactionGroup={reactions}

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroup.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroup.shorthand.tsx
@@ -31,7 +31,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+    gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
     message: <Chat.Message reactionGroup={reactions} content="Hi" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />,
     key: 'message-3',
   },

--- a/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Content/ChatExampleReactionGroupMeReacting.shorthand.tsx
@@ -40,7 +40,7 @@ const items: ShorthandCollection<ChatItemProps> = [
     ),
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+    gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
     message: <Chat.Message reactionGroup={reactions} content="Hi" author="Jane Doe" timestamp="Yesterday, 10:15 PM" />,
     key: 'message-3',
   },

--- a/packages/fluentui/docs/src/examples/components/Chat/Rtl/ChatExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Rtl/ChatExample.rtl.tsx
@@ -11,7 +11,12 @@ const items: ShorthandCollection<ChatItemProps> = [
     key: 'message-id-1',
   },
   {
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" status={{ color: 'green', icon: <AcceptIcon /> }} />,
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
     message: <Chat.Message content="تأكد منJohn. دعونا جدولة اجتماع." author="Jane Doe" timestamp="بالأمس ، 10:15" />,
     attached: 'top',
     key: 'message-id-2',

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExample.shorthand.tsx
@@ -3,7 +3,7 @@ import { Avatar, Chat, ChatItemProps, Divider, ShorthandCollection } from '@flue
 import { AcceptIcon } from '@fluentui/react-icons-northstar';
 
 const janeAvatar = {
-  image: 'public/images/avatar/small/ade.jpg',
+  image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
   status: { color: 'green', icon: <AcceptIcon /> },
 };
 

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleContentPosition.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleContentPosition.shorthand.tsx
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/react-northstar';
 import { AcceptIcon } from '@fluentui/react-icons-northstar';
 
-const [janeAvatar, johnAvatar] = ['public/images/avatar/small/ade.jpg', 'public/images/avatar/small/joe.jpg'].map(
-  src => ({
-    image: src,
-    status: { color: 'green', icon: <AcceptIcon /> },
-  }),
-);
+const [janeAvatar, johnAvatar] = [
+  'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
+  'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg',
+].map(src => ({
+  image: src,
+  status: { color: 'green', icon: <AcceptIcon /> },
+}));
 
 const items: ShorthandCollection<ChatItemProps> = [
   {

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleDetails.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatExampleDetails.shorthand.tsx
@@ -5,7 +5,12 @@ import { AcceptIcon, TranslationIcon } from '@fluentui/react-icons-northstar';
 const items: ShorthandCollection<ChatItemProps> = [
   {
     contentPosition: 'start',
-    gutter: <Avatar image="public/images/avatar/small/ade.jpg" status={{ color: 'green', icon: <AcceptIcon /> }} />,
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
     message: (
       <Chat.Message
         content="Hello"
@@ -22,7 +27,12 @@ const items: ShorthandCollection<ChatItemProps> = [
   },
   {
     contentPosition: 'end',
-    gutter: <Avatar image="public/images/avatar/small/joe.jpg" status={{ color: 'green', icon: <AcceptIcon /> }} />,
+    gutter: (
+      <Avatar
+        image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg"
+        status={{ color: 'green', icon: <AcceptIcon /> }}
+      />
+    ),
     message: (
       <Chat.Message
         content="Hi"

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleBadge.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleBadge.shorthand.tsx
@@ -3,7 +3,7 @@ import { Avatar, Chat, ChatItemProps, ShorthandCollection } from '@fluentui/reac
 import { MentionIcon, RedbangIcon, AcceptIcon } from '@fluentui/react-icons-northstar';
 
 const janeAvatar = {
-  image: 'public/images/avatar/small/ade.jpg',
+  image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
   status: { color: 'green', icon: <AcceptIcon /> },
 };
 

--- a/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Types/ChatMessageExampleStyled.shorthand.tsx
@@ -8,7 +8,7 @@ const reactions: ShorthandCollection<ReactionProps> = [
 ];
 
 const janeAvatar: AvatarProps = {
-  image: 'public/images/avatar/small/ade.jpg',
+  image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
   status: { color: 'green', icon: <AcceptIcon /> },
 };
 

--- a/packages/fluentui/docs/src/examples/components/Chat/Usage/ChatExampleInScrollable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Chat/Usage/ChatExampleInScrollable.shorthand.tsx
@@ -105,7 +105,7 @@ const ChatExampleInScrollableShorthand = () => {
       ),
     },
     {
-      gutter: <Avatar image="public/images/avatar/small/ade.jpg" />,
+      gutter: <Avatar image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />,
       message: (
         <Chat.Message
           actionMenu={actionMenu}

--- a/packages/fluentui/docs/src/examples/components/Divider/Variations/DividerExampleVertical.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Divider/Variations/DividerExampleVertical.shorthand.tsx
@@ -8,7 +8,7 @@ const DividerVerticalExampleShorthand = () => (
     <Text content="Application Title" />
     <Divider vertical />
     <Avatar
-      image="public/images/avatar/large/jerry.png"
+      image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jerry.png"
       status={{
         color: 'green',
         title: 'Available',

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Variations/DropdownExampleSearchMultipleImageAndContent.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Variations/DropdownExampleSearchMultipleImageAndContent.shorthand.tsx
@@ -4,47 +4,47 @@ import { Dropdown } from '@fluentui/react-northstar';
 const inputItems = [
   {
     header: 'Bruce Wayne',
-    image: 'public/images/avatar/small/matt.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
     content: 'Software Engineer',
   },
   {
     header: 'Natasha Romanoff',
-    image: 'public/images/avatar/small/jenny.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/jenny.jpg',
     content: 'UX Designer 2',
   },
   {
     header: 'Steven Strange',
-    image: 'public/images/avatar/small/joe.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg',
     content: 'Principal Software Engineering Manager',
   },
   {
     header: 'Alfred Pennyworth',
-    image: 'public/images/avatar/small/justen.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/justen.jpg',
     content: 'Technology Consultant',
   },
   {
     header: `Scarlett O'Hara`,
-    image: 'public/images/avatar/small/laura.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/laura.jpg',
     content: 'Software Engineer 2',
   },
   {
     header: 'Imperator Furiosa',
-    image: 'public/images/avatar/small/veronika.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/veronika.jpg',
     content: 'Boss',
   },
   {
     header: 'Bruce Banner',
-    image: 'public/images/avatar/small/chris.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/chris.jpg',
     content: 'Senior Computer Scientist',
   },
   {
     header: 'Peter Parker',
-    image: 'public/images/avatar/small/daniel.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/daniel.jpg',
     content: 'Partner Software Engineer',
   },
   {
     header: 'Selina Kyle',
-    image: 'public/images/avatar/small/ade.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
     content: 'Graphic Designer',
   },
 ];

--- a/packages/fluentui/docs/src/examples/components/Flex/Rtl/FlexExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Flex/Rtl/FlexExample.rtl.tsx
@@ -5,7 +5,7 @@ const FlexExampleMediaCard = () => (
   <Flex gap="gap.medium" padding="padding.medium" debug>
     <Flex.Item size="size.medium">
       <div style={{ position: 'relative' }}>
-        <Image fluid src="public/images/avatar/large/ade.jpg" />
+        <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg" />
       </div>
     </Flex.Item>
 

--- a/packages/fluentui/docs/src/examples/components/Flex/Types/FlexExampleMediaCard.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Flex/Types/FlexExampleMediaCard.shorthand.tsx
@@ -5,7 +5,7 @@ const FlexExampleMediaCard = () => (
   <Flex gap="gap.medium" padding="padding.medium" debug>
     <Flex.Item size="size.medium">
       <div style={{ position: 'relative' }}>
-        <Image fluid src="public/images/avatar/large/ade.jpg" />
+        <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg" />
       </div>
     </Flex.Item>
 

--- a/packages/fluentui/docs/src/examples/components/Grid/Types/GridExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Types/GridExample.shorthand.tsx
@@ -5,61 +5,61 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridRow: 1, msGridColumn: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridRow: 1, msGridColumn: 2 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridRow: 1, msGridColumn: 3 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridRow: 1, msGridColumn: 4 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridRow: 1, msGridColumn: 5 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridRow: 2, msGridColumn: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridRow: 2, msGridColumn: 2 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridRow: 2, msGridColumn: 3 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridRow: 2, msGridColumn: 4 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridRow: 2, msGridColumn: 5 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Types/GridExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Types/GridExample.tsx
@@ -5,61 +5,61 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridRow: 1, msGridColumn: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridRow: 1, msGridColumn: 2 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridRow: 1, msGridColumn: 3 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridRow: 1, msGridColumn: 4 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridRow: 1, msGridColumn: 5 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridRow: 2, msGridColumn: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridRow: 2, msGridColumn: 2 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridRow: 2, msGridColumn: 3 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridRow: 2, msGridColumn: 4 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridRow: 2, msGridColumn: 5 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumns.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumns.shorthand.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumns.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumns.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumnsAndRows.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumnsAndRows.shorthand.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumnsAndRows.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleColumnsAndRows.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.shorthand.tsx
@@ -42,7 +42,7 @@ const renderImages = () => {
       key={imageName}
       style={getMSGridPositions(index % 7, index % 3)}
       fluid
-      src={`public/images/avatar/large/${imageName}.jpg`}
+      src={`https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/${imageName}.jpg`}
       data-is-focusable="true"
     />
   ));
@@ -55,7 +55,7 @@ const renderImageButtons = () => {
       style={{ ...imageButtonStyles, ...getMSGridPositions(index % 7, index % 3) }}
       title={imageName}
     >
-      <Image fluid src={`public/images/avatar/large/${imageName}.jpg`} />
+      <Image fluid src={`https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/${imageName}.jpg`} />
     </Button>
   ));
 };

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleKeyboardNavigable.tsx
@@ -43,7 +43,7 @@ const renderImages = () => {
       key={imageName}
       style={getMSGridPositions(index % 7, index % 3)}
       fluid
-      src={`public/images/avatar/large/${imageName}.jpg`}
+      src={`https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/${imageName}.jpg`}
       data-is-focusable="true"
     />
   ));
@@ -56,7 +56,7 @@ const renderImageButtons = () => {
       style={{ ...imageButtonStyles, ...getMSGridPositions(index % 7, index % 3) }}
       title={imageName}
     >
-      <Image fluid src={`public/images/avatar/large/${imageName}.jpg`} />
+      <Image fluid src={`https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/${imageName}.jpg`} />
     </Button>
   ));
 };

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleRows.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleRows.shorthand.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleRows.tsx
+++ b/packages/fluentui/docs/src/examples/components/Grid/Variations/GridExampleRows.tsx
@@ -5,139 +5,139 @@ const images = [
   <Image
     key="ade"
     fluid
-    src="public/images/avatar/large/ade.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/ade.jpg"
     style={{ msGridColumn: 1, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="chris"
     fluid
-    src="public/images/avatar/large/chris.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/chris.jpg"
     style={{ msGridColumn: 2, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="christian"
     fluid
-    src="public/images/avatar/large/christian.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/christian.jpg"
     style={{ msGridColumn: 3, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="daniel"
     fluid
-    src="public/images/avatar/large/daniel.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/daniel.jpg"
     style={{ msGridColumn: 4, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elliot"
     fluid
-    src="public/images/avatar/large/elliot.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elliot.jpg"
     style={{ msGridColumn: 5, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="elyse"
     fluid
-    src="public/images/avatar/large/elyse.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/elyse.png"
     style={{ msGridColumn: 6, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="helen"
     fluid
-    src="public/images/avatar/large/helen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/helen.jpg"
     style={{ msGridColumn: 7, msGridRow: 1 } as React.CSSProperties}
   />,
   <Image
     key="jenny"
     fluid
-    src="public/images/avatar/large/jenny.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/jenny.jpg"
     style={{ msGridColumn: 1, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="joe"
     fluid
-    src="public/images/avatar/large/joe.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/joe.jpg"
     style={{ msGridColumn: 2, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="justen"
     fluid
-    src="public/images/avatar/large/justen.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/justen.jpg"
     style={{ msGridColumn: 3, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="kristy"
     fluid
-    src="public/images/avatar/large/kristy.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/kristy.png"
     style={{ msGridColumn: 4, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="laura"
     fluid
-    src="public/images/avatar/large/laura.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/laura.jpg"
     style={{ msGridColumn: 5, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matt"
     fluid
-    src="public/images/avatar/large/matt.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matt.jpg"
     style={{ msGridColumn: 6, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="matthew"
     fluid
-    src="public/images/avatar/large/matthew.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/matthew.png"
     style={{ msGridColumn: 7, msGridRow: 2 } as React.CSSProperties}
   />,
   <Image
     key="molly"
     fluid
-    src="public/images/avatar/large/molly.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/molly.png"
     style={{ msGridColumn: 1, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nan"
     fluid
-    src="public/images/avatar/large/nan.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nan.jpg"
     style={{ msGridColumn: 2, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="nom"
     fluid
-    src="public/images/avatar/large/nom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/nom.jpg"
     style={{ msGridColumn: 3, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="patrick"
     fluid
-    src="public/images/avatar/large/patrick.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/patrick.png"
     style={{ msGridColumn: 4, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="rachel"
     fluid
-    src="public/images/avatar/large/rachel.png"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/rachel.png"
     style={{ msGridColumn: 5, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="steve"
     fluid
-    src="public/images/avatar/large/steve.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/steve.jpg"
     style={{ msGridColumn: 6, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="stevie"
     fluid
-    src="public/images/avatar/large/stevie.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/stevie.jpg"
     style={{ msGridColumn: 7, msGridRow: 3 } as React.CSSProperties}
   />,
   <Image
     key="tom"
     fluid
-    src="public/images/avatar/large/tom.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/tom.jpg"
     style={{ msGridColumn: 1, msGridRow: 4 } as React.CSSProperties}
   />,
   <Image
     key="veronika"
     fluid
-    src="public/images/avatar/large/veronika.jpg"
+    src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/large/veronika.jpg"
     style={{ msGridColumn: 2, msGridRow: 4 } as React.CSSProperties}
   />,
 ];

--- a/packages/fluentui/docs/src/examples/components/Image/Rtl/ImageExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Image/Rtl/ImageExample.rtl.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Image } from '@fluentui/react-northstar';
 
-const ImageExampleRtl = () => <Image src="public/images/leaves/4.png" />;
+const ImageExampleRtl = () => <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/leaves/4.png" />;
 
 export default ImageExampleRtl;

--- a/packages/fluentui/docs/src/examples/components/Image/Types/ImageExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Image/Types/ImageExample.shorthand.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Image } from '@fluentui/react-northstar';
 
-const ImageExample = () => <Image src="public/images/wireframe/square-image.png" />;
+const ImageExample = () => (
+  <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
+);
 
 export default ImageExample;

--- a/packages/fluentui/docs/src/examples/components/Image/Types/ImageExampleAvatar.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Image/Types/ImageExampleAvatar.shorthand.tsx
@@ -3,9 +3,9 @@ import { Image } from '@fluentui/react-northstar';
 
 const ImageExampleAvatar = () => (
   <div>
-    <Image avatar src="public/images/avatar/small/ade.jpg" />
-    <Image avatar src="public/images/avatar/small/chris.jpg" />
-    <Image avatar src="public/images/avatar/small/joe.jpg" />
+    <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg" />
+    <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/chris.jpg" />
+    <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg" />
   </div>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Image/Variations/ImageExampleCircular.tsx
+++ b/packages/fluentui/docs/src/examples/components/Image/Variations/ImageExampleCircular.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { Image } from '@fluentui/react-northstar';
 
-const ImageExampleCircular = () => <Image circular src="public/images/avatar/small/matt.jpg" />;
+const ImageExampleCircular = () => (
+  <Image circular src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" />
+);
 
 export default ImageExampleCircular;

--- a/packages/fluentui/docs/src/examples/components/Image/Variations/ImageExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Image/Variations/ImageExampleFluid.tsx
@@ -6,17 +6,23 @@ const ImageExampleFluent = () => (
     <Layout
       styles={{ maxWidth: '70px' }}
       debug
-      renderMainArea={() => <Image fluid src="public/images/wireframe/square-image.png" />}
+      renderMainArea={() => (
+        <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
+      )}
     />
     <Layout
       styles={{ maxWidth: '100px' }}
       debug
-      renderMainArea={() => <Image fluid src="public/images/wireframe/square-image.png" />}
+      renderMainArea={() => (
+        <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
+      )}
     />
     <Layout
       styles={{ maxWidth: '150px' }}
       debug
-      renderMainArea={() => <Image fluid src="public/images/wireframe/square-image.png" />}
+      renderMainArea={() => (
+        <Image fluid src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
+      )}
     />
   </div>
 );

--- a/packages/fluentui/docs/src/examples/components/ItemLayout/Content/ItemLayoutExampleMedia.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/ItemLayout/Content/ItemLayoutExampleMedia.shorthand.tsx
@@ -3,7 +3,7 @@ import { ItemLayout, Image } from '@fluentui/react-northstar';
 
 const ItemLayoutExampleMediaShorthand = () => (
   <ItemLayout
-    media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+    media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />}
     header="Dante Schneider"
     headerMedia="5:22:40 PM"
     content="The GB pixel is down, navigate the virtual interface!"

--- a/packages/fluentui/docs/src/examples/components/ItemLayout/Types/ItemLayoutExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/ItemLayout/Types/ItemLayoutExample.shorthand.tsx
@@ -7,7 +7,7 @@ const ItemLayoutExampleShorthand = () => {
 
   return (
     <ItemLayout
-      media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />}
       header="Irving Kuhic"
       headerMedia="7:26:56 AM"
       content="Program the sensor to the SAS alarm through the haptic SQL card!"

--- a/packages/fluentui/docs/src/examples/components/ItemLayout/Types/ItemLayoutExampleSelection.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/ItemLayout/Types/ItemLayoutExampleSelection.shorthand.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 const ItemLayoutExampleSelectionShorthand = () => {
   return (
     <ItemLayout
-      media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />}
       header="Irving Kuhic"
       headerMedia="7:26:56 AM"
       content="Program the sensor to the SAS alarm through the haptic SQL card!"

--- a/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleContentCustomization.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleContentCustomization.shorthand.tsx
@@ -19,7 +19,10 @@ class LabelExampleContentCustomizationShorthand extends React.Component {
       <Label
         content="You can remove me!"
         circular
-        image={{ src: 'public/images/avatar/small/matt.jpg', avatar: true }}
+        image={{
+          src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
+          avatar: true,
+        }}
         icon={<CloseIcon {...{ onClick: this.hide }} />}
       />
     );

--- a/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleImage.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleImage.shorthand.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 import { Label } from '@fluentui/react-northstar';
 
-const LabelExampleImageShorthand = () => <Label content="John Doe" image="public/images/avatar/small/matt.jpg" />;
+const LabelExampleImageShorthand = () => (
+  <Label
+    content="John Doe"
+    image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+  />
+);
 
 export default LabelExampleImageShorthand;

--- a/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleImagePosition.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Label/Content/LabelExampleImagePosition.shorthand.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Label } from '@fluentui/react-northstar';
 
 const LabelExampleImageShorthand = () => (
-  <Label content="John Doe" image="public/images/avatar/small/matt.jpg" imagePosition="end" />
+  <Label
+    content="John Doe"
+    image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
+    imagePosition="end"
+  />
 );
 
 export default LabelExampleImageShorthand;

--- a/packages/fluentui/docs/src/examples/components/Label/Rtl/LabelExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/Label/Rtl/LabelExample.rtl.tsx
@@ -6,7 +6,7 @@ const LabelExampleRtl = () => (
   <Label
     content="جين دو"
     circular
-    image={{ src: 'public/images/avatar/small/matt.jpg', avatar: true }}
+    image={{ src: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg', avatar: true }}
     icon={<CloseIcon {...{}} />} // TODO: it's a bummer that it looks like this, but it is correct :\
   />
 );

--- a/packages/fluentui/docs/src/examples/components/List/Content/ListExampleMedia.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Content/ListExampleMedia.shorthand.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const items = [
   {
     key: 'irving',
-    media: <Image avatar src="public/images/avatar/small/matt.jpg" />,
+    media: <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" />,
     header: 'Irving Kuhic',
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
   },
   {
     key: 'skyler',
-    media: <Image avatar src="public/images/avatar/small/steve.jpg" />,
+    media: <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" />,
     header: 'Skyler Parks',
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
   },
   {
     key: 'dante',
-    media: <Image avatar src="public/images/avatar/small/nom.jpg" />,
+    media: <Image avatar src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" />,
     header: 'Dante Schneider',
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Content/ListExampleMedia.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Content/ListExampleMedia.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const ListExampleMedia = () => (
   <List>
     <List.Item
-      media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />}
       header="Irving Kuhic"
       headerMedia="7:26:56 AM"
       content="Program the sensor to the SAS alarm through the haptic SQL card!"
       index={0}
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/steve.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />}
       header="Skyler Parks"
       headerMedia="11:30:17 PM"
       content="Use the online FTP application to input the multi-byte application!"
       index={1}
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />}
       header="Dante Schneider"
       headerMedia="5:22:40 PM"
       content="The GB pixel is down, navigate the virtual interface!"

--- a/packages/fluentui/docs/src/examples/components/List/Rtl/ListExample.rtl.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Rtl/ListExample.rtl.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const items = [
   {
     key: 'irving',
-    media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
     header: 'ايرفينغ كوهيك',
     headerMedia: '7:26:56 AM',
     content: 'برنامج الاستشعار إلى التنبيه SAS من خلال بطاقة SQL ملحن!',
   },
   {
     key: 'skyler',
-    media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
     header: 'سكايلر باركس',
     headerMedia: '11:30:17 PM',
     content: 'استخدم تطبيق FTP عبر الإنترنت لإدخال تطبيق متعدد البايت!',
   },
   {
     key: 'dante',
-    media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
     header: 'دانتي شنايدر',
     headerMedia: '5:22:40 PM',
     content: 'بكسل GB لأسفل ، وتصفح الواجهة الافتراضية!',

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExample.shorthand.tsx
@@ -5,21 +5,21 @@ import * as React from 'react';
 const items = [
   {
     key: 'irving',
-    media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
     header: 'Irving Kuhic',
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
   },
   {
     key: 'skyler',
-    media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
     header: 'Skyler Parks',
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
   },
   {
     key: 'dante',
-    media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
     header: 'Dante Schneider',
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExample.tsx
@@ -8,21 +8,25 @@ const ListExampleSelectable = () => {
   return (
     <List debug={debug}>
       <List.Item
-        media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+        media={
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />
+        }
         header="Irving Kuhic"
         headerMedia="7:26:56 AM"
         content="Program the sensor to the SAS alarm through the haptic SQL card!"
         index={0}
       />
       <List.Item
-        media={<Image src="public/images/avatar/small/steve.jpg" avatar />}
+        media={
+          <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />
+        }
         header="Skyler Parks"
         headerMedia="11:30:17 PM"
         content="Use the online FTP application to input the multi-byte application!"
         index={1}
       />
       <List.Item
-        media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+        media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />}
         header="Dante Schneider"
         headerMedia="5:22:40 PM"
         content="The GB pixel is down, navigate the virtual interface!"

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.shorthand.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const items = [
   {
     key: 'irving',
-    media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
     header: 'Irving Kuhic',
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
   },
   {
     key: 'skyler',
-    media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
     header: 'Skyler Parks',
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
   },
   {
     key: 'dante',
-    media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
     header: 'Dante Schneider',
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleNavigable.tsx
@@ -4,7 +4,7 @@ import { List, Image } from '@fluentui/react-northstar';
 const ListExampleNavigable = () => (
   <List navigable>
     <List.Item
-      media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />}
       header="Irving Kuhic"
       headerMedia="7:26:56 AM"
       content="Program the sensor to the SAS alarm through the haptic SQL card!"
@@ -12,7 +12,7 @@ const ListExampleNavigable = () => (
       index={0}
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/steve.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />}
       header="Skyler Parks"
       headerMedia="11:30:17 PM"
       content="Use the online FTP application to input the multi-byte application!"
@@ -20,7 +20,7 @@ const ListExampleNavigable = () => (
       index={1}
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />}
       header="Dante Schneider"
       headerMedia="5:22:40 PM"
       content="The GB pixel is down, navigate the virtual interface!"

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.shorthand.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const items = [
   {
     key: 'irving',
-    media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
     header: 'Irving Kuhic',
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
   },
   {
     key: 'skyler',
-    media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
     header: 'Skyler Parks',
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
   },
   {
     key: 'dante',
-    media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
     header: 'Dante Schneider',
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectable.tsx
@@ -4,21 +4,21 @@ import { List, Image } from '@fluentui/react-northstar';
 const ListExampleSelectable = () => (
   <List selectable>
     <List.Item
-      media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />}
       header="Irving Kuhic"
       headerMedia="7:26:56 AM"
       index={0}
       content="Program the sensor to the SAS alarm through the haptic SQL card!"
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/steve.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />}
       header="Skyler Parks"
       headerMedia="11:30:17 PM"
       index={1}
       content="Use the online FTP application to input the multi-byte application!"
     />
     <List.Item
-      media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+      media={<Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />}
       header="Dante Schneider"
       headerMedia="5:22:40 PM"
       index={2}

--- a/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectableControlled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Types/ListExampleSelectableControlled.shorthand.tsx
@@ -7,21 +7,21 @@ class SelectableListControlledExample extends React.Component<any, any> {
   items = [
     {
       key: 'irving',
-      media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+      media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
       header: 'Irving Kuhic',
       headerMedia: '7:26:56 AM',
       content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
     },
     {
       key: 'skyler',
-      media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+      media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
       header: 'Skyler Parks',
       headerMedia: '11:30:17 PM',
       content: 'Use the online FTP application to input the multi-byte application!',
     },
     {
       key: 'dante',
-      media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+      media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
       header: 'Dante Schneider',
       headerMedia: '5:22:40 PM',
       content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Variations/ListExampleTruncate.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Variations/ListExampleTruncate.shorthand.tsx
@@ -27,7 +27,7 @@ const actions = (
 const items = [
   {
     key: 'irving',
-    media: <Image src="public/images/avatar/small/matt.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />,
     header: 'Irving Kuhic - Super long title here',
     headerMedia: '7:26:56 AM',
     content: 'Program the sensor to the SAS alarm through the haptic SQL card!',
@@ -36,7 +36,7 @@ const items = [
   },
   {
     key: 'skyler',
-    media: <Image src="public/images/avatar/small/steve.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />,
     header: 'Skyler Parks - Super long title here',
     headerMedia: '11:30:17 PM',
     content: 'Use the online FTP application to input the multi-byte application!',
@@ -45,7 +45,7 @@ const items = [
   },
   {
     key: 'dante',
-    media: <Image src="public/images/avatar/small/nom.jpg" avatar />,
+    media: <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />,
     header: 'Dante Schneider - Super long title here',
     headerMedia: '5:22:40 PM',
     content: 'The GB pixel is down, navigate the virtual interface!',

--- a/packages/fluentui/docs/src/examples/components/List/Variations/ListExampleTruncate.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Variations/ListExampleTruncate.tsx
@@ -12,7 +12,9 @@ const ListExample = () => {
     <div style={{ width }}>
       <List debug={debug} truncateHeader={truncateHeader} truncateContent={truncateContent}>
         <List.Item
-          media={<Image src="public/images/avatar/small/matt.jpg" avatar />}
+          media={
+            <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />
+          }
           header="Irving Kuhic - Super long title here"
           headerMedia="7:26:56 AM"
           content="Program the sensor to the SAS alarm through the haptic SQL card!"
@@ -20,7 +22,9 @@ const ListExample = () => {
           index={0}
         />
         <List.Item
-          media={<Image src="public/images/avatar/small/steve.jpg" avatar />}
+          media={
+            <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/steve.jpg" avatar />
+          }
           header="Skyler Parks - Super long title here"
           headerMedia="11:30:17 PM"
           content="Use the online FTP application to input the multi-byte application!"
@@ -28,7 +32,9 @@ const ListExample = () => {
           index={1}
         />
         <List.Item
-          media={<Image src="public/images/avatar/small/nom.jpg" avatar />}
+          media={
+            <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/nom.jpg" avatar />
+          }
           header="Dante Schneider - Super long title here"
           headerMedia="5:22:40 PM"
           content="The GB pixel is down, navigate the virtual interface!"

--- a/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.tsx
@@ -6,47 +6,47 @@ import { UserFriendsIcon } from '@fluentui/react-icons-northstar';
 const inputItems = [
   {
     header: 'Bruce Wayne',
-    image: 'public/images/avatar/small/matt.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
     content: 'Software Engineer',
   },
   {
     header: 'Natasha Romanoff',
-    image: 'public/images/avatar/small/jenny.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/jenny.jpg',
     content: 'UX Designer 2',
   },
   {
     header: 'Steven Strange',
-    image: 'public/images/avatar/small/joe.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg',
     content: 'Principal Software Engineering Manager',
   },
   {
     header: 'Alfred Pennyworth',
-    image: 'public/images/avatar/small/justen.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/justen.jpg',
     content: 'Technology Consultant',
   },
   {
     header: `Scarlett O'Hara`,
-    image: 'public/images/avatar/small/laura.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/laura.jpg',
     content: 'Software Engineer 2',
   },
   {
     header: 'Imperator Furiosa',
-    image: 'public/images/avatar/small/veronika.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/veronika.jpg',
     content: 'Boss',
   },
   {
     header: 'Bruce Banner',
-    image: 'public/images/avatar/small/chris.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/chris.jpg',
     content: 'Senior Computer Scientist',
   },
   {
     header: 'Peter Parker',
-    image: 'public/images/avatar/small/daniel.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/daniel.jpg',
     content: 'Partner Software Engineer',
   },
   {
     header: 'Selina Kyle',
-    image: 'public/images/avatar/small/ade.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
     content: 'Graphic Designer',
   },
 ];

--- a/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.tsx
+++ b/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.tsx
@@ -6,47 +6,47 @@ import { UserFriendsIcon } from '@fluentui/react-icons-northstar';
 const inputItems = [
   {
     header: 'Bruce Wayne',
-    image: 'public/images/avatar/small/matt.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg',
     content: 'Software Engineer',
   },
   {
     header: 'Natasha Romanoff',
-    image: 'public/images/avatar/small/jenny.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/jenny.jpg',
     content: 'UX Designer 2',
   },
   {
     header: 'Steven Strange',
-    image: 'public/images/avatar/small/joe.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/joe.jpg',
     content: 'Principal Software Engineering Manager',
   },
   {
     header: 'Alfred Pennyworth',
-    image: 'public/images/avatar/small/justen.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/justen.jpg',
     content: 'Technology Consultant',
   },
   {
     header: `Scarlett O'Hara`,
-    image: 'public/images/avatar/small/laura.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/laura.jpg',
     content: 'Software Engineer 2',
   },
   {
     header: 'Imperator Furiosa',
-    image: 'public/images/avatar/small/veronika.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/veronika.jpg',
     content: 'Boss',
   },
   {
     header: 'Bruce Banner',
-    image: 'public/images/avatar/small/chris.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/chris.jpg',
     content: 'Senior Computer Scientist',
   },
   {
     header: 'Peter Parker',
-    image: 'public/images/avatar/small/daniel.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/daniel.jpg',
     content: 'Partner Software Engineer',
   },
   {
     header: 'Selina Kyle',
-    image: 'public/images/avatar/small/ade.jpg',
+    image: 'https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/ade.jpg',
     content: 'Graphic Designer',
   },
 ];

--- a/packages/fluentui/docs/src/examples/components/Provider/Types/ProviderExampleScrollbar.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Provider/Types/ProviderExampleScrollbar.shorthand.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 const ProviderExampleScrollbar = () => (
   <div style={{ height: '100px', overflow: 'scroll' }}>
-    <Image src="public/images/leaves/4.png" />
+    <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/leaves/4.png" />
   </div>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Skeleton/Usage/SkeletonExampleCard.tsx
+++ b/packages/fluentui/docs/src/examples/components/Skeleton/Usage/SkeletonExampleCard.tsx
@@ -25,7 +25,7 @@ const SkeletonExampleCard = () => {
         ) : (
           <Flex gap="gap.small">
             <Avatar
-              image="public/images/avatar/small/matt.jpg"
+              image="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg"
               label="Copy bandwidth"
               name="Evie yundt"
               status="unknown"
@@ -50,7 +50,7 @@ const SkeletonExampleCard = () => {
           </Skeleton>
         ) : (
           <Flex column gap="gap.small">
-            <Image src="public/images/wireframe/square-image.png" />
+            <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/wireframe/square-image.png" />
             <Text content="Citizens of distant epochs muse about at the edge of forever hearts of the..." />
           </Flex>
         )}

--- a/packages/fluentui/docs/src/examples/components/Skeleton/Usage/SkeletonExampleList.tsx
+++ b/packages/fluentui/docs/src/examples/components/Skeleton/Usage/SkeletonExampleList.tsx
@@ -23,7 +23,7 @@ const SkeletonExampleList = () => {
                 <Skeleton.Shape round width="32px" height="32px" />
               </Skeleton>
             ) : (
-              <Image src="public/images/avatar/small/matt.jpg" avatar />
+              <Image src="https://fabricweb.azureedge.net/fabric-website/assets/images/avatar/small/matt.jpg" avatar />
             )
           }
           header={

--- a/packages/fluentui/docs/src/index.ejs
+++ b/packages/fluentui/docs/src/index.ejs
@@ -4,7 +4,7 @@
   <base href='<%= __BASENAME__ %>'>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <link rel="shortcut icon" type="image/x-icon" href='<%= __BASENAME__ + (__PROD__ ? 'public/images/fluent-ui-logo.png' : 'public/images/fluent-ui-logo-dev.png') %>'/>
+  <link rel="shortcut icon" type="image/x-icon" href='<%= __PROD__ ? 'https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png' : 'https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo-dev.png' %>'/>
   <title>Fluent UI</title>
   <script>
     // Redirect to HTTPs

--- a/packages/fluentui/docs/src/pages/Debugging.mdx
+++ b/packages/fluentui/docs/src/pages/Debugging.mdx
@@ -29,7 +29,7 @@ There are two ways of how the theme can be overridden: by nesting a different th
 
 In order to compute CSS styles, all the theme pieces are merged:
 
-![Merge order](public/images/merge-themes.png)
+![Merge order](https://fabricweb.azureedge.net/fabric-website/assets/images/merge-themes.png)
 
 1. First, site variables are merged together.
 2. Merged site variables are passed as input to component variables, resolved component variables are merged together.
@@ -42,7 +42,7 @@ As the merged component styles are processed by CSSInJS and the way how those ar
 
 For that reason Fluent UI contains a Debug panel which displays the whole processing chain from bottom to top to final *merged component styles*:
 
-![Debug panel](public/images/debug-panel.png)
+![Debug panel](https://fabricweb.azureedge.net/fabric-website/assets/images/debug-panel.png)
 
 ### Enabling Debug panel in an application
 
@@ -71,7 +71,7 @@ const theme = withDebugId(themeObject, 'themeName');
 Both browser and React DevTools provide developers with great tools to measure performance. Fluent UI adds its own Telemetry popover to give developers
 a way to drill down into the pipeline internals:
 
-![Telemetry popover](public/images/telemetry-popover.png)
+![Telemetry popover](https://fabricweb.azureedge.net/fabric-website/assets/images/telemetry-popover.png)
 
 ### What you see in the table
 

--- a/packages/fluentui/docs/src/pages/Layout.mdx
+++ b/packages/fluentui/docs/src/pages/Layout.mdx
@@ -15,8 +15,8 @@ Fluent UI has `Flex` and `Grid` components to handle layout aspects, they repres
 
 `Flex` is for either columns _or_ rows. This means that if you are laying out items in one direction (for example buttons inside a header), then you should use `Flex`.
 
-![Flex layout](public/images/flex.svg)
-![Flex layout](public/images/flex-column.svg)
+![Flex layout](https://fabricweb.azureedge.net/fabric-website/assets/images/flex.svg)
+![Flex layout](https://fabricweb.azureedge.net/fabric-website/assets/images/flex-column.svg)
 
 `Flex` component addresses all common [Flexbox](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox) layout scenarios and defines additional props to address most common [Flexbox usage scenarios](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox) (e.g. `push` prop). `Flex.Item` component can be used to tweak flex styles of individual child item and will not produce additional DOM nodes.
 
@@ -43,8 +43,8 @@ You can learn more in [Flex component docs](/components/flex).
 
 `Grid` is for lining things up in columns _and_ rows, it implements [Grid layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) module.
 
-![Grid layout](public/images/grid-page.svg)
-![Grid layout](public/images/grid.svg)
+![Grid layout](https://fabricweb.azureedge.net/fabric-website/assets/images/grid-page.svg)
+![Grid layout](https://fabricweb.azureedge.net/fabric-website/assets/images/grid.svg)
 
 <ExampleSnippet>
   <Grid styles={{

--- a/packages/fluentui/react-builder/src/components/Toolbar.tsx
+++ b/packages/fluentui/react-builder/src/components/Toolbar.tsx
@@ -45,7 +45,10 @@ export const Toolbar: React.FunctionComponent<ToolbarProps> = ({
       ...style,
     }}
   >
-    <Image styles={{ height: '1.5rem', marginRight: '0.25rem' }} src={`public/images/fluent-ui-logo.png`} />
+    <Image
+      styles={{ height: '1.5rem', marginRight: '0.25rem' }}
+      src="https://fabricweb.azureedge.net/fabric-website/assets/images/fluent-ui-logo.png"
+    />
     <div style={{ position: 'relative', width: '8em', fontSize: '18px', lineHeight: 1 }}>
       FluentUI
       <div style={{ position: 'absolute', fontSize: '11px', opacity: 0.625 }}>Builder</div>

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -177,6 +177,13 @@ task('serve:docs:hot', async () => {
   const compiler = webpack(webpackConfig);
 
   server = await serve(paths.docsDist(), config.server_host, config.server_port, app => {
+    app.get('/public/*', (req, res) => {
+      res.status(404);
+      res.send(
+        'Assets from "/public" should be served from CDN, please check "packages/fluentui/docs/README.md" to check how you can upload images.',
+      );
+    });
+
     app.use(
       WebpackDevMiddleware(compiler, {
         publicPath: webpackConfig.output.publicPath,


### PR DESCRIPTION
A followup on #15097, tries to solve continuous issues with Screener that serves our images from Azure Blob (#14880):

![image](https://user-images.githubusercontent.com/14183168/93764641-be916800-fc13-11ea-991c-f17f33ba0f92.png)

Before this PR images were served from Azure Blob, with these changes they will be served from CDN. This will make them load faster than if we uploaded them to normal blob storages, which can be important for getting correct results in screener tests.

---

**The images will upload only on master builds** (mainly to avoid accidental changes). This means that if you want to use a new image, you'll have to check it in separately first, but that shouldn't be a big issue since it won't happen very often. An FAQ entry to `@fluentui/docs` was added.

This also solves an issue with CodeSandbox where we got broken images:
- before https://codesandbox.io/s/otjqi?module=/example.js
- after https://codesandbox.io/s/jj04y?module=/example.js

