### PR TITLE
Expose filetypeIcon src through a utility

### DIFF
--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -8,10 +8,18 @@ const SVG_SUFFIX = '_svg';
 const DEFAULT_BASE_URL = 'https://spoprod-a.akamaihd.net/files/fabric-cdn-prod_20200921.001/assets/item-types/';
 const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 
+const _iconSources: { [iconName: string]: string } = {};
+
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {
   ICON_SIZES.forEach((size: number) => {
     _initializeIcons(baseUrl, size, options);
   });
+}
+
+export function getIconSource(iconName: string): string | undefined {
+  if (_iconSources.hasOwnProperty(iconName)) {
+    return _iconSources[iconName];
+  }
 }
 
 function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIconOptions>): void {
@@ -20,8 +28,18 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
 
   iconTypes.forEach((type: string) => {
     const baseUrlSizeType = baseUrl + size + '/' + type;
-    fileTypeIcons[type + size + PNG_SUFFIX] = <img src={baseUrlSizeType + '.png'} alt="" />;
-    fileTypeIcons[type + size + SVG_SUFFIX] = <img src={baseUrlSizeType + '.svg'} alt="" />;
+    let src: string;
+    let iconName: string;
+
+    src = `{${baseUrlSizeType} + '.png'}`;
+    iconName = type + size + PNG_SUFFIX;
+    fileTypeIcons[iconName] = <img src={src} alt="" />;
+    _iconSources[iconName] = src;
+
+    src = `{${baseUrlSizeType} + '.svg'}`;
+    iconName = type + size + SVG_SUFFIX;
+    fileTypeIcons[iconName] = <img src={src} alt="" />;
+    _iconSources[iconName] = src;
 
     // For high resolution screens, register additional versions
     // Apply height=100% and width=100% to force image to fit into containing element
@@ -29,22 +47,30 @@ function _initializeIcons(baseUrl: string, size: number, options?: Partial<IIcon
     // SVGs scale well, so you can generally use the default image.
     // 1.5x is a special case where both SVGs and PNGs need a different image.
 
-    fileTypeIcons[type + size + '_1.5x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_1.5x/' + type + '.png'} height="100%" width="100%" />
-    );
-    fileTypeIcons[type + size + '_1.5x' + SVG_SUFFIX] = (
-      <img src={baseUrl + size + '_1.5x/' + type + '.svg'} height="100%" width="100%" />
-    );
+    iconName = type + size + '_1.5x' + PNG_SUFFIX;
+    src = `{${baseUrl} + ${size} + _1.5x/ + ${type} + .png}`;
+    fileTypeIcons[iconName] = <img src={src} height="100%" width="100%" />;
+    _iconSources[iconName] = src;
 
-    fileTypeIcons[type + size + '_2x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_2x/' + type + '.png'} height="100%" width="100%" />
-    );
-    fileTypeIcons[type + size + '_3x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_3x/' + type + '.png'} height="100%" width="100%" />
-    );
-    fileTypeIcons[type + size + '_4x' + PNG_SUFFIX] = (
-      <img src={baseUrl + size + '_4x/' + type + '.png'} height="100%" width="100%" />
-    );
+    iconName = type + size + '_1.5x' + SVG_SUFFIX;
+    src = `{${baseUrl} + ${size} + _1.5x/ + ${type} + .svg}`;
+    fileTypeIcons[iconName] = <img src={src} height="100%" width="100%" />;
+    _iconSources[iconName] = src;
+
+    iconName = type + size + '_2x' + PNG_SUFFIX;
+    src = `{${baseUrl} + ${size} + _2x/ + ${type} + .png}`;
+    fileTypeIcons[iconName] = <img src={src} height="100%" width="100%" />;
+    _iconSources[iconName] = src;
+
+    iconName = type + size + '_3x' + PNG_SUFFIX;
+    src = `{${baseUrl} + ${size} + _3x/ + ${type} + .png}`;
+    fileTypeIcons[iconName] = <img src={src} height="100%" width="100%" />;
+    _iconSources[iconName] = src;
+
+    iconName = type + size + '_4x' + PNG_SUFFIX;
+    src = `{${baseUrl} + ${size} + _4x/ + ${type} + .png}`;
+    fileTypeIcons[iconName] = <img src={src} height="100%" width="100%" />;
+    _iconSources[iconName] = src;
   });
 
   registerIcons(


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This change is mainly in regard to starting a discussion on the best practice to consume the `src` of FileTypeIcons. [This ](https://onedrive.visualstudio.com/OneDriveWeb/_git/odsp-common?path=%2Futilities%2Fcustom-formatter%2Fsrc%2FCustomFormatter.ts&version=GBarkgupta%2FthumbnailPoc2&line=789&lineEnd=797&lineStartColumn=1&lineEndColumn=6&lineStyle=plain)is a change in a [PR](https://onedrive.visualstudio.com/OneDriveWeb/_git/odsp-common/pullrequest/531880) where I am currently consuming it  using getIcon(iconName).code.props.src. The idea is to compose raw `<img>` tags and set the innerHtml rather than directly using a React Component. Can accessing the src from the React element obtained from getIcon like this cause any issues in the longer run ?

The idea which I wanted to discuss was what if we expose the src through a utility in the way I have done in this PR?

#### Focus areas to test

(optional)
