### PR TITLE
Rename theme packages

### DIFF
--- a/apps/codesandbox-react-next-template/package.json
+++ b/apps/codesandbox-react-next-template/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/react-next": "^8.0.0-alpha.118",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "react": "16.8.6",
     "react-dom": "16.8.6",
     "tslib": "^1.10.0"

--- a/apps/codesandbox-react-next-template/src/index.tsx
+++ b/apps/codesandbox-react-next-template/src/index.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { DefaultCustomizations } from '@uifabric/theme-samples';
+import { DefaultCustomizations } from '@fluentui/theme-samples';
 import {
   initializeIcons,
   Checkbox,

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -47,7 +47,7 @@
     "@uifabric/icons": "^7.5.8",
     "@uifabric/mdl2-theme": "^0.3.17",
     "@uifabric/set-version": "^7.0.23",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "@uifabric/tsx-editor": "^0.13.18",
     "office-ui-fabric-core": "^11.0.0",
     "tslib": "^1.10.0"

--- a/apps/public-docsite-resources/package.json
+++ b/apps/public-docsite-resources/package.json
@@ -42,7 +42,7 @@
     "@fluentui/react-internal": "^7.142.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/api-docs": "^7.5.18",
-    "@uifabric/azure-themes": "^7.5.18",
+    "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/example-app-base": "^7.15.18",
     "@uifabric/icons": "^7.5.8",
     "@uifabric/mdl2-theme": "^0.3.17",

--- a/apps/public-docsite-resources/src/customizations/customizations.ts
+++ b/apps/public-docsite-resources/src/customizations/customizations.ts
@@ -6,7 +6,7 @@ import {
   WordCustomizations,
   DefaultCustomizations,
   DarkCustomizations,
-} from '@uifabric/theme-samples';
+} from '@fluentui/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Default', customizations: DefaultCustomizations },

--- a/apps/public-docsite-resources/src/customizations/customizations.ts
+++ b/apps/public-docsite-resources/src/customizations/customizations.ts
@@ -1,6 +1,6 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
 import { MDL2Customizations } from '@uifabric/mdl2-theme';
-import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
+import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
 import {
   TeamsCustomizations,
   WordCustomizations,

--- a/apps/public-docsite/package.json
+++ b/apps/public-docsite/package.json
@@ -53,7 +53,7 @@
     "@uifabric/file-type-icons": "^7.6.9",
     "@uifabric/icons": "^7.5.8",
     "@uifabric/set-version": "^7.0.23",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "json-loader": "^0.5.7",
     "office-ui-fabric-core": "^11.0.0",
     "tslib": "^1.10.0",

--- a/apps/public-docsite/src/components/Site/customizations.ts
+++ b/apps/public-docsite/src/components/Site/customizations.ts
@@ -1,4 +1,4 @@
-import { DefaultCustomizations, DarkCustomizations } from '@uifabric/theme-samples';
+import { DefaultCustomizations, DarkCustomizations } from '@fluentui/theme-samples';
 import { IAppCustomizations, IExampleCardCustomizations } from '@uifabric/example-app-base';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [

--- a/change/@fluentui-azure-themes-2020-10-09-16-58-10-rename-themes.json
+++ b/change/@fluentui-azure-themes-2020-10-09-16-58-10-rename-themes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rename theme packages",
+  "packageName": "@fluentui/azure-themes",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T23:57:41.847Z"
+}

--- a/change/@fluentui-storybook-2020-10-09-16-58-10-rename-themes.json
+++ b/change/@fluentui-storybook-2020-10-09-16-58-10-rename-themes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rename theme packages",
+  "packageName": "@fluentui/storybook",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T23:58:08.049Z"
+}

--- a/change/@fluentui-theme-samples-2020-10-09-16-58-10-rename-themes.json
+++ b/change/@fluentui-theme-samples-2020-10-09-16-58-10-rename-themes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rename theme packages",
+  "packageName": "@fluentui/theme-samples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T23:58:10.792Z"
+}

