### PR TITLE
Azure-theme pivots + dropdowns for 7.0 

### DIFF
--- a/change/@fluentui-react-examples-2020-10-06-21-14-27-azure-theme-control-lines.json
+++ b/change/@fluentui-react-examples-2020-10-06-21-14-27-azure-theme-control-lines.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Added error message to check color",
+  "packageName": "@fluentui/react-examples",
+  "email": "jagaheri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T04:14:27.039Z"
+}

--- a/change/@uifabric-azure-themes-2020-10-06-21-14-27-azure-theme-control-lines.json
+++ b/change/@uifabric-azure-themes-2020-10-06-21-14-27-azure-theme-control-lines.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Control outlines, pivot indentation, label weight",
+  "packageName": "@uifabric/azure-themes",
+  "email": "jagaheri@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-07T04:13:13.772Z"
+}

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -131,6 +131,9 @@ export const AzureThemeDark: ITheme = createTheme({
       fontFamily: StyleConstants.fontFamily,
       fontSize: FontSizes.size13,
     },
+    large: {
+      fontSize: FontSizes.size14,
+    },
   },
   palette: {
     themePrimary: DarkSemanticColors.controlOutlines.accent,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -131,6 +131,9 @@ export const AzureThemeHighContrastDark: ITheme = createTheme({
       fontFamily: StyleConstants.fontFamily,
       fontSize: FontSizes.size13,
     },
+    large: {
+      fontSize: FontSizes.size14,
+    },
   },
   palette: {
     themePrimary: HighContrastDarkSemanticColors.controlOutlines.accent,

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -132,6 +132,9 @@ export const AzureThemeHighContrastLight: ITheme = createTheme({
       fontFamily: StyleConstants.fontFamily,
       fontSize: FontSizes.size13,
     },
+    large: {
+      fontSize: FontSizes.size14,
+    },
   },
   palette: {
     themePrimary: HighContrastLightSemanticColors.controlOutlines.accent,

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -131,6 +131,9 @@ export const AzureThemeLight: ITheme = createTheme({
       fontFamily: StyleConstants.fontFamily,
       fontSize: FontSizes.size13,
     },
+    large: {
+      fontSize: FontSizes.size14,
+    },
   },
   palette: {
     themePrimary: LightSemanticColors.controlOutlines.accent,

--- a/packages/azure-themes/src/azure/Constants.ts
+++ b/packages/azure-themes/src/azure/Constants.ts
@@ -9,6 +9,7 @@ export const borderWidth = '1px';
 export const borderWidthError = '2px';
 export const borderSolid = 'solid';
 export const borderNone = 'none';
+export const dropDownItemHeight = '32px';
 export const fontFamily =
   // eslint-disable-next-line @fluentui/max-len
   'Segoe UI, "Segoe UI Web (West European)", "Segoe UI", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue",sans-serif';

--- a/packages/azure-themes/src/azure/styles/Callout.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Callout.styles.ts
@@ -1,6 +1,5 @@
 import { ICalloutContentStyleProps, ICalloutContentStyles } from 'office-ui-fabric-react/lib/Callout';
 import { Depths } from '../AzureDepths';
-import * as StyleConstants from '../Constants';
 
 export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<ICalloutContentStyles> => {
   const { theme } = props;
@@ -8,10 +7,7 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<
 
   return {
     root: {
-      borderColor: semanticColors.inputBorder,
-      borderStyle: StyleConstants.borderSolid,
-      borderWidth: StyleConstants.borderWidth,
-      boxShadow: Depths.depth8,
+      boxShadow: Depths.depth16,
     },
     calloutMain: {
       color: semanticColors.bodyText,

--- a/packages/azure-themes/src/azure/styles/Callout.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Callout.styles.ts
@@ -7,7 +7,7 @@ export const CalloutContentStyles = (props: ICalloutContentStyleProps): Partial<
 
   return {
     root: {
-      boxShadow: Depths.depth16,
+      boxShadow: Depths.depth8,
     },
     calloutMain: {
       color: semanticColors.bodyText,

--- a/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ComboBox.styles.ts
@@ -69,16 +69,7 @@ export const ComboBoxStyles = (theme: ITheme): Partial<IComboBoxStyles> => {
       borderColor: semanticColors.focusBorder,
     },
     callout: {
-      border: 'none',
       boxShadow: Depths.depth8,
-      selectors: {
-        '.ms-Callout-main': {
-          backgroundColor: semanticColors.inputBackground,
-          borderColor: semanticColors.inputBorder,
-          borderStyle: StyleConstants.borderSolid,
-          borderWidth: StyleConstants.borderWidth,
-        },
-      },
     },
     divider: {
       backgroundColor: semanticColors.inputBorder,
@@ -91,7 +82,11 @@ export const ComboBoxStyles = (theme: ITheme): Partial<IComboBoxStyles> => {
     },
     optionsContainer: {
       verticalAlign: 'middle',
+      border: 'none',
       selectors: {
+        '.ms-ComboBox-divider': {
+          backgroundColor: extendedSemanticColors.rowBorder,
+        },
         '.ms-ComboBox-header': {
           color: semanticColors.inputText,
           fontSize: theme.fonts.medium.fontSize,

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -1,13 +1,16 @@
 import { IDropdownStyleProps, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
 import { Depths } from '../AzureDepths';
 import * as StyleConstants from '../Constants';
+import { IExtendedSemanticColors } from '../IExtendedSemanticColors';
 
 export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownStyles> => {
   const { disabled, theme, hasError, isOpen } = props;
+
   if (!theme) {
     return {};
   }
   const { semanticColors } = theme;
+  const extendedSemanticColors = semanticColors as IExtendedSemanticColors;
   return {
     callout: {
       border: 'none',
@@ -42,7 +45,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
         border: 0,
         selectors: {
           ':focus::after, :focus': {
-            borderColor: semanticColors.inputBorderHovered,
+            borderColor: extendedSemanticColors.controlAccent,
           },
           ['.ms-Dropdown-titleIsPlaceHolder']: {
             color: semanticColors.inputPlaceholderText,
@@ -78,7 +81,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
       },
     ],
     dropdownDivider: {
-      backgroundColor: semanticColors.inputBorder,
+      backgroundColor: extendedSemanticColors.rowBorder,
     },
     title: [
       {

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -12,6 +12,13 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
   const { semanticColors } = theme;
   const extendedSemanticColors = semanticColors as IExtendedSemanticColors;
   return {
+    root: {
+      selectors: {
+        '.ms-Dropdown': {
+          height: StyleConstants.inputControlHeight,
+        },
+      },
+    },
     callout: {
       border: 'none',
       boxShadow: Depths.depth8,
@@ -40,7 +47,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     dropdown: [
       {
         fontSize: theme.fonts.medium.fontSize,
-        height: StyleConstants.inputControlHeight,
+        height: StyleConstants.dropDownItemHeight,
         color: semanticColors.inputText,
         border: 0,
         selectors: {

--- a/packages/azure-themes/src/azure/styles/DropDown.styles.ts
+++ b/packages/azure-themes/src/azure/styles/DropDown.styles.ts
@@ -17,7 +17,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
           backgroundColor: semanticColors.inputBackground,
           borderColor: semanticColors.inputBorder,
           borderStyle: StyleConstants.borderSolid,
-          borderWidth: '0',
+          borderWidth: 0,
         },
       },
     },
@@ -39,10 +39,10 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
         fontSize: theme.fonts.medium.fontSize,
         height: StyleConstants.inputControlHeight,
         color: semanticColors.inputText,
-
+        border: 0,
         selectors: {
           ':focus::after, :focus': {
-            //borderColor: semanticColors.inputBorderHovered,
+            borderColor: semanticColors.inputBorderHovered,
           },
           ['.ms-Dropdown-titleIsPlaceHolder']: {
             color: semanticColors.inputPlaceholderText,
@@ -107,6 +107,7 @@ export const DropdownStyles = (props: IDropdownStyleProps): Partial<IDropdownSty
     dropdownItemsWrapper: {
       backgroundColor: semanticColors.bodyBackground,
       borderColor: semanticColors.inputBorder,
+      border: 0,
     },
     dropdownItem: {
       color: semanticColors.bodyText,

--- a/packages/azure-themes/src/azure/styles/Label.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Label.styles.ts
@@ -11,6 +11,7 @@ export const LabelStyles = (props: ILabelStyleProps): Partial<ILabelStyles> => {
       {
         fontSize: theme.fonts.medium.fontSize,
         color: extendedSemanticColors.labelText,
+        fontWeight: 400,
       },
       disabled && {
         color: semanticColors.disabledBodyText,

--- a/packages/azure-themes/src/azure/styles/Pivot.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Pivot.styles.ts
@@ -44,20 +44,23 @@ export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
       {
         color: semanticColors.buttonText,
         height: 36,
+        paddingLeft: 0,
+        paddingRight: 0,
+        marginRight: 24,
       },
       !rootIsLarge && {
-        fontSize: theme.fonts.medium.fontSize,
+        fontSize: theme.fonts.large.fontSize,
       },
       !rootIsTabs && {
         selectors: {
           ':hover': {
-            backgroundColor: extendedSemanticColors.tabHover,
+            backgroundColor: extendedSemanticColors.bodyBackground,
             border: StyleConstants.borderNone,
             color: semanticColors.bodyText,
             transition: 'background-color .2s ease-out',
           },
           ':active': {
-            backgroundColor: semanticColors.listItemBackgroundCheckedHovered,
+            backgroundColor: semanticColors.bodyBackground,
             border: StyleConstants.borderNone,
             color: semanticColors.bodyText,
           },
@@ -70,13 +73,13 @@ export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
         marginBottom: '-1px',
         selectors: {
           ':hover': {
-            backgroundColor: semanticColors.listItemBackgroundHovered,
+            backgroundColor: semanticColors.bodyBackground,
             border: StyleConstants.borderNone,
             borderBottom: `1px solid ${semanticColors.inputBorder}`,
             transition: 'background-color .2s ease-out',
           },
           ':active': {
-            backgroundColor: semanticColors.listItemBackgroundHovered,
+            backgroundColor: semanticColors.bodyBackground,
             border: StyleConstants.borderNone,
             borderBottom: `1px solid ${semanticColors.inputBorder}`,
             transition: 'background-color .2s ease-out',
@@ -85,16 +88,37 @@ export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
       },
     ],
     linkIsSelected: [
+      {
+        marginRight: 24,
+        selectors: {
+          '.ms-Fabric--isFocusVisible': {
+            outline: '1px solid black !important',
+          },
+          '::focus': {
+            // waiting on design team's input for focus behavior
+          },
+          ':active': {
+            backgroundColor: semanticColors.bodyBackground,
+          },
+        },
+      },
       !rootIsLarge && {
-        fontSize: theme.fonts.medium.fontSize,
+        fontSize: theme.fonts.large.fontSize,
         height: 36,
+        paddingLeft: 0,
+        paddingRight: 0,
+        // the selected underline
+        '::before': {
+          left: 0,
+          right: 0,
+        },
       },
       !rootIsTabs && {
         color: semanticColors.bodyText,
         paddingBottom: '1px',
         selectors: {
           ':hover': {
-            backgroundColor: extendedSemanticColors.tabHover,
+            backgroundColor: extendedSemanticColors.bodyBackground,
             color: extendedSemanticColors.bodyTextHovered,
             border: StyleConstants.borderNone,
           },

--- a/packages/azure-themes/src/azure/styles/Pivot.styles.ts
+++ b/packages/azure-themes/src/azure/styles/Pivot.styles.ts
@@ -94,9 +94,6 @@ export const PivotStyles = (props: IPivotStyleProps): Partial<IPivotStyles> => {
           '.ms-Fabric--isFocusVisible': {
             outline: '1px solid black !important',
           },
-          '::focus': {
-            // waiting on design team's input for focus behavior
-          },
           ':active': {
             backgroundColor: semanticColors.bodyBackground,
           },

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -45,6 +45,9 @@ import { MessageBarBasicExample } from '../components/messageBar.stories';
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
+      <Text>This branch is looking into drop down outlines</Text>
+      <ComboBoxBasicExample />
+      <DropdownBasicExample />
       <Text>13px body text</Text>
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -45,9 +45,6 @@ import { MessageBarBasicExample } from '../components/messageBar.stories';
 const Example = () => (
   <Stack gap={8} horizontalAlign="center" style={{ maxWidth: 1000 }}>
     <Stack gap={8} horizontalAlign="center">
-      <Text>This branch is looking into drop down outlines</Text>
-      <ComboBoxBasicExample />
-      <DropdownBasicExample />
       <Text>13px body text</Text>
       <Label>MessageBar / InfoBox</Label>
       <MessageBarBasicExample />

--- a/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
@@ -26,9 +26,16 @@ export const DropdownBasicExample: React.FunctionComponent = () => {
     <Stack tokens={stackTokens}>
       <Dropdown
         placeholder="Select an option"
+        label="Basic uncontrolled example with error"
+        options={options}
+        errorMessage={'Error message!'}
+        styles={dropdownStyles}
+      />
+
+      <Dropdown
+        placeholder="Select an option"
         label="Basic uncontrolled example"
         options={options}
-        // errorMessage={'Error message!'}
         styles={dropdownStyles}
       />
 

--- a/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
@@ -28,6 +28,7 @@ export const DropdownBasicExample: React.FunctionComponent = () => {
         placeholder="Select an option"
         label="Basic uncontrolled example"
         options={options}
+        errorMessage={'Error message!'}
         styles={dropdownStyles}
       />
 

--- a/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/components/dropdown.stories.tsx
@@ -28,7 +28,7 @@ export const DropdownBasicExample: React.FunctionComponent = () => {
         placeholder="Select an option"
         label="Basic uncontrolled example"
         options={options}
-        errorMessage={'Error message!'}
+        // errorMessage={'Error message!'}
         styles={dropdownStyles}
       />
 


### PR DESCRIPTION
#### Pull request checklist

- [ x ] Addresses an existing issue: Fixes DevOps # 7692163
- [ x ] Include a change request file using `$ yarn change`


### Dropdowns 
- Removed control outline via callout, updated separator line for each theme
- Per Figma designs: dropdown input 24px and dropdown items 32px 
<img src="https://user-images.githubusercontent.com/30805892/95404206-3ffe2100-08c9-11eb-97c6-7db40b327ef4.png"
 width="300px" />


### Callout
- implementation vs figma 
<div style="display:flex">
<img src="https://user-images.githubusercontent.com/30805892/95381197-a882d900-089c-11eb-8205-e57cd8c45cdd.png" width="300"  />
<img src="https://user-images.githubusercontent.com/30805892/95386103-aa03cf80-08a3-11eb-9f38-426c81ee2762.png" width="300"  />
</div>

### Label 
- removed semibold from label per label redesign 
<img src="https://user-images.githubusercontent.com/30805892/95286530-6c0d9980-0818-11eb-9a23-c213ae153115.png" width="500" />

### Pivots
- Removed left/right padding from individual pivot
- Fixed indentation of Pivot on rest state, aligned with rest of content on the page.

#### Light theme
<img src="https://user-images.githubusercontent.com/30805892/92654600-e93f0080-f2a4-11ea-8c4b-1a0a1fb9794b.png" width="500" />

#### Dark theme 
<img src="https://user-images.githubusercontent.com/30805892/92654562-d9272100-f2a4-11ea-9745-2be5e1187bc0.png" width="500" />

#### High contrast light theme
<img src="https://user-images.githubusercontent.com/30805892/92654575-df1d0200-f2a4-11ea-949c-2c652263e0da.png" width="500" />

#### High contrast dark theme
<img src="https://user-images.githubusercontent.com/30805892/92654586-e3e1b600-f2a4-11ea-87c2-dc15be591b8a.png" width="500" />

