### PR TITLE
Clarify interoperability between projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Fluent UI web represents a collection of utilities, React components, and web components for building web applications.
 
-The Fluent UI web repository is home to 3 main projects today, the following table will help navigate them and understand their differences.
+This repo is home to 3 separate projects today. Mixing components between projects is not currently supported. The goal of these projects is to dedupe functionality and enable interoperability over time. For now, choose the project that best suits your needs.
+
+The following table will help you navigate the 3 projects and understand their differences.
 
 <!-- prettier-ignore-start -->
 |   | React | React Northstar | Web Components |
@@ -20,7 +22,7 @@ The Fluent UI web repository is home to 3 main projects today, the following tab
 | **Issues**      | [![Fluent UI React GitHub Issues](https://img.shields.io/github/issues/microsoft/fluentui/Fluent%20UI%20react?label=issues&style=flat-square)](https://github.com/microsoft/fluentui/issues?q=is%3Aissue+is%3Aopen+label%3A%22Fluent+UI+react%22) | [![Fluent UI React Northstar GitHub Issues](https://img.shields.io/github/issues/microsoft/fluentui/Fluent%20UI%20react-northstar?label=issues&style=flat-square)](https://github.com/microsoft/fluentui/issues?q=is%3Aissue+is%3Aopen+label%3A%22Fluent+UI+react-northstar%22) | [![Fluent UI Web Components GitHub Issues](https://img.shields.io/github/issues/microsoft/fluentui/web-components?label=issues&style=flat-square)](https://github.com/microsoft/fluentui/issues?q=is%3Aissue+is%3Aopen+label%3A%22web-components%22) |
 <!-- prettier-ignore-end -->
 
-> The goal of these projects is to dedupe functionality and increase interoperability over time. Why are there two React versions? See the [FAQ on Fabric and Stardust](https://github.com/microsoft/fluentui/wiki/FAQ---Fabric-and-Stardust-to-Fluent-UI)
+> Why are there two React versions? See the [FAQ on Fabric and Stardust](https://github.com/microsoft/fluentui/wiki/FAQ---Fabric-and-Stardust-to-Fluent-UI).
 
 ## Licenses
 


### PR DESCRIPTION
We have folks trying to install both /react and /react-northstar and use them on the same page.  While we're targeting this type of use, we do not yet support this setup.

This change clarifies the state of interop between the projects within the repo.