### PR TITLE
[DRAFT]FloatingSuggestionsComposite: Making the overflow scrollable for the callout to see more suggestions

### DIFF
--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.styles.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.styles.ts
@@ -30,7 +30,7 @@ export const getStyles = (props: IFloatingSuggestionsListStyleProps): IFloatingS
       classNames.suggestionsContainer,
       {
         overflowX: 'auto',
-        overflowY: 'hidden',
+        overflowY: 'auto',
         maxHeight: '300px',
         borderBottom: `1px solid ${neutralLight}`,
       },

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -51,6 +51,22 @@ const _suggestions = [
     isSelected: false,
     showRemoveButton: true,
   },
+  {
+    key: '6',
+    id: '6',
+    displayText: 'Suggestion 6',
+    item: people[5],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '7',
+    id: '7',
+    displayText: 'Suggestion 7',
+    item: people[6],
+    isSelected: false,
+    showRemoveButton: true,
+  },
 ] as IFloatingSuggestionItem<IPersonaProps>[];
 
 export const UnifiedPeoplePickerExample = (): JSX.Element => {


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Updating the floating suggestion css to allow for showing a scroll bar when suggestions are long list
Updated example to show the same.
Will not be checking this in till the freeze is over

#### Focus areas to test

(optional)
