### PR TITLE
Add new FileIcon distinction between List and ListItem

### DIFF
--- a/change/@uifabric-file-type-icons-2020-09-22-15-33-20-caperez-add_list_itemtype.json
+++ b/change/@uifabric-file-type-icons-2020-09-22-15-33-20-caperez-add_list_itemtype.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding new FileIconType to differentiate List from ListItem. Existing enum called listitem has been reassigned to bring back the right listitem icon.",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-22T22:33:20.234Z"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -21,4 +21,4 @@ export enum FileIconType {
   list = 13,
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13;

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -18,6 +18,7 @@ export enum FileIconType {
   documentsFolder = 10,
   picturesFolder = 11,
   linkedFolder = 12,
+  list = 13,
 }
 
 export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -7,7 +7,8 @@ const GENERIC_FILE = 'genericfile';
 const FOLDER = 'folder';
 const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
-const LIST_ITEM = 'splist';
+const LIST_ITEM = 'listitem';
+const LIST = 'splist';
 const MULTIPLE_ITEMS = 'multiple';
 const NEWS = 'sponews';
 const STREAM = 'stream';
@@ -92,6 +93,9 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
         break;
       case FileIconType.linkedFolder:
         iconBaseName = LINKED_FOLDER;
+        break;
+      case FileIconType.list:
+        iconBaseName = LIST;
         break;
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Update List-related FileType icons to new brand
- [x] Create clearer distinction in the FileTypeIcon enum between List and ListItem
- [x] Include a change request file using `$ yarn change`


#### Focus areas to test

getFileTypeIconProps method with FileIconType.listItem and FileIconType.list as submitted types.
