### PR TITLE
withSlots: refactor out redundant React.Children traversal

### DIFF
--- a/change/@uifabric-foundation-2020-10-11-10-30-57-keco-slots.json
+++ b/change/@uifabric-foundation-2020-10-11-10-30-57-keco-slots.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "withSlots: avoid calling traverseAllChildren twice",
+  "packageName": "@uifabric/foundation",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-11T17:30:57.102Z"
+}

--- a/packages/foundation/src/slots.tsx
+++ b/packages/foundation/src/slots.tsx
@@ -40,13 +40,6 @@ export function withSlots<P>(
 ): ReturnType<React.FunctionComponent<P>> {
   const slotType = type as ISlot<P>;
   if (slotType.isSlot) {
-    // TODO: There is something weird going on here with children embedded in props vs. rest args.
-    // Comment out these lines to see. Make sure this function is doing the right things.
-    const numChildren = React.Children.count(children);
-    if (numChildren === 0) {
-      return slotType(props);
-    }
-
     // Since we are bypassing createElement, use React.Children.toArray to make sure children are
     // properly assigned keys.
     // TODO: should this be mutating? does React mutate children subprop with createElement?
@@ -55,6 +48,12 @@ export function withSlots<P>(
     //        Even children passed to createElement without keys don't generate this warning.
     //        Is there a better way to prevent slots from appearing in hierarchy? toArray doesn't address root issue.
     children = React.Children.toArray(children);
+
+    // TODO: There is something weird going on here with children embedded in props vs. rest args.
+    // Comment out these lines to see. Make sure this function is doing the right things.
+    if (children.length === 0) {
+      return slotType(props);
+    }
 
     return slotType({ ...(props as any), children });
   } else {


### PR DESCRIPTION
Visible while profiling `<Stack />`. Avoid traversing React.Children twice for children count, re-use `toArray`'s traversal.

![image](https://user-images.githubusercontent.com/706967/95685525-48967600-0bad-11eb-910b-069955a61e65.png)

Ideally this wrapper could re-use children already being traversed within `<Stack />` itself.

![image](https://user-images.githubusercontent.com/706967/95685550-6532ae00-0bad-11eb-9591-6a8af50b039f.png)

