### PR TITLE
Fix expand/collapse for grouping in DetailsList

### DIFF
--- a/change/office-ui-fabric-react-2020-09-28-13-15-09-group-expand.json
+++ b/change/office-ui-fabric-react-2020-09-28-13-15-09-group-expand.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Ensure GroupedList version is invalidated when parent list is invalidated",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-28T20:15:08.995Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5061,6 +5061,8 @@ export interface IGroupedListState {
     // (undocumented)
     lastSelectionMode?: SelectionMode;
     // (undocumented)
+    listProps?: IGroupedListProps['listProps'];
+    // (undocumented)
     version: {};
 }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -23,6 +23,7 @@ const { rowHeight: ROW_HEIGHT, compactRowHeight: COMPACT_ROW_HEIGHT } = DEFAULT_
 export interface IGroupedListState {
   lastSelectionMode?: SelectionMode;
   groups?: IGroup[];
+  listProps?: IGroupedListProps['listProps'];
   version: {};
 }
 
@@ -46,17 +47,20 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   ): IGroupedListState {
     let nextState = previousState;
 
-    const { listProps: { version = undefined } = {} } = nextProps;
-
-    if (version) {
-      nextState = {
-        ...nextState,
-        version,
-      };
-    }
-
     const { groups, selectionMode, compact } = nextProps;
     let shouldForceUpdates = false;
+
+    nextState = {
+      ...previousState,
+      listProps: nextProps.listProps,
+    };
+
+    const nextVersion = nextProps.listProps && nextProps.listProps.version;
+    const version = previousState.listProps && previousState.listProps.version;
+
+    if (nextVersion !== version) {
+      shouldForceUpdates = true;
+    }
 
     if (nextProps.groups !== groups) {
       nextState = {
@@ -90,6 +94,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     this.state = {
       groups: props.groups,
+      listProps: props.listProps,
       version,
     };
   }


### PR DESCRIPTION
#### Description of changes

Fixed an issue where expanding and collapsing group headers in `DetailsList` stopped working, even though a previous fix made it work for `GroupedList` directly.

#### Focus areas to test

Validated that the DetailsList Grouped example *and* the GroupedList example both support working group headers.