--- a/change/@uifabric-azure-themes-2020-09-30-13-43-32-merge-oufr-react.json
+++ b/change/@uifabric-azure-themes-2020-09-30-13-43-32-merge-oufr-react.json
@@ -1,7 +1,7 @@
 {
   "type": "minor",
   "comment": "Rename office-ui-fabric-react package and update references",
-  "packageName": "@uifabric/azure-themes",
+  "packageName": "@fluentui/azure-themes",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-09-30T20:42:57.618Z"

--- a/change/@uifabric-azure-themes-2020-10-07-17-45-15-feat-react-internal-spinbutton.json
+++ b/change/@uifabric-azure-themes-2020-10-07-17-45-15-feat-react-internal-spinbutton.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "Updating SpinButton.styles to a StyleFunction.",
-  "packageName": "@uifabric/azure-themes",
+  "packageName": "@fluentui/azure-themes",
   "email": "czearing@outlook.com",
   "dependentChangeType": "patch",
   "date": "2020-10-08T00:45:15.624Z"

--- a/change/@uifabric-experiments-2020-10-09-16-58-10-rename-themes.json
+++ b/change/@uifabric-experiments-2020-10-09-16-58-10-rename-themes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unneeded dep on azure-themes",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T23:57:57.552Z"
+}

--- a/change/@uifabric-react-cards-2020-10-09-16-58-10-rename-themes.json
+++ b/change/@uifabric-react-cards-2020-10-09-16-58-10-rename-themes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove unneeded dep on azure-themes",
+  "packageName": "@uifabric/react-cards",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-09T23:58:03.948Z"
+}

--- a/change/@uifabric-theme-samples-2020-09-30-13-43-32-merge-oufr-react.json
+++ b/change/@uifabric-theme-samples-2020-09-30-13-43-32-merge-oufr-react.json
@@ -1,7 +1,7 @@
 {
   "type": "minor",
   "comment": "Rename office-ui-fabric-react package and update references",
-  "packageName": "@uifabric/theme-samples",
+  "packageName": "@fluentui/theme-samples",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-09-30T20:43:29.368Z"

--- a/packages/azure-themes/LICENSE
+++ b/packages/azure-themes/LICENSE
@@ -1,4 +1,4 @@
-@uifabric/azure-themes
+@fluentui/azure-themes
 
 Copyright (c) Microsoft Corporation
 

--- a/packages/azure-themes/README.md
+++ b/packages/azure-themes/README.md
@@ -1,4 +1,4 @@
-# @uifabric/azure-themes
+# @fluentui/azure-themes
 
 **Azure theme for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))

--- a/packages/azure-themes/README.md
+++ b/packages/azure-themes/README.md
@@ -7,7 +7,7 @@ The Azure themes require the following import statements:
 
 ```js
 import { Fabric, Customizer } from '@fluentui/react';
-import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
+import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
 ```
 
 The theme may subsequently be set to either the Azure or Azure-Dark themes

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uifabric/azure-themes",
+  "name": "@fluentui/azure-themes",
   "version": "7.5.18",
   "description": "Azure themes for Fluent UI React",
   "main": "lib-commonjs/index.js",

--- a/packages/azure-themes/src/version.ts
+++ b/packages/azure-themes/src/version.ts
@@ -1,4 +1,4 @@
 // Do not modify this file; it is generated as part of publish.
 // The checked in version is a placeholder only and will not be updated.
 import { setVersion } from '@uifabric/set-version';
-setVersion('@uifabric/azure-themes', '0.0.0');
+setVersion('@fluentui/azure-themes', '0.0.0');

--- a/packages/azure-themes/webpack.config.js
+++ b/packages/azure-themes/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
 
   output: {
     libraryTarget: 'var',
-    library: 'FabricAzureThemes',
+    library: 'FluentUIAzureThemes',
   },
 
   externals: [{ react: 'React' }, { 'react-dom': 'ReactDOM' }],

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -56,7 +56,7 @@
     "@fluentui/react-internal": "^7.142.0",
     "@fluentui/theme": "^1.2.1",
     "@microsoft/load-themed-styles": "^1.10.26",
-    "@uifabric/azure-themes": "^7.5.18",
+    "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/example-data": "^7.1.5",
     "@uifabric/file-type-icons": "^7.6.9",
     "@uifabric/foundation": "^7.9.9",

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -65,7 +65,7 @@
     "@uifabric/react-hooks": "^7.13.5",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.9",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "@uifabric/utilities": "^7.32.3",
     "@uifabric/variants": "^7.2.21",
     "deep-assign": "^2.0.0",

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -40,7 +40,7 @@
     "@uifabric/build": "^7.0.0",
     "@uifabric/example-app-base": "^7.15.18",
     "@uifabric/jest-serializer-merge-styles": "^7.2.2",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "enzyme": "~3.10.0",
     "enzyme-adapter-react-16": "^1.15.0",
     "react": "16.8.6",
