### PR TITLE
Add role prop to breadcrumb item

### DIFF
--- a/change/@fluentui-react-next-2020-09-24-11-02-17-breadcrumbitem-role.json
+++ b/change/@fluentui-react-next-2020-09-24-11-02-17-breadcrumbitem-role.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Breadcrumb: add role prop for items",
+  "packageName": "@fluentui/react-next",
+  "email": "erabelle@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T18:02:17.377Z"
+}

--- a/change/office-ui-fabric-react-2020-09-23-15-11-04-breadcrumbitem-role.json
+++ b/change/office-ui-fabric-react-2020-09-23-15-11-04-breadcrumbitem-role.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Breadcrumb: add role prop for items",
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-23T22:11:04.633Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1830,6 +1830,7 @@ export interface IBreadcrumbItem {
     isCurrentItem?: boolean;
     key: string;
     onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IBreadcrumbItem) => void;
+    role?: string;
     text: string;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -255,6 +255,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
           aria-current={item.isCurrentItem ? 'page' : undefined}
           // eslint-disable-next-line react/jsx-no-bind
           onClick={this._onBreadcrumbClicked.bind(this, item)}
+          role={item.role}
         >
           <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -142,6 +142,11 @@ export interface IBreadcrumbItem {
    * This is not generally recommended because it may prevent activating the link using the keyboard.
    */
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
+
+  /**
+   * Optional role for the breadcrumb item (which renders as a button by default)
+   */
+  role?: string;
 }
 
 /**

--- a/packages/react-next/etc/react-next.api.md
+++ b/packages/react-next/etc/react-next.api.md
@@ -731,6 +731,7 @@ export interface IBreadcrumbItem {
     isCurrentItem?: boolean;
     key: string;
     onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IBreadcrumbItem) => void;
+    role?: string;
     text: string;
 }
 

--- a/packages/react-next/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/react-next/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -256,6 +256,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
           aria-current={item.isCurrentItem ? 'page' : undefined}
           // eslint-disable-next-line react/jsx-no-bind
           onClick={this._onBreadcrumbClicked.bind(this, item)}
+          role={item.role}
         >
           <TooltipHost content={item.text} overflowMode={TooltipOverflowMode.Parent} {...this.props.tooltipHostProps}>
             {item.text}

--- a/packages/react-next/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/react-next/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -142,6 +142,11 @@ export interface IBreadcrumbItem {
    * This is not generally recommended because it may prevent activating the link using the keyboard.
    */
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
+
+  /**
+   * Optional role for the breadcrumb item (which renders as a button by default)
+   */
+  role?: string;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add optional `role` prop to `IBreadcrumbItem` that gets passed to the `<Link>`. Breadcrumb items render as a button by default, or as a link if an `href` is passed in. This prop will allow consumers to give breadcrumb items a role of `link`, for example, while still rendering it as a button.
