### PR TITLE
fix(Breadcrumb): use a11y slot for breadcrumb items' container

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
-- Fix `Breadcrumb` to have the `div` wrapping all items obtain a11y attributes from `itemsContainer` slot @yuanboxue-amber ([#15303](https://github.com/microsoft/fluentui/pull/15303))
+- Fix `Breadcrumb` to have the `div` wrapping all items obtain a11y attributes from `container` slot @yuanboxue-amber ([#15303](https://github.com/microsoft/fluentui/pull/15303))
 - Fix scrollbar color to have higher contrast ratio @yuanboxue-amber ([#15209](https://github.com/microsoft/fluentui/pull/15209))
 - Fix `Tree` to have un-selectable `treeItem` with `selectable` prop false @yuanboxue-amber ([#15170](https://github.com/microsoft/fluentui/pull/15170))
 - Fix default focused outline in Safari @yuanboxue-amber ([#14917](https://github.com/microsoft/fluentui/pull/14917))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
+- Fix `Breadcrumb` to have the `div` wrapping all items obtain a11y attributes from `itemsContainer` slot @yuanboxue-amber ([#15303](https://github.com/microsoft/fluentui/pull/15303))
 - Fix scrollbar color to have higher contrast ratio @yuanboxue-amber ([#15209](https://github.com/microsoft/fluentui/pull/15209))
 - Fix `Tree` to have un-selectable `treeItem` with `selectable` prop false @yuanboxue-amber ([#15170](https://github.com/microsoft/fluentui/pull/15170))
 - Fix default focused outline in Safari @yuanboxue-amber ([#14917](https://github.com/microsoft/fluentui/pull/14917))

--- a/packages/fluentui/accessibility/src/behaviors/Breadcrumb/breadcrumbBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Breadcrumb/breadcrumbBehavior.ts
@@ -5,13 +5,13 @@ import { FocusZoneDirection } from '../../focusZone/types';
  * @description
  * Implements arrow key navigation for breadcrumb
  * @specification
- * Adds attribute 'role=list' to 'itemsContainer' slot.
+ * Adds attribute 'role=list' to 'container' slot.
  * Provides arrow key navigation in bidirectional direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */
 export const breadcrumbBehavior: Accessibility<BreadcrumbBehaviorProps> = () => ({
   attributes: {
-    itemsContainer: {
+    container: {
       role: 'list',
     },
   },

--- a/packages/fluentui/accessibility/src/behaviors/Breadcrumb/breadcrumbBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Breadcrumb/breadcrumbBehavior.ts
@@ -5,10 +5,16 @@ import { FocusZoneDirection } from '../../focusZone/types';
  * @description
  * Implements arrow key navigation for breadcrumb
  * @specification
+ * Adds attribute 'role=list' to 'itemsContainer' slot.
  * Provides arrow key navigation in bidirectional direction.
  * When component's container element receives focus, focus will be set to the default focusable child element of the component.
  */
 export const breadcrumbBehavior: Accessibility<BreadcrumbBehaviorProps> = () => ({
+  attributes: {
+    itemsContainer: {
+      role: 'list',
+    },
+  },
   focusZone: {
     props: {
       shouldFocusInnerElementWhenReceivedFocus: true,

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -91,7 +91,13 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
         })}
       >
         <BreadcrumbContext.Provider value={contextValue}>
-          <div role="list">{childrenExist(children) ? children : content}</div>
+          <div
+            {...getA11yProps('itemsContainer', {
+              className: classes.itemsContainerWrapper,
+            })}
+          >
+            {childrenExist(children) ? children : content}
+          </div>
         </BreadcrumbContext.Provider>
       </ElementType>,
     );
@@ -104,6 +110,7 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
   {
     className: breadcrumbClassName,
     displayName: 'Breadcrumb',
+
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables', 'size'],
     mapPropsToStylesProps: ({ size }) => ({
       size,

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -92,8 +92,8 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
       >
         <BreadcrumbContext.Provider value={contextValue}>
           <div
-            {...getA11yProps('itemsContainer', {
-              className: classes.itemsContainer,
+            {...getA11yProps('container', {
+              className: classes.container,
             })}
           >
             {childrenExist(children) ? children : content}

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -93,7 +93,7 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
         <BreadcrumbContext.Provider value={contextValue}>
           <div
             {...getA11yProps('itemsContainer', {
-              className: classes.itemsContainerWrapper,
+              className: classes.itemsContainer,
             })}
           >
             {childrenExist(children) ? children : content}

--- a/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
+++ b/packages/fluentui/react-northstar/src/components/Breadcrumb/Breadcrumb.tsx
@@ -110,7 +110,6 @@ export const Breadcrumb = compose<'nav', BreadcrumbProps, BreadcrumbStylesProps,
   {
     className: breadcrumbClassName,
     displayName: 'Breadcrumb',
-
     handledProps: ['accessibility', 'as', 'children', 'className', 'content', 'design', 'styles', 'variables', 'size'],
     mapPropsToStylesProps: ({ size }) => ({
       size,


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Breadcrumb component wrap all its items in a `div`. Before this change, a 'role=list' is add directly on this div. After this change, the role is obtained from accessibility package.

#### Focus areas to test

(optional)
