### PR TITLE
Fix issues with drag item index

### DIFF
--- a/change/@uifabric-experiments-2020-09-24-11-26-47-zeroindexbug.json
+++ b/change/@uifabric-experiments-2020-09-24-11-26-47-zeroindexbug.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix bug where drag index is set to -1 when it's 0",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T18:26:47.618Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -143,6 +143,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragStart = (item?: any, itemIndex?: number, tempSelectedItems?: any[], event?: DragEvent): void => {
+    /* eslint-disable-next-line eqeqeq */
     const draggedItemIndex = itemIndex != null ? itemIndex! : -1;
     setDraggedIndex(draggedItemIndex);
     if (event) {

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -99,7 +99,8 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     return dragEnterClass;
   };
 
-  const _dropItemsAt = (insertIndex: number, newItems: T[]): void => {
+  let insertIndex = -1;
+  const _dropItemsAt = (newItems: T[]): void => {
     let indicesToRemove: number[] = [];
     // If we are moving items within the same picker, remove them from their old places as well
     if (draggedIndex > -1) {
@@ -110,6 +111,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     }
     dropItemsAt(insertIndex, newItems, indicesToRemove);
     unselectAll();
+    insertIndex = -1;
   };
 
   const _canDrop = (dropContext?: IDragDropContext, dragContext?: IDragDropContext): boolean => {
@@ -117,7 +119,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDrop = (item?: any, event?: DragEvent): void => {
-    const insertIndex = selectedItems.indexOf(item);
+    insertIndex = selectedItems.indexOf(item);
     let isDropHandled = false;
     if (event?.dataTransfer) {
       event.preventDefault();
@@ -128,7 +130,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           data[i].getAsString((dropText: string) => {
             if (props.selectedItemsListProps.deserializeItemsFromDrop) {
               const newItems = props.selectedItemsListProps.deserializeItemsFromDrop(dropText);
-              _dropItemsAt(insertIndex, newItems);
+              _dropItemsAt(newItems);
             }
           });
         }
@@ -138,7 +140,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       const newItems = focusedItemIndices.includes(draggedIndex)
         ? (getSelectedItems() as T[])
         : [selectedItems[draggedIndex]];
-      _dropItemsAt(insertIndex, newItems);
+      _dropItemsAt(newItems);
     }
   };
 

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -143,7 +143,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   };
 
   const _onDragStart = (item?: any, itemIndex?: number, tempSelectedItems?: any[], event?: DragEvent): void => {
-    const draggedItemIndex = itemIndex ? itemIndex! : -1;
+    const draggedItemIndex = itemIndex != null ? itemIndex! : -1;
     setDraggedIndex(draggedItemIndex);
     if (event) {
       const dataList = event?.dataTransfer?.items;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Was attempting to assign the drag index to be -1 if the incoming index was null, accidently was changing it when it's 0 as well. Fixed that.
- For onDrop, getAsString is an async callback, so I couldn't have the insertIndex as an onDrop. So now it's a global variable.
