### PR TITLE
Delete update-api script which is no longer needed

### DIFF
--- a/change/@fluentui-date-time-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-date-time-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/date-time-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:09.378Z"
+}

--- a/change/@fluentui-dom-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-dom-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/dom-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:11.379Z"
+}

--- a/change/@fluentui-keyboard-key-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-keyboard-key-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/keyboard-key",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:14.720Z"
+}

--- a/change/@fluentui-react-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:40.148Z"
+}

--- a/change/@fluentui-react-avatar-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-avatar-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-avatar",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:18.131Z"
+}

--- a/change/@fluentui-react-button-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-button-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-button",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:19.039Z"
+}

--- a/change/@fluentui-react-checkbox-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-checkbox-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:20.673Z"
+}

--- a/change/@fluentui-react-compose-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-compose-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-compose",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:21.674Z"
+}

--- a/change/@fluentui-react-flex-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-flex-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-flex",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:22.804Z"
+}

--- a/change/@fluentui-react-focus-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-focus-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:23.706Z"
+}

--- a/change/@fluentui-react-icons-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-icons-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:25.921Z"
+}

--- a/change/@fluentui-react-image-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-image-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-image",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:27.323Z"
+}

--- a/change/@fluentui-react-internal-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-internal-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:29.670Z"
+}

--- a/change/@fluentui-react-link-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-link-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-link",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:30.796Z"
+}

--- a/change/@fluentui-react-next-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-next-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:32.435Z"
+}

--- a/change/@fluentui-react-slider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-slider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-slider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:33.489Z"
+}

--- a/change/@fluentui-react-stylesheets-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-stylesheets-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-stylesheets",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:34.566Z"
+}

--- a/change/@fluentui-react-tabs-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-tabs-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-tabs",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:36.060Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-theme-provider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:36.949Z"
+}

--- a/change/@fluentui-react-toggle-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-toggle-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-toggle",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:37.703Z"
+}

--- a/change/@fluentui-react-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:38.599Z"
+}

--- a/change/@fluentui-react-window-provider-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-react-window-provider-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:39.373Z"
+}

--- a/change/@fluentui-theme-2020-10-06-21-15-44-update-api.json
+++ b/change/@fluentui-theme-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:43.486Z"
+}

--- a/change/@uifabric-date-time-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-date-time-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:10.498Z"
+}

--- a/change/@uifabric-example-data-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-example-data-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/example-data",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:12.257Z"
+}

--- a/change/@uifabric-foundation-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-foundation-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:13.105Z"
+}

--- a/change/@uifabric-icons-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-icons-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/icons",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:13.972Z"
+}

--- a/change/@uifabric-merge-styles-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-merge-styles-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/merge-styles",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:15.522Z"
+}

--- a/change/@uifabric-react-cards-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-react-cards-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:19.917Z"
+}

--- a/change/@uifabric-react-hooks-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-react-hooks-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/react-hooks",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:24.905Z"
+}

--- a/change/@uifabric-styling-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-styling-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:41.077Z"
+}

--- a/change/@uifabric-test-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-test-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/test-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:41.795Z"
+}

--- a/change/@uifabric-utilities-2020-10-06-21-15-44-update-api.json
+++ b/change/@uifabric-utilities-2020-10-06-21-15-44-update-api.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Delete update-api script which is no longer needed",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-07T04:15:44.403Z"
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "test:fluentui:circulars": "gulp test:circulars:run",
     "test:fluentui:e2e": "yarn workspace @fluentui/e2e test",
     "test:fluentui:projects": "yarn workspace @fluentui/projects-test test",
-    "update-api": "cd packages/react && yarn update-api",
+    "update-api": "echo API files are now updated when running yarn build",
     "update-snapshots": "lage update-snapshots --verbose",
     "update-a11y": "cd apps/a11y-tests && yarn update-snapshots",
     "vrtest": "cd apps && cd vr-tests && yarn screener"

