### PR TITLE
Additional ChoiceGroup v8 cleanup

### DIFF
--- a/change/@fluentui-react-internal-2020-10-22-00-02-17-choicegroup-updates.json
+++ b/change/@fluentui-react-internal-2020-10-22-00-02-17-choicegroup-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "ChoiceGroup option props cleanup",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T07:02:07.168Z"
+}

--- a/change/@fluentui-react-next-2020-10-22-00-02-17-choicegroup-updates.json
+++ b/change/@fluentui-react-next-2020-10-22-00-02-17-choicegroup-updates.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update ChoiceGroup release notes",
+  "packageName": "@fluentui/react-next",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-22T07:02:17.152Z"
+}

--- a/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
+++ b/packages/react-examples/src/react/ChoiceGroup/ChoiceGroup.Custom.Example.tsx
@@ -30,7 +30,6 @@ const options: IChoiceGroupOption[] = [
             defaultSelectedKey="A"
             styles={dropdownStyles}
             options={dropdownOptions}
-            // eslint-disable-next-line deprecation/deprecation
             disabled={props ? !props.checked : false}
             ariaLabel="Select a time span"
           />

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -1532,7 +1532,7 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
         height: number;
     };
     imageSrc?: string;
-    key?: string;
+    key: string;
     labelId?: string;
     onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;
     onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
@@ -1543,18 +1543,11 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
 
 // @public (undocumented)
 export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'> {
-<<<<<<< HEAD
-    componentRef?: IRefObject<IChoiceGroupOption>;
-    focused?: boolean;
-    // (undocumented)
-    itemKey?: string;
-=======
     checked?: boolean;
     componentRef?: IRefObject<IChoiceGroupOption>;
     focused?: boolean;
     itemKey: string;
     key?: string;
->>>>>>> Move ChoiceGroup v8 changes to react
     name?: string;
     onBlur?: (ev?: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOptionProps) => void;
     onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void;

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -1521,10 +1521,8 @@ export interface IChoiceGroup {
 }
 
 // @public (undocumented)