@@ -61,7 +61,7 @@
     "@uifabric/react-hooks": "^7.13.5",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.9",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "@uifabric/utilities": "^7.32.3",
     "tslib": "^1.10.0"
   },

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "16.8.4",
     "@types/react-test-renderer": "^16.0.0",
     "@types/webpack-env": "1.15.1",
-    "@uifabric/azure-themes": "^7.5.18",
+    "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/build": "^7.0.0",
     "@uifabric/example-app-base": "^7.15.18",
     "@uifabric/jest-serializer-merge-styles": "^7.2.2",

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -67,7 +67,7 @@
     "@fluentui/theme": "^1.2.1",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/api-docs": "^7.5.18",
-    "@uifabric/azure-themes": "^7.5.18",
+    "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/charting": "^4.2.5",
     "@uifabric/date-time": "^7.17.16",
     "@uifabric/example-app-base": "^7.15.18",

--- a/packages/react-examples/package.json
+++ b/packages/react-examples/package.json
@@ -81,7 +81,7 @@
     "@uifabric/react-cards": "^0.113.3",
     "@uifabric/react-hooks": "^7.13.5",
     "@uifabric/styling": "^7.16.9",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "@uifabric/utilities": "^7.32.3",
     "@uifabric/variants": "^7.2.21",
     "d3-format": "^1.4.4",

--- a/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
+++ b/packages/react-examples/src/azure-themes/stories/Themes/Themes.stories.tsx
@@ -18,7 +18,7 @@ import {
   AzureCustomizationsDark,
   AzureCustomizationsHighContrastLight,
   AzureCustomizationsHighContrastDark,
-} from '@uifabric/azure-themes';
+} from '@fluentui/azure-themes';
 import { ButtonCommandBarExample } from '../components/commandBarButton.stories';
 import { ButtonSplitExample } from '../components/splitButton.stories';
 import { ButtonIconExample } from '../components/iconButton.stories';

--- a/packages/react-examples/src/experiments/demo/customizations.ts
+++ b/packages/react-examples/src/experiments/demo/customizations.ts
@@ -1,6 +1,6 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
-import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
+import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@fluentui/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Default', customizations: DefaultCustomizations },

