### PR TITLE
chore: improve dist size for N*

### DIFF
--- a/scripts/gulp/tasks/bundle.ts
+++ b/scripts/gulp/tasks/bundle.ts
@@ -14,16 +14,7 @@ const packageName = config.package;
 // Clean
 // ----------------------------------------
 
-task('bundle:package:clean', () =>
-  del(
-    [
-      `${paths.packageDist(packageName)}/es/*`,
-      `${paths.packageDist(packageName)}/commonjs/*`,
-      `${paths.packageDist(packageName)}/dts`,
-    ],
-    { force: true },
-  ),
-);
+task('bundle:package:clean', () => del([`${paths.packageDist(packageName)}`], { force: true }));
 
 // ----------------------------------------
 // Build
@@ -35,7 +26,7 @@ task('bundle:package:commonjs', () =>
   src(componentsSrc)
     .pipe(sourcemaps.init())
     .pipe(babel())
-    .pipe(sourcemaps.write('.'))
+    .pipe(sourcemaps.write())
     .pipe(dest(paths.packageDist(packageName, 'commonjs'))),
 );
 
@@ -43,7 +34,7 @@ task('bundle:package:es', () =>
   src(componentsSrc)
     .pipe(sourcemaps.init())
     .pipe(babel({ caller: { useESModules: true } } as any))
-    .pipe(sourcemaps.write('.'))
+    .pipe(sourcemaps.write())
     .pipe(dest(paths.packageDist(packageName, 'es'))),
 );
 
@@ -53,7 +44,14 @@ task('bundle:package:types:tsc', () => {
 task('bundle:package:types:copy', () => {
   return src(paths.packageDist(packageName, 'dts/src/**/*.d.ts')).pipe(dest(paths.packageDist(packageName, 'es')));
 });
-task('bundle:package:types', series('bundle:package:types:tsc', 'bundle:package:types:copy'));
+task('bundle:package:types:clean', () => {
+  return del([`${paths.packageDist(packageName)}/dts`], { force: true });
+});
+
+task(
+  'bundle:package:types',
+  series('bundle:package:types:tsc', 'bundle:package:types:copy', 'bundle:package:types:clean'),
+);
 
 // ----------------------------------------
 // Default


### PR DESCRIPTION
### warnings about sourcemaps

![image](https://user-images.githubusercontent.com/14183168/94800591-1a62aa80-03e5-11eb-8750-d62c7688acb2.png)

The basic Webpack setup was screaming about missing sourcemaps, now there are inlined so there it's not an issue anymore.

### cleanup build

With @miroslavstastny we mentioned that artifacts published to NPM are too heavy.

- `dist` folder was not cleaned up properly (`/*` does not work at least on Windows) so I was publishing `processedIcons` folder that was removed a decade ago
- `dts` folder was also published however it's not required at all

The result is **31MB => 14MB** on published artifacts for `@fluentui/react-northstar`, this should speed up install of packages on CodeSandbox.