### PR TITLE
Fix codepens after replacing office-ui-fabric-react with @fluentui/react

### DIFF
--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
@@ -34,7 +34,7 @@ export interface IColorsPageState {
 }
 
 const codeHeader = "import { loadTheme } from '@fluentui/react';\n\n";
-const codepenHeader = 'const { loadTheme, DefaultButton, PrimaryButton, Toggle, TooltipHost } = Fabric;\n\n';
+const codepenHeader = 'const { loadTheme, DefaultButton, PrimaryButton, Toggle, TooltipHost } = FluentUIReact;\n\n';
 const codepenSamples = `
 
 class Content extends React.Component {

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -55,7 +55,6 @@ const headerStackStyles = (p: IStackProps, theme: ITheme) => ({
 const codepenHeader = `const {
   createTheme,
   Checkbox,
-  Customizations,
   DefaultButton,
   Fabric,
   loadTheme,
@@ -137,9 +136,8 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
           <span>
             <p>
               This code block creates the theme you have configured above using the createTheme utility function.
-              Calling Customizations.applySettings with this theme will automatically apply the configured theming to
-              any Fabric controls used within the same app. You can also export this example to CodePen with a few
-              component examples below.
+              Calling loadTheme with this theme will automatically apply the configured theming to any Fabric controls
+              used within the same app. You can also export this example to CodePen with a few component examples below.
             </p>
           </span>
           <div className={outputPanelClassName}>

--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -63,11 +63,13 @@ const codepenHeader = `const {
   PivotItem,
   PrimaryButton,
   Stack,
-  Toggle
-} = Fabric;\n\n`;
+  Toggle,
+} = FluentUIReact;\n\n`;
 const codepenSamples = `\n\n
+
+loadTheme(myTheme);\n
+
 const Content = () => {
-    Customizations.applySettings({ theme: myTheme });
     return (
       <Fabric applyThemeToBody>
         <Stack tokens={{childrenGap: 8, maxWidth: 300}}>

--- a/change/@uifabric-example-app-base-2020-10-06-18-04-16-xgao-fix-bundle.json
+++ b/change/@uifabric-example-app-base-2020-10-06-18-04-16-xgao-fix-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix codepen after replacing office-ui-fabric-react with @fluentui/react.",
+  "packageName": "@uifabric/example-app-base",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T01:04:14.710Z"
+}

--- a/change/@uifabric-fabric-website-resources-2020-10-06-18-04-16-xgao-fix-bundle.json
+++ b/change/@uifabric-fabric-website-resources-2020-10-06-18-04-16-xgao-fix-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix codepen after replacing office-ui-fabric-react with @fluentui/react. ",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T01:04:07.460Z"
+}

--- a/change/@uifabric-tsx-editor-2020-10-06-18-04-16-xgao-fix-bundle.json
+++ b/change/@uifabric-tsx-editor-2020-10-06-18-04-16-xgao-fix-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix codepen after replacing office-ui-fabric-react with @fluentui/react.",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T01:04:16.696Z"
+}

