### PR TITLE
Charting: Vertical stacked bar chart minor changes including uncaught type error issue fix.

### DIFF
--- a/change/@fluentui-react-examples-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
+++ b/change/@fluentui-react-examples-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "Vertical stacked bar chart minor edits",
+  "comment": "Vertical stacked bar chart styled examples code updated.",
   "packageName": "@fluentui/react-examples",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-10-09T15:29:43.827Z"
 }

--- a/change/@fluentui-react-examples-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
+++ b/change/@fluentui-react-examples-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Vertical stacked bar chart minor edits",
+  "packageName": "@fluentui/react-examples",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T15:29:43.827Z"
+}

--- a/change/@uifabric-charting-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
+++ b/change/@uifabric-charting-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Vertical stacked bar chart minor edits",
+  "packageName": "@uifabric/charting",
+  "email": "email not defined",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T15:29:42.466Z"
+}

--- a/change/@uifabric-charting-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
+++ b/change/@uifabric-charting-2020-10-09-20-59-43-user-v-jasha-VerticalStackedBarChrtIssueFix.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "Vertical stacked bar chart minor edits",
+  "comment": "Vertical stacked bar chart uncaught type error fixed. Minor edits to margins",
   "packageName": "@uifabric/charting",
-  "email": "email not defined",
+  "email": "v-jasha@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-10-09T15:29:42.466Z"
 }

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -15,7 +15,6 @@ import {
   createDateXAxis,
   createYAxis,
   createStringYAxis,
-  additionalMarginRight,
   IMargins,
   getMinMaxOfYAxis,
   XAxisTypes,
@@ -200,7 +199,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
                 this.xAxisElement = e;
               }}
               id={`xAxisGElement${this.idForGraph}`}
-              transform={`translate(0, ${svgDimensions.height - 35})`}
+              transform={`translate(0, ${svgDimensions.height - this.margins.bottom!})`}
               className={this._classNames.xAxis}
             />
             <g
@@ -208,9 +207,8 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
                 this.yAxisElement = e;
               }}
               id={`yAxisGElement${this.idForGraph}`}
-              transform={`translate(${
-                this._isRtl ? svgDimensions.width - this.margins.right! - additionalMarginRight : 40
-              }, 0)`}
+              // Removing margins.right 2 times from width for RTL.
+              transform={`translate(${this._isRtl ? svgDimensions.width - 2 * this.margins.right! : 40}, 0)`}
               className={this._classNames.yAxis}
             />
             {children}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -59,11 +59,17 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       _height: this.props.height || 350,
     };
     this.idForGraph = getId('chart_');
+    /**
+     * In RTL mode, Only graph will be rendered left/right. We need to provide left and right margins manually.
+     * So that, in RTL, left margins becomes right margins and viceversa.
+     * As graph needs to be drawn perfecty, these values consider as default values.
+     * Same margins using for all other cartesian charts. Can be accessible through 'getMargins' call back method.
+     */
     this.margins = {
       top: this.props.margins?.top || 20,
-      right: this.props.margins?.right || 20,
       bottom: this.props.margins?.bottom || 35,
-      left: this.props.margins?.left || 40,
+      right: this._isRtl ? this.props.margins?.left || 40 : this.props.margins?.right || 20,
+      left: this._isRtl ? this.props.margins?.right || 20 : this.props.margins?.left || 40,
     };
   }
 
@@ -207,8 +213,9 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
                 this.yAxisElement = e;
               }}
               id={`yAxisGElement${this.idForGraph}`}
-              // Removing margins.right 2 times from width for RTL.
-              transform={`translate(${this._isRtl ? svgDimensions.width - 2 * this.margins.right! : 40}, 0)`}
+              transform={`translate(${
+                this._isRtl ? svgDimensions.width - this.margins.right! : this.margins.left!
+              }, 0)`}
               className={this._classNames.yAxis}
             />
             {children}

