### PR TITLE
fix(Ref): do not return Fibers as refs for "react-test-renderer"

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove `aria-selected` attribute from `TreeItem` when `Tree` is not selectable @assuncaocharles ([#15115](https://github.com/microsoft/fluentui/pull/15115))
 - Add `shouldPreventDefault` on `keyDown` event for `TreeTitle` to allow enter trigger when `TreeTitle` is rendered as an `anchor` @assuncaocharles ([#15095](https://github.com/microsoft/fluentui/pull/15095))
 - Fix screen reader experience in multiple `dropdown` @kolaps33 ([#15066](https://github.com/microsoft/fluentui/pull/15066))
+- Fix of handling refs in `Ref` component for `react-test-render` @layershifter ([#15144](https://github.com/microsoft/fluentui/pull/15144))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -17,6 +17,7 @@
     "lerna-alias": "^3.0.3-0",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-test-renderer": "^16.3.0",
     "typescript": "3.7.2"
   },
   "files": [

--- a/packages/fluentui/react-component-ref/src/RefFindNode.tsx
+++ b/packages/fluentui/react-component-ref/src/RefFindNode.tsx
@@ -3,17 +3,60 @@ import * as ReactDOM from 'react-dom';
 
 import { handleRef, RefProps } from './utils';
 
+// ========================================================
+// react/packages/react-reconciler/src/ReactFiber.js
+// ========================================================
+
+type Fiber = {
+  // Tag identifying the type of fiber.
+  tag: string;
+  // The resolved function/class/ associated with this fiber.
+  type: any;
+};
+
+/**
+ * Detects if a passed element is a Fiber object instead of an element. Is needed as `ReactDOM.findDOMNode()` returns
+ * a Fiber in `react-test-renderer` that can cause issues with tests. Is used only in non-production env.
+ *
+ * @see https://github.com/facebook/react/issues/7371#issuecomment-317396864
+ * @see https://github.com/Semantic-Org/Semantic-UI-React/issues/4061#issuecomment-694895617
+ */
+function isFiberRef(node: Element | Fiber | Text | null): boolean {
+  if (node === null) {
+    return false;
+  }
+
+  if (node instanceof Element || node instanceof Text) {
+    return false;
+  }
+
+  return !!(node.type && node.tag);
+}
+
 export class RefFindNode extends React.Component<RefProps> {
   prevNode: Node | null = null;
 
   componentDidMount() {
-    this.prevNode = ReactDOM.findDOMNode(this);
+    let currentNode = ReactDOM.findDOMNode(this);
 
-    handleRef(this.props.innerRef, this.prevNode);
+    if (process.env.NODE_ENV !== 'production') {
+      if (isFiberRef(currentNode)) {
+        currentNode = null;
+      }
+    }
+
+    this.prevNode = currentNode;
+    handleRef(this.props.innerRef, currentNode);
   }
 
   componentDidUpdate(prevProps: RefProps) {
-    const currentNode = ReactDOM.findDOMNode(this);
+    let currentNode = ReactDOM.findDOMNode(this);
+
+    if (process.env.NODE_ENV !== 'production') {
+      if (isFiberRef(currentNode)) {
+        currentNode = null;
+      }
+    }
 
     if (this.prevNode !== currentNode) {
       this.prevNode = currentNode;

--- a/packages/fluentui/react-component-ref/test/RefFindNode-test.tsx
+++ b/packages/fluentui/react-component-ref/test/RefFindNode-test.tsx
@@ -1,6 +1,7 @@
 import { RefFindNode } from '@fluentui/react-component-ref';
 import { mount } from 'enzyme';
 import * as React from 'react';
+import { create } from 'react-test-renderer';
 
 import { CompositeClass, CompositeFunction, DOMClass, DOMFunction } from './fixtures';
 
@@ -96,6 +97,20 @@ describe('RefFindNode', () => {
 
       expect(initialRef).not.toHaveBeenCalled();
       expect(updatedRef).toHaveBeenCalled();
+    });
+
+    it('always returns "null" for react-test-renderer', () => {
+      const innerRef = jest.fn();
+      const ref = jest.fn();
+
+      create(
+        <RefFindNode innerRef={innerRef}>
+          <div ref={ref} />
+        </RefFindNode>,
+      );
+
+      expect(innerRef).toHaveBeenCalledWith(null);
+      expect(ref).toHaveBeenCalledWith(null);
     });
   });
 });


### PR DESCRIPTION
This PR fixes an issue that can lead us to very weird bugs (https://github.com/Semantic-Org/Semantic-UI-React/issues/4061) as `ReactDOM.findDOMNode()` for `react-test-renderer` will return a React Fiber https://github.com/facebook/react/issues/7371#issuecomment-317396864.


