### PR TITLE
chore: fix unstable VR tests in N*

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.steps.ts
@@ -4,6 +4,8 @@ const config: ScreenerTestsConfig = {
   steps: [
     builder =>
       builder
+        .click('#set-open')
+        .snapshot('Default positioning')
         .click('#above')
         .snapshot('Sets positions to above')
         .click('#before')

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Menu, MenuProps } from '@fluentui/react-northstar';
 
 const MenuExamplePositioningShorthand = () => {
+  const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
   const [position, setPosition] = React.useState<'above' | 'before'>(undefined);
 
   const items: MenuProps['items'] = [
@@ -23,14 +24,14 @@ const MenuExamplePositioningShorthand = () => {
                 position,
               },
             },
-            menuOpen: true,
+            menuOpen,
           },
         ],
         popper: position && {
           position,
         },
       },
-      menuOpen: true,
+      menuOpen,
     },
   ];
 
@@ -47,6 +48,10 @@ const MenuExamplePositioningShorthand = () => {
       <Menu defaultActiveIndex={0} items={items} />
 
       <hr style={{ margin: 50 }} />
+
+      <button id="open" onClick={() => setMenuOpen(true)}>
+        Set open
+      </button>
       <button id="above" onClick={() => setPosition('above')}>
         Set above
       </button>

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioning.shorthand.tsx
@@ -49,7 +49,7 @@ const MenuExamplePositioningShorthand = () => {
 
       <hr style={{ margin: 50 }} />
 
-      <button id="open" onClick={() => setMenuOpen(true)}>
+      <button id="set-open" onClick={() => setMenuOpen(true)}>
         Set open
       </button>
       <button id="above" onClick={() => setPosition('above')}>

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.steps.ts
@@ -4,6 +4,7 @@ const config: ScreenerTestsConfig = {
   steps: [
     builder =>
       builder
+        .click('#set-open')
         .click('#set-height')
         .snapshot('Updates height to collide with top edge')
         .click('#reposition')

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.steps.ts
@@ -5,6 +5,7 @@ const config: ScreenerTestsConfig = {
     builder =>
       builder
         .click('#set-open')
+        .snapshot('Default positioning')
         .click('#set-height')
         .snapshot('Updates height to collide with top edge')
         .click('#reposition')

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Menu, MenuProps, PopperRefHandle } from '@fluentui/react-northstar';
 
 const MenuExamplePositioningUpdateShorthand = () => {
+  const [menuOpen, setMenuOpen] = React.useState<boolean>(false);
   const [height, setHeight] = React.useState<number>(50);
   const popperRef = React.useRef<PopperRefHandle>();
 
@@ -22,7 +23,7 @@ const MenuExamplePositioningUpdateShorthand = () => {
         ],
         popper: { position: 'above', popperRef },
       },
-      menuOpen: true,
+      menuOpen,
     },
   ];
 
@@ -40,6 +41,9 @@ const MenuExamplePositioningUpdateShorthand = () => {
 
       <hr style={{ margin: 100 }} />
       <div style={{ float: 'right' }}>
+        <button id="open" onClick={() => setMenuOpen(true)}>
+          Set open
+        </button>
         <button id="set-height" onClick={() => setHeight(300)}>
           Set height
         </button>

--- a/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Menu/Visual/MenuExamplePositioningUpdate.shorthand.tsx
@@ -41,7 +41,7 @@ const MenuExamplePositioningUpdateShorthand = () => {
 
       <hr style={{ margin: 100 }} />
       <div style={{ float: 'right' }}>
-        <button id="open" onClick={() => setMenuOpen(true)}>
+        <button id="set-open" onClick={() => setMenuOpen(true)}>
           Set open
         </button>
         <button id="set-height" onClick={() => setHeight(300)}>

--- a/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.steps.ts
+++ b/packages/fluentui/docs/src/examples/components/Popup/Usage/PopupExampleCloseButton.shorthand.steps.ts
@@ -15,6 +15,10 @@ const config: ScreenerTestsConfig = {
         .click(selectors.popupTrigger)
         .click(selectors.toggleIndicator)
         .hover(selectors.item(2))
+
+        // A hack to load images properly in Screener
+        .wait(500)
+
         .snapshot('Prepares to select item out of popup.')
         .click(selectors.item(2))
         .snapshot('Item should be selected.'),


### PR DESCRIPTION
This PR tries to make three more tests stable in Screener to avoid phantom regressions.