--- a/packages/date-time-utilities/package.json
+++ b/packages/date-time-utilities/package.json
@@ -20,8 +20,7 @@
     "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
     "start-test": "just-scripts jest-watch",
-    "lint": "just-scripts lint",
-    "update-api": "just-scripts update-api"
+    "lint": "just-scripts lint"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -24,8 +24,7 @@
     "start": "just-scripts dev:storybook",
     "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
-    "update-snapshots": "just-scripts jest -u",
-    "update-api": "just-scripts update-api"
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/dom-utilities/package.json
+++ b/packages/dom-utilities/package.json
@@ -22,8 +22,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/example-data/package.json
+++ b/packages/example-data/package.json
@@ -17,7 +17,6 @@
     "test": "just-scripts test",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -23,7 +23,6 @@
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,8 +20,7 @@
     "test": "just-scripts test",
     "just": "just-scripts",
     "clean": "just-scripts clean",
-    "code-style": "just-scripts code-style",
-    "update-api": "just-scripts update-api"
+    "code-style": "just-scripts code-style"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/keyboard-key/package.json
+++ b/packages/keyboard-key/package.json
@@ -17,8 +17,7 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
-    "test": "just-scripts test",
-    "update-api": "just-scripts update-api"
+    "test": "just-scripts test"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/merge-styles/package.json
+++ b/packages/merge-styles/package.json
@@ -21,8 +21,7 @@
     "just": "just-scripts",
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
-    "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api"
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -24,7 +24,6 @@
     "start:legacy": "just-scripts dev",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -23,7 +23,6 @@
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -21,7 +21,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -20,8 +20,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@types/react": "16.8.25",

