### PR TITLE
Bump theme package version to be 1.0.0 since it's used by other major packages

### DIFF
--- a/change/@fluentui-react-button-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@fluentui-react-button-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "set theme package version to be 1.0.0.",
+  "packageName": "@fluentui/react-button",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-22T19:42:23.993Z"
+}

--- a/change/@fluentui-react-button-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@fluentui-react-button-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,8 +1,8 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "set theme package version to be 1.0.0.",
   "packageName": "@fluentui/react-button",
   "email": "xgao@microsoft.com",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-09-22T19:42:23.993Z"
 }

--- a/change/@fluentui-react-theme-provider-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@fluentui-react-theme-provider-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,8 +1,8 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "set theme package version to be 1.0.0.",
   "packageName": "@fluentui/react-theme-provider",
   "email": "xgao@microsoft.com",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-09-22T19:42:26.638Z"
 }

--- a/change/@fluentui-react-theme-provider-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@fluentui-react-theme-provider-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "set theme package version to be 1.0.0.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-22T19:42:26.638Z"
+}

--- a/change/@fluentui-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@fluentui-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Bump theme package version to be 1.0.0 since it's used by other major packages.",
+  "packageName": "@fluentui/theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T19:43:20.359Z"
+}

--- a/change/@uifabric-fluent-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@uifabric-fluent-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,8 +1,8 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "set theme package version to be 1.0.0.",
   "packageName": "@uifabric/fluent-theme",
   "email": "xgao@microsoft.com",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-09-22T19:42:14.903Z"
 }

--- a/change/@uifabric-fluent-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@uifabric-fluent-theme-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "set theme package version to be 1.0.0.",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-22T19:42:14.903Z"
+}

--- a/change/@uifabric-styling-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@uifabric-styling-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "set theme package version to be 1.0.0.",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-09-22T19:42:32.689Z"
+}

--- a/change/@uifabric-styling-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
+++ b/change/@uifabric-styling-2020-09-22-12-43-20-xgao-fix-theme-package-version.json
@@ -1,8 +1,8 @@
 {
-  "type": "none",
+  "type": "patch",
   "comment": "set theme package version to be 1.0.0.",
   "packageName": "@uifabric/styling",
   "email": "xgao@microsoft.com",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-09-22T19:42:32.689Z"
 }

--- a/packages/fluent-theme/package.json
+++ b/packages/fluent-theme/package.json
@@ -26,7 +26,7 @@
     "@uifabric/build": "^7.0.0"
   },
   "dependencies": {
-    "@fluentui/theme": "^0.4.0",
+    "@fluentui/theme": "^1.0.0",
     "@uifabric/merge-styles": "^7.19.1",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.6",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -54,7 +54,7 @@
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react-icons": "^0.3.5",
     "@fluentui/react-theme-provider": "^0.13.4",
-    "@fluentui/theme": "^0.4.0",
+    "@fluentui/theme": "^1.0.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/react-hooks": "^7.13.5",
     "@uifabric/set-version": "^7.0.23",

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -39,7 +39,7 @@
     "@fluentui/react-button": "^0.13.4",
     "@fluentui/react-compose": "^0.19.4",
     "@fluentui/react-theme-provider": "^0.13.4",
-    "@fluentui/theme": "^0.4.0",
+    "@fluentui/theme": "^1.0.0",
     "@uifabric/set-version": "^7.0.23",
     "office-ui-fabric-react": "^7.139.1",
     "tslib": "^1.10.0"

--- a/packages/react-theme-provider/package.json
+++ b/packages/react-theme-provider/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@fluentui/react-compose": "^0.19.4",
     "@fluentui/react-stylesheets": "^0.2.2",
-    "@fluentui/theme": "^0.4.0",
+    "@fluentui/theme": "^1.0.0",
     "@fluentui/react-window-provider": "^0.3.3",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/merge-styles": "^7.19.1",

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.10.26",
-    "@fluentui/theme": "^0.4.0",
+    "@fluentui/theme": "^1.0.0",
     "@uifabric/merge-styles": "^7.19.1",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/utilities": "^7.32.3",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/theme",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "description": "Basic building blocks for Fluent UI React Component themes",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`@fluentui/theme` package is currently in `v0.*`. But it's consumed as dependency from production packages like `@uifabric/styling`, `@uifabirc/fluent-theme`. From [versioning perspective](https://semver.org/spec/v1.0.0.html#how-do-i-know-when-to-release-100), it's more correct to start versioning it from `v1` instead of `v0`.

#### Focus areas to test

(optional)
