### PR TITLE
fix(tree): treeItem that can't be selected has selectable true

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
+- Fix `Tree` to have un-selectable `treeItem` with `selectable` prop false @yuanboxue-amber ([#15170](https://github.com/microsoft/fluentui/pull/15170))
 - Fix `MenuItem` and `CarouselNavigationItem` to correctly map `active` prop to behavior @yuanboxue-amber ([#14970](https://github.com/microsoft/fluentui/pull/14970))
 - Fix default focused outline in Safari @yuanboxue-amber ([#14917](https://github.com/microsoft/fluentui/pull/14917))
 - Fix a warning when the `inverted` prop was used in `TextArea` @layershifter ([#14357](https://github.com/microsoft/fluentui/pull/14357))

--- a/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/Tree.tsx
@@ -429,6 +429,7 @@ export const Tree: ComponentWithAs<'div', TreeProps> &
               expanded: isSubtreeExpanded,
               selected: isSelectedItem(item),
               selectable,
+              ...(isSubtree && !item.selectableParent && { selectable: false }),
               renderItemTitle,
               id,
               key: id,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

When a `Tree` is `selectable`, all its `treeItem` will have `selectable: true`.
However when a `treeItem` renders a `treeTitle`, it will check:
- if the current tree node has subtree, and `selectableParent: false`, the rendered `treeTitle` will have `seletable: false`

So when a tree node is not selectable, the rendered treeItem will have `selectable: true`, and the nested treeTitle will have `selectable: false`.

This fix put a similar check when a treeItem is being rendered, to make sure an un-selectable `treeItem` and its nested `treeTitle` will both have `selectable: false`.

## Before the fix:
<img width="714" alt="Screenshot 2020-09-22 at 17 15 41" src="https://user-images.githubusercontent.com/28751745/93903466-f7efd380-fcf8-11ea-8139-863c03c6df73.png">


## After the fix:
<img width="713" alt="Screenshot 2020-09-22 at 17 14 38" src="https://user-images.githubusercontent.com/28751745/93903480-faeac400-fcf8-11ea-9280-e6c1b9245724.png">




#### Focus areas to test

(optional)
