### PR TITLE
chore: deploy perf-test for N* properly

### DIFF
--- a/apps/perf-test/tasks/fluentPerfRegressions.ts
+++ b/apps/perf-test/tasks/fluentPerfRegressions.ts
@@ -28,7 +28,7 @@ export function getFluentPerfRegressions() {
 
 function linkToFlamegraph(value: string, filename: string) {
   const urlForDeployPath = process.env.BUILD_SOURCEBRANCH
-    ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test/fluentui`
+    ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/${process.env.BUILD_SOURCEBRANCH}/perf-test-northstar`
     : 'file://' + config.paths.packageDist('perf-test');
 
   return `[${value}](${urlForDeployPath}/${path.basename(filename)})`;

--- a/apps/pr-deploy-site/just.config.ts
+++ b/apps/pr-deploy-site/just.config.ts
@@ -17,6 +17,7 @@ let instructions = copyInstructions.copyFilesToDestinationDirectory(
 // Dependencies are listed here and NOT in package.json because we do not want to allow for partial builds for scoping
 const dependencies = [
   '@fluentui/docs',
+  '@fluentui/perf-test',
   '@fluentui/react-button',
   '@fluentui/react-checkbox',
   '@fluentui/react-image',
@@ -57,6 +58,9 @@ repoDeps.forEach(dep => {
       deployedPackages.add(dep.packageJson.name);
     } else if (dep.packageJson.name === '@fluentui/docs') {
       instructions.push(...copyInstructions.copyFilesInDirectory(sourcePath, path.join('dist', 'react-northstar')));
+      deployedPackages.add(dep.packageJson.name);
+    } else if (dep.packageJson.name === '@fluentui/perf-test') {
+      instructions.push(...copyInstructions.copyFilesInDirectory(sourcePath, path.join('dist', 'perf-test-northstar')));
       deployedPackages.add(dep.packageJson.name);
     } else {
       instructions.push(

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -55,7 +55,7 @@ steps:
       azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
       storage: fabricweb
       ContainerName: '$web'
-      BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test/fluentui'
+      BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test-northstar'
 
   - task: AzureUpload@2
     displayName: Upload Perf Test Result to PR deploy site

--- a/packages/fluentui/perf-test/tasks/perf-test.ts
+++ b/packages/fluentui/perf-test/tasks/perf-test.ts
@@ -49,8 +49,8 @@ export default async function getPerfRegressions(baselineOnly: boolean = false) 
 
   if (!baselineOnly) {
     urlForMaster = process.env.SYSTEM_PULLREQUEST_TARGETBRANCH
-      ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test/fluentui/index.html`
-      : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test/fluentui/index.html';
+      ? `http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/${process.env.SYSTEM_PULLREQUEST_TARGETBRANCH}/perf-test-northstar/index.html`
+      : 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/perf-test-northstar/index.html';
   }
 
   // TODO: support iteration/kind/story via commandline as in other perf-test script


### PR DESCRIPTION
This PR fixes deployment of `@fluentui/perf-test` to avoid false positive warnings on **each** PR:

![image](https://user-images.githubusercontent.com/14183168/94271785-62e01b00-ff42-11ea-81d0-e5b22d7f38e4.png)

_These failures somehow are related to Lage-related changes happened in August when the migration was done, 8 August was the last day when we published artifacts for `@fluentui/perf-test` on `master` branch._

---

Currently only `azure-pipelines.perf-test.yml` uploads artifacts for `@fluentui/perf-test`, but as it's not running for `master` it will be never deployed. To fix this `@fluentui/perf-test` was added to the list of deployed sites in `pr-deploy-site/just.config.ts`, this will guarantee that we will have artifacts on `master` build. I also changed a directory where artifacts will be stored due collisions with copying via `copyInstructions` from Just.

At the same we cannot to deploy `@fluentui/perf-test` only via `pr-deploy-site` as PR builds are scoped and `azure-pipelines.perf-test.yml` guaranties that it will be uploaded.