### PR TITLE
Fix expanding and collapsing groups in GroupedList

### DIFF
--- a/change/@fluentui-examples-2020-09-24-15-33-34-group-expand.json
+++ b/change/@fluentui-examples-2020-09-24-15-33-34-group-expand.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix GroupedList expand/collapse behavior",
+  "packageName": "@fluentui/examples",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T22:33:26.049Z"
+}

--- a/change/office-ui-fabric-react-2020-09-24-15-33-34-group-expand.json
+++ b/change/office-ui-fabric-react-2020-09-24-15-33-34-group-expand.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix GroupedList expand/collapse behavior",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-24T22:33:34.015Z"
+}

--- a/packages/examples/src/office-ui-fabric-react/GroupedList/GroupedList.Basic.Example.tsx
+++ b/packages/examples/src/office-ui-fabric-react/GroupedList/GroupedList.Basic.Example.tsx
@@ -32,7 +32,7 @@ export const GroupedListBasicExample: React.FunctionComponent = () => {
   });
 
   const onRenderCell = (nestingDepth?: number, item?: IExampleItem, itemIndex?: number): React.ReactNode => {
-    return item && itemIndex ? (
+    return item && typeof itemIndex === 'number' && itemIndex > -1 ? (
       <DetailsRow
         columns={columns}
         groupNestingDepth={nestingDepth}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -40,8 +40,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _isSomeGroupExpanded: boolean;
 
-  private _groupRefs: Record<string, GroupedListSection | null> = {};
-
   public static getDerivedStateFromProps(
     nextProps: IGroupedListProps,
     previousState: IGroupedListState,
@@ -224,7 +222,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     return (
       <GroupedListSection
-        ref={ref => (this._groupRefs['group_' + groupIndex] = ref)}
         key={this._getGroupKey(group, groupIndex)}
         dragDropEvents={dragDropEvents}
         dragDropHelper={dragDropHelper}
@@ -333,25 +330,9 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   };
 
   private _forceListUpdates(groups?: IGroup[]): void {
-    groups = groups || this.state.groups;
-
-    const groupCount = groups ? groups.length : 1;
-
-    if (this._list.current) {
-      this._list.current.forceUpdate();
-
-      for (let i = 0; i < groupCount; i++) {
-        const group = this._list.current.pageRefs['group_' + String(i)] as GroupedListSection;
-        if (group) {
-          group.forceListUpdate();
-        }
-      }
-    } else {
-      const group = this._groupRefs['group_' + String(0)];
-      if (group) {
-        group.forceListUpdate();
-      }
-    }
+    this.setState({
+      version: {},
+    });
   }
 
   private _onToggleSummarize = (group: IGroup): void => {


### PR DESCRIPTION
Addresses #14589

#### Description of changes

Fixed an issue where clicking the expand/collapse button on a group header wouldn't seem to work. The issue is that the `forceUpdate()` flow isn't compatible with the updated render flow. This change switches to using `setState()` with a fresh `version` object to properly cascade an update.

#### Focus areas to test

Updated the `GroupedList.Basic.Example` so the first item properly renders. The various `GroupedList` examples now all appear to work, where the didn't before.
