### PR TITLE
Pivot overflow: fix scrollbars appearing when the window is just barely wide enough to show all tabs

### DIFF
--- a/change/@fluentui-react-examples-2020-09-29-15-43-49-tabs-overflow-overflow.json
+++ b/change/@fluentui-react-examples-2020-09-29-15-43-49-tabs-overflow-overflow.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update test snapshots in Keytips example, from Pivot overflow styling change",
+  "packageName": "@fluentui/react-examples",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-29T22:43:48.976Z"
+}

--- a/change/@fluentui-react-tabs-2020-09-28-19-33-43-tabs-overflow-overflow.json
+++ b/change/@fluentui-react-tabs-2020-09-28-19-33-43-tabs-overflow-overflow.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Pivot overflow: fix scrollbars appearing when the window is just barely wide enough to show all tabs",
+  "packageName": "@fluentui/react-tabs",
+  "email": "behowell@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-29T02:33:43.902Z"
+}

--- a/packages/react-examples/src/react-next/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react-next/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -150,9 +150,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             &[data-is-overflowing='true'] {
               display: none;
             }
-            &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-              visibility: visible;
-            }
             @media screen and (-ms-high-contrast: active){&:before {
               background-color: Highlight;
             }
@@ -325,9 +322,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             &[data-is-overflowing='true'] {
               display: none;
             }
-            &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-              visibility: visible;
-            }
         data-content="Pivot 2"
         data-is-focusable={true}
         data-ktp-execute-target="ktp-b"
@@ -489,9 +483,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             }
             &[data-is-overflowing='true'] {
               display: none;
-            }
-            &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-              visibility: visible;
             }
         data-content="Pivot 3"
         data-is-focusable={true}

