### PR TITLE
fix WC button font inheritance issues

### DIFF
--- a/change/@fluentui-web-components-2020-10-08-15-22-21-users-chhol-button-font-inheritance-issues.json
+++ b/change/@fluentui-web-components-2020-10-08-15-22-21-users-chhol-button-font-inheritance-issues.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix: ensure font properties are inherited to control and start/end content",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-08T22:22:21.243Z"
+}

--- a/packages/web-components/src/styles/patterns/button.ts
+++ b/packages/web-components/src/styles/patterns/button.ts
@@ -61,6 +61,10 @@ export const BaseButtonStyles: ElementStyles = css`
         font-family: inherit;
     }
 
+    .control, .end, .start {
+        font: inherit;
+    }
+
     :host(:hover) {
         background-color: ${neutralFillHoverBehavior.var};
     }


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)