--- a/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -66,10 +66,10 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
      * Same margins using for all other cartesian charts. Can be accessible through 'getMargins' call back method.
      */
     this.margins = {
-      top: this.props.margins?.top || 20,
-      bottom: this.props.margins?.bottom || 35,
-      right: this._isRtl ? this.props.margins?.left || 40 : this.props.margins?.right || 20,
-      left: this._isRtl ? this.props.margins?.right || 20 : this.props.margins?.left || 40,
+      top: this.props.margins?.top ?? 20,
+      bottom: this.props.margins?.bottom ?? 35,
+      right: this._isRtl ? this.props.margins?.left ?? 40 : this.props.margins?.right ?? 20,
+      left: this._isRtl ? this.props.margins?.right ?? 20 : this.props.margins?.left ?? 40,
     };
   }
 

--- a/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -157,11 +157,7 @@ export interface ICartesianChartProps {
 
   /**
    * Margins for the chart
-   * @default top: 20
-   * @default bottom: 35
-   * @default left: 40
-   * @default right: 20
-   *
+   * @default `{ top: 20, bottom: 35, left: 40, right: 20 }`
    * To avoid edge cuttings to the chart, we recommend you use default values or greater then default values
    */
   margins?: IMargins;

--- a/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -157,6 +157,12 @@ export interface ICartesianChartProps {
 
   /**
    * Margins for the chart
+   * @default top: 20
+   * @default bottom: 35
+   * @default left: 40
+   * @default right: 20
+   *
+   * To avoid edge cuttings to the chart, we recommend you use default values or greater then default values
    */
   margins?: IMargins;
 

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -298,7 +298,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       >
         <div
           className={classNames.overflowIndicationTextStyle}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           {...(allowFocusOnLegends && {
             'aria-expanded': this.state.isHoverCardVisible,
@@ -378,7 +377,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         {...(data.nativeButtonProps && { ...data.nativeButtonProps })}
         key={index}
         className={classNames.legend}
-        /* eslint-disable react/jsx-no-bind */
         onClick={onClickHandler}
         onMouseOver={onHoverHandler}
         onMouseOut={onMouseOut}

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -21,7 +21,7 @@ import {
   IVSChartDataPoint,
 } from '../../index';
 import { FocusZoneDirection } from '@fluentui/react-focus';
-import { ChartTypes, XAxisTypes, additionalMarginRight } from '../../utilities/index';
+import { ChartTypes, XAxisTypes } from '../../utilities/index';
 
 const getClassNames = classNamesFunction<IVerticalStackedBarChartStyleProps, IVerticalStackedBarChartStyles>();
 type NumericAxis = D3Axis<number | { valueOf(): number }>;
@@ -374,8 +374,8 @@ export class VerticalStackedBarChartBase extends React.Component<
     });
   };
 
-  private _redirectToUrl(): void {
-    this.props.href ? (window.location.href = this.props.href) : '';
+  private _redirectToUrl(href: string): void {
+    href ? (window.location.href = href) : '';
   }
 
   private _getYMax(dataset: IDataPoint[]) {
@@ -420,7 +420,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           onMouseLeave: this._handleMouseOut,
           onFocus: this._onRectFocus.bind(this, point, singleChartData.xAxisPoint, color, refArrayIndexNumber),
           onBlur: this._handleMouseOut,
-          onClick: this._redirectToUrl,
+          onClick: this._redirectToUrl.bind(this, this.props.href!),
         };
         return (
           <rect
@@ -445,7 +445,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         onMouseLeave: this._handleMouseOut,
         onFocus: this._onStackFocus.bind(this, singleChartData.xAxisPoint),
         onBlur: this._handleMouseOut,
-        onClick: this._redirectToUrl,
+        onClick: this._redirectToUrl.bind(this, this.props.href!),
       };
       return (
         <g
@@ -473,7 +473,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       .nice()
       .range([
         this.margins.left!,
-        containerWidth - this.margins.right! - this._barWidth - (this._isRtl ? additionalMarginRight : 0),
+        containerWidth - this.margins.right! - this._barWidth - (this._isRtl ? this.margins.right! : 0),
       ]);
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])
@@ -494,7 +494,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           this.margins.right! -
           endpointDistance -
           0.5 * this._barWidth -
-          (this._isRtl ? additionalMarginRight : 0),
+          (this._isRtl ? this.margins.right! : 0),
       ]);
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -13,7 +13,6 @@ import {
   IChildProps,
   IDataPoint,
   IMargins,
-  IRefArrayData,
   IVerticalStackedBarChartProps,
   IVerticalStackedBarChartStyleProps,
   IVerticalStackedBarChartStyles,
@@ -28,9 +27,9 @@ type NumericAxis = D3Axis<number | { valueOf(): number }>;
 type NumericScale = D3ScaleLinear<number, number>;
 type StringScale = D3ScaleLinear<string, string>;
 const COMPONENT_NAME = 'VERTICAL STACKED BAR CHART';
-interface IBarRef {
-  index: number | string;
-  refElement: SVGGElement;
+
+interface IRefArrayData {
+  refElement?: SVGGElement | null;
 }
 
 export interface IVerticalStackedBarChartState extends IBasestate {
@@ -50,8 +49,6 @@ export class VerticalStackedBarChartBase extends React.Component<
   private _barWidth: number;
   private _calloutId: string;
   private _classNames: IProcessedStyleSet<IVerticalStackedBarChartStyles>;
-  private _refArray: IRefArrayData[];
-  private _barRefArray: IBarRef[];
   private _colors: string[];
   private margins: IMargins;
   private _isRtl: boolean = getRTL();
@@ -78,8 +75,6 @@ export class VerticalStackedBarChartBase extends React.Component<
     this._onLegendLeave = this._onLegendLeave.bind(this);
     this._handleMouseOut = this._handleMouseOut.bind(this);
     this._calloutId = getId('callout');
-    this._refArray = [];
-    this._barRefArray = [];
     this._adjustProps();
     this._dataset = this._createDataSetLayer();
   }
@@ -280,14 +275,6 @@ export class VerticalStackedBarChartBase extends React.Component<
     );
   }
 
