### PR TITLE
ThemeProvider: add instructions to replace Fabric, Customizer, loadTheme in README

### DIFF
--- a/change/@fluentui-react-next-2020-09-24-11-31-02-xgao-update-theme-provider-readme.json
+++ b/change/@fluentui-react-next-2020-09-24-11-31-02-xgao-update-theme-provider-readme.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Update release notes related to ThemeProvider.",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T18:31:02.768Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-09-23-10-15-42-xgao-update-theme-provider-readme.json
+++ b/change/@fluentui-react-theme-provider-2020-09-23-10-15-42-xgao-update-theme-provider-readme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add instructions to replace Fabric, Customizer, loadTheme in README.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T17:15:42.192Z"
+}

--- a/packages/react-next/RELEASE_NOTES.md
+++ b/packages/react-next/RELEASE_NOTES.md
@@ -101,9 +101,14 @@ If you would like to continue using the previous button components for now, upda
   - If you need a former state property which is not included in the relevant `IComponentName` interface, please file an issue and we can consider adding it.
 - In your components which use the converted components, you may need to wrap certain test operations in `act` from `react-dom/test-utils`. [More details here.](https://reactjs.org/docs/test-utils.html#act)
 
+### ThemeProvider
+
+`ThemeProvider` is required to use if any button from `@fluentui/react/lib/Button` is used. We also deprecated `Fabric`, `Customizer` components in favor of using `ThemeProvider`.
+
+Please see the [`@fluentui/react-theme-provider` package README](https://github.com/microsoft/fluentui/blob/master/packages/react-theme-provider/README.md) for details about usage and a migration guide.
+
 ### Others
 
-- `ThemeProvider` is required. (new)
 - `KeytipData`/`keytipProps` removed from `Link`/`Toggle`/`Checkbox`.
 - `Button` and `Card` are new components that break from their previous implementation.
 - `WindowProvider` is required for child windows/embeds.

--- a/packages/react-theme-provider/README.md
+++ b/packages/react-theme-provider/README.md
@@ -149,13 +149,13 @@ Deprecations remain to be functional as is but they will be removed in Fluent UI
 
 Before:
 
-```
+```jsx
 <Customizer settings={{ theme }} />
 ```
 
 After:
 
-```
+```jsx
 <ThemeProvider theme={theme} />
 ```
 
@@ -163,11 +163,11 @@ After:
 
 Before:
 
-```
+```jsx
 <Customizer
   scopedSettings={{
     Checkbox: {
-      styles: CheckboxStyles
+      styles: CheckboxStyles,
     },
   }}
 />
@@ -175,7 +175,7 @@ Before:
 
 After:
 
-```
+```jsx
 <ThemeProvider
   theme={{
     components: { Checkbox: { styles: CheckboxStyles } },
@@ -187,7 +187,7 @@ After:
 
 Before:
 
-```
+```jsx
   <CustomizerContext.Consumer>
     {(parentContext: ICustomizerContext) => {
       const theme = parentContext.customizations.settings;
@@ -205,7 +205,7 @@ See options in [Accessing theme](https://github.com/microsoft/fluentui/blob/mast
 
 To do that, instead of calling `loadTheme(your_theme)`, you will simply wrap the root component of your React application once with `ThemeProvider`:
 
-```
+```jsx
 <ThemeProvider theme={your_theme}>
   <App />
 </ThemeProvider>
@@ -213,9 +213,9 @@ To do that, instead of calling `loadTheme(your_theme)`, you will simply wrap the
 
 One caveat here is that if you app has styles which relies on `@microsoft/load-themed-styles`, `ThemeProvider` won't be able to replace `loadTheme` in this case.
 
-### Fabric
+### Fabric component
 
-Instead of using `Fabric`, you can now replace it fully with `ThemeProvider`. Here is how to replace each prop usage:
+Instead of using `Fabric` component, you can now replace it fully with `ThemeProvider`. Here is how to replace each prop usage:
 
 | Fabric             | ThemeProvider                                                                                                                                                                                       |
 | ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/packages/react-theme-provider/README.md
+++ b/packages/react-theme-provider/README.md
@@ -135,3 +135,99 @@ const Foo = props => {
   return <div className={classes.root} />;
 };
 ```
+
+## How does this change other existing ways of theming Fluent UI components?
+
+### Customizer
+
+`Customizer` is now deprecated and you should replace it with `ThemeProvider`.
+`CustomizerContext` is now deprecated and you should replace it with `ThemeContext` or `useTheme` hook.
+
+Deprecations remain to be functional as is but they will be removed in Fluent UI v9 release.
+
+#### Replace settings prop
+
+Before:
+
+```
+<Customizer settings={{ theme }} />
+```
+
+After:
+
+```
+<ThemeProvider theme={theme} />
+```
+
+#### Replace scopedSettings prop
+
+Before:
+
+```
+<Customizer
+  scopedSettings={{
+    Checkbox: {
+      styles: CheckboxStyles
+    },
+  }}
+/>
+```
+
+After:
+
+```
+<ThemeProvider
+  theme={{
+    components: { Checkbox: { styles: CheckboxStyles } },
+  }}
+/>
+```
+
+#### Replace CustomizerContext
+
+Before:
+
+```
+  <CustomizerContext.Consumer>
+    {(parentContext: ICustomizerContext) => {
+      const theme = parentContext.customizations.settings;
+      ...
+    }
+  </CustomizerContext.Consumer>
+```
+
+After:
+See options in `Accessing theme` section above.
+
+### loadTheme
+
+`loadTheme` remains to work as is. However, you are recommended to replace `loadTheme` with `ThemeProvider`. That way, your application consistently has one way of providing theme.
+
+To do that, instead of calling `loadTheme(your_theme)`, you will simply wrap the root component of your React application once with `ThemeProvider`:
+
+```
+<ThemeProvider theme={your_theme}>
+  <App />
+</ThemeProvider>
+```
+
+One caveat here is that if you app has styles which relies on `@microsoft/load-themed-styles`, `ThemeProvider` won't be able to replace `loadTheme` in this case.
+
+### Fabric
+
+Instead of using `Fabric`, you can now replace it fully with `ThemeProvider`. Here is how to replace each prop usage:
+
+| Fabric             | ThemeProvider                                                                                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `componentRef`     | `ref`                                                                                                                                                                                               |
+| `as`               | `as`                                                                                                                                                                                                |
+| `theme`            | `theme`                                                                                                                                                                                             |
+| `styles`           | Not longer support `styles` prop. If you need to style the root element, you can do that using (inline) style or className prop. Setting arbitrary styles for document body is no longer supported. |
+| `applyTheme`       | This is now applied by default, or by setting `applyTo="element"`. If you don't want any body styles to be applied on root element, you can set `applyTo="none"`.                                   |
+| `applyThemeToBody` | `applyTo="body"`                                                                                                                                                                                    |
+| `dir`              | set `rtl` in `theme` prop                                                                                                                                                                           |
+
+#### Other call-outs
+
+- `ThemeProvider` by default sets `background-color` for the root element using `theme.semanticColors.bodyBackground`. If you find the background color being incorrect after switching to `ThemeProvider`, the right fix is likely that you need to update your theme definition to have the correct `bodyBackground`. Or, if you don't want any default stylings applied to the root element, you can set `applyTo` prop to `"none"`.
+- `ThemeProvider` does not set `font-family: inherit` on all native `button`, `input`, `textArea` elements. If you find any Fluent UI component having incorrect fonts after switching to `ThemeProvider`, please [report an issue](https://github.com/microsoft/fluentui/issues/new?template=bug_report.md).

--- a/packages/react-theme-provider/README.md
+++ b/packages/react-theme-provider/README.md
@@ -197,7 +197,7 @@ Before:
 ```
 
 After:
-See options in `Accessing theme` section above.
+See options in [Accessing theme](https://github.com/microsoft/fluentui/blob/master/packages/react-theme-provider/README.md#accessing-theme).
 
 ### loadTheme
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Add instructions for how to replace `Fabric`, `Customizer`, and `loadTheme` with `ThemeProvider`.

Related issue: #14740

#### Focus areas to test

(optional)
