### PR TITLE
Add theme and react-theme-provider exports and remove foundation exports from @fluentui/react

### DIFF
--- a/apps/theming-designer/package.json
+++ b/apps/theming-designer/package.json
@@ -25,6 +25,7 @@
     "@uifabric/react-cards": "^0.113.3",
     "@uifabric/merge-styles": "^7.19.1",
     "@uifabric/example-app-base": "^7.15.18",
+    "@uifabric/foundation": "^7.9.9",
     "@uifabric/variants": "^7.2.21",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/icons": "^7.5.8",

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -19,7 +19,7 @@ import { Samples } from './Samples/index';
 import { Stack, IStackProps } from '@fluentui/react/lib/Stack';
 import { ThemeDesignerColorPicker } from './ThemeDesignerColorPicker';
 import { Text } from '@fluentui/react';
-import { ThemeProvider } from '@fluentui/react/lib/Foundation';
+import { ThemeProvider } from '@uifabric/foundation';
 import { MainPanelWidth } from '../shared/MainPanelStyles';
 
 export interface IThemingDesignerState {

--- a/change/@fluentui-react-2020-10-02-17-04-03-xgao-export-from-react.json
+++ b/change/@fluentui-react-2020-10-02-17-04-03-xgao-export-from-react.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export @fluentui/theme and react-theme-provider. Remove Foundation exports.",
+  "packageName": "@fluentui/react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-03T00:04:03.784Z"
+}

--- a/change/@fluentui-react-internal-2020-10-02-17-04-03-xgao-export-from-react.json
+++ b/change/@fluentui-react-internal-2020-10-02-17-04-03-xgao-export-from-react.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export @fluentui/theme and react-theme-provider. Remove Foundation exports.",
+  "packageName": "@fluentui/react-internal",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-03T00:03:45.900Z"
+}

--- a/change/@fluentui-react-next-2020-10-02-17-04-03-xgao-export-from-react.json
+++ b/change/@fluentui-react-next-2020-10-02-17-04-03-xgao-export-from-react.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Export @fluentui/theme and react-theme-provider. Remove Foundation exports.",
+  "packageName": "@fluentui/react-next",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-03T00:03:57.365Z"
+}

--- a/change/@uifabric-example-app-base-2020-10-02-17-04-03-xgao-export-from-react.json
+++ b/change/@uifabric-example-app-base-2020-10-02-17-04-03-xgao-export-from-react.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update import paths from foundation package.",
+  "packageName": "@uifabric/example-app-base",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-03T00:02:45.799Z"
+}

--- a/change/@uifabric-experiments-2020-10-02-17-04-03-xgao-export-from-react.json
+++ b/change/@uifabric-experiments-2020-10-02-17-04-03-xgao-export-from-react.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update import paths from foundation package.",
+  "packageName": "@uifabric/experiments",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-03T00:03:06.469Z"
+}

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -46,6 +46,7 @@
     "@fluentui/theme": "^1.2.1",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/example-data": "^7.1.5",
+    "@uifabric/foundation": "^7.9.9",
     "@uifabric/react-hooks": "^7.13.5",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/tsx-editor": "^0.13.18",

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CommandButton } from '@fluentui/react/lib/Button';
 import { Dropdown, IDropdownOption } from '@fluentui/react/lib/Dropdown';
-import { ThemeProvider } from '@fluentui/react/lib/Foundation';
+import { ThemeProvider } from '@uifabric/foundation';
 import {
   styled,
   Customizer,

--- a/packages/experiments/src/components/Accordion/Accordion.tsx
+++ b/packages/experiments/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, getSlots } from '../../Foundation';
-import { createComponent } from '../../Foundation';
+import { createComponent, withSlots, getSlots } from '@uifabric/foundation';
 import { CollapsibleSection, ICollapsibleSectionProps } from '../../CollapsibleSection';
 import { IAccordionComponent, IAccordionProps, IAccordionSlots } from './Accordion.types';
 import { styles } from './Accordion.styles';

--- a/packages/experiments/src/components/Accordion/Accordion.types.ts
+++ b/packages/experiments/src/components/Accordion/Accordion.types.ts
@@ -1,5 +1,5 @@
 import { IStyle } from '../../Styling';