--- a/packages/react-examples/src/experiments/demo/customizations.ts
+++ b/packages/react-examples/src/experiments/demo/customizations.ts
@@ -1,5 +1,5 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
-import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
+import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [

--- a/packages/react-examples/src/react-cards/demo/customizations.ts
+++ b/packages/react-examples/src/react-cards/demo/customizations.ts
@@ -1,6 +1,6 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
 import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
-import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
+import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@fluentui/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [
   { title: 'Default', customizations: DefaultCustomizations },

--- a/packages/react-examples/src/react-cards/demo/customizations.ts
+++ b/packages/react-examples/src/react-cards/demo/customizations.ts
@@ -1,5 +1,5 @@
 import { IExampleCardCustomizations, IAppCustomizations } from '@uifabric/example-app-base';
-import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
+import { AzureCustomizationsLight, AzureCustomizationsDark } from '@fluentui/azure-themes';
 import { DefaultCustomizations, TeamsCustomizations, WordCustomizations } from '@uifabric/theme-samples';
 
 const exampleCardCustomizations: IExampleCardCustomizations[] = [

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -33,7 +33,7 @@
     "@storybook/addons": "^5.3.8",
     "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/mdl2-theme": "^0.3.17",
-    "@uifabric/theme-samples": "^7.1.21",
+    "@fluentui/theme-samples": "^7.1.21",
     "tslib": "^1.10.0"
   },
   "peerDependencies": {

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -31,7 +31,7 @@
     "@fluentui/theme": "^1.2.1",
     "@storybook/addon-knobs": "^5.3.8",
     "@storybook/addons": "^5.3.8",
-    "@uifabric/azure-themes": "^7.5.18",
+    "@fluentui/azure-themes": "^7.5.18",
     "@uifabric/mdl2-theme": "^0.3.17",
     "@uifabric/theme-samples": "^7.1.21",
     "tslib": "^1.10.0"

--- a/packages/storybook/src/themes/v7/AzureDarkTheme.ts
+++ b/packages/storybook/src/themes/v7/AzureDarkTheme.ts
@@ -1,4 +1,4 @@
-import { AzureCustomizationsDark } from '@uifabric/azure-themes';
+import { AzureCustomizationsDark } from '@fluentui/azure-themes';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const AzureDarkTheme: Theme = AzureCustomizationsDark.settings.theme;

--- a/packages/storybook/src/themes/v7/AzureLightTheme.ts
+++ b/packages/storybook/src/themes/v7/AzureLightTheme.ts
@@ -1,4 +1,4 @@
-import { AzureCustomizationsLight } from '@uifabric/azure-themes';
+import { AzureCustomizationsLight } from '@fluentui/azure-themes';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const AzureLightTheme: Theme = AzureCustomizationsLight.settings.theme;

--- a/packages/storybook/src/themes/v7/DarkTheme.ts
+++ b/packages/storybook/src/themes/v7/DarkTheme.ts
@@ -1,4 +1,4 @@
-import { DarkCustomizations } from '@uifabric/theme-samples';
+import { DarkCustomizations } from '@fluentui/theme-samples';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const DarkTheme: Theme = DarkCustomizations.settings.theme;

--- a/packages/storybook/src/themes/v7/FluentTheme.ts
+++ b/packages/storybook/src/themes/v7/FluentTheme.ts
@@ -1,4 +1,4 @@
-import { DefaultCustomizations } from '@uifabric/theme-samples';
+import { DefaultCustomizations } from '@fluentui/theme-samples';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const FluentTheme: Theme = DefaultCustomizations.settings.theme;

--- a/packages/storybook/src/themes/v7/TeamsTheme.ts
+++ b/packages/storybook/src/themes/v7/TeamsTheme.ts
@@ -1,4 +1,4 @@
-import { TeamsCustomizations } from '@uifabric/theme-samples';
+import { TeamsCustomizations } from '@fluentui/theme-samples';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const TeamsTheme: Theme = TeamsCustomizations.settings.theme;

--- a/packages/storybook/src/themes/v7/WordTheme.ts
+++ b/packages/storybook/src/themes/v7/WordTheme.ts
@@ -1,4 +1,4 @@
-import { WordCustomizations } from '@uifabric/theme-samples';
+import { WordCustomizations } from '@fluentui/theme-samples';
 import { Theme } from '@fluentui/react-theme-provider';
 
 export const WordTheme: Theme = WordCustomizations.settings.theme;

--- a/packages/theme-samples/README.md
+++ b/packages/theme-samples/README.md
@@ -1,4 +1,4 @@
-# @uifabric/theme-samples
+# @fluentui/theme-samples
 
 **Theme samples for [Fluent UI React](https://developer.microsoft.com/en-us/fluentui)**
 ([formerly Office UI Fabric React](https://developer.microsoft.com/en-us/office/blogs/ui-fabric-is-evolving-into-fluent-ui/))
@@ -8,5 +8,5 @@ This is not a production-ready package and **should never be used in product**. 
 To import sample themes:
 
 ```js
-import { ThemeName } from '@uifabric/theme-samples';
+import { ThemeName } from '@fluentui/theme-samples';
 ```

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@uifabric/theme-samples",
+  "name": "@fluentui/theme-samples",
   "version": "7.1.21",
   "description": "Sample themes for use with Fabric components.",
   "main": "lib-commonjs/index.js",

--- a/packages/theme-samples/src/version.ts
+++ b/packages/theme-samples/src/version.ts
@@ -1,4 +1,4 @@
 // Do not modify this file; it is generated as part of publish.
 // The checked in version is a placeholder only and will not be updated.
 import { setVersion } from '@uifabric/set-version';
-setVersion('@uifabric/theme-samples', '0.0.0');
+setVersion('@fluentui/theme-samples', '0.0.0');

--- a/packages/theme-samples/webpack.config.js
+++ b/packages/theme-samples/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
 
   output: {
     libraryTarget: 'var',
-    library: 'FabricThemeSamples',
+    library: 'FluentUIThemeSamples',
   },
 
   resolve: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #13384
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Move `azure-themes` and `theme-samples` to `@fluentui` scope (same names).

Plus some fixes to the rename script.