-  private _refCallback(rectElement: SVGRectElement, legendTitle: string, index: number): void {
-    this._refArray[index] = { index: legendTitle, refElement: rectElement };
-  }
-
-  private _barRefCallback = (barElement: SVGGElement, index: number, xAxisPoint: number | string): void => {
-    this._barRefArray[index] = { index: xAxisPoint, refElement: barElement };
-  };
-
   private _onRectHover(
     xAxisPoint: string,
     point: IVSChartDataPoint,
@@ -327,44 +314,36 @@ export class VerticalStackedBarChartBase extends React.Component<
     });
   };
 
-  private _onRectFocus(point: IVSChartDataPoint, xAxisPoint: string, color: string, refArrayIndexNumber: number): void {
+  private _onRectFocus(point: IVSChartDataPoint, xAxisPoint: string, color: string, ref: IRefArrayData): void {
     if (
       this.state.isLegendSelected === false ||
       (this.state.isLegendSelected && this.state.selectedLegendTitle === point.legend)
     ) {
-      this._refArray.forEach((obj: IRefArrayData, index: number) => {
-        if (obj.index === point.legend && refArrayIndexNumber === index) {
-          this.setState({
-            refSelected: obj.refElement,
-            isCalloutVisible: true,
-            selectedLegendTitle: point.legend,
-            dataForHoverCard: point.data,
-            color: color,
-            xCalloutValue: point.xAxisCalloutData ? point.xAxisCalloutData : xAxisPoint,
-            yCalloutValue: point.yAxisCalloutData,
-            dataPointCalloutProps: point,
-          });
-        }
+      this.setState({
+        refSelected: ref.refElement,
+        isCalloutVisible: true,
+        selectedLegendTitle: point.legend,
+        dataForHoverCard: point.data,
+        color: color,
+        xCalloutValue: point.xAxisCalloutData ? point.xAxisCalloutData : xAxisPoint,
+        yCalloutValue: point.yAxisCalloutData,
+        dataPointCalloutProps: point,
       });
     }
   }
 
-  private _onStackFocus = (xAxisPoint: string | number): void => {
+  private _onStackFocus = (xAxisPoint: string | number, groupRef: IRefArrayData): void => {
     const found = find(
       this._points,
       (sinlgePoint: { xAxisPoint: string | number; chartData: IVSChartDataPoint[] }) =>
         sinlgePoint.xAxisPoint === xAxisPoint,
     );
-    this._barRefArray.forEach((obj: IBarRef) => {
-      if (obj.index === xAxisPoint) {
-        this.setState({
-          refSelected: obj.refElement,
-          isCalloutVisible: true,
-          YValueHover: found!.chartData,
-          hoverXValue: xAxisPoint,
-          stackCalloutProps: found!,
-        });
-      }
+    this.setState({
+      refSelected: groupRef.refElement,
+      isCalloutVisible: true,
+      YValueHover: found!.chartData,
+      hoverXValue: xAxisPoint,
+      stackCalloutProps: found!,
     });
   };
 
@@ -391,10 +370,18 @@ export class VerticalStackedBarChartBase extends React.Component<
       let startingPointOfY = 0;
       const isCalloutForStack = this.props.isCalloutForStack || false;
 
-      const singleBar = singleChartData.chartData.map((point: IVSChartDataPoint, index: number) => {
+      let xPoint: number | string;
+      if (this._isNumeric) {
+        xPoint = xBarScale(singleChartData.xAxisPoint as number);
+      } else {
+        xPoint = xBarScale(indexNumber);
+      }
+      // Removing datapoints with zero data
+      const nonZeroBars = singleChartData.chartData.filter(point => point.data > 0);
+      const singleBar = nonZeroBars.map((point: IVSChartDataPoint, index: number) => {
         startingPointOfY = startingPointOfY + point.data;
         const color = point.color ? point.color : this._colors[index];
-        const refArrayIndexNumber = indexNumber * singleChartData.chartData.length + index;
+        const ref: IRefArrayData = {};
 
         let shouldHighlight = true;
         if (this.state.isLegendHovered || this.state.isLegendSelected) {
@@ -405,20 +392,13 @@ export class VerticalStackedBarChartBase extends React.Component<
           shouldHighlight: shouldHighlight,
           href: this.props.href,
         });
-        let xPoint;
-        if (this._isNumeric) {
-          xPoint = xBarScale(singleChartData.xAxisPoint as number);
-        } else {
-          xPoint = xBarScale(indexNumber);
-        }
-
         const rectFocusProps = !isCalloutForStack && {
           'data-is-focusable': true,
           'aria-labelledby': this._calloutId,
           onMouseOver: this._onRectHover.bind(this, singleChartData.xAxisPoint, point),
           onMouseMove: this._onRectHover.bind(this, singleChartData.xAxisPoint, point),
           onMouseLeave: this._handleMouseOut,
-          onFocus: this._onRectFocus.bind(this, point, singleChartData.xAxisPoint, color, refArrayIndexNumber),
+          onFocus: this._onRectFocus.bind(this, point, singleChartData.xAxisPoint, color, ref),
           onBlur: this._handleMouseOut,
           onClick: this._redirectToUrl,
         };
@@ -431,19 +411,18 @@ export class VerticalStackedBarChartBase extends React.Component<
             width={this._barWidth}
             height={Math.max(yBarScale(point.data), 0)}
             fill={color}
-            ref={(e: SVGRectElement) => {
-              this._refCallback(e, point.legend, refArrayIndexNumber);
-            }}
+            ref={e => (ref.refElement = e)}
             {...rectFocusProps}
           />
         );
       });
+      const groupRef: IRefArrayData = {};
       const stackFocusProps = isCalloutForStack && {
         'data-is-focusable': true,
         onMouseOver: this._onStackHover.bind(this, singleChartData.xAxisPoint),
         onMouseMove: this._onStackHover.bind(this, singleChartData.xAxisPoint),
         onMouseLeave: this._handleMouseOut,
-        onFocus: this._onStackFocus.bind(this, singleChartData.xAxisPoint),
+        onFocus: this._onStackFocus.bind(this, singleChartData.xAxisPoint, groupRef),
         onBlur: this._handleMouseOut,
         onClick: this._redirectToUrl,
       };
@@ -452,9 +431,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           key={indexNumber}
           id={`${indexNumber}-singleBar`}
           data-is-focusable={this.props.isCalloutForStack}
-          ref={(gElement: SVGGElement) => {
-            this._barRefCallback(gElement, indexNumber, singleChartData.xAxisPoint);
-          }}
+          ref={e => (groupRef.refElement = e)}
           {...stackFocusProps}
         >
           {singleBar}
@@ -482,7 +459,6 @@ export class VerticalStackedBarChartBase extends React.Component<
   private _createStringBars = (containerHeight: number, containerWidth: number): JSX.Element[] => {
     const yMax = this._getYMax(this._dataset);
     const endpointDistance = 0.5 * ((containerWidth - this.margins.right!) / this._dataset.length);
-
     const xBarScale = d3ScaleLinear()
       .domain(this._isRtl ? [this._dataset.length - 1, 0] : [0, this._dataset.length - 1])
       .range([

--- a/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
+++ b/packages/charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.base.tsx
@@ -374,9 +374,9 @@ export class VerticalStackedBarChartBase extends React.Component<
     });
   };
 
-  private _redirectToUrl(href: string): void {
-    href ? (window.location.href = href) : '';
-  }
+  private _redirectToUrl = (): void => {
+    this.props.href ? (window.location.href = this.props.href) : '';
+  };
 
   private _getYMax(dataset: IDataPoint[]) {
     return Math.max(d3Max(dataset, (point: IDataPoint) => point.y)!, this.props.yMaxValue || 0);
@@ -420,7 +420,7 @@ export class VerticalStackedBarChartBase extends React.Component<
           onMouseLeave: this._handleMouseOut,
           onFocus: this._onRectFocus.bind(this, point, singleChartData.xAxisPoint, color, refArrayIndexNumber),
           onBlur: this._handleMouseOut,
-          onClick: this._redirectToUrl.bind(this, this.props.href!),
+          onClick: this._redirectToUrl,
         };
         return (
           <rect
@@ -445,7 +445,7 @@ export class VerticalStackedBarChartBase extends React.Component<
         onMouseLeave: this._handleMouseOut,
         onFocus: this._onStackFocus.bind(this, singleChartData.xAxisPoint),
         onBlur: this._handleMouseOut,
-        onClick: this._redirectToUrl.bind(this, this.props.href!),
+        onClick: this._redirectToUrl,
       };
       return (
         <g
@@ -471,10 +471,7 @@ export class VerticalStackedBarChartBase extends React.Component<
     const xBarScale = d3ScaleLinear()
       .domain(this._isRtl ? [xMax, 0] : [0, xMax])
       .nice()
-      .range([
-        this.margins.left!,
-        containerWidth - this.margins.right! - this._barWidth - (this._isRtl ? this.margins.right! : 0),
-      ]);
+      .range([this.margins.left!, containerWidth - this.margins.right! - this._barWidth]);
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])
       .range([0, containerHeight - this.margins.bottom! - this.margins.top!]);
@@ -490,11 +487,7 @@ export class VerticalStackedBarChartBase extends React.Component<
       .domain(this._isRtl ? [this._dataset.length - 1, 0] : [0, this._dataset.length - 1])
       .range([
         this.margins.left! + endpointDistance - 0.5 * this._barWidth,
-        containerWidth -
-          this.margins.right! -
-          endpointDistance -
-          0.5 * this._barWidth -
-          (this._isRtl ? this.margins.right! : 0),
+        containerWidth - this.margins.right! - endpointDistance - 0.5 * this._barWidth,
       ]);
     const yBarScale = d3ScaleLinear()
       .domain([0, yMax])

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -46,18 +46,22 @@ export interface IWrapLabelProps {
 export interface IMargins {
   /**
    * left margin for the chart.
+   * @default 40
    */
   left?: number;
   /**
    * Right margin for the chart.
+   * @default 20
    */
   right?: number;
   /**
    * Top margin for the chart.
+   * @default 20
    */
   top?: number;
   /**
    * Bottom margin for the chart.
+   * @default 35
    */
   bottom?: number;
 }
@@ -529,7 +533,7 @@ export function domainRangeOfDateForAreaChart(
   });
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? margins.right! : 0);
+  const rEndValue = width - margins.right!;
 
   return isRTL
     ? { dStartValue: lDate, dEndValue: sDate, rStartValue, rEndValue }
@@ -563,7 +567,7 @@ export function domainRangeOfNumericForAreaChart(
   })!;
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? margins.right! : 0);
+  const rEndValue = width - margins.right!;
 
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue, rEndValue }
@@ -583,7 +587,7 @@ export function domainRangeOfNumericForAreaChart(
  */
 export function domainRangeOfStrForVSBC(margins: IMargins, width: number, isRTL: boolean): IDomainNRange {
   const rMin = margins.left!;
-  const rMax = width - margins.right! - (isRTL ? margins.right! : 0);
+  const rMax = width - margins.right!;
 
   return isRTL
     ? { dStartValue: 0, dEndValue: 0, rStartValue: rMax, rEndValue: rMin }
@@ -627,7 +631,7 @@ export function domainRangeOfVSBCNumeric(
   const xMax = d3Max(points, (point: IDataPoint) => point.x as number)!;
   // barWidth / 2 - for to get tick middle of the bar
   const rMax = margins.left! + barWidth / 2;
-  const rMin = width - margins.right! - barWidth / 2 - (isRTL ? margins.right! : 0);
+  const rMin = width - margins.right! - barWidth / 2;
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue: rMax, rEndValue: rMin }
     : { dStartValue: xMin, dEndValue: xMax, rStartValue: rMax, rEndValue: rMin };

--- a/packages/charting/src/utilities/utilities.ts
+++ b/packages/charting/src/utilities/utilities.ts
@@ -118,7 +118,6 @@ export interface IFitContainerParams {
   legendContainer: HTMLDivElement;
   container: HTMLDivElement | null | HTMLElement;
 }
-export const additionalMarginRight: number = 20;
 
 /**
  * Create Numeric X axis
@@ -530,7 +529,7 @@ export function domainRangeOfDateForAreaChart(
   });
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rEndValue = width - margins.right! - (isRTL ? margins.right! : 0);
 
   return isRTL
     ? { dStartValue: lDate, dEndValue: sDate, rStartValue, rEndValue }
@@ -564,7 +563,7 @@ export function domainRangeOfNumericForAreaChart(
   })!;
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rEndValue = width - margins.right! - (isRTL ? margins.right! : 0);
 
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue, rEndValue }
@@ -584,7 +583,7 @@ export function domainRangeOfNumericForAreaChart(
  */
 export function domainRangeOfStrForVSBC(margins: IMargins, width: number, isRTL: boolean): IDomainNRange {
   const rMin = margins.left!;
-  const rMax = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rMax = width - margins.right! - (isRTL ? margins.right! : 0);
 
   return isRTL
     ? { dStartValue: 0, dEndValue: 0, rStartValue: rMax, rEndValue: rMin }
@@ -628,7 +627,7 @@ export function domainRangeOfVSBCNumeric(
   const xMax = d3Max(points, (point: IDataPoint) => point.x as number)!;
   // barWidth / 2 - for to get tick middle of the bar
   const rMax = margins.left! + barWidth / 2;
-  const rMin = width - margins.right! - barWidth / 2 - (isRTL ? additionalMarginRight : 0);
+  const rMin = width - margins.right! - barWidth / 2 - (isRTL ? margins.right! : 0);
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue: rMax, rEndValue: rMin }
     : { dStartValue: xMin, dEndValue: xMax, rStartValue: rMax, rEndValue: rMin };

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -74,6 +74,11 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
 
     const customStyles: IVerticalStackedBarChartProps['styles'] = () => {
       return {
+        xAxis: {
+          selectors: {
+            text: { fill: 'black', fontSize: '8px' },
+          },
+        },
         chart: {
           paddingBottom: '45px',
         },
@@ -99,6 +104,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             height={this.state.height}
             width={this.state.width}
             yAxisTickCount={10}
+            // Just test link
             href={'www.google.com'}
             // eslint-disable-next-line react/jsx-no-bind
             styles={customStyles}
@@ -109,7 +115,11 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             }}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisTickFormat={(x: number | string) => `${x} h`}
-            margins={{ left: 50 }}
+            margins={{
+              bottom: 40,
+              left: 45,
+              right: 30,
+            }}
             legendProps={{
               allowFocusOnLegends: true,
               styles: {
@@ -118,8 +128,8 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 },
               },
             }}
-            // eslint-disable-next-line react/jsx-no-bind
-            onRenderCalloutPerDataPoint={props =>
+            // eslint-disable-next-line react/jsx-no-bind @typescript-eslint/no-explicit-any
+            onRenderCalloutPerDataPoint={(props: any) =>
               props ? (
                 <ChartHoverCard
                   XValue={props.xAxisCalloutData}

--- a/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -37,7 +37,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
     const firstChartPoints: IVSChartDataPoint[] = [
       { legend: 'Metadata1', data: 40, color: DefaultPalette.accent },
       { legend: 'Metadata2', data: 5, color: DefaultPalette.blueMid },
-      { legend: 'Metadata3', data: 15, color: DefaultPalette.blueLight },
+      { legend: 'Metadata3', data: 0, color: DefaultPalette.blueLight },
     ];
 
     const secondChartPoints: IVSChartDataPoint[] = [
@@ -116,9 +116,10 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             // eslint-disable-next-line react/jsx-no-bind
             yAxisTickFormat={(x: number | string) => `${x} h`}
             margins={{
-              bottom: 40,
-              left: 45,
-              right: 30,
+              bottom: 0,
+              top: 0,
+              left: 0,
+              right: 0,
             }}
             legendProps={{
               allowFocusOnLegends: true,
@@ -128,7 +129,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 },
               },
             }}
-            // eslint-disable-next-line react/jsx-no-bind @typescript-eslint/no-explicit-any
+            // eslint-disable-next-line react/jsx-no-bind, @typescript-eslint/no-explicit-any
             onRenderCalloutPerDataPoint={(props: any) =>
               props ? (
                 <ChartHoverCard


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #https://github.com/microsoft/fluentui/issues/15465
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Vertical stacked bar chart.

1. 'Uncaught type error' issue fixed when click event triggers on bars.
2. Adjusted margin props to the cartesian/specific charts.
3. Updated below conditions as like previous PR:  https://github.com/microsoft/fluentui/pull/14912/
     -  Non zero bars condition added
     - Changed 'data-is-focusable' param to undefined instead of false.
    - Ref's data updated.
4. Margins condition updated. Now 0 value can be accepted.
5. Added description(default prop values) to the margins prop

Note: As Cartesian component consumed by other charts, Due to small change in cartesian, cross checked all other charts and added screenshots.

#### Focus areas to test

Vertical stacked bar chart
Vertical bar chart
Area chart
Line chart

### After fix
 ```
margins: {
left: 45,
right: 30
}
```
#### Vertical stacked bar chart
![image](https://user-images.githubusercontent.com/20105532/95721574-6f79a880-0c90-11eb-9d95-e8d83f772044.png)

#### Vertical stacked bar chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95722889-24f92b80-0c92-11eb-978b-ca85cd544f73.png)

```
margins: {{
left: 45,
right: 30
}}
```
#### Vertical bar chart 
![image](https://user-images.githubusercontent.com/20105532/95722624-ccc22980-0c91-11eb-866e-824e72322e7c.png)

#### Vertical bar chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95722710-e95e6180-0c91-11eb-8acc-5e8c5901a33b.png)

#### No margins given - It can take default values  ``` left:40, right: 20 ```
#### Area chart
![image](https://user-images.githubusercontent.com/20105532/95723508-db5d1080-0c92-11eb-9edf-11d77d00cd06.png)

#### Area chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95723183-7d302d80-0c92-11eb-9b7b-b3794cff8534.png)

#### Line chart
![image](https://user-images.githubusercontent.com/20105532/95723730-165f4400-0c93-11eb-9488-ac0696a13249.png)

#### Line chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95723775-2414c980-0c93-11eb-8c19-47ce185c4f91.png)

#### Test link: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/15447/merge/charting/dist/index.html#/examples/VerticalStackedBarChart
