### PR TITLE
perf: memoize context value in Provider

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `useAutoControlled` hook to suport functions updates @assuncaocharles ([#15137](https://github.com/microsoft/fluentui/pull/15137))
 - Fix `TreeTitle` arrow left navigation @assuncaocharles ([#15262](https://github.com/microsoft/fluentui/pull/15262))
 - Updated `ReactionsIcon` @TanelVari ([#15358](https://github.com/microsoft/fluentui/pull/15358))
+- Memoize context value in `Provider` to avoid rerenders @layershifter ([#15358](https://github.com/microsoft/fluentui/pull/15380))
 
 ### Features
 - Add basic keyboard navigation for `Datepicker` @pompompon ([#14138](https://github.com/microsoft/fluentui/pull/14138))

--- a/packages/fluentui/react-bindings/src/context.ts
+++ b/packages/fluentui/react-bindings/src/context.ts
@@ -41,7 +41,7 @@ export const defaultPerformanceFlags: StylesContextPerformance = {
   enableBooleanVariablesCaching: false,
 };
 
-const defaultContext: ProviderContextPrepared = {
+export const defaultContextValue: ProviderContextPrepared = {
   // A default value for `rtl` is undefined to let compute `Provider` a proper one
   rtl: undefined as any,
   disableAnimations: false,
@@ -52,7 +52,7 @@ const defaultContext: ProviderContextPrepared = {
   target: undefined,
 };
 
-const FluentContext = React.createContext<ProviderContextPrepared>(defaultContext);
+const FluentContext = React.createContext<ProviderContextPrepared>(defaultContextValue);
 
 export function useFluentContext(): ProviderContextPrepared {
   return React.useContext(FluentContext);

--- a/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
+++ b/packages/fluentui/react-northstar/src/components/Provider/Provider.tsx
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   ComponentWithAs,
+  defaultContextValue,
   getElementType,
   useUnhandledProps,
   StylesContextPerformanceInput,
@@ -112,20 +113,32 @@ export const Provider: ComponentWithAs<'div', ProviderProps> & {
 
     return telemetryRef.current;
   }, [telemetryRef]);
-  const inputContext: ProviderContextInput = {
-    disableAnimations: props.disableAnimations,
-    performance: props.performance,
-    rtl: props.rtl,
-    target: props.target,
-    telemetry,
-    theme: props.theme,
-  };
 
   const consumedContext = useFluentContext();
-  const incomingContext: ProviderContextInput | ProviderContextPrepared = overwrite ? {} : consumedContext;
+  const incomingContext: ProviderContextInput | ProviderContextPrepared = overwrite
+    ? defaultContextValue
+    : consumedContext;
   const createRenderer = React.useContext(RendererContext);
 
-  const outgoingContext = mergeProviderContexts(createRenderer, incomingContext, inputContext);
+  // Memoization of `inputContext` & `outgoingContext` is required to avoid useless notifications of components that
+  // consume `useFluentContext()` on each render
+  // @see https://reactjs.org/docs/context.html#caveats
+  const inputContext = React.useMemo<ProviderContextInput>(
+    () => ({
+      disableAnimations: props.disableAnimations,
+      performance: props.performance,
+      rtl: props.rtl,
+      target: props.target,
+      telemetry,
+      theme: props.theme,
+    }),
+    [props.disableAnimations, props.performance, props.rtl, props.target, telemetry, props.theme],
+  );
+  const outgoingContext = React.useMemo(() => mergeProviderContexts(createRenderer, incomingContext, inputContext), [
+    createRenderer,
+    incomingContext,
+    inputContext,
+  ]);
 
   const rtlProps: { dir?: 'rtl' | 'ltr' } = {};
   // only add dir attribute for top level provider or when direction changes from parent to child

--- a/packages/fluentui/react-northstar/test/specs/components/Provider/Provider-test.tsx
+++ b/packages/fluentui/react-northstar/test/specs/components/Provider/Provider-test.tsx
@@ -344,4 +344,44 @@ describe('Provider', () => {
       expect(document.querySelector(`.${newClassName} #sample`)).toBeInTheDocument();
     });
   });
+
+  describe('context', () => {
+    it('should memoize passed context value', () => {
+      const onRender = jest.fn();
+      const Consumer: React.FC = () => {
+        useFluentContext();
+        onRender();
+
+        return null;
+      };
+
+      const wrapper = mount(
+        <Provider>
+          <Consumer />
+        </Provider>,
+      );
+      wrapper.setProps({});
+
+      expect(onRender).toHaveBeenCalledTimes(1);
+    });
+
+    it('should propagate props updates', () => {
+      const onRender = jest.fn();
+      const Consumer: React.FC = () => {
+        useFluentContext();
+        onRender();
+
+        return null;
+      };
+
+      const wrapper = mount(
+        <Provider>
+          <Consumer />
+        </Provider>,
+      );
+      wrapper.setProps({ theme: {} });
+
+      expect(onRender).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
### Description of changes

This PR solves a re-render issue with `Provider`, for example if `Provider` will be re-rendered even without any prop changes all components from `@fluentui/react-northstar` will be also re-rendered as they are consuming that context. This caveat is described in [React docs](https://reactjs.org/docs/context.html#caveats).