--- a/packages/react-focus/package.json
+++ b/packages/react-focus/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -21,7 +21,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "just": "just-scripts"
   },
   "devDependencies": {

--- a/packages/react-icons/package.json
+++ b/packages/react-icons/package.json
@@ -22,7 +22,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-internal/package.json
+++ b/packages/react-internal/package.json
@@ -22,7 +22,6 @@
     "lint": "just-scripts lint",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-next/package.json
+++ b/packages/react-next/package.json
@@ -30,8 +30,7 @@
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
-    "update-snapshots": "just-scripts jest -u",
-    "update-api": "just-scripts update-api"
+    "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {
     "@fluentui/common-styles": "^0.2.6",

--- a/packages/react-slider/package.json
+++ b/packages/react-slider/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-spinbutton/package.json
+++ b/packages/react-spinbutton/package.json
@@ -21,8 +21,7 @@
     "code-style": "just-scripts code-style",
     "just": "just-scripts",
     "lint": "just-scripts lint",
-    "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api"
+    "start": "just-scripts dev:storybook"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/react-stylesheets/package.json
+++ b/packages/react-stylesheets/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-tabs/package.json
+++ b/packages/react-tabs/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-theme-provider/package.json
+++ b/packages/react-theme-provider/package.json
@@ -22,7 +22,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-toggle/package.json
+++ b/packages/react-toggle/package.json
@@ -21,7 +21,6 @@
     "just": "just-scripts",
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch"

--- a/packages/react-utilities/package.json
+++ b/packages/react-utilities/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -24,7 +24,6 @@
     "lint": "just-scripts lint",
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -23,7 +23,6 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -21,8 +21,7 @@
     "clean": "just-scripts clean",
     "code-style": "just-scripts code-style",
     "start": "just-scripts dev",
-    "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api"
+    "start-test": "just-scripts jest-watch"
   },
   "devDependencies": {
     "@fluentui/eslint-plugin": "^0.54.1",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -23,7 +23,6 @@
     "start": "just-scripts dev:storybook",
     "test": "just-scripts test",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -22,7 +22,6 @@
     "code-style": "just-scripts code-style",
     "clean": "just-scripts clean",
     "start-test": "just-scripts jest-watch",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/scripts/create-package/plop-templates-react/package.json.hbs
+++ b/scripts/create-package/plop-templates-react/package.json.hbs
@@ -22,7 +22,6 @@
     "start": "just-scripts dev:storybook",
     "start-test": "just-scripts jest-watch",
     "test": "just-scripts test",
-    "update-api": "just-scripts update-api",
     "update-snapshots": "just-scripts jest -u"
   },
   "devDependencies": {

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -13,7 +13,7 @@ const { sass } = require('./tasks/sass');
 const { ts } = require('./tasks/ts');
 const { eslint } = require('./tasks/eslint');
 const { webpack, webpackDevServer } = require('./tasks/webpack');
-const { verifyApiExtractor, updateApiExtractor } = require('./tasks/api-extractor');
+const { apiExtractor } = require('./tasks/api-extractor');
 const lintImports = require('./tasks/lint-imports');
 const prettier = require('./tasks/prettier');
 const bundleSizeCollect = require('./tasks/bundle-size-collect');
@@ -77,8 +77,7 @@ module.exports = function preset() {
   task('ts:commonjs-only', ts.commonjsOnly);
   task('webpack', webpack);
   task('webpack-dev-server', webpackDevServer);
-  task('api-extractor:verify', verifyApiExtractor());
-  task('api-extractor:update', updateApiExtractor());
+  task('api-extractor', apiExtractor());
   task('lint-imports', lintImports);
   task('prettier', prettier);
   task('bundle-size-collect', bundleSizeCollect);
@@ -111,7 +110,6 @@ module.exports = function preset() {
   task('lint', parallel('lint-imports', 'eslint'));
 
   task('code-style', series('prettier', 'lint'));
-  task('update-api', series('clean', 'copy', 'sass', 'ts', 'api-extractor:update'));
 
   task('dev:storybook', series('storybook:start'));
   task('dev', series('copy', 'sass', 'webpack-dev-server'));
@@ -125,7 +123,7 @@ module.exports = function preset() {
       'copy',
       'sass',
       'ts',
-      condition('api-extractor:verify', () => !argv().min),
+      condition('api-extractor', () => !argv().min),
     ),
   ).cached();
 

--- a/scripts/tasks/api-extractor.js
+++ b/scripts/tasks/api-extractor.js
@@ -2,7 +2,7 @@
 
 const glob = require('glob');
 const path = require('path');
-const { apiExtractorVerifyTask, apiExtractorUpdateTask, task, series } = require('just-scripts');
+const { apiExtractorVerifyTask, task, series } = require('just-scripts');
 
 const apiExtractorConfigs = glob
   .sync(path.join(process.cwd(), 'config/api-extractor*.json'))
@@ -11,11 +11,11 @@ const apiExtractorConfigs = glob
 // Whether to update automatically on build
 const localBuild = !process.env.TF_BUILD;
 
-function verifyApiExtractor() {
+function apiExtractor() {
   return apiExtractorConfigs.length
     ? series(
         ...apiExtractorConfigs.map(([configPath, configName]) => {
-          const taskName = `api-extractor:${configName}:verify`;
+          const taskName = `api-extractor:${configName}`;
           task(taskName, apiExtractorVerifyTask({ configJsonFilePath: configPath, localBuild }));
           return taskName;
         }),
@@ -23,16 +23,4 @@ function verifyApiExtractor() {
     : 'no-op';
 }
 
-function updateApiExtractor() {
-  return apiExtractorConfigs.length
-    ? series(
-        ...apiExtractorConfigs.map(([configPath, configName]) => {
-          const taskName = `api-extractor:${configName}:update`;
-          task(taskName, apiExtractorUpdateTask({ configJsonFilePath: configPath, localBuild }));
-          return taskName;
-        }),
-      )
-    : 'no-op';
-}
-
-module.exports = { verifyApiExtractor, updateApiExtractor };
+module.exports = { apiExtractor };


### PR DESCRIPTION
Now that API Extractor updates are run automatically, we don't need the `update-api` command.