--- a/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
@@ -262,7 +262,9 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
           {items}
           {overflowBehavior === 'menu' && (
             <CommandButton
-              className={classNames.overflowMenuButton}
+              // TODO when the span wrapper is removed from <CommandButton>, set
+              // className={classNames.link + ' ' + classNames.overflowMenuButton}
+              className={classNames.link}
               ref={setOverflowMenuButtonRef}
               componentRef={overflowMenuButtonComponentRef as React.RefObject<IButton>}
               menuProps={overflowMenuProps}

--- a/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
+++ b/packages/react-tabs/src/components/Pivot/Pivot.base.tsx
@@ -244,8 +244,11 @@ export const PivotBase: React.FunctionComponent<IPivotProps> = React.forwardRef<
       (button: React.Component | null) => {
         const node = ReactDOM.findDOMNode(button);
         overflowMenuButtonRef(node instanceof HTMLElement ? node : null);
+        if (overflowMenuButtonRef.current) {
+          overflowMenuButtonRef.current.className = classNames.overflowMenuButton;
+        }
       },
-      [overflowMenuButtonRef],
+      [overflowMenuButtonRef, classNames.overflowMenuButton],
     );
 
     return (

--- a/packages/react-tabs/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react-tabs/src/components/Pivot/Pivot.styles.ts
@@ -199,8 +199,9 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
         [`&[data-is-overflowing='true']`]: {
           display: 'none',
           selectors: {
-            [`~ * .${classNames.overflowMenuButton}`]: {
+            [`~ .${classNames.overflowMenuButton}`]: {
               visibility: 'visible',
+              position: 'relative',
             },
           },
         },
@@ -208,9 +209,17 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
     ],
     overflowMenuButton: [
       classNames.overflowMenuButton,
-      ...getLinkStyles(props, classNames),
       {
-        visibility: 'hidden',
+        // TODO after the extra span wrapper around the button is removed,
+        // remove the 'button&' and 'span&' selectors and combine the styles
+        ['button&']: [...getLinkStyles(props, classNames)],
+        ['span&']: [
+          {
+            visibility: 'hidden',
+            position: 'absolute',
+            right: 0,
+          },
+        ],
       },
     ],
     linkInMenu: [

--- a/packages/react-tabs/src/components/Pivot/Pivot.styles.ts
+++ b/packages/react-tabs/src/components/Pivot/Pivot.styles.ts
@@ -198,28 +198,19 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
       {
         [`&[data-is-overflowing='true']`]: {
           display: 'none',
-          selectors: {
-            [`~ .${classNames.overflowMenuButton}`]: {
-              visibility: 'visible',
-              position: 'relative',
-            },
-          },
         },
       },
     ],
     overflowMenuButton: [
       classNames.overflowMenuButton,
       {
-        // TODO after the extra span wrapper around the button is removed,
-        // remove the 'button&' and 'span&' selectors and combine the styles
-        ['button&']: [...getLinkStyles(props, classNames)],
-        ['span&']: [
-          {
-            visibility: 'hidden',
-            position: 'absolute',
-            right: 0,
-          },
-        ],
+        visibility: 'hidden',
+        position: 'absolute',
+        right: 0,
+        [`.${classNames.link}[data-is-overflowing='true'] ~ &`]: {
+          visibility: 'visible',
+          position: 'relative',
+        },
       },
     ],
     linkInMenu: [

--- a/packages/react-tabs/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/react-tabs/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -145,9 +145,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -316,9 +313,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content=""
       data-is-focusable={true}

--- a/packages/react-tabs/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/react-tabs/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -145,9 +145,6 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -316,9 +313,6 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content="Test Link (20+)"
       data-is-focusable={true}
@@ -547,9 +541,6 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -718,9 +709,6 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content="Test Link 2"
       data-is-focusable={true}
@@ -938,9 +926,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -1109,9 +1094,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content="Test Link (12)"
       data-is-focusable={true}
@@ -1283,9 +1265,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content="Text with icon xx"
       data-is-focusable={true}
@@ -1523,9 +1502,6 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -1694,9 +1670,6 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content=""
       data-is-focusable={true}
@@ -1948,9 +1921,6 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -2153,9 +2123,6 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content=""
       data-is-focusable={true}
@@ -2371,9 +2338,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -2542,9 +2506,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content=""
       data-is-focusable={true}
@@ -2795,9 +2756,6 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;
           }
@@ -3000,9 +2958,6 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
       data-content=""
       data-is-focusable={true}
@@ -3217,9 +3172,6 @@ exports[`Pivot supports JSX expressions 1`] = `
           &[data-is-overflowing='true'] {
             display: none;
           }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
-          }
       data-content="Test Link 1"
       data-is-focusable={true}
       id="Pivot0-Tab0"
@@ -3379,9 +3331,6 @@ exports[`Pivot supports JSX expressions 1`] = `
           }
           &[data-is-overflowing='true'] {
             display: none;
-          }
-          &[data-is-overflowing='true'] ~ * .ms-Pivot-overflowMenuButton {
-            visibility: visible;
           }
           @media screen and (-ms-high-contrast: active){&:before {
             background-color: Highlight;

--- a/packages/react-tabs/src/next/Pivot.scss
+++ b/packages/react-tabs/src/next/Pivot.scss
@@ -70,7 +70,7 @@
 
 // Additional styles for Links NOT in the overflow menu
 .link,
-.overflowMenuButton {
+button.overflowMenuButton {
   text-align: center;
   display: inline-block;
   line-height: 44px;
@@ -184,11 +184,16 @@
 }
 
 // The overflow menu button is hidden until there's at least one link in the overflow
-.overflowMenuButton {
+// TODO after the extra span wrapper around the button is removed,
+// remove the 'span' selector here, and 'button' selector on the .overflowMenuButton class above
+span.overflowMenuButton {
   visibility: hidden;
+  position: absolute;
+  right: 0;
 }
-.link[data-is-overflowing='true'] ~ * .overflowMenuButton {
+.link[data-is-overflowing='true'] ~ .overflowMenuButton {
   visibility: visible;
+  position: relative;
 }
 
 .linkContent {

--- a/packages/react-tabs/src/next/Pivot.scss
+++ b/packages/react-tabs/src/next/Pivot.scss
@@ -14,8 +14,7 @@
 
 // Shared styles for tab links and links in the overflow menu
 .link,
-.linkInMenu,
-.overflowMenuButton {
+.linkInMenu {
   @include fonts-medium;
   color: var($semanticColorsActionLink);
   padding: 0 8px;
@@ -69,8 +68,7 @@
 }
 
 // Additional styles for Links NOT in the overflow menu
-.link,
-button.overflowMenuButton {
+.link {
   text-align: center;
   display: inline-block;
   line-height: 44px;
@@ -184,9 +182,7 @@ button.overflowMenuButton {
 }
 
 // The overflow menu button is hidden until there's at least one link in the overflow
-// TODO after the extra span wrapper around the button is removed,
-// remove the 'span' selector here, and 'button' selector on the .overflowMenuButton class above
-span.overflowMenuButton {
+.overflowMenuButton {
   visibility: hidden;
   position: absolute;
   right: 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15292
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Pivot overflow: fix scrollbars appearing when the window is just barely wide enough to show all tabs

Set the overflow button to have `position: absolute; right: 0;` when it is hidden. This causes it to not take up layout space while hidden, but still have a size that can be measured by the `useOverflow` algorithm.

#### Focus areas to test

Pivot overflow
