### PR TITLE
Fixed Info MessageBar's dismiss button background color

### DIFF
--- a/change/@fluentui-react-examples-2020-09-28-13-08-38-infoMessageBarDismissal.json
+++ b/change/@fluentui-react-examples-2020-09-28-13-08-38-infoMessageBarDismissal.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed Info MessageBar's dismiss button background color",
+  "packageName": "@fluentui/react-examples",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T05:08:38.866Z"
+}

--- a/change/@uifabric-azure-themes-2020-09-28-13-08-38-infoMessageBarDismissal.json
+++ b/change/@uifabric-azure-themes-2020-09-28-13-08-38-infoMessageBarDismissal.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed Info MessageBar's dismiss button background color",
+  "packageName": "@uifabric/azure-themes",
+  "email": "67673432+q-xg@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T05:08:32.828Z"
+}

--- a/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
+++ b/packages/azure-themes/src/azure/styles/MessageBar.styles.ts
@@ -39,7 +39,7 @@ const IconButtonStyles = (props: IMessageBarStyleProps): IStyle => {
     (messageBarType === MessageBarType.warning || messageBarType === MessageBarType.blocked) &&
       generateBaseStyle(semanticColors.statusWarningBackground, semanticColors.statusWarningText),
 
-    !messageBarType && generateBaseStyle(semanticColors.bodyBackground, semanticColors.bodyText),
+    typeof messageBarType !== 'number' && generateBaseStyle(semanticColors.bodyBackground, semanticColors.bodyText),
   ];
 };
 

--- a/packages/react-examples/src/azure-themes/stories/components/messageBar.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/messageBar.stories.tsx
@@ -31,8 +31,8 @@ const choiceGroupStyles = {
   },
 };
 
-const DefaultExample = () => (
-  <MessageBar>
+const DefaultExample = (p: IExampleProps) => (
+  <MessageBar onDismiss={p.resetChoice}>
     Info/Default MessageBar.
     <Link href="www.bing.com" target="_blank">
       Visit our website.
@@ -173,7 +173,7 @@ export const MessageBarBasicExample: React.FunctionComponent = () => {
         />
       </StackItem>
       <Stack {...verticalStackProps}>
-        {(choice === 'default' || showAll) && <DefaultExample />}
+        {(choice === 'default' || showAll) && <DefaultExample resetChoice={resetChoice} />}
 
         {(choice === 'error' || showAll) && <ErrorExample resetChoice={resetChoice} />}
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
MessageBar.Info is incorrectly compared to falsey value, 
https://github.com/microsoft/fluentui/blob/8eef5f6d39659d2f64519e00ae91b2908b1373a3/packages/azure-themes/src/azure/styles/MessageBar.styles.ts#L42
causing the default styles always override info styles.

Before the fix
![image](https://user-images.githubusercontent.com/67673432/94393104-c2316b80-018c-11eb-93c4-cf41e89305e2.png)
After the fix
![image](https://user-images.githubusercontent.com/67673432/94393122-cb223d00-018c-11eb-9b51-1a1dec473241.png)


#### Focus areas to test

(optional)
