### PR TITLE
Add custom KeyUp support to Group Header

### DIFF
--- a/change/office-ui-fabric-react-2020-10-12-13-11-10-7.0.json
+++ b/change/office-ui-fabric-react-2020-10-12-13-11-10-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add custom KeyUp support for Group Header",
+  "packageName": "office-ui-fabric-react",
+  "email": "bcoard@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T20:11:10.321Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4968,6 +4968,7 @@ export interface IGroupDividerProps {
     isSelected?: boolean;
     loadingText?: string;
     onGroupHeaderClick?: (group: IGroup) => void;
+    onGroupHeaderKeyUp?: (group: IGroup, ev: React.KeyboardEvent<HTMLElement>) => void;
     onRenderTitle?: IRenderFunction<IGroupHeaderProps>;
     onToggleCollapse?: (group: IGroup) => void;
     onToggleSelectGroup?: (group: IGroup) => void;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4968,7 +4968,7 @@ export interface IGroupDividerProps {
     isSelected?: boolean;
     loadingText?: string;
     onGroupHeaderClick?: (group: IGroup) => void;
-    onGroupHeaderKeyUp?: (group: IGroup, ev: React.KeyboardEvent<HTMLElement>) => void;
+    onGroupHeaderKeyUp?: (ev: React.KeyboardEvent<HTMLElement>, group: IGroup) => void;
     onRenderTitle?: IRenderFunction<IGroupHeaderProps>;
     onToggleCollapse?: (group: IGroup) => void;
     onToggleSelectGroup?: (group: IGroup) => void;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -185,13 +185,20 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
   };
 
   private _onKeyUp = (ev: React.KeyboardEvent<HTMLElement>): void => {
-    const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
-    const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
-    if (shouldClose || shouldOpen) {
-      this._toggleCollapse();
-      ev.stopPropagation();
-      ev.preventDefault();
+    const { group, onGroupHeaderKeyUp } = this.props;
+
+    if (onGroupHeaderKeyUp) {
+      onGroupHeaderKeyUp(group!, ev);
+    } else {
+      const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
+      const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
+      if (shouldClose || shouldOpen) {
+        this._toggleCollapse();
+      }
     }
+
+    ev.stopPropagation();
+    ev.preventDefault();
   };
 
   private _onToggleClick = (ev: React.MouseEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -191,12 +191,14 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       onGroupHeaderKeyUp(ev, group!);
     }
 
-    const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
-    const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
-    if (shouldClose || shouldOpen) {
-      this._toggleCollapse();
-      ev.stopPropagation();
-      ev.preventDefault();
+    if (!ev.defaultPrevented) {
+      const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
+      const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
+      if (shouldClose || shouldOpen) {
+        this._toggleCollapse();
+        ev.stopPropagation();
+        ev.preventDefault();
+      }
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -195,10 +195,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
     if (shouldClose || shouldOpen) {
       this._toggleCollapse();
+      ev.stopPropagation();
+      ev.preventDefault();
     }
-
-    ev.stopPropagation();
-    ev.preventDefault();
   };
 
   private _onToggleClick = (ev: React.MouseEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -189,16 +189,16 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
 
     if (onGroupHeaderKeyUp) {
       onGroupHeaderKeyUp(ev, group!);
-    } else {
-      const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
-      const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
-      if (shouldClose || shouldOpen) {
-        this._toggleCollapse();
-      }
-
-      ev.stopPropagation();
-      ev.preventDefault();
     }
+
+    const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
+    const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
+    if (shouldClose || shouldOpen) {
+      this._toggleCollapse();
+    }
+
+    ev.stopPropagation();
+    ev.preventDefault();
   };
 
   private _onToggleClick = (ev: React.MouseEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -188,17 +188,17 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     const { group, onGroupHeaderKeyUp } = this.props;
 
     if (onGroupHeaderKeyUp) {
-      onGroupHeaderKeyUp(group!, ev);
+      onGroupHeaderKeyUp(ev, group!);
     } else {
       const shouldOpen = this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
       const shouldClose = !this.state.isCollapsed && ev.which === getRTLSafeKeyCode(KeyCodes.left, this.props.theme);
       if (shouldClose || shouldOpen) {
         this._toggleCollapse();
       }
-    }
 
-    ev.stopPropagation();
-    ev.preventDefault();
+      ev.stopPropagation();
+      ev.preventDefault();
+    }
   };
 
   private _onToggleClick = (ev: React.MouseEvent<HTMLElement>): void => {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -314,6 +314,9 @@ export interface IGroupDividerProps {
   /** Callback for when the group header is clicked. */
   onGroupHeaderClick?: (group: IGroup) => void;
 
+  /** Callback for when KeyUp on  the group header is invoked. */
+  onGroupHeaderKeyUp?: (group: IGroup, ev: React.KeyboardEvent<HTMLElement>) => void;
+
   /** Callback for when the group is expanded or collapsed. */
   onToggleCollapse?: (group: IGroup) => void;
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -315,7 +315,7 @@ export interface IGroupDividerProps {
   onGroupHeaderClick?: (group: IGroup) => void;
 
   /** Callback for when KeyUp on  the group header is invoked. */
-  onGroupHeaderKeyUp?: (group: IGroup, ev: React.KeyboardEvent<HTMLElement>) => void;
+  onGroupHeaderKeyUp?: (ev: React.KeyboardEvent<HTMLElement>, group: IGroup) => void;
 
   /** Callback for when the group is expanded or collapsed. */
   onToggleCollapse?: (group: IGroup) => void;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -314,7 +314,7 @@ export interface IGroupDividerProps {
   /** Callback for when the group header is clicked. */
   onGroupHeaderClick?: (group: IGroup) => void;
 
-  /** Callback for when KeyUp on  the group header is invoked. */
+  /** Callback for when KeyUp on the group header is invoked. */
   onGroupHeaderKeyUp?: (ev: React.KeyboardEvent<HTMLElement>, group: IGroup) => void;
 
   /** Callback for when the group is expanded or collapsed. */


### PR DESCRIPTION
#### Pull request checklist

- [NA ] Addresses an existing issue: Fixes #0000
- [✔ ] Include a change request file using `$ yarn change`

#### Description of changes

Give the user the ability to override what happens with KeyUp. Currently it is only used with Right/Left to expand and collapse the group.

#### Focus areas to test

Ensure that Right/Left to expand and collapse still works.
