### PR TITLE
Move PR deploy site status to main deploy task and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,12 +16,12 @@
 # docs/  docs@example.com
 
 #### Core build stuff
-scripts/ @dzearing @ecraig12345
+scripts/ @dzearing @ecraig12345 @xugao
 scripts/babel/ @layershifter @miroslavstastny
 scripts/gulp/ @layershifter @miroslavstastny
 scripts/webpack/ @layershifter @miroslavstastny
 scripts/webpack/ @layershifter @miroslavstastny
-package.json @ecraig12345 @dzearing
+package.json @ecraig12345 @dzearing @xugao
 prettier.config.js @ecraig12345
 webpack.config.js @ecraig12345
 webpack.serve.config.js @ecraig12345
@@ -29,7 +29,7 @@ jest.config.js @ecraig12345
 tsconfig.json @ecraig12345
 lerna.json @ecraig12345
 LICENSE @ecraig12345
-*.yml @ecraig12345
+azure-pipelines* @ecraig12345
 .eslintrc.* @ecraig12345
 .npmrc @ecraig12345
 .npmignore @ecraig12345

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -75,15 +75,6 @@ steps:
       status: '$(PerfCommentStatus)'
       uniqueId: 'perfComment9423'
 
-  - task: GithubPRStatus@0
-    displayName: 'Update Github Pull Request Status'
-    inputs:
-      githubOwner: microsoft
-      githubRepo: 'fluentui'
-      githubContext: 'Pull Request Deployed Site'
-      githubDescription: 'Click "Details" to go to the Deployed Site'
-      githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
-
   - script: |
       yarn stats:build
     condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -99,6 +99,15 @@ jobs:
           ContainerName: '$web'
           BlobPrefix: '$(deployBasePath)'
 
+      - task: GithubPRStatus@0
+        displayName: 'Update PR deploy site github status'
+        inputs:
+          githubOwner: microsoft
+          githubRepo: fluentui
+          githubContext: 'Pull request demo site'
+          githubDescription: 'Click "Details" to go to the deployed demo site for this pull request'
+          githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
+
       - task: AzureUpload@2
         displayName: Upload demo images (master)
         condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
Adding the PR deploy site github status was being done in the perf-test job for some reason, which currently tends to be slower than the deploy job. Move the status to the deploy job so it can show up sooner (since the main thing people are likely to be interested in is the deployed sites, not perf results).

Also attempt to fix codeowners for pipeline files, and add @xugao as a codeowner for some of the build things as discussed earlier.