### PR TITLE
fix(TreeTitle): arrow left navigation

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `shouldPreventDefault` on `keyDown` event for `TreeTitle` to allow enter trigger when `TreeTitle` is rendered as an `anchor` @assuncaocharles ([#15095](https://github.com/microsoft/fluentui/pull/15095))
 - Fix screen reader experience in multiple `dropdown` @kolaps33 ([#15066](https://github.com/microsoft/fluentui/pull/15066))
 - Fix `useAutoControlled` hook to suport functions updates @assuncaocharles ([#15137](https://github.com/microsoft/fluentui/pull/15137))
+- Fix `TreeTitle` arrow left navigation @assuncaocharles ([#15262](https://github.com/microsoft/fluentui/pull/15262))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeTitleBehavior.ts
@@ -1,4 +1,4 @@
-import { EnterKey, SpacebarKey } from '@fluentui/keyboard-key';
+import { EnterKey, SpacebarKey, keyboardKey } from '@fluentui/keyboard-key';
 
 import { IS_FOCUSABLE_ATTRIBUTE } from '../../attributes';
 import { Accessibility, AriaRole } from '../../types';
@@ -36,6 +36,9 @@ export const treeTitleBehavior: Accessibility<TreeTitleBehaviorProps> = props =>
           keyCombinations: props.selectable
             ? [{ keyCode: SpacebarKey }]
             : [{ keyCode: SpacebarKey }, { keyCode: EnterKey }],
+        },
+        focusParent: {
+          keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
         },
       },
     },

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-example.tsx
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-example.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Tree } from '@fluentui/react-northstar';
+
+const items = [
+  {
+    id: 'lannister',
+    title: 'House Lannister',
+    items: [
+      {
+        id: 'twyin',
+        title: 'Tywin',
+        items: [
+          {
+            id: 'jaime',
+            title: 'Jaime',
+          },
+        ],
+      },
+      {
+        id: 'tree-item-12',
+        title: 'Kevan',
+        items: [
+          {
+            id: 'tree-item-121',
+            title: 'Lancel',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+const TreeKeyboardNavigation = () => <Tree aria-label="default" items={items} />;
+
+export default TreeKeyboardNavigation;

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
@@ -1,0 +1,41 @@
+import { treeItemClassName, treeTitleClassName, treeClassName } from '@fluentui/react-northstar';
+
+const selectors = {
+  tree: `.${treeClassName}`,
+  treeItem: `.${treeItemClassName}`,
+  treeTitleAt: (itemIndex: number) => `.${treeItemClassName}:nth-of-type(${itemIndex}) .${treeTitleClassName}`,
+  treeItemAt: (itemIndex: number) => `.${treeItemClassName}:nth-of-type(${itemIndex}) `,
+};
+
+const navigateToLastLevel = async () => {
+  await e2e.focusOn(selectors.treeItemAt(1));
+  await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(1), 'ArrowRight'); // Expand first level item
+  await e2e.expectCount(selectors.treeItem, 3);
+  await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(1), 'ArrowRight'); // Focus first child  2nd level
+  await e2e.isFocused(selectors.treeItemAt(2));
+  await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowRight'); // Expand second level item
+  await e2e.expectCount(selectors.treeItem, 4);
+  await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowRight'); // Focus first child 3rd level
+  await e2e.isFocused(selectors.treeTitleAt(3)); // last levet has always tree title focused
+};
+
+describe('Tree keyboard navigation', () => {
+  beforeEach(async () => {
+    await e2e.gotoTestCase(__filename, selectors.tree);
+  });
+
+  it('Should navigate down with right arrow', async () => {
+    await navigateToLastLevel();
+  });
+
+  it('Should navigate up with left arrow', async () => {
+    await navigateToLastLevel();
+
+    await e2e.waitForSelectorAndPressKey(selectors.treeTitleAt(3), 'ArrowLeft'); // Focus parent 2nd level
+    await e2e.isFocused(selectors.treeItemAt(2));
+    await e2e.expectCount(selectors.treeItem, 4);
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // Focus parent 1nd level and closes 3rd level
+    await e2e.expectCount(selectors.treeItem, 3);
+    await e2e.isFocused(selectors.treeItemAt(1));
+  });
+});

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeItem.tsx
@@ -136,6 +136,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
     selectable,
     indeterminate,
     id,
+    parent,
   } = props;
 
   const hasSubtreeItem = hasSubtree(props);
@@ -224,7 +225,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
   };
   const handleFocusParent = e => {
     _.invoke(props, 'onFocusParent', e, props);
-    onFocusParent(props.parent);
+    onFocusParent(parent);
   };
   const handleSiblingsExpand = e => {
     _.invoke(props, 'onSiblingsExpand', e, props);
@@ -262,6 +263,7 @@ export const TreeItem: ComponentWithAs<'div', TreeItemProps> & FluentComponentSt
                 index,
                 selected,
                 selectable,
+                parent,
                 ...(hasSubtreeItem && !selectableParent && { selectable: false }),
                 ...(selectableParent && { indeterminate }),
                 selectableParent,

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -26,6 +26,7 @@ import {
   shouldPreventDefaultOnKeyDown,
 } from '../../utils';
 import { ComponentEventHandler, FluentComponentStaticProps, ShorthandValue } from '../../types';
+import { TreeContext } from './utils/index';
 
 export interface TreeTitleSlotClassNames {
   indicator: string;
@@ -95,7 +96,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
   const context = useFluentContext();
   const { setStart, setEnd } = useTelemetry(TreeTitle.displayName, context.telemetry);
   setStart();
-
+  const { onFocusParent } = React.useContext(TreeContext);
   const {
     accessibility,
     children,
@@ -117,6 +118,11 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     indeterminate,
   } = props;
 
+  const handleFocusParent = e => {
+    _.invoke(props, 'onFocusParent', e, props);
+    onFocusParent(props.parent);
+  };
+
   const getA11Props = useAccessibility(accessibility, {
     debugName: TreeTitle.displayName,
     actionHandlers: {
@@ -126,6 +132,12 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         }
         e.stopPropagation();
         handleClick(e);
+      },
+      focusParent: e => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        handleFocusParent(e);
       },
       performSelection: e => {
         e.preventDefault();
@@ -144,6 +156,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     }),
     rtl: context.rtl,
   });
+
   const { classes, styles: resolvedStyles } = useStyles<TreeTitleStylesProps>(TreeTitle.displayName, {
     className: treeTitleClassName,
     mapPropsToStyles: () => ({

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -121,10 +121,6 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
     indeterminate,
   } = props;
 
-  const handleFocusParent = e => {
-    onFocusParent(props.parent);
-  };
-
   const getA11Props = useAccessibility(accessibility, {
     debugName: TreeTitle.displayName,
     actionHandlers: {

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -136,8 +136,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         handleClick(e);
       },
       focusParent: e => {
-
-        handleFocusParent(e);
+        onFocusParent(props.parent);
       },
       performSelection: e => {
         e.preventDefault();

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -76,6 +76,9 @@ export interface TreeTitleProps extends UIComponentProps, ChildrenComponentProps
 
   /** For selectable parents define if all nested children are checked */
   indeterminate?: boolean;
+
+  /** The id of the parent tree title, if any. */
+  parent?: string;
 }
 
 export type TreeTitleStylesProps = Pick<
@@ -232,6 +235,7 @@ TreeTitle.propTypes = {
   treeSize: PropTypes.number,
   selectionIndicator: customPropTypes.shorthandAllowingChildren,
   indeterminate: PropTypes.bool,
+  parent: PropTypes.string,
 };
 TreeTitle.defaultProps = {
   as: 'a',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15134
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We are always rendering `TreeTitle` for the last level in the `Tree` ( read "non-expandable" items )  and we were missing left arrow navigation to focus parent for it. This PR fixes it and adds e2e tests to avoid regression.

![TKFRbsewN0](https://user-images.githubusercontent.com/8545105/94339659-bfebd780-fffb-11ea-8709-b6c057a0ce33.gif)

This fixes the issue with the current implementation but I believe a proper fix should be getting rid of `TreeTitle` and having only `TreeItem`

#### Focus areas to test

(optional)