-export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElement | HTMLInputElement> {
+export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLElement | HTMLInputElement>, 'checked'> {
     ariaLabel?: string;
-    // @deprecated
-    checked?: boolean;
     disabled?: boolean;
     iconProps?: IIconProps;
     id?: string;
@@ -1536,8 +1534,8 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
     imageSrc?: string;
     key?: string;
     labelId?: string;
-    onRenderField?: IRenderFunction<IChoiceGroupOption>;
-    onRenderLabel?: IRenderFunction<IChoiceGroupOption>;
+    onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;
+    onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
     selectedImageSrc?: string;
     styles?: IStyleFunctionOrObject<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>;
     text: string;
@@ -1545,14 +1543,22 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
 
 // @public (undocumented)
 export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'> {
+<<<<<<< HEAD
     componentRef?: IRefObject<IChoiceGroupOption>;
     focused?: boolean;
     // (undocumented)
     itemKey?: string;
+=======
+    checked?: boolean;
+    componentRef?: IRefObject<IChoiceGroupOption>;
+    focused?: boolean;
+    itemKey: string;
+    key?: string;
+>>>>>>> Move ChoiceGroup v8 changes to react
     name?: string;
-    onBlur?: (ev: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOption) => void;
-    onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
-    onFocus?: (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
+    onBlur?: (ev?: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOptionProps) => void;
+    onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void;
+    onFocus?: (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void | undefined;
     required?: boolean;
     theme?: ITheme;
 }
@@ -5922,12 +5928,6 @@ export class NormalPeoplePickerBase extends BasePeoplePicker {
         createGenericItem: typeof createGenericItem;
     };
 }
-
-// @public @deprecated (undocumented)
-export type OnChangeCallback = IChoiceGroupOptionProps['onChange'];
-
-// @public @deprecated (undocumented)
-export type OnFocusCallback = IChoiceGroupOptionProps['onFocus'];
 
 // @public (undocumented)
 export enum OpenCardMode {

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -88,24 +88,30 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
   useDebugWarnings(props);
   useComponentRef(options, keyChecked, id, componentRef);
 
-  const onFocus = React.useCallback((ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOptionProps) => {
-    setKeyFocused(option.itemKey);
+  const onFocus = React.useCallback((ev?: React.FocusEvent<HTMLElement>, option?: IChoiceGroupOptionProps) => {
+    if (option) {
+      setKeyFocused(option.itemKey);
+      option.onFocus?.(ev);
+    }
   }, []);
 
-  const onBlur = React.useCallback((ev: React.FocusEvent<HTMLElement>) => {
+  const onBlur = React.useCallback((ev: React.FocusEvent<HTMLElement>, option?: IChoiceGroupOptionProps) => {
     setKeyFocused(undefined);
+    option?.onBlur?.(ev);
   }, []);
 
   const onOptionChange = React.useCallback(
-    (evt: React.FormEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOptionProps) => {
+    (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOptionProps) => {
+      if (!option) {
+        return;
+      }
       setKeyChecked(option.itemKey);
 
-      if (onChange) {
-        onChange(
-          evt,
-          find(options || [], (value: IChoiceGroupOption) => value.key === option.itemKey),
-        );
-      }
+      option.onChange?.(evt);
+      onChange?.(
+        evt,
+        find(options || [], (value: IChoiceGroupOption) => value.key === option.itemKey),
+      );
     },
     [onChange, options, setKeyChecked],
   );
@@ -124,10 +130,10 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
               <ChoiceGroupOption
                 key={option.key}
                 itemKey={option.key}
+                {...option}
                 onBlur={onBlur}
                 onFocus={onFocus}
                 onChange={onOptionChange}
-                {...option}
                 focused={option.key === keyFocused}
                 checked={option.key === keyChecked}
                 disabled={option.disabled || disabled}

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -18,8 +18,9 @@ const getOptionId = (option: IChoiceGroupOption, id: string): string => {
   return `${id}-${option.key}`;
 };
 
-const getCheckedOption = (options: IChoiceGroupOption[], keyChecked: string | number) =>
-  find(options, (value: IChoiceGroupOption) => value.key === keyChecked);
+const findOption = (options: IChoiceGroupOption[], key: string | number | undefined) => {
+  return key === undefined ? undefined : find(options, value => value.key === key);
+};
 
 const useComponentRef = (
   options: IChoiceGroupOption[],
@@ -31,10 +32,10 @@ const useComponentRef = (
     componentRef,
     () => ({
       get checkedOption() {
-        return getCheckedOption(options, keyChecked!);
+        return findOption(options, keyChecked);
       },
       focus() {
-        const optionToFocus = getCheckedOption(options, keyChecked!) || options.filter(option => !option.disabled)[0];
+        const optionToFocus = findOption(options, keyChecked) || options.filter(option => !option.disabled)[0];
         const elementToFocus = optionToFocus && document.getElementById(getOptionId(optionToFocus, id));
 
         if (elementToFocus) {
@@ -108,10 +109,7 @@ export const ChoiceGroupBase: React.FunctionComponent<IChoiceGroupProps> = React
       setKeyChecked(option.itemKey);
 
       option.onChange?.(evt);
-      onChange?.(
-        evt,
-        find(options || [], (value: IChoiceGroupOption) => value.key === option.itemKey),
-      );
+      onChange?.(evt, findOption(options, option.itemKey));
     },
     [onChange, options, setKeyChecked],
   );

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -3,7 +3,11 @@ import * as React from 'react';
 import { IIconProps } from '../../Icon';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
-import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption/ChoiceGroupOption.types';
+import {
+  IChoiceGroupOptionStyleProps,
+  IChoiceGroupOptionStyles,
+  IChoiceGroupOptionProps,
+} from './ChoiceGroupOption/ChoiceGroupOption.types';
 
 /**
  * {@docCategory ChoiceGroup}
@@ -79,7 +83,7 @@ export interface IChoiceGroupProps
 /**
  * {@docCategory ChoiceGroup}
  */
-export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElement | HTMLInputElement> {
+export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLElement | HTMLInputElement>, 'checked'> {
   /**
    * A required key to uniquely identify the option.
    */
@@ -93,12 +97,12 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
   /**
    * Used to customize option rendering.
    */
-  onRenderField?: IRenderFunction<IChoiceGroupOption>;
+  onRenderField?: IRenderFunction<IChoiceGroupOptionProps>;
 
   /**
    * Used to customize label rendering.
    */
-  onRenderLabel?: IRenderFunction<IChoiceGroupOption>;
+  onRenderLabel?: IRenderFunction<IChoiceGroupOptionProps>;
 
   /**
    * Props for an icon to display with this option.
@@ -131,17 +135,6 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
    * Whether or not the option is disabled.
    */
   disabled?: boolean;
-
-  /**
-   * Whether or not the option is checked.
-   * @deprecated Do not track checked state in the options themselves. Instead, either pass
-   * `defaultSelectedKey` to the `ChoiceGroup` and allow it to track selection state internally
-   * (uncontrolled), or pass `selectedKey` and `onChange` to the `ChoiceGroup` to track/update
-   * the selection state manually (controlled).
-   */
-  // This should move from IChoiceGroupOption to IChoiceGroupOptionProps, so that the ChoiceGroup
-  // can still set the option as checked for rendering purposes
-  checked?: boolean;
 
   /**
    * ID used on the option's input element.

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -87,7 +87,7 @@ export interface IChoiceGroupOption extends Omit<React.InputHTMLAttributes<HTMLE
   /**
    * A required key to uniquely identify the option.
    */
-  key?: string;
+  key: string;
 
   /**
    * The text string for the option.

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -25,7 +25,9 @@ const DEFAULT_PROPS: Partial<IChoiceGroupOptionProps> = {
 };
 
 export const ChoiceGroupOptionBase: React.FunctionComponent<IChoiceGroupOptionProps> = propsWithoutDefaults => {
-  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+  // Mix the `key` prop back in since custom render functions may be expecting it
+  // (React uses `key` internally rather than passing it through to the component)
+  const props = getPropsWithDefaults({ ...DEFAULT_PROPS, key: propsWithoutDefaults.itemKey }, propsWithoutDefaults);
 
   const {
     ariaLabel,
@@ -36,7 +38,6 @@ export const ChoiceGroupOptionBase: React.FunctionComponent<IChoiceGroupOptionPr
     imageSrc,
     imageSize,
     disabled,
-    // eslint-disable-next-line deprecation/deprecation
     checked,
     id,
     styles,

--- a/packages/react-internal/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/react-internal/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -4,22 +4,9 @@ import { IRefObject } from '../../../Utilities';
 import { IChoiceGroupOption } from '../ChoiceGroup.types';
 
 /**
- * @deprecated Use `IChoiceGroupOptionProps['onFocus']` directly
- * {@docCategory ChoiceGroup}
- */
-export type OnFocusCallback = IChoiceGroupOptionProps['onFocus'];
-
-/**
- * @deprecated Use `IChoiceGroupOptionProps['onChange']` directly
- * {@docCategory ChoiceGroup}
- */
-export type OnChangeCallback = IChoiceGroupOptionProps['onChange'];
-
-/**
  * {@docCategory ChoiceGroup}
  */
 export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'> {
-  itemKey?: string;
   /**
    * Optional callback to access the IChoiceGroup interface. Use this instead of ref for accessing
    * the public methods and properties of the component.
@@ -27,19 +14,39 @@ export interface IChoiceGroupOptionProps extends Omit<IChoiceGroupOption, 'key'>
   componentRef?: IRefObject<IChoiceGroupOption>;
 
   /**
-   * A callback for receiving a notification when the choice has been changed.
+   * Unique key for the option, set based on `IChoiceGroupOption.key`.
    */
-  onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
+  itemKey: string;
 
   /**
-   * A callback for receiving a notification when the choice has received focus.
+   * The option key. This will always be provided for callbacks (copied from `itemKey`) but is
+   * optional when manually creating ChoiceGroupOptions.
    */
-  onFocus?: (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
+  key?: string;
 
   /**
-   * A callback for receiving a notification when the choice has lost focus.
+   * Whether or not the option is checked. Set by `ChoiceGroup` based on `selectedKey` or
+   * `defaultSelectedKey` from `IChoiceGroupProps`.
    */
-  onBlur?: (ev: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOption) => void;
+  checked?: boolean;
+
+  /**
+   * Callback for the ChoiceGroup creating the option to be notified when the choice has been changed.
+   */
+  onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOptionProps) => void;
+
+  /**
+   * Callback for the ChoiceGroup creating the option to be notified when the choice has received focus.
+   */
+  onFocus?: (
+    ev?: React.FocusEvent<HTMLElement | HTMLInputElement>,
+    props?: IChoiceGroupOptionProps,
+  ) => void | undefined;
+
+  /**
+   * Callback for the ChoiceGroup creating the option to be notified when the choice has lost focus.
+   */
+  onBlur?: (ev?: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOptionProps) => void;
 
   /**
    * Indicates if the ChoiceGroupOption should appear focused, visually

--- a/packages/react-next/RELEASE_NOTES.md
+++ b/packages/react-next/RELEASE_NOTES.md
@@ -23,9 +23,14 @@ If you would like to continue using the previous button components for now, upda
 
 ### ChoiceGroup
 
-- Moved `root` class to the actual root element by replacing `applicationRole`.
-- Removed `applicationRole` from IChoiceGroupStyles.
-- Removed deprecated `onChanged` prop.
+- Setting `checked` on individual options to indicate their checked state is no longer supported. Instead, use `defaultSelectedKey` or `selectedKey`.
+- Moved `root` style to the actual root element and removed `applicationRole` style.
+- Removed deprecated props and types:
+  - `onChanged` from `IChoiceGroupProps` (use `onChange`)
+  - `checked` from `IChoiceGroupOption`. (See above for alternative. Also note that this is still available via `IChoiceGroupOptionProps` for custom rendering purposes only, and will be set correctly by the parent `ChoiceGroup`.)
+  - `applicationRole` from `IChoiceGroupStyles`
+  - Type aliases `OnFocusCallback` and `OnChangeCallback`: use `IChoiceGroupOptionProps['onFocus']` and `IChoiceGroupOptionProps['onChange']`
+- Only if manually rendering the `ChoiceGroupOption` component, the new prop `itemKey` is now required. (You can still use `key` when passing options via `IChoiceGroupProps.options`, which is by far the most common.)
 
 ### Coachmark
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Additional cleanup related to the FC/v8 changes: primarily around removing more deprecated things and cleaning up handling of keys and checked state.

- Remove deprecated `IChoiceGroupOption.checked` and replace it with `IChoiceGroupOptionProps.checked` for custom rendering use only
- Make `IChoiceGroupOptionProps.itemKey` required (and `IChoiceGroupOptionProps.itemKey` optional)
- Update custom render callbacks to take `IChoiceGroupOptionProps` so that they can have the proper `checked` values.
  - In `ChoiceGroupOption`, when passing the option back to custom render callbacks, mix the `key` back in 
- Remove deprecated `OnChangeCallback` and `OnFocusCallback`
- Add explicit FC type to ChoiceGroupOption
- When creating the options, don't let users' custom `onChange`/`onFocus`/`onBlur` overwrite the default ones provided by ChoiceGroup. And in the unlikely event that these custom handlers are provided (I don't know why this would be needed on individual options), call them from the default handlers.
- Update release notes