### PR TITLE
Fix release pipeline: incorrect package versions

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -91,6 +91,7 @@ steps:
 
   - script: |
       npm run publish:beachball -- -b origin/7.0 -n $(npmToken) --access public -y
+      git reset --hard origin/7.0
     env:
       GITHUB_PAT: $(githubPAT)
     displayName: 'Publish Change Requests and Bump Versions'


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Fix release not picking up the latest versions after `beachball publish`.
After beachball publish, we stay on a branch without the commit which actually bumps the packages during beachball publish.

*Note: we have been having this issue for a while and master has the same issue.*

The bug affects ONLY the latest release. site and release notes are fixed for vCurrent after vNext release finishes.

#### Focus areas to test

(optional)
