### PR TITLE
react-stylesheets: fix error when target is undefined (in case of SSR).

### DIFF
--- a/change/@fluentui-react-stylesheets-2020-10-01-20-02-41-xgao-fix-ssr.json
+++ b/change/@fluentui-react-stylesheets-2020-10-01-20-02-41-xgao-fix-ssr.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix error when target is undefined (in case of SSR).",
+  "packageName": "@fluentui/react-stylesheets",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T03:02:41.498Z"
+}

--- a/packages/react-stylesheets/src/StylesheetContext.tsx
+++ b/packages/react-stylesheets/src/StylesheetContext.tsx
@@ -51,7 +51,7 @@ export const registerStyles = (sheets: undefined | string | string[], context: S
  * Default renderStyles implementation, which will render the give sheets to the contextual
  * target.
  */
-const renderStyles = (sheets: string[], context: StylesheetContextType): void => {
+const renderStyles = (sheets: string[], context: StylesheetContextType) => {
   const { target } = context;
 
   if (sheets.length && target) {

--- a/packages/react-stylesheets/src/StylesheetContext.tsx
+++ b/packages/react-stylesheets/src/StylesheetContext.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 export type HTMLDirection = 'rtl' | 'ltr' | 'auto';
 
+const defaultDocument = { document: 'document' };
+
 export interface StylesheetContextType {
   target: Document | undefined;
   registerStyles: (stylesheets: undefined | string | string[], context: StylesheetContextType) => void;
-  styleCache: WeakMap<Document, Map<string, boolean>>;
+  styleCache: WeakMap<Document | typeof defaultDocument, Map<string, boolean>>;
   renderStyles: (stylesheets: string[], context: StylesheetContextType) => void;
 }
 
@@ -15,7 +17,7 @@ export interface StylesheetContextType {
  */
 export const registerStyles = (sheets: undefined | string | string[], context: StylesheetContextType) => {
   const { styleCache, target } = context;
-  if (!sheets) {
+  if (!sheets || sheets.length < 1) {
     return;
   }
 
@@ -25,11 +27,12 @@ export const registerStyles = (sheets: undefined | string | string[], context: S
 
   // Grab the style cache for the target document.
   const sheetsToRender = [];
-  let targetStylesheets = styleCache.get(target!);
+  const cacheKey = target || defaultDocument;
+  let targetStylesheets = styleCache.get(cacheKey);
 
   if (!targetStylesheets) {
     targetStylesheets = new Map();
-    styleCache.set(target!, targetStylesheets);
+    styleCache.set(cacheKey, targetStylesheets);
   }
 
   for (const sheet of sheets) {
@@ -48,7 +51,7 @@ export const registerStyles = (sheets: undefined | string | string[], context: S
  * Default renderStyles implementation, which will render the give sheets to the contextual
  * target.
  */
-const renderStyles = (sheets: string[], context: StylesheetContextType) => {
+const renderStyles = (sheets: string[], context: StylesheetContextType): void => {
   const { target } = context;
 
   if (sheets.length && target) {
@@ -64,5 +67,5 @@ export const StylesheetContext = React.createContext<StylesheetContextType>({
   registerStyles,
   renderStyles,
   target: typeof window === 'object' ? window.document : undefined,
-  styleCache: new WeakMap<Document, Map<string, boolean>>(),
+  styleCache: new WeakMap<Document | typeof defaultDocument, Map<string, boolean>>(),
 });

--- a/packages/react-stylesheets/src/StylesheetProvider.test.tsx
+++ b/packages/react-stylesheets/src/StylesheetProvider.test.tsx
@@ -63,6 +63,18 @@ describe('StylesheetProvider', () => {
     expect(result).toEqual([FooStylesheet]);
   });
 
+  it('can render without target (ssr)', () => {
+    mountWithContext(
+      <StylesheetProvider target={undefined}>
+        <Foo />
+        <Foo />
+      </StylesheetProvider>,
+    );
+
+    expect(lastContext?.target).toBe(undefined);
+    expect(result).toEqual([FooStylesheet]);
+  });
+
   it('can provide a custom target', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const customTarget: any = {};


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
When target is `undefined`, we are setting `undefined` as key in `WeakMap` which causes error.

#### Focus areas to test

(optional)
