### PR TITLE
docs(Accessibility): Add titles for component pages, fix narration layout, fix dialog exmple accessibility

### DIFF
--- a/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
+++ b/packages/fluentui/docs/src/components/ComponentDoc/ComponentDoc.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import DocumentTitle from 'react-document-title';
 import { tabListBehavior, Header, Dropdown, Text, Flex, Menu } from '@fluentui/react-northstar';
 import { ArrowDownIcon } from '@fluentui/react-icons-northstar';
 
@@ -140,6 +141,7 @@ class ComponentDoc extends React.Component<ComponentDocProps, ComponentDocState>
     const PAGE_PADDING = '20px';
     return (
       <div>
+        <DocumentTitle title={`Fluent UI - ${info.displayName}`} />
         <div
           id="docs-sticky-header"
           style={{

--- a/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
+++ b/packages/fluentui/docs/src/components/ExternalExampleLayout.tsx
@@ -2,11 +2,12 @@ import { Provider, teamsTheme, teamsHighContrastTheme, teamsDarkTheme } from '@f
 import * as _ from 'lodash';
 import * as React from 'react';
 import { match } from 'react-router-dom';
+import DocumentTitle from 'react-document-title';
 import { KnobProvider } from '@fluentui/docs-components';
 
 import { examplesContext } from '../contexts/examplesContext';
 import PageNotFound from '../views/PageNotFound';
-import { exampleKebabNameToFilename, parseExamplePath } from '../utils';
+import { exampleKebabNameToFilename, exampleKebabNameToDisplayName, parseExamplePath } from '../utils';
 
 const examplePaths = examplesContext.keys();
 
@@ -44,6 +45,7 @@ const ExternalExampleLayout: React.FC<ExternalExampleLayoutProps> = props => {
 
   return (
     <Provider key={renderId} theme={theme} rtl={rtl === 'true'}>
+      <DocumentTitle title={`Fluent UI - ${exampleKebabNameToDisplayName(exampleName)}`} />
       <KnobProvider>
         <Example />
       </KnobProvider>

--- a/packages/fluentui/docs/src/examples/components/Dialog/Variations/DialogExampleBackdrop.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dialog/Variations/DialogExampleBackdrop.shorthand.tsx
@@ -14,12 +14,13 @@ const DialogExampleBackdrop = () => {
           <p>
             <code>Dialog</code> has <code>backdrop={backdrop.toString()}</code> now.
           </p>
-          <Button content="Close Dialog" onClick={() => setOpen(false)} />
         </>
       }
       open={open}
       onOpen={() => setOpen(true)}
       trigger={<Button content="Open a dialog" />}
+      cancelButton="Close Dialog"
+      onCancel={() => setOpen(false)}
     />
   );
 };

--- a/packages/fluentui/docs/src/utils/exampleKebabNameToFilename.ts
+++ b/packages/fluentui/docs/src/utils/exampleKebabNameToFilename.ts
@@ -13,3 +13,11 @@ export const exampleKebabNameToFilename = (exampleKebabName: string) => {
     .replace(/Perf$/, '.perf')
     .replace(/Bsize$/, '.bsize')}.tsx`;
 };
+
+/**
+ * Converts kebab-cased-example-name to readable name.
+ */
+export const exampleKebabNameToDisplayName = (exampleKebabName: string) => {
+  // button-example           => Button Example
+  return _.startCase(exampleKebabName);
+};

--- a/packages/fluentui/docs/src/utils/index.tsx
+++ b/packages/fluentui/docs/src/utils/index.tsx
@@ -1,5 +1,5 @@
 export { default as componentInfoContext } from './componentInfoContext';
-export { exampleKebabNameToFilename } from './exampleKebabNameToFilename';
+export { exampleKebabNameToFilename, exampleKebabNameToDisplayName } from './exampleKebabNameToFilename';
 export { default as examplePathToHash } from './examplePathToHash';
 export { default as getComponentGroup } from './getComponentGroup';
 export { default as getComponentPathname } from './getComponentPathname';

--- a/packages/fluentui/docs/src/views/PageNotFound.tsx
+++ b/packages/fluentui/docs/src/views/PageNotFound.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
+import DocumentTitle from 'react-document-title';
 import { Grid, Segment, Header } from '@fluentui/react-northstar';
 
 const PageNotFound = () => (
   <Grid>
+    <DocumentTitle title={`Fluent UI - 404`} />
     <div>
       <Header as="h1" align="center">
         :( 404

--- a/packages/fluentui/react-builder/package.json
+++ b/packages/fluentui/react-builder/package.json
@@ -15,6 +15,7 @@
     "lz-string": "^1.4.4",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-document-title": "^2.0.3",
     "react-frame-component": "^4.1.1",
     "react-is": "^16.6.3",
     "use-immer": "^0.4.1"

--- a/packages/fluentui/react-builder/src/components/Canvas.tsx
+++ b/packages/fluentui/react-builder/src/components/Canvas.tsx
@@ -332,7 +332,11 @@ export const Canvas: React.FunctionComponent<CanvasProps> = ({
               )}
               {inUseMode && <EventListener capture type="focus" listener={handleFocus} target={document} />}
               {renderJSONTreeToJSXElement(jsonTree, renderJSONTreeElement)}
-              {selectedComponent && <ReaderNarration selector={`[data-builder-id="${selectedComponent.uuid}"]`} />}
+              {selectedComponent && (
+                <div style={{ bottom: '0', position: 'absolute' }}>
+                  <ReaderNarration selector={`[data-builder-id="${selectedComponent.uuid}"]`} />
+                </div>
+              )}
             </Provider>
           </>
         )}

--- a/packages/fluentui/react-builder/src/components/Canvas.tsx
+++ b/packages/fluentui/react-builder/src/components/Canvas.tsx
@@ -224,7 +224,7 @@ export const Canvas: React.FunctionComponent<CanvasProps> = ({
           `
           [data-builder-id="builder-root"] {
             ${isExpanding ? `padding: ${debugSize};` : ''}
-            min-height: 'calc(100vh - 1.5rem)';
+            min-height: calc(100vh - 1.5rem);
           }
           `,
         isExpanding &&

--- a/packages/fluentui/react-builder/src/components/Designer.tsx
+++ b/packages/fluentui/react-builder/src/components/Designer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useImmerReducer, Reducer } from 'use-immer';
+import DocumentTitle from 'react-document-title';
 import { Text, Button, Divider } from '@fluentui/react-northstar';
 import { FilesCodeIcon, AcceptIcon } from '@fluentui/react-icons-northstar';
 import { EventListener } from '@fluentui/react-component-event-listener';
@@ -589,6 +590,7 @@ export const Designer: React.FunctionComponent = () => {
         overflow: 'hidden',
       }}
     >
+      <DocumentTitle title={`Fluent UI Builder`} />
       <EventListener type="keydown" listener={handleKeyDown} target={document} />
       {insertComponent && (
         <InsertComponent onDismiss={handleCloseAddComponentDialog} onComponentAdded={handleAddComponent} />

--- a/packages/fluentui/react-builder/src/components/ReaderNarration.tsx
+++ b/packages/fluentui/react-builder/src/components/ReaderNarration.tsx
@@ -5,6 +5,7 @@ import { DescendantsNarrationsComputer } from './../narration/DescendantsNarrati
 
 const computer: DescendantsNarrationsComputer = new DescendantsNarrationsComputer();
 let narrationTexts: Record<string, string> = {};
+const aomMissing = !(window as any).getComputedAccessibleNode;
 
 export type ReaderNarrationProps = {
   selector: string;
@@ -20,6 +21,11 @@ export const ReaderNarration: React.FunctionComponent<ReaderNarrationProps> = ({
     if (!ref.current) {
       return;
     }
+
+    if (aomMissing) {
+      return;
+    }
+
     const element = ref.current.ownerDocument.querySelector(selector) as IAriaElement;
 
     // Compute and store the narrations for the element and its focusable descendants
@@ -74,7 +80,20 @@ export const ReaderNarration: React.FunctionComponent<ReaderNarrationProps> = ({
       <Ref innerRef={ref}>
         <Alert
           warning
-          content={narrationText !== null ? narrationText : 'The selected component has no focusable elements.'}
+          content={
+            aomMissing ? (
+              <>
+                AOM is not available.{' '}
+                <a target="_blank" href="http://wicg.github.io/aom/caniuse.html">
+                  Enable AOM
+                </a>
+              </>
+            ) : narrationText !== null ? (
+              narrationText
+            ) : (
+              'The selected component has no focusable elements.'
+            )
+          }
         />
       </Ref>
     </>


### PR DESCRIPTION
Added page titles to component pages, popout examples, builder and 404
Fixed Dialog example accessibility - moved button to the actions area
Fixed a glitch in the Builder layout where the narration was not aligned to the bottom of the canvas