-import { IComponent, IHTMLSlot, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IHTMLSlot, IStyleableComponentProps } from '@uifabric/foundation';
 
 export type IAccordionComponent = IComponent<IAccordionProps, IAccordionTokens, IAccordionStyles>;
 

--- a/packages/experiments/src/components/Button/Actionable/Actionable.types.ts
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.types.ts
@@ -8,7 +8,7 @@ import {
   ISlotProp,
   ISlottableProps,
   IStyleableComponentProps,
-} from '../../../Foundation';
+} from '@uifabric/foundation';
 import { IBaseProps } from '../../../Utilities';
 
 /**

--- a/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
+++ b/packages/experiments/src/components/Button/Actionable/Actionable.view.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { KeytipData } from '@fluentui/react';
-import { withSlots } from '../../../Foundation';
+import { withSlots } from '@uifabric/foundation';
 import { getNativeProps, anchorProperties, buttonProperties } from '../../../Utilities';
 
 import { IActionableComponent, IActionableViewProps } from './Actionable.types';

--- a/packages/experiments/src/components/Button/Button.types.tsx
+++ b/packages/experiments/src/components/Button/Button.types.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
 import { IRawFontStyle, IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';
 import { ITextSlot } from '@fluentui/react';
-import { IComponentStyles, ISlottableProps, ISlotProp, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, ISlottableProps, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
 import { IFontIconSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';
 import {

--- a/packages/experiments/src/components/Button/Button.view.tsx
+++ b/packages/experiments/src/components/Button/Button.view.tsx
@@ -1,7 +1,7 @@
 /** @jsx withSlots */
 import * as React from 'react';
 import { Text, KeytipData } from '@fluentui/react';
