### PR TITLE
chore: try to use midgard-yarn

### DIFF
--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '14.x'
+      versionSpec: '12.x'
     displayName: 'Install Node.js'
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '12.x'
     displayName: 'Install Node.js'
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3

--- a/.devops/templates/tools.yml
+++ b/.devops/templates/tools.yml
@@ -2,7 +2,7 @@
 steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '12.x'
+      versionSpec: '14.x'
     displayName: 'Install Node.js'
 
   - task: geeklearningio.gl-vsts-tasks-yarn.yarn-installer-task.YarnInstaller@3

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,8 +17,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: |
-          yarn
+      - script: npx midgard-yarn install
         displayName: yarn
 
       - template: .devops/templates/pr-target-branch.yml
@@ -58,8 +57,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: |
-          yarn
+      - script: npx midgard-yarn install
         displayName: yarn
 
       - template: .devops/templates/pr-target-branch.yml
@@ -120,7 +118,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: yarn
+      - script: npx midgard-yarn install
         displayName: yarn
 
       - script: yarn workspace @fluentui/docs vr:build
@@ -147,8 +145,7 @@ jobs:
     steps:
       - template: .devops/templates/tools.yml
 
-      - script: |
-          yarn
+      - script: npx midgard-yarn install
         displayName: yarn
 
       - template: .devops/templates/pr-target-branch.yml


### PR DESCRIPTION
This PR tryouts to use `midgard-yarn` for CI installs. `midgard-yarn` is a hard fork of Yarn v1 that improves install speed mainly.

---

This PR:
- updates install tasks for use `midgard-yarn`
- bumps Node to 12 in CI as `migrard-yarn` requires `worker_threads` module

### Before

![image](https://user-images.githubusercontent.com/14183168/94041509-9ac45280-fdca-11ea-8c5e-0d63952dd406.png)

### After

![image](https://user-images.githubusercontent.com/14183168/94041539-a6177e00-fdca-11ea-95fd-d2ea5794327c.png)