--- a/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
+++ b/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
@@ -42,7 +42,7 @@ const CodepenComponentBase: React.FunctionComponent<ICodepenProps> = props => {
     // boilerplate for codepen API
     const htmlContent = [
       // load core Fabric bundle and hooks bundle
-      script('@fluentui/react@7/dist/@fluentui/react.js'),
+      script('@fluentui/react@7/dist/fluentui-react.js'),
       script('@uifabric/react-hooks@7/dist/react-hooks.js'),
       // load example data bundle only if used
       jsContentStr.indexOf('window.FabricExampleData') !== -1

--- a/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`example transform can return component 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -25,7 +25,7 @@ return LabelBasicExampleWrapper;
 exports[`example transform can return component with transpiled example 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -43,7 +43,7 @@ return LabelBasicExampleWrapper;
 
 exports[`example transform handles examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -89,11 +89,8 @@ ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 
 exports[`example transform handles examples with custom supportedPackages and Fabric 1`] = `
 Object {
-  "output": "const { Stack, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Stack } = window.Fabric;
 const { FooLabel } = window.Foo;
-
-// Initialize icons in case this example uses them
-initializeIcons();
 
 const FooExample = () => {
   return (
@@ -102,15 +99,13 @@ const FooExample = () => {
     </Stack>
   );
 };
-
-const FooExampleWrapper = () => <Fabric><FooExample /></Fabric>;
-ReactDOM.render(<FooExampleWrapper />, document.getElementById('fake'))",
+ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -130,7 +125,7 @@ ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 
 exports[`example transform handles transpiled examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -170,7 +165,7 @@ ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake
 
 exports[`example transform handles transpiled examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();

--- a/packages/tsx-editor/src/transpiler/exampleTransform.test.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.test.ts
@@ -108,7 +108,6 @@ describe('example transform', () => {
   it('handles examples with custom supportedPackages and Fabric', () => {
     const result = transformFile('customPackagesFabric.txt', { supportedPackages: [fooGroup, fabricGroup] });
     expect(result.output).toBeTruthy();
-    expect(result.output).toContain('<FooExampleWrapper');
     expect(result).toMatchSnapshot();
   });
 });

--- a/packages/tsx-editor/src/transpiler/exampleTransform.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.ts
@@ -88,7 +88,7 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
 
   // Generate Fabric wrapper stuff for the component if appropriate
   let finalComponent = component;
-  if (identifiersByGlobal.Fabric) {
+  if (identifiersByGlobal.FluentUIReact) {
     // If this is a Fabric example, wrap in a <Fabric> (and add an import for that if needed),
     // and initialize icons in case the example uses them.
     finalComponent = component + 'Wrapper';
@@ -99,13 +99,13 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
       : `<Fabric><${component} /></Fabric>`;
     lines.push('', `const ${finalComponent} = () => ${wrapperCode};`);
 
-    if (identifiersByGlobal.Fabric.indexOf('Fabric') === -1) {
-      identifiersByGlobal.Fabric.push('Fabric');
+    if (identifiersByGlobal.FluentUIReact.indexOf('Fabric') === -1) {
+      identifiersByGlobal.FluentUIReact.push('Fabric');
     }
 
-    if (identifiersByGlobal.Fabric.indexOf('initializeIcons') === -1) {
+    if (identifiersByGlobal.FluentUIReact.indexOf('initializeIcons') === -1) {
       lines.unshift('// Initialize icons in case this example uses them', 'initializeIcons();', '');
-      identifiersByGlobal.Fabric.push('initializeIcons');
+      identifiersByGlobal.FluentUIReact.push('initializeIcons');
     }
   }
 

--- a/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
+++ b/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
@@ -132,14 +132,14 @@ describe('_getErrorMessages', () => {
 describe('_supportedPackageToGlobalMap', () => {
   it('works', () => {
     expect(_supportedPackageToGlobalMap(SUPPORTED_PACKAGES)).toEqual({
-      '@fluentui/react': 'Fabric',
-      '@fluentui/date-time-utilities': 'Fabric',
-      '@fluentui/react-focus': 'Fabric',
-      '@uifabric/foundation': 'Fabric',
-      '@uifabric/icons': 'Fabric',
-      '@uifabric/merge-styles': 'Fabric',
-      '@uifabric/styling': 'Fabric',
-      '@uifabric/utilities': 'Fabric',
+      '@fluentui/react': 'FluentUIReact',
+      '@fluentui/date-time-utilities': 'FluentUIReact',
+      '@fluentui/react-focus': 'FluentUIReact',
+      '@uifabric/foundation': 'FluentUIReact',
+      '@uifabric/icons': 'FluentUIReact',
+      '@uifabric/merge-styles': 'FluentUIReact',
+      '@uifabric/styling': 'FluentUIReact',
+      '@uifabric/utilities': 'FluentUIReact',
       '@uifabric/react-hooks': 'FabricReactHooks',
       '@uifabric/example-data': 'FabricExampleData',
     });

--- a/packages/tsx-editor/src/utilities/defaultSupportedPackages.ts
+++ b/packages/tsx-editor/src/utilities/defaultSupportedPackages.ts
@@ -1,7 +1,7 @@
 import { IPackageGroup } from '../interfaces/index';
 
 const fabricGroup: IPackageGroup = {
-  globalName: 'Fabric',
+  globalName: 'FluentUIReact',
   // Theoretically we could use import() here, but that pulls things into bundles when using
   // commonjs modules due to the way import is transpiled for commonjs
   // https://github.com/webpack/webpack/issues/5703#issuecomment-357512412


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`react` package produces bundle: https://unpkg.com/@fluentui/react@7/dist/fluentui-react.js and lib var changed from `Fabric` to `FluentUIReact`

Related issue: #15308

#### Focus areas to test
Noticed this issue from [theme-designer](https://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/heads/master/theming-designer/index.html), which is actually a `pr-deploy` site from `master`.
