### PR TITLE
chore: add bundle script for @fluentui/perf-test

### DIFF
--- a/packages/fluentui/perf-test/package.json
+++ b/packages/fluentui/perf-test/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "just-scripts build",
+    "bundle": "just-scripts perf-test:bundle",
     "clean": "just-scripts clean",
     "test": "just-scripts test",
     "perf:test": "just-scripts perf-test",


### PR DESCRIPTION
A small follow up from #15243.

---

Artifacts for `@fluentui/perf-test` are still not deployed in the `bundle (master)` step defined in "Fluent UI React - PR and CI" pipeline as there is no `bundle` task that will create output for `dist` directory. `perf-test` has `bundle` task defined in `apps/perf-test/package.json`.
