### PR TITLE
ThemeProvider: set correct dir based on rtl value in theme.

### DIFF
--- a/change/@fluentui-react-theme-provider-2020-10-02-12-18-14-xgao-themeprovider-set-dir.json
+++ b/change/@fluentui-react-theme-provider-2020-10-02-12-18-14-xgao-themeprovider-set-dir.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Set correct dir on root element based on rtl value in theme.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-02T19:18:14.759Z"
+}

--- a/packages/react-theme-provider/src/ThemeProvider.test.tsx
+++ b/packages/react-theme-provider/src/ThemeProvider.test.tsx
@@ -58,6 +58,34 @@ describe('ThemeProvider', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('sets correct dir', () => {
+    const wrapper = mount(
+      <ThemeProvider className="tp-1" theme={{ rtl: true }}>
+        <ThemeProvider className="tp-2" theme={{ rtl: false }}>
+          Hello
+        </ThemeProvider>
+      </ThemeProvider>,
+    );
+
+    const themeProvider1 = wrapper
+      .find('.tp-1')
+      .first()
+      .getDOMNode();
+    const themeProvider2 = wrapper
+      .find('.tp-2')
+      .first()
+      .getDOMNode();
+
+    expect(themeProvider1.getAttribute('dir')).toBe('rtl');
+    expect(themeProvider2.getAttribute('dir')).toBe('ltr');
+
+    wrapper.setProps({ theme: { rtl: false } });
+    expect(themeProvider1.getAttribute('dir')).toBe('ltr');
+    expect(themeProvider2.getAttribute('dir')).toBe(null);
+
+    wrapper.unmount();
+  });
+
   it('renders a div with styling', () => {
     const component = renderer.create(<ThemeProvider theme={lightTheme}>Hello</ThemeProvider>);
     const tree = component.toJSON();

--- a/packages/react-theme-provider/src/useThemeProviderState.tsx
+++ b/packages/react-theme-provider/src/useThemeProviderState.tsx
@@ -52,4 +52,8 @@ export const useThemeProviderState = (draftState: ThemeProviderState) => {
     }),
     [theme],
   );
+
+  if (draftState.theme.rtl !== parentTheme.rtl) {
+    draftState.dir = draftState.theme.rtl ? 'rtl' : 'ltr';
+  }
 };


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
set `dir` on ThemeProvider root element based on the value of `theme.rtl`.

#### Focus areas to test
Added UT