-import { withSlots } from '../../Foundation';
+import { withSlots } from '@uifabric/foundation';
 import { getNativeProps, anchorProperties, buttonProperties } from '../../Utilities';
 import { FontIcon } from '../../utilities/factoryComponents';
 

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.state.ts
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.state.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useControlledState } from '../../../Foundation';
+import { useControlledState } from '@uifabric/foundation';
 import { KeyCodes } from '../../../Utilities';
 import { IMenuButtonComponent, IMenuButtonViewProps } from './MenuButton.types';
 

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
-import { IComponentStyles, IHTMLSlot, ISlottableProps, ISlotProp, IStyleableComponentProps } from '../../../Foundation';
+import {
+  IComponentStyles,
+  IHTMLSlot,
+  ISlottableProps,
+  ISlotProp,
+  IStyleableComponentProps,
+} from '@uifabric/foundation';
 import { IContextualMenuSlot, IFontIconSlot } from '../../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../../Utilities';
 import {

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { ContextualMenu, DirectionalHint, Text } from '@fluentui/react';
-import { withSlots } from '../../../Foundation';
+import { withSlots } from '@uifabric/foundation';
 import { FontIcon } from '../../../utilities/factoryComponents';
 
 import { Button } from '../Button';

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.types.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 // Temporary import file to experiment with next version of foundation.
 import { IComponent } from '@uifabric/foundation/lib/next/IComponent';
-import { IComponentStyles, IHTMLSlot, ISlotProp, ISlottableProps, IStyleableComponentProps } from '../../../Foundation';
+import {
+  IComponentStyles,
+  IHTMLSlot,
+  ISlotProp,
+  ISlottableProps,
+  IStyleableComponentProps,
+} from '@uifabric/foundation';
 import { IBaseProps } from '../../../Utilities';
 import { INativeButtonProps } from '../Button.types';
 import {

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { ContextualMenu, Text } from '@fluentui/react';
-import { withSlots } from '../../../Foundation';
+import { withSlots } from '@uifabric/foundation';
 import { FontIcon } from '../../../utilities/factoryComponents';
 
 import { Button } from '../Button';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useCallback, useImperativeHandle, useRef } from 'react';
-import { useControlledState } from '../../Foundation';
+import { useControlledState } from '@uifabric/foundation';
 import { getRTL, KeyCodes } from '../../Utilities';
 import {
   ICollapsibleSectionProps,

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.ts
@@ -3,7 +3,7 @@ import { CollapsibleSectionView } from './CollapsibleSection.view';
 import { useCollapsibleSectionState } from './CollapsibleSection.state';
 import { collapsibleSectionStyles } from './CollapsibleSection.styles';
 import { ICollapsibleSectionProps } from './CollapsibleSection.types';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 
 export const CollapsibleSection: React.FunctionComponent<ICollapsibleSectionProps> = createComponent(
   CollapsibleSectionView,

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.types.ts
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { IComponent, IComponentStyles, IHTMLSlot, ISlottableProps, IStyleableComponentProps } from '../../Foundation';
+import {
+  IComponent,
+  IComponentStyles,
+  IHTMLSlot,
+  ISlottableProps,
+  IStyleableComponentProps,
+} from '@uifabric/foundation';
 import { IBaseProps, IRefObject } from '../../Utilities';
 import { ICollapsibleSectionTitleSlot } from './CollapsibleSectionTitle.types';
 

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.view.tsx
@@ -1,5 +1,5 @@
 /** @jsx withSlots */
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 
 import {
   ICollapsibleSectionComponent,

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 import { CollapsibleSectionTitleView } from './CollapsibleSectionTitle.view';
 import { getStyles as styles } from './CollapsibleSectionTitle.styles';
 import { ICollapsibleSectionTitleProps } from './CollapsibleSectionTitle.types';

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.types.ts
@@ -7,7 +7,7 @@ import {
   ISlotProp,
   ISlottableProps,
   IStyleableComponentProps,
-} from '../../Foundation';
+} from '@uifabric/foundation';
 import { ITextSlot } from '@fluentui/react';
 import { IIconSlot } from '../../utilities/factoryComponents.types';
 

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSectionTitle.view.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { Icon, Text } from '@fluentui/react';
 import { getNativeProps, buttonProperties } from '@fluentui/react/lib/Utilities';
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 import {
   ICollapsibleSectionTitleComponent,
   ICollapsibleSectionTitleProps,

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.tsx
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 import { useMicroFeedbackState as state } from './MicroFeedback.state';
 import { MicroFeedbackStyles as styles, MicroFeedbackTokens as tokens } from './MicroFeedback.styles';
 import { IMicroFeedbackProps } from './MicroFeedback.types';

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '../../Foundation';
+import { IComponent, IComponentStyles, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
 import { ICalloutSlot, IListSlot } from '../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../Utilities';
 import { IButtonSlot } from '../Button/Button.types';

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
@@ -2,7 +2,7 @@
 import { Callout, IconButton, FocusZone, FocusZoneDirection, List, Stack, Text } from '@fluentui/react';
 import { Button } from '../Button/Button';
 import { IButtonTokens } from '../Button/Button.types';
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 
 import {
   IMicroFeedbackComponent,

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { VerticalPersonaView } from './VerticalPersona.view';
 import { VerticalPersonaStyles, VerticalPersonaTokens } from './VerticalPersona.styles';
 import { IVerticalPersonaProps } from './VerticalPersona.types';
-import { createComponent } from '../../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 
 export const VerticalPersona: React.FunctionComponent<IVerticalPersonaProps> = createComponent(VerticalPersonaView, {
   displayName: 'VerticalPersona',

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.types.ts
@@ -1,5 +1,5 @@
 import { IStyle, IFontWeight } from '@uifabric/styling';
-import { IComponent, IHTMLSlot, IStyleableComponentProps } from '../../../Foundation';
+import { IComponent, IHTMLSlot, IStyleableComponentProps } from '@uifabric/foundation';
 import { ITextSlot } from '@fluentui/react';
 import { IPersonaCoinSlot } from '../../PersonaCoin/PersonaCoin.types';
 

--- a/packages/experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
+++ b/packages/experiments/src/components/Persona/Vertical/VerticalPersona.view.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import { PersonaCoin } from '../../PersonaCoin/PersonaCoin';
-import { getSlots, withSlots } from '../../../Foundation';
+import { getSlots, withSlots } from '@uifabric/foundation';
 import { IVerticalPersonaComponent, IVerticalPersonaProps, IVerticalPersonaSlots } from './VerticalPersona.types';
 import { PersonaText } from '../PersonaText/PersonaText';
 

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 import { usePersonaCoinState } from './PersonaCoin.state';
 import { PersonaCoinStyles } from './PersonaCoin.styles';
 import { IPersonaCoinProps } from './PersonaCoin.types';

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.types.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.types.ts
@@ -1,5 +1,5 @@
 import { ImageLoadState, IBaseProps } from '@fluentui/react';
-import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, IStyleableComponentProps } from '../../Foundation';
+import { IComponentStyles, IHTMLSlot, ISlotProp, IComponent, IStyleableComponentProps } from '@uifabric/foundation';
 import { IPersonaPresenceSlot } from '../../utilities/factoryComponents.types';
 import { IPersonaCoinImageSlot } from './PersonaCoinImage/PersonaCoinImage.types';
 import { IPersonaCoinSize10Slot } from './PersonaCoinSize10/PersonaCoinSize10';

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.view.tsx
@@ -1,5 +1,5 @@
 /** @jsx withSlots */
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 import { PersonaPresence } from '../../utilities/factoryComponents';
 import { IPersonaCoinComponent, IPersonaCoinProps, IPersonaCoinSlots } from './PersonaCoin.types';
 import { PersonaCoinImage } from './PersonaCoinImage/PersonaCoinImage';

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Image, ImageFit } from '@fluentui/react';
-import { createComponent } from '../../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 import { IPersonaCoinImageProps } from './PersonaCoinImage.types';
 import { IPersonaCoinComponent } from '../PersonaCoin.types';
 import { DEFAULT_PERSONA_COIN_SIZE } from '../PersonaCoin.styles';

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.types.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinImage/PersonaCoinImage.types.ts
@@ -1,5 +1,5 @@
 import { ImageLoadState } from '@fluentui/react';
-import { ISlotProp } from '../../../Foundation';
+import { ISlotProp } from '@uifabric/foundation';
 import { IPersonaCoinProps } from '../PersonaCoin.types';
 
 export type IPersonaCoinImageSlot = ISlotProp<IPersonaCoinImageProps>;

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinInitials/PersonaCoinInitials.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinInitials/PersonaCoinInitials.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Icon, Text } from '@fluentui/react';
-import { ISlotProp } from '../../../Foundation';
+import { ISlotProp } from '@uifabric/foundation';
 import { IPersonaCoinProps } from '../PersonaCoin.types';
 import { getInitials, getRTL } from '../../../Utilities';
 

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoinSize10/PersonaCoinSize10.tsx
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoinSize10/PersonaCoinSize10.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Icon } from '@fluentui/react';
-import { ISlotProp } from '../../../Foundation';
+import { ISlotProp } from '@uifabric/foundation';
 
 export interface IPersonaCoinSizeProps {}
 

--- a/packages/experiments/src/components/Toggle/Toggle.state.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.state.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { getControlledDerivedProps, useControlledState } from '../../Foundation';
+import { getControlledDerivedProps, useControlledState } from '@uifabric/foundation';
 import { IToggleComponent, IToggleViewProps } from './Toggle.types';
 
 export const useToggleState: IToggleComponent['state'] = props => {

--- a/packages/experiments/src/components/Toggle/Toggle.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.ts
@@ -3,7 +3,7 @@ import { ToggleView } from './Toggle.view';
 import { ToggleStyles as styles, ToggleTokens as tokens } from './Toggle.styles';
 import { useToggleState as state } from './Toggle.state';
 import { IToggleProps } from './Toggle.types';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 
 export const Toggle: React.FunctionComponent<IToggleProps> = createComponent(ToggleView, {
   displayName: 'Toggle',

--- a/packages/experiments/src/components/Toggle/Toggle.types.ts
+++ b/packages/experiments/src/components/Toggle/Toggle.types.ts
@@ -6,7 +6,7 @@ import {
   IHTMLSlot,
   ISlottableProps,
   IStyleableComponentProps,
-} from '../../Foundation';
+} from '@uifabric/foundation';
 import { IKeytipProps } from '@fluentui/react/lib/Keytip';
 import { IBaseProps, IComponentAs } from '../../Utilities';
 import { IRawStyleBase } from '@uifabric/merge-styles/lib/IRawStyleBase';

--- a/packages/experiments/src/components/Toggle/Toggle.view.tsx
+++ b/packages/experiments/src/components/Toggle/Toggle.view.tsx
@@ -2,7 +2,7 @@
 import { KeytipData } from '@fluentui/react/lib/KeytipData';
 import { Label } from '../../utilities/factoryComponents';
 
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 import { inputProperties, getNativeProps } from '../../Utilities';
 import { IToggleComponent, IToggleProps, IToggleSlots } from './Toggle.types';
 

--- a/packages/experiments/src/utilities/factoryComponents.tsx
+++ b/packages/experiments/src/utilities/factoryComponents.tsx
@@ -10,7 +10,7 @@ import {
 } from '@fluentui/react';
 // PersonaPresence is not exported by OUFR, so we have to import it directly.
 import { PersonaPresence as FabricPersonaPresence } from '@fluentui/react/lib/PersonaPresence';
-import { createFactory, ISlottableComponentType, ISlotFactory } from '../Foundation';
+import { createFactory, ISlottableComponentType, ISlotFactory } from '@uifabric/foundation';
 
 // TODO: All contents of this file should be moved to each respective component as they are converted to use slots.
 // TODO: createFactory should no longer have to be explicitly called with component options containing defaultProp.

--- a/packages/experiments/src/utilities/factoryComponents.types.tsx
+++ b/packages/experiments/src/utilities/factoryComponents.types.tsx
@@ -8,7 +8,7 @@ import {
   IPersonaPresenceProps,
   PersonaPresence,
 } from '@fluentui/react';
-import { ISlotProp } from '../Foundation';
+import { ISlotProp } from '@uifabric/foundation';
 
 // TODO: All contents of this file should be moved to each respective component after slots utilities are promoted.
 

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -7570,6 +7570,8 @@ export const VerticalDivider: React.FunctionComponent<IVerticalDividerProps>;
 
 
 export * from "@fluentui/react-focus";
+export * from "@fluentui/react-theme-provider";
+export * from "@fluentui/theme";
 export * from "@uifabric/icons";
 export * from "@uifabric/styling";
 export * from "@uifabric/utilities";

--- a/packages/react-internal/package.json
+++ b/packages/react-internal/package.json
@@ -59,6 +59,8 @@
   "dependencies": {
     "@fluentui/react-focus": "^7.16.9",
     "@fluentui/react-icons": "^0.3.5",
+    "@fluentui/react-theme-provider": "^0.14.2",
+    "@fluentui/theme": "^1.2.1",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/date-time-utilities": "^7.9.0",
     "@uifabric/foundation": "^7.9.9",

--- a/packages/react-internal/src/Foundation.ts
+++ b/packages/react-internal/src/Foundation.ts
@@ -1,1 +1,0 @@
-export * from '@uifabric/foundation';

--- a/packages/react-internal/src/Styling.ts
+++ b/packages/react-internal/src/Styling.ts
@@ -1,4 +1,2 @@
 import './version';
 export * from '@uifabric/styling';
-export * from '@fluentui/theme';
-export * from '@fluentui/react-theme-provider';

--- a/packages/react-internal/src/Styling.ts
+++ b/packages/react-internal/src/Styling.ts
@@ -1,2 +1,4 @@
 import './version';
 export * from '@uifabric/styling';
+export * from '@fluentui/theme';
+export * from '@fluentui/react-theme-provider';

--- a/packages/react-internal/src/Theme.ts
+++ b/packages/react-internal/src/Theme.ts
@@ -1,0 +1,2 @@
+export * from '@fluentui/theme';
+export * from '@fluentui/react-theme-provider';

--- a/packages/react-internal/src/components/Stack/Stack.tsx
+++ b/packages/react-internal/src/components/Stack/Stack.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, createComponent, getSlots } from '../../Foundation';
+import { withSlots, createComponent, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties, warnDeprecations } from '../../Utilities';
 import { styles } from './Stack.styles';
 import { IStackComponent, IStackProps, IStackSlots } from './Stack.types';

--- a/packages/react-internal/src/components/Stack/Stack.types.ts
+++ b/packages/react-internal/src/components/Stack/Stack.types.ts
@@ -6,7 +6,7 @@ import {
   IComponent,
   IStyleableComponentProps,
   ISlottableProps,
-} from '../../Foundation';
+} from '@uifabric/foundation';
 
 /**
  * Defines a type made by the union of the different values that the align-items and justify-content flexbox

--- a/packages/react-internal/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/react-internal/src/components/Stack/StackItem/StackItem.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, createComponent, getSlots } from '../../../Foundation';
+import { withSlots, createComponent, getSlots } from '@uifabric/foundation';
 import { IStackItemComponent, IStackItemProps, IStackItemSlots } from './StackItem.types';
 import { StackItemStyles as styles } from './StackItem.styles';
 

--- a/packages/react-internal/src/components/Stack/StackItem/StackItem.types.ts
+++ b/packages/react-internal/src/components/Stack/StackItem/StackItem.types.ts
@@ -1,4 +1,4 @@
-import { IComponentStyles, IHTMLSlot, IComponent, ISlotProp, IStyleableComponentProps } from '../../../Foundation';
+import { IComponentStyles, IHTMLSlot, IComponent, ISlotProp, IStyleableComponentProps } from '@uifabric/foundation';
 
 /**
  * {@docCategory Stack}

--- a/packages/react-internal/src/components/Text/Text.ts
+++ b/packages/react-internal/src/components/Text/Text.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { createComponent } from '../../Foundation';
+import { createComponent } from '@uifabric/foundation';
 import { ITextProps } from './Text.types';
 import { TextView } from './Text.view';
 import { TextStyles as styles } from './Text.styles';

--- a/packages/react-internal/src/components/Text/Text.types.tsx
+++ b/packages/react-internal/src/components/Text/Text.types.tsx
@@ -6,7 +6,7 @@ import {
   IComponent,
   IStyleableComponentProps,
   ISlottableProps,
-} from '../../Foundation';
+} from '@uifabric/foundation';
 import { IFontStyles } from '../../Styling';
 
 /**

--- a/packages/react-internal/src/components/Text/Text.view.tsx
+++ b/packages/react-internal/src/components/Text/Text.view.tsx
@@ -1,6 +1,6 @@
 /** @jsx withSlots */
 import * as React from 'react';
-import { withSlots, getSlots } from '../../Foundation';
+import { withSlots, getSlots } from '@uifabric/foundation';
 import { getNativeProps, htmlElementProperties } from '../../Utilities';
 import { ITextComponent, ITextProps, ITextSlots } from './Text.types';
 

--- a/packages/react-internal/src/index.ts
+++ b/packages/react-internal/src/index.ts
@@ -68,6 +68,7 @@ export * from './SwatchColorPicker';
 export * from './TeachingBubble';
 export * from './Text';
 export * from './TextField';
+export * from './Theme';
 export * from './ThemeGenerator';
 export * from './Tooltip';
 export * from './Utilities';

--- a/packages/react-next/src/Foundation.ts
+++ b/packages/react-next/src/Foundation.ts
@@ -1,2 +1,0 @@
-import './version';
-export * from '@fluentui/react/lib/Foundation';

--- a/packages/react/src/Foundation.ts
+++ b/packages/react/src/Foundation.ts
@@ -1,1 +1,0 @@
-export * from '@fluentui/react-internal/lib/Foundation';

--- a/packages/react/src/Theme.ts
+++ b/packages/react/src/Theme.ts
@@ -1,0 +1,1 @@
+export * from '@fluentui/react-internal/lib/Theme';


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Export * from `@fluentui/react` and `fluentui/react-theme-provider` from `react` (and `react-internal`)
- Remove `@uifabric/foundation` export from `react` (and `react-internal`)

#### Focus areas to test

(optional)
