### PR TITLE
Revert "fix(button): extra width when loading=false"

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
-- Fix `Button` to not have extra width when loading prop is false @yuanboxue-amber ([#15306](https://github.com/microsoft/fluentui/pull/15306))
 - Fix `Breadcrumb` to have the `div` wrapping all items obtain a11y attributes from `container` slot @yuanboxue-amber ([#15303](https://github.com/microsoft/fluentui/pull/15303))
 - Fix scrollbar color to have higher contrast ratio @yuanboxue-amber ([#15209](https://github.com/microsoft/fluentui/pull/15209))
 - Fix `Tree` to have un-selectable `treeItem` with `selectable` prop false @yuanboxue-amber ([#15170](https://github.com/microsoft/fluentui/pull/15170))

--- a/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react-northstar/src/themes/teams/components/Button/buttonStyles.ts
@@ -1,3 +1,4 @@
+import * as _ from 'lodash';
 import { pxToRem } from '../../../../utils';
 import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { loaderSlotClassNames } from '../../../../components/Loader/Loader';
@@ -22,7 +23,7 @@ export const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, Button
 
     return {
       height: v.height,
-      minWidth: p.loading ? v.loadingMinWidth : v.minWidth,
+      minWidth: _.isNil(p.loading) ? v.minWidth : v.loadingMinWidth,
       maxWidth: v.maxWidth,
       color: v.color,
       backgroundColor: v.backgroundColor,


### PR DESCRIPTION
Reverts microsoft/fluentui#15306

According to design spec, button within the same action flow should have the same size.
For a loading button, when loading=true, button is wider than regular button. Then when loading=false, button should keep the same size.
