### PR TITLE
fix(Tree): onFocusParent not working on leaf node

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Remove the `disabled` property from `Dialog` and `Popup` behaviors @rymeskar ([#14885](https://github.com/microsoft/fluentui/pull/14885))
 
 ### Fixes
+- Fix `Tree` to have prop `onFocusParent` triggered on `ArrowLeft` for leaf node @yuanboxue-amber ([#15442](https://github.com/microsoft/fluentui/pull/15442))
 - Use `aria-checked` for multi-select tree instead of `aria-selected` @yuanboxue-amber ([#15142](https://github.com/microsoft/fluentui/pull/15142))
 - Fix `Breadcrumb` to have the `div` wrapping all items obtain a11y attributes from `container` slot @yuanboxue-amber ([#15303](https://github.com/microsoft/fluentui/pull/15303))
 - Fix scrollbar color to have higher contrast ratio @yuanboxue-amber ([#15209](https://github.com/microsoft/fluentui/pull/15209))

--- a/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Tree/treeItemBehavior.ts
@@ -20,6 +20,7 @@ import { treeTitleBehavior } from './treeTitleBehavior';
  * Triggers 'performClick' action with 'Enter' or 'Spacebar' on 'root'.
  * Triggers 'expandSiblings' action with '*' on 'root'.
  * Triggers 'focusParent' action with 'ArrowLeft' on 'root', when has a closed subtree.
+ * Triggers 'focusParent' action with 'ArrowLeft' on 'root', when has no subtree.
  * Triggers 'collapse' action with 'ArrowLeft' on 'root', when has an opened subtree.
  * Triggers 'expand' action with 'ArrowRight' on 'root', when has a closed subtree.
  * Triggers 'focusFirstChild' action with 'ArrowRight' on 'root', when has an opened subtree.
@@ -48,26 +49,29 @@ export const treeItemBehavior: Accessibility<TreeItemBehaviorProps> = props => {
         performClick: {
           keyCombinations: [{ keyCode: EnterKey }, { keyCode: SpacebarKey }],
         },
-        ...(isSubtreeExpanded(props) && {
-          collapse: {
-            keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
-          },
-          focusFirstChild: {
-            keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
-          },
-          focusParent: {
-            keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
-          },
-        }),
-        ...(!isSubtreeExpanded(props) &&
-          props.hasSubtree && {
-            expand: {
-              keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
-            },
-            focusParent: {
-              keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
-            },
-          }),
+        ...(props.hasSubtree
+          ? props.expanded
+            ? {
+                collapse: {
+                  keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+                },
+                focusFirstChild: {
+                  keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+                },
+              }
+            : {
+                expand: {
+                  keyCombinations: [{ keyCode: keyboardKey.ArrowRight }],
+                },
+                focusParent: {
+                  keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+                },
+              }
+          : {
+              focusParent: {
+                keyCombinations: [{ keyCode: keyboardKey.ArrowLeft }],
+              },
+            }),
         expandSiblings: {
           keyCombinations: [{ keyCode: keyboardKey['*'] }],
         },
@@ -104,10 +108,4 @@ export type TreeItemBehaviorProps = {
   selectable?: boolean;
   selected?: boolean;
   indeterminate?: boolean;
-};
-
-/** Checks if current tree item has a subtree and it is expanded */
-const isSubtreeExpanded = (props: TreeItemBehaviorProps): boolean => {
-  const { hasSubtree, expanded } = props;
-  return !!(hasSubtree && expanded);
 };

--- a/packages/fluentui/accessibility/test/behaviors/testDefinitions.ts
+++ b/packages/fluentui/accessibility/test/behaviors/testDefinitions.ts
@@ -674,6 +674,21 @@ definitions.push({
   },
 });
 
+// Triggers 'focusParent' action with 'ArrowLeft' on 'root', when has no subtree.
+definitions.push({
+  regexp: /Triggers '(\w+)' action with '(\w+)' on '([\w-]+)', when has no subtree\./g,
+  testMethod: (parameters: TestMethod) => {
+    const [action, key, elementToPerformAction] = [...parameters.props];
+    const propertyNoSubtree = {
+      hasItems: false,
+      hasSubtree: false,
+    };
+    const expectedKeyNumberVertical = parameters.behavior(propertyNoSubtree).keyActions[elementToPerformAction][action]
+      .keyCombinations[0].keyCode;
+    expect(expectedKeyNumberVertical).toBe(keysAndAliases[key]);
+  },
+});
+
 // Triggers 'expand' action with 'ArrowRight' on 'root', when has a closed subtree.
 definitions.push({
   regexp: /Triggers '(\w+)' action with '(\w+)' on '([\w-]+)', when has a closed subtree\./g,

--- a/packages/fluentui/accessibility/test/behaviors/treeItemBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/treeItemBehavior-test.tsx
@@ -61,6 +61,33 @@ describe('TreeItemBehavior', () => {
       expect(expectedResult.keyActions.root.performClick.keyCombinations).toHaveLength(1);
       expect(expectedResult.keyActions.root.performClick.keyCombinations[0].keyCode).toEqual(keyboardKey.Enter);
     });
+
+    test(`arrow left navigation, should collapse when tree expanded`, () => {
+      const expectedResult = treeItemBehavior({ expanded: true, hasSubtree: true });
+      expect(expectedResult.keyActions.root.collapse.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.collapse.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowLeft);
+    });
+    test(`arrow left navigation, should focus on parent when tree is not expanded`, () => {
+      const expectedResult = treeItemBehavior({ expanded: false, hasSubtree: true });
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowLeft);
+    });
+    test(`arrow left navigation, should focus on parent when treeItem has no subtree`, () => {
+      const expectedResult = treeItemBehavior({ hasSubtree: false });
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowLeft);
+    });
+
+    test(`arrow right navigation, should expand when tree collapsed`, () => {
+      const expectedResult = treeItemBehavior({ expanded: false, hasSubtree: true });
+      expect(expectedResult.keyActions.root.expand.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.expand.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowRight);
+    });
+    test(`arrow right navigation, should focus on frist child when tree expanded`, () => {
+      const expectedResult = treeItemBehavior({ expanded: true, hasSubtree: true });
+      expect(expectedResult.keyActions.root.focusFirstChild.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.focusFirstChild.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowRight);
+    });
   });
 
   describe('aria-checked', () => {

--- a/packages/fluentui/accessibility/test/behaviors/treeTitleBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/treeTitleBehavior-test.tsx
@@ -1,5 +1,5 @@
 import { treeTitleBehavior } from '@fluentui/accessibility';
-import { SpacebarKey } from '@fluentui/keyboard-key';
+import { keyboardKey, SpacebarKey } from '@fluentui/keyboard-key';
 
 describe('TreeTitleBehavior', () => {
   describe('tabIndex', () => {
@@ -45,6 +45,12 @@ describe('TreeTitleBehavior', () => {
       const expectedResult = treeTitleBehavior({ selectable: true, hasSubtree: true });
       expect(expectedResult.keyActions.root.performClick.keyCombinations).toHaveLength(1);
       expect(expectedResult.keyActions.root.performClick.keyCombinations[0].keyCode).toEqual(SpacebarKey);
+    });
+
+    test(`arrow left navigation, should focus on parent  `, () => {
+      const expectedResult = treeTitleBehavior({ hasSubtree: false });
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations).toHaveLength(1);
+      expect(expectedResult.keyActions.root.focusParent.keyCombinations[0].keyCode).toEqual(keyboardKey.ArrowLeft);
     });
   });
 });

--- a/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
+++ b/packages/fluentui/e2e/tests/treeKeyboardNavigation-test.ts
@@ -38,7 +38,11 @@ describe('Tree keyboard navigation', () => {
     await e2e.isFocused(selectors.treeItemAt(2));
     await e2e.expectCount(selectors.treeItem, 4);
 
-    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // Focus parent 1nd level and closes 3rd level
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // closes 3rd level
+    await e2e.expectCount(selectors.treeItem, 3);
+    await e2e.isFocused(selectors.treeItemAt(2));
+
+    await e2e.waitForSelectorAndPressKey(selectors.treeItemAt(2), 'ArrowLeft'); // Focus parent 1nd level
     await e2e.expectCount(selectors.treeItem, 3);
     await e2e.isFocused(selectors.treeItemAt(1));
   });

--- a/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
+++ b/packages/fluentui/react-northstar/src/components/Tree/TreeTitle.tsx
@@ -132,6 +132,7 @@ export const TreeTitle: ComponentWithAs<'a', TreeTitleProps> & FluentComponentSt
         handleClick(e);
       },
       focusParent: e => {
+        // allow bubbling up to parent treeItem
         onFocusParent(props.parent);
       },
       performSelection: e => {


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

- Description
Before this change, customised `onFocusParent` on a leaf node won't work. 

For example, our virtualizedTree prototype using customised `onFocusParent`, to make sure parent node can be focused on by `ArrowLeft` key, even when parent node is scrolled out of rendering window. However it does not work:
![old](https://user-images.githubusercontent.com/28751745/95562056-ea865900-0a1b-11eb-832d-0476908352b0.gif)
(I'm pressing `ArrowLeft` on the leaf node Tree-Item-0-21 and it does nothing)

- Cause: 
When `ArrowLeft` is pressed, `keydown` event does bubble up from treeTitle to treeItem. However when treeItem has no subtree, it has no listener for this event. 
- Fix: 
Add `onFocusParent` on treeItem, when it has no subtree. And `onFocusParent` listens to ArrowLeft event

- Fixed Behavior:
our virtualizedTree prototype:
![new](https://user-images.githubusercontent.com/28751745/95562381-608ac000-0a1c-11eb-8adb-f852e4949986.gif)


#### Focus areas to test

(optional)
