### PR TITLE
fix: correct palette generation behavior in Card

### DIFF
--- a/change/@fluentui-web-components-2020-10-08-10-29-03-users-nicholasrice-fix-card-palette-generation.json
+++ b/change/@fluentui-web-components-2020-10-08-10-29-03-users-nicholasrice-fix-card-palette-generation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "removes palette generation for every card and adds better null checking to avoid runtime errors",
+  "packageName": "@fluentui/web-components",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-08T17:29:03.955Z"
+}

--- a/packages/web-components/src/card/card.stories.ts
+++ b/packages/web-components/src/card/card.stories.ts
@@ -1,3 +1,5 @@
+import { createColorPalette } from '@microsoft/fast-components-styles-msft';
+import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { FluentDesignSystemProvider } from '../design-system-provider';
 import CardTemplate from './fixtures/card.html';
 import { FluentCard } from './';
@@ -11,3 +13,10 @@ export default {
 };
 
 export const Card = (): string => CardTemplate;
+
+document.addEventListener('readystatechange', e => {
+  if (document.readyState === 'complete') {
+    const red = document.getElementById('red') as FluentDesignSystemProvider;
+    red.neutralPalette = createColorPalette(new ColorRGBA64(1, 0, 0));
+  }
+});

--- a/packages/web-components/src/card/fixtures/card.html
+++ b/packages/web-components/src/card/fixtures/card.html
@@ -39,7 +39,7 @@
       </fluent-card>
     </fluent-design-system-provider>
 
-    <fluent-design-system-provider use-defaults background-color="#FF0000">
+    <fluent-design-system-provider use-defaults background-color="#FF0000" id="red">
       <fluent-card style="--card-height: 400px; --card-width: 500px;">
         Red
         <div class="controls">

--- a/packages/web-components/src/card/index.ts
+++ b/packages/web-components/src/card/index.ts
@@ -34,7 +34,10 @@ export class FluentCard extends FluentDesignSystemProvider
   public backgroundColor: string;
   protected backgroundColorChanged(): void {
     const parsedColor = parseColorHexRGB(this.backgroundColor);
-    this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
+
+    if (parsedColor !== null) {
+      this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
+    }
   }
 
   /**
@@ -49,8 +52,11 @@ export class FluentCard extends FluentDesignSystemProvider
   public cardBackgroundColor: string;
   private cardBackgroundColorChanged(): void {
     const parsedColor = parseColorHexRGB(this.cardBackgroundColor);
-    this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
-    this.backgroundColor = this.cardBackgroundColor;
+
+    if (parsedColor !== null) {
+      this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64); // This palette should *probably* come from the parent. Also, I'm not sure that
+      this.backgroundColor = this.cardBackgroundColor;
+    }
   }
 
   /**
@@ -69,21 +75,15 @@ export class FluentCard extends FluentDesignSystemProvider
    */
   public handleChange(source: DesignSystem, name: string): void {
     if (!this.cardBackgroundColor) {
-      const parsedColor = parseColorHexRGB(source[name]);
-      this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
-      const designSystem: DesignSystem = Object.assign({}, this.designSystem, {
-        backgroundColor: source[name],
-        neutralPallette: this.neutralPalette,
-      } as any);
-      this.backgroundColor = neutralFillCard(designSystem);
+      this.backgroundColor = neutralFillCard(source);
     }
   }
 
   connectedCallback(): void {
     super.connectedCallback();
-    const desinSystemNotifier: Notifier = Observable.getNotifier(this.provider?.designSystem);
-    desinSystemNotifier.subscribe(this, 'backgroundColor');
-    desinSystemNotifier.subscribe(this, 'neutralPalette');
+    const designSystemNotifier: Notifier = Observable.getNotifier(this.provider?.designSystem);
+    designSystemNotifier.subscribe(this, 'backgroundColor');
+    designSystemNotifier.subscribe(this, 'neutralPalette');
     this.handleChange(this.provider?.designSystem as DesignSystem, 'backgroundColor');
   }
 }

--- a/packages/web-components/src/card/index.ts
+++ b/packages/web-components/src/card/index.ts
@@ -1,5 +1,5 @@
 import { attr, Notifier, Observable } from '@microsoft/fast-element';
-import { ColorRGBA64, parseColorHexRGB } from '@microsoft/fast-colors';
+import { parseColorHexRGB } from '@microsoft/fast-colors';
 import { designSystemProperty, designSystemProvider, CardTemplate as template } from '@microsoft/fast-foundation';
 import { createColorPalette, DesignSystem, neutralFillCard } from '@microsoft/fast-components-styles-msft';
 import { FluentDesignSystemProvider } from '../design-system-provider';
@@ -36,7 +36,7 @@ export class FluentCard extends FluentDesignSystemProvider
     const parsedColor = parseColorHexRGB(this.backgroundColor);
 
     if (parsedColor !== null) {
-      this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
+      this.neutralPalette = createColorPalette(parsedColor);
     }
   }
 
@@ -54,7 +54,7 @@ export class FluentCard extends FluentDesignSystemProvider
     const parsedColor = parseColorHexRGB(this.cardBackgroundColor);
 
     if (parsedColor !== null) {
-      this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64); // This palette should *probably* come from the parent. Also, I'm not sure that
+      this.neutralPalette = createColorPalette(parsedColor);
       this.backgroundColor = this.cardBackgroundColor;
     }
   }


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The `FluentCard` was always generating a `neutralPalette` when a `card-background-color` was unset (this is most cases) which is undesirable for several reasons:
1. Generating palettes is reasonably expensive.
2. The palette *source* was the incoming background color, which results in a different palette than the upstream palette, which is generally undesirable.

This PR changes the behavior to use the upstream design-system to generate the card's background, which is the correct behavior when no local overrides have been set. It also adds some null checking that prevents runtime errors.
(give an overview)

#### Focus areas to test
`FluentCard` component.

