### PR TITLE
Fix issue in GroupedList where paging new data into existing groups did not re-render

### DIFF
--- a/change/office-ui-fabric-react-2020-10-01-12-01-52-group-update.json
+++ b/change/office-ui-fabric-react-2020-10-01-12-01-52-group-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix paging within groups for GroupedList",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-01T19:01:52.700Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5061,6 +5061,8 @@ export interface IGroupedListState {
     // (undocumented)
     groups?: IGroup[];
     // (undocumented)
+    items?: IGroupedListProps['items'];
+    // (undocumented)
     listProps?: IGroupedListProps['listProps'];
     // (undocumented)
     selectionMode?: IGroupedListProps['selectionMode'];

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -639,4 +639,110 @@ describe('DetailsList', () => {
 
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  it('handles paged updates to items within groups', () => {
+    const roundOneItems = [
+      {
+        f1: 'A1',
+        f2: 'B1',
+        f3: 'C1',
+      },
+      undefined,
+      {
+        f1: 'A3',
+        f2: 'B3',
+        f3: 'C3',
+      },
+      undefined,
+    ];
+    const roundTwoItems = [
+      {
+        f1: 'A1',
+        f2: 'B1',
+        f3: 'C1',
+      },
+      {
+        f1: 'A2',
+        f2: 'B2',
+        f3: 'C2',
+      },
+      {
+        f1: 'A3',
+        f2: 'B3',
+        f3: 'C3',
+      },
+      {
+        f1: 'A4',
+        f2: 'B4',
+        f3: 'C4',
+      },
+    ];
+
+    const groups: IGroup[] = [
+      { key: 'two-1', name: 'two 1', count: 2, startIndex: 0 },
+      { key: 'two-2', name: 'two 2', count: 2, startIndex: 2 },
+    ];
+
+    const onRenderDetailsHeader: IRenderFunction<IDetailsHeaderProps> = (headerProps: IDetailsHeaderProps) => {
+      return (
+        <div>
+          {headerProps.columns.map((column: IColumn) => {
+            return <div key={column.key}>{column.name}</div>;
+          })}
+        </div>
+      );
+    };
+
+    const onRenderRow = (rowProps: IDetailsRowProps) => {
+      return (
+        <div>
+          {rowProps.columns.map((column: IColumn) => {
+            return <div key={column.key}>{rowProps.item[column.key]}</div>;
+          })}
+        </div>
+      );
+    };
+
+    const onRenderMissingItem = () => {
+      return <div>Placeholder</div>;
+    };
+
+    const onRenderGroupHeader: IRenderFunction<IDetailsGroupDividerProps> = (
+      groupDividerProps: IDetailsGroupDividerProps,
+    ) => {
+      return <div>{groupDividerProps.group?.name}</div>;
+    };
+
+    const component = renderer.create(
+      <DetailsList
+        onRenderDetailsHeader={onRenderDetailsHeader}
+        onRenderRow={onRenderRow}
+        onRenderMissingItem={onRenderMissingItem}
+        groupProps={{ onRenderHeader: onRenderGroupHeader }}
+        items={roundOneItems}
+        groups={groups}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        skipViewportMeasures={true}
+      />,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+
+    // New items, same groups
+
+    component.update(
+      <DetailsList
+        onRenderDetailsHeader={onRenderDetailsHeader}
+        onRenderRow={onRenderRow}
+        onRenderMissingItem={onRenderMissingItem}
+        groupProps={{ onRenderHeader: onRenderGroupHeader }}
+        items={roundTwoItems}
+        groups={groups}
+        layoutMode={DetailsListLayoutMode.fixedColumns}
+        skipViewportMeasures={true}
+      />,
+    );
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -1,5 +1,549 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DetailsList handles paged updates to items within groups 1`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-fixed
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={5}
+      aria-readonly="true"
+      aria-rowcount={7}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div>
+          <div>
+            f1
+          </div>
+          <div>
+            f2
+          </div>
+          <div>
+            f3
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                ms-GroupedList
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  position: relative;
+                }
+                & .ms-List-cell {
+                  min-height: 38px;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-automationid="GroupedList"
+            data-focuszone-id="FocusZone116"
+            data-is-scrollable="false"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
+                      role="presentation"
+                    >
+                      <div>
+                        two 1
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection117"
+                        role="presentation"
+                      >
+                        <div
+                          className="ms-List-surface"
+                          role="presentation"
+                        >
+                          <div
+                            className="ms-List-page"
+                            role="presentation"
+                            style={Object {}}
+                          >
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={0}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A1
+                                </div>
+                                <div>
+                                  B1
+                                </div>
+                                <div>
+                                  C1
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={1}
+                              role="presentation"
+                            >
+                              <div>
+                                Placeholder
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
+                      role="presentation"
+                    >
+                      <div>
+                        two 2
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection118"
+                        role="presentation"
+                      >
+                        <div
+                          className="ms-List-surface"
+                          role="presentation"
+                        >
+                          <div
+                            className="ms-List-page"
+                            role="presentation"
+                            style={Object {}}
+                          >
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={2}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A3
+                                </div>
+                                <div>
+                                  B3
+                                </div>
+                                <div>
+                                  C3
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={3}
+                              role="presentation"
+                            >
+                              <div>
+                                Placeholder
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`DetailsList handles paged updates to items within groups 2`] = `
+<div
+  className="ms-Viewport"
+  style={
+    Object {
+      "minHeight": 1,
+      "minWidth": 1,
+    }
+  }
+>
+  <div
+    className=
+        ms-DetailsList
+        is-fixed
+        is-horizontalConstrained
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          -webkit-overflow-scrolling: touch;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+          overflow-x: auto;
+          overflow-y: visible;
+          position: relative;
+        }
+        & .ms-List-cell {
+          min-height: 38px;
+          word-break: break-word;
+        }
+    data-automationid="DetailsList"
+    data-is-scrollable="false"
+  >
+    <div
+      aria-colcount={5}
+      aria-readonly="true"
+      aria-rowcount={7}
+      role="grid"
+    >
+      <div
+        className="ms-DetailsList-headerWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div>
+          <div>
+            f1
+          </div>
+          <div>
+            f2
+          </div>
+          <div>
+            f3
+          </div>
+        </div>
+      </div>
+      <div
+        className="ms-DetailsList-contentWrapper"
+        onKeyDown={[Function]}
+        role="presentation"
+      >
+        <div
+          className="ms-SelectionZone"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onFocusCapture={[Function]}
+          onKeyDown={[Function]}
+          onKeyDownCapture={[Function]}
+          onMouseDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                ms-GroupedList
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  position: relative;
+                }
+                & .ms-List-cell {
+                  min-height: 38px;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-automationid="GroupedList"
+            data-focuszone-id="FocusZone116"
+            data-is-scrollable="false"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
+          >
+            <div
+              className="ms-List"
+              role="presentation"
+            >
+              <div
+                className="ms-List-surface"
+                role="presentation"
+              >
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={0}
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
+                      role="presentation"
+                    >
+                      <div>
+                        two 1
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection117"
+                        role="presentation"
+                      >
+                        <div
+                          className="ms-List-surface"
+                          role="presentation"
+                        >
+                          <div
+                            className="ms-List-page"
+                            role="presentation"
+                            style={Object {}}
+                          >
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={0}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A1
+                                </div>
+                                <div>
+                                  B1
+                                </div>
+                                <div>
+                                  C1
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={1}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A2
+                                </div>
+                                <div>
+                                  B2
+                                </div>
+                                <div>
+                                  C2
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  className="ms-List-page"
+                  role="presentation"
+                  style={Object {}}
+                >
+                  <div
+                    className="ms-List-cell"
+                    data-automationid="ListCell"
+                    data-list-index={1}
+                    role="presentation"
+                  >
+                    <div
+                      className=
+                          ms-GroupedList-group
+                          {
+                            transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                          }
+                      role="presentation"
+                    >
+                      <div>
+                        two 2
+                      </div>
+                      <div
+                        className="ms-List"
+                        id="GroupedListSection118"
+                        role="presentation"
+                      >
+                        <div
+                          className="ms-List-surface"
+                          role="presentation"
+                        >
+                          <div
+                            className="ms-List-page"
+                            role="presentation"
+                            style={Object {}}
+                          >
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={2}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A3
+                                </div>
+                                <div>
+                                  B3
+                                </div>
+                                <div>
+                                  C3
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              className="ms-List-cell"
+                              data-automationid="ListCell"
+                              data-list-index={3}
+                              role="presentation"
+                            >
+                              <div>
+                                <div>
+                                  A4
+                                </div>
+                                <div>
+                                  B4
+                                </div>
+                                <div>
+                                  C4
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DetailsList handles updates to items and groups 1`] = `
 <div
   className="ms-Viewport"
@@ -522,13 +1066,13 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                             >
                               <div>
                                 <div>
-                                  A1
+                                  D1
                                 </div>
                                 <div>
-                                  B1
+                                  E1
                                 </div>
                                 <div>
-                                  C1
+                                  F1
                                 </div>
                               </div>
                             </div>
@@ -582,13 +1126,13 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                             >
                               <div>
                                 <div>
-                                  A2
+                                  D2
                                 </div>
                                 <div>
-                                  B2
+                                  E2
                                 </div>
                                 <div>
-                                  C2
+                                  F2
                                 </div>
                               </div>
                             </div>
@@ -642,13 +1186,13 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                             >
                               <div>
                                 <div>
-                                  A3
+                                  D3
                                 </div>
                                 <div>
-                                  B3
+                                  E3
                                 </div>
                                 <div>
-                                  C3
+                                  F3
                                 </div>
                               </div>
                             </div>
@@ -702,13 +1246,13 @@ exports[`DetailsList handles updates to items and groups 2`] = `
                             >
                               <div>
                                 <div>
-                                  A4
+                                  D4
                                 </div>
                                 <div>
-                                  B4
+                                  E4
                                 </div>
                                 <div>
-                                  C4
+                                  F4
                                 </div>
                               </div>
                             </div>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -24,6 +24,7 @@ export interface IGroupedListState {
   selectionMode?: IGroupedListProps['selectionMode'];
   compact?: IGroupedListProps['compact'];
   groups?: IGroup[];
+  items?: IGroupedListProps['items'];
   listProps?: IGroupedListProps['listProps'];
   version: {};
 }
@@ -46,13 +47,14 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     nextProps: IGroupedListProps,
     previousState: IGroupedListState,
   ): IGroupedListState {
-    const { groups, selectionMode, compact, listProps } = nextProps;
+    const { groups, selectionMode, compact, items, listProps } = nextProps;
     const listVersion = listProps && listProps.version;
 
     let nextState = {
       ...previousState,
       selectionMode,
       compact,
+      groups,
       listProps,
     };
 
@@ -60,18 +62,16 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     const previousListVersion = previousState.listProps && previousState.listProps.version;
 
-    if (listVersion !== previousListVersion) {
-      shouldForceUpdates = true;
-    }
-
-    if (groups !== previousState.groups) {
-      nextState = {
-        ...nextState,
-        groups,
-      };
-    }
-
-    if (selectionMode !== previousState.selectionMode || compact !== previousState.compact) {
+    if (
+      listVersion !== previousListVersion ||
+      items !== previousState.items ||
+      groups !== previousState.groups ||
+      selectionMode !== previousState.selectionMode ||
+      compact !== previousState.compact
+    ) {
+      // If there are any props not passed explicitly to `List` which have an impact on the behavior of `onRenderCell`,
+      // these need to 'force-update' this component by revving the version. Otherwise, the List might render with stale
+      // data.
       shouldForceUpdates = true;
     }
 
@@ -96,6 +96,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
     this.state = {
       groups: props.groups,
+      items: props.items,
       listProps: props.listProps,
       version,
     };


### PR DESCRIPTION
#### Description of changes

Reworked the logic in the new `getDerivedStateFromProps` function in `GroupedList` so it properly re-renders the `List` if any of the dependent props change. This fixes an issue where updating only the `items` would not actually trigger a re-render because they were not explicitly passed as props to the child `List` components.

#### Focus areas to test

Added a new unit test to validate updating the `items` in-place with the same groupings, using some placeholders to simulate paging.
