### PR TITLE
Use midgard-yarn in all pipelines

### DIFF
--- a/apps/test-bundles/webpack.config.js
+++ b/apps/test-bundles/webpack.config.js
@@ -3,7 +3,12 @@ const { createWebpackConfig, buildEntries, buildEntry } = require('./webpackUtil
 
 // Create entries for all top level imports.
 const entries = buildEntries('@fluentui/react');
-buildEntries('@fluentui/react-next', entries, false /* do not include stats for better performance. */);
+buildEntries(
+  '@fluentui/react-next',
+  entries,
+  false /* do not include stats for better performance. */,
+  true /* onlyOwnComponents */,
+);
 
 // Create entries for single top level import.
 entries['react-compose'] = buildEntry('@fluentui/react-compose');

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - task: NodeTool@0
         inputs:
-          versionSpec: '10.x'
+          versionSpec: '12.x'
         displayName: 'Install Node.js'
 
       - script: npx midgard-yarn install

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -7,8 +7,7 @@ trigger: none
 jobs:
   - job: build
     pool:
-      name: Hosted VS2017
-      demands: npm
+      vmImage: 'windows-2019'
     steps:
       - task: NodeTool@0
         inputs:

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -9,7 +9,7 @@ jobs:
           versionSpec: '10.x'
         displayName: 'Install Node.js'
 
-      - script: yarn
+      - script: npx midgard-yarn install
         displayName: yarn
 
       - script: yarn build --to test-bundles --no-cache --grouped

--- a/azure-pipelines.hotfix.yml
+++ b/azure-pipelines.hotfix.yml
@@ -20,7 +20,7 @@ steps:
     displayName: 'Check targetNpmVersion is valid semver'
 
   - script: |
-      yarn
+      npx midgard-yarn install
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -16,7 +16,7 @@ steps:
   - template: .devops/templates/tools.yml
 
   - script: |
-      yarn
+      npx midgard-yarn install
     displayName: yarn
 
   # @fluentui/perf-test needs build and bundle steps

--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -23,7 +23,7 @@ steps:
     displayName: Authenticate git for pushes
 
   - script: |
-      yarn
+      npx midgard-yarn install
     displayName: yarn
 
   - script: |

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -33,7 +33,7 @@ steps:
     displayName: Authenticate git for pushes
 
   - script: |
-      yarn
+      npx midgard-yarn install
     displayName: yarn
 
   - script: |


### PR DESCRIPTION
@layershifter recently updated our main PR pipeline to use `midgard-yarn` just for install, which made builds a lot faster. Do that in all the other pipelines too.

Other updates for size auditor:
- Use Node 12 so midgard-yarn works
- Update `test-bundles` webpack config to only include `react-next` components which actually have their implementations in `react-next` (as opposed to just being re-exported). This will make the builds faster without any loss of meaningful info.
- Use the Windows 2019 pool for size auditor instead of the deprecated "Hosted VS2017" pool per [these docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#software)