### PR TITLE
[UnifiedPicker] Fixing the input width for UnifiedPicker allowing for input text to show correctly

### DIFF
--- a/change/@uifabric-experiments-2020-09-25-08-56-34-u-nebhatna-fixInputWidthUpp.json
+++ b/change/@uifabric-experiments-2020-09-25-08-56-34-u-nebhatna-fixInputWidthUpp.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing input width in upp",
+  "packageName": "@uifabric/experiments",
+  "email": "nebhatna@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-25T15:56:34.285Z"
+}

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
+                flex: 1 1 auto;
                 min-height: 32px;
                 min-width: 180px;
                 padding-bottom: 1px;
@@ -61,6 +62,13 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
           <div
             aria-expanded={false}
             aria-haspopup="listbox"
+            className=
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
+                {
+                  display: flex;
+                  flex: 1 1 auto;
+                }
             role="combobox"
           >
             <input
@@ -72,7 +80,9 @@ exports[`UnifiedPeoplePicker renders correctly with no items 1`] = `
                   ms-UnifiedPicker-input
                   {
                     border: none;
+                    display: flex;
                     flex-grow: 1;
+                    flex: 1 1 auto;
                     height: 34px;
                     margin-bottom: 1px;
                     margin-left: 1px;
@@ -162,6 +172,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
+                flex: 1 1 auto;
                 min-height: 32px;
                 min-width: 180px;
                 padding-bottom: 1px;
@@ -785,6 +796,13 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
           <div
             aria-expanded={false}
             aria-haspopup="listbox"
+            className=
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
+                {
+                  display: flex;
+                  flex: 1 1 auto;
+                }
             role="combobox"
           >
             <input
@@ -796,7 +814,9 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                   ms-UnifiedPicker-input
                   {
                     border: none;
+                    display: flex;
                     flex-grow: 1;
+                    flex: 1 1 auto;
                     height: 34px;
                     margin-bottom: 1px;
                     margin-left: 1px;

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.styles.ts
@@ -5,11 +5,13 @@ export interface IUnifiedPickerStyleProps {}
 export interface IUnifiedPickerStyles {
   pickerText: IStyle;
   pickerInput: IStyle;
+  pickerDiv: IStyle;
 }
 
 const GlobalClassNames = {
   pickerText: 'ms-UnifiedPicker-text',
   pickerInput: 'ms-UnifiedPicker-input',
+  pickerDiv: 'ms-UnifiedPicker-div',
 };
 
 export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles => {
@@ -28,6 +30,7 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
       classNames.pickerText,
       {
         display: 'flex',
+        flex: '1 1 auto',
         flexWrap: 'wrap',
         alignItems: 'center',
         boxSizing: 'border-box',
@@ -45,6 +48,8 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
     pickerInput: [
       classNames.pickerInput,
       {
+        display: 'flex',
+        flex: '1 1 auto',
         height: '34px',
         border: 'none',
         flexGrow: '1',
@@ -56,6 +61,13 @@ export const getStyles = (props: IUnifiedPickerStyleProps): IUnifiedPickerStyles
             display: 'none',
           },
         },
+      },
+    ],
+    pickerDiv: [
+      classNames.pickerDiv,
+      {
+        display: 'flex',
+        flex: '1 1 auto',
       },
     ],
   };

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -363,6 +363,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
                   aria-expanded={isSuggestionsShown}
                   aria-haspopup="listbox"
                   role="combobox"
+                  className={css('ms-BasePicker-div', classNames.pickerDiv)}
                 >
                   <Autofill
                     {...(inputProps as IInputProps)}

--- a/packages/experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
+                flex: 1 1 auto;
                 min-height: 32px;
                 min-width: 180px;
                 padding-bottom: 1px;
@@ -61,6 +62,13 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
           <div
             aria-expanded={false}
             aria-haspopup="listbox"
+            className=
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
+                {
+                  display: flex;
+                  flex: 1 1 auto;
+                }
             role="combobox"
           >
             <input
@@ -72,7 +80,9 @@ exports[`UnifiedPicker renders correctly with no items 1`] = `
                   ms-UnifiedPicker-input
                   {
                     border: none;
+                    display: flex;
                     flex-grow: 1;
+                    flex: 1 1 auto;
                     height: 34px;
                     margin-bottom: 1px;
                     margin-left: 1px;
@@ -162,6 +172,7 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
+                flex: 1 1 auto;
                 min-height: 32px;
                 min-width: 180px;
                 padding-bottom: 1px;
@@ -190,6 +201,13 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
           <div
             aria-expanded={false}
             aria-haspopup="listbox"
+            className=
+                ms-BasePicker-div
+                ms-UnifiedPicker-div
+                {
+                  display: flex;
+                  flex: 1 1 auto;
+                }
             role="combobox"
           >
             <input
@@ -201,7 +219,9 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
                   ms-UnifiedPicker-input
                   {
                     border: none;
+                    display: flex;
                     flex-grow: 1;
+                    flex: 1 1 auto;
                     height: 34px;
                     margin-bottom: 1px;
                     margin-left: 1px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
-Fixing the input width in the UnifiedPicker. Before this bug was fixed, input was fixed width as a result of which the input text was hidden when there was an overflow.
-Fixed snapshots for unit tests as well.

#### Focus areas to test

(optional)
