### PR TITLE
Fix ParitialTheme typing: remove variants

### DIFF
--- a/apps/vr-tests/src/stories/ThemeProvider.stories.tsx
+++ b/apps/vr-tests/src/stories/ThemeProvider.stories.tsx
@@ -57,10 +57,12 @@ storiesOf('ThemeProvider', module)
   .addStory('Use variants on new button', () => (
     <ThemeProvider
       theme={{
-        variants: {
+        components: {
           Button: {
-            root: {
-              background: 'yellow',
+            variants: {
+              root: {
+                background: 'yellow',
+              },
             },
           },
         },

--- a/change/@fluentui-theme-2020-10-05-16-28-47-xgao-variants-fix.json
+++ b/change/@fluentui-theme-2020-10-05-16-28-47-xgao-variants-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix ParitalTheme typing.",
+  "packageName": "@fluentui/theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-05T23:28:47.487Z"
+}

--- a/packages/theme/etc/theme.api.md
+++ b/packages/theme/etc/theme.api.md
@@ -740,8 +740,6 @@ export interface PartialTheme extends IPartialTheme {
     stylesheets?: string[];
     // (undocumented)
     tokens?: RecursivePartial<Tokens>;
-    // (undocumented)
-    variants?: RecursivePartial<Variants>;
 }
 
 // @public

--- a/packages/theme/src/types/Theme.ts
+++ b/packages/theme/src/types/Theme.ts
@@ -107,5 +107,4 @@ export interface PartialTheme extends IPartialTheme {
   components?: ComponentStyles;
   tokens?: RecursivePartial<Tokens>;
   stylesheets?: string[];
-  variants?: RecursivePartial<Variants>;
 }


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fix ParitalTheme typing.

#### Focus areas to test

(optional)
