### PR TITLE
Make ITheme/IPartialTheme to be identical with Theme/PartialTheme typings

### DIFF
--- a/change/@fluentui-theme-2020-10-12-13-41-45-xgao-theme-itheme-typing.json
+++ b/change/@fluentui-theme-2020-10-12-13-41-45-xgao-theme-itheme-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Make ITheme/IPartialTheme to be identical with Theme/PartialTheme typings.",
+  "packageName": "@fluentui/theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T20:41:45.515Z"
+}

--- a/change/office-ui-fabric-react-2020-10-12-15-21-55-xgao-theme-itheme-typing.json
+++ b/change/office-ui-fabric-react-2020-10-12-15-21-55-xgao-theme-itheme-typing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update office-ui-fabric-react.api.md due to ITheme typing change.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T22:21:55.030Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1322,7 +1322,7 @@ export const getMeasurementCache: () => {
 };
 
 // @public (undocumented)
-export const getMenuItemStyles: (theme: ITheme) => IMenuItemStyles;
+export const getMenuItemStyles: (theme: import("@fluentui/theme/lib/types").Theme) => IMenuItemStyles;
 
 // @public
 export const getNextResizeGroupStateProvider: (measurementCache?: {

--- a/packages/theme/etc/theme.api.md
+++ b/packages/theme/etc/theme.api.md
@@ -58,13 +58,15 @@ export namespace CommunicationColors {
     tint40 = "#eff6fc";
 }
 
-// @public (undocumented)
+// @public
+export type ComponentsStyles = {
+    [componentName: string]: ComponentStyles;
+};
+
+// @public
 export interface ComponentStyles {
-    // (undocumented)
-    [componentName: string]: {
-        styles?: IStyleFunctionOrObject<any, any>;
-        variants?: Variants;
-    };
+    styles?: IStyleFunctionOrObject<any, any>;
+    variants?: Variants;
 }
 
 // @public (undocumented)
@@ -383,20 +385,7 @@ export interface IPalette {
 }
 
 // @public (undocumented)
-export type IPartialTheme = {
-    palette?: Partial<IPalette>;
-    fonts?: Partial<IFontStyles>;
-    defaultFontStyle?: IRawStyle;
-    semanticColors?: Partial<ISemanticColors>;
-    isInverted?: boolean;
-    disableGlobalClassNames?: boolean;
-    rtl?: boolean;
-    spacing?: Partial<ISpacing>;
-    effects?: Partial<IEffects>;
-    schemes?: {
-        [P in ISchemeNames]?: IScheme;
-    };
-};
+export type IPartialTheme = PartialTheme;
 
 // @public (undocumented)
 export interface IScheme {
@@ -556,12 +545,7 @@ export interface ISpacing {
 }
 
 // @public (undocumented)
-export interface ITheme extends IScheme {
-    // @internal
-    schemes?: {
-        [P in ISchemeNames]?: IScheme;
-    };
-}
+export type ITheme = Theme;
 
 // @public (undocumented)
 export namespace LocalizedFontFamilies {
@@ -733,12 +717,35 @@ export namespace NeutralColors {
 }
 
 // @public
-export interface PartialTheme extends IPartialTheme {
+export interface PartialTheme {
     // (undocumented)
-    components?: ComponentStyles;
+    components?: ComponentsStyles;
+    defaultFontStyle?: IRawStyle;
+    // (undocumented)
+    disableGlobalClassNames?: boolean;
+    // (undocumented)
+    effects?: Partial<IEffects>;
+    // (undocumented)
+    fonts?: Partial<IFontStyles>;
+    // (undocumented)
+    isInverted?: boolean;
+    // (undocumented)
+    palette?: Partial<IPalette>;
+    // (undocumented)
+    rtl?: boolean;
+    // @internal
+    schemes?: {
+        [P in ISchemeNames]?: IScheme;
+    };
+    // (undocumented)
+    semanticColors?: Partial<ISemanticColors>;
+    // Warning: (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
+    //
+    // (undocumented)
+    spacing?: Partial<ISpacing>;
     // (undocumented)
     stylesheets?: string[];
-    // (undocumented)
+    // @internal
     tokens?: RecursivePartial<Tokens>;
 }
 
@@ -826,12 +833,14 @@ export namespace SharedColors {
 export type SizeValue = 'smallest' | 'smaller' | 'small' | 'medium' | 'large' | 'larger' | 'largest';
 
 // @public
-export interface Theme extends ITheme {
-    // (undocumented)
-    components?: ComponentStyles;
-    // (undocumented)
+export interface Theme extends IScheme {
+    components?: ComponentsStyles;
+    // @internal
     id?: string;
-    // (undocumented)
+    // @internal
+    schemes?: {
+        [P in ISchemeNames]?: IScheme;
+    };
     stylesheets?: string[];
     // @internal
     tokens?: RecursivePartial<Tokens>;
@@ -854,14 +863,9 @@ export type TokenSetType = {
     [key: string]: TokenSetType | string | number | undefined;
 };
 
-// @public (undocumented)
+// @public
 export type Variants = Record<string, any>;
 
-
-// Warnings were encountered during analysis:
-//
-// lib/types/ITheme.d.ts:70:5 - (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
-// lib/types/ITheme.d.ts:72:5 - (ae-incompatible-release-tags) The symbol "schemes" is marked as @public, but its signature references "ISchemeNames" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/theme/src/types/IScheme.ts
+++ b/packages/theme/src/types/IScheme.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { IPalette } from './IPalette';
+import { IFontStyles } from './IFontStyles';
+import { ISemanticColors } from './ISemanticColors';
+import { ISpacing } from './ISpacing';
+import { IEffects } from './IEffects';
+
+/**
+ * @internal
+ * Predefined scheme identifiers.
+ * Schemes are is still in an experimental phase.
+ * This interface's naming and values are not finalized and are subject to change.
+ * {@docCategory IScheme}
+ */
+export type ISchemeNames = 'default' | 'neutral' | 'soft' | 'strong';
+
+/**
+ * {@docCategory IScheme}
+ */
+export interface IScheme {
+  rtl?: boolean;
+  palette: IPalette;
+  fonts: IFontStyles;
+  semanticColors: ISemanticColors;
+  isInverted: boolean;
+
+  /**
+   * This setting is for a very narrow use case and you probably don't need to worry about,
+   * unless you share a environment with others that also use fabric.
+   * It is used for disabling global styles on fabric components. This will prevent global
+   * overrides that might have been set by other fabric users from applying to your components.
+   * When you set this setting to `true` on your theme the components in the subtree of your
+   * Customizer will not get the global styles applied to them.
+   */
+  disableGlobalClassNames: boolean;
+
+  /**
+   * @internal
+   * The spacing property is still in an experimental phase. The intent is to have it
+   * be used for padding and margin sizes in a future release, but it is still undergoing review.
+   * Avoid using it until it is finalized.
+   */
+  spacing: ISpacing;
+
+  effects: IEffects;
+}

--- a/packages/theme/src/types/ITheme.ts
+++ b/packages/theme/src/types/ITheme.ts
@@ -1,82 +1,12 @@
-/* eslint-disable @typescript-eslint/naming-convention */
-
-import { IPalette } from './IPalette';
-import { IFontStyles } from './IFontStyles';
-import { ISemanticColors } from './ISemanticColors';
-import { ISpacing } from './ISpacing';
-import { IEffects } from './IEffects';
-import { IRawStyle } from '@uifabric/merge-styles';
-
-/**
- * @internal
- * Predefined scheme identifiers.
- * Schemes are is still in an experimental phase.
- * This interface's naming and values are not finalized and are subject to change.
- * {@docCategory IScheme}
- */
-export type ISchemeNames = 'default' | 'neutral' | 'soft' | 'strong';
-
-/**
- * {@docCategory IScheme}
- */
-export interface IScheme {
-  rtl?: boolean;
-  palette: IPalette;
-  fonts: IFontStyles;
-  semanticColors: ISemanticColors;
-  isInverted: boolean;
-
-  /**
-   * This setting is for a very narrow use case and you probably don't need to worry about,
-   * unless you share a environment with others that also use fabric.
-   * It is used for disabling global styles on fabric components. This will prevent global
-   * overrides that might have been set by other fabric users from applying to your components.
-   * When you set this setting to `true` on your theme the components in the subtree of your
-   * Customizer will not get the global styles applied to them.
-   */
-  disableGlobalClassNames: boolean;
-
-  /**
-   * @internal
-   * The spacing property is still in an experimental phase. The intent is to have it
-   * be used for padding and margin sizes in a future release, but it is still undergoing review.
-   * Avoid using it until it is finalized.
-   */
-  spacing: ISpacing;
-
-  effects: IEffects;
-}
+import { Theme, PartialTheme } from './Theme';
+export { ISchemeNames, IScheme } from './IScheme';
 
 /**
  * {@docCategory ITheme}
  */
-export interface ITheme extends IScheme {
-  /**
-   * @internal
-   * The schemes property is still in an experimental phase. The intent is to have it work
-   * in conjunction with new 'schemes' prop that any component making use of Foundation can use.
-   * Alternative themes that can be referred to by name.
-   */
-  schemes?: { [P in ISchemeNames]?: IScheme };
-}
+export type ITheme = Theme;
 
 /**
  * {@docCategory ITheme}
  */
-export type IPartialTheme = {
-  palette?: Partial<IPalette>;
-  fonts?: Partial<IFontStyles>;
-
-  /**
-   * Use this property to specify font property defaults.
-   */
-  defaultFontStyle?: IRawStyle;
-
-  semanticColors?: Partial<ISemanticColors>;
-  isInverted?: boolean;
-  disableGlobalClassNames?: boolean;
-  rtl?: boolean;
-  spacing?: Partial<ISpacing>;
-  effects?: Partial<IEffects>;
-  schemes?: { [P in ISchemeNames]?: IScheme };
-};
+export type IPartialTheme = PartialTheme;

--- a/packages/theme/src/types/Theme.ts
+++ b/packages/theme/src/types/Theme.ts
@@ -1,5 +1,11 @@
-import { IPartialTheme, ITheme } from './ITheme';
+import { IRawStyle } from '@uifabric/merge-styles';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
+import { IPalette } from './IPalette';
+import { IFontStyles } from './IFontStyles';
+import { ISemanticColors } from './ISemanticColors';
+import { ISpacing } from './ISpacing';
+import { IEffects } from './IEffects';
+import { IScheme, ISchemeNames } from './IScheme';
 
 /**
  * A ramp of size values.
@@ -79,36 +85,108 @@ export interface Tokens {
   [key: string]: TokenSetType;
 }
 
+/**
+ * A set of style configurations for variants of a component (e.g. primary is a variant for the Button component).
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export declare type Variants = Record<string, any>;
+export type Variants = Record<string, any>;
 
+/**
+ * {@docCategory Theme}
+ * Component-level styles and variants.
+ */
 export interface ComponentStyles {
-  [componentName: string]: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    styles?: IStyleFunctionOrObject<any, any>;
-    variants?: Variants;
-  };
+  /**
+   * styles prop for a component.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  styles?: IStyleFunctionOrObject<any, any>;
+
+  /**
+   * The variants property is still in an experimental phase. This is only applied by `ThemeProvider`.
+   */
+  variants?: Variants;
 }
 
 /**
+ * {@docCategory Theme}
+ * Component-level styles and token set.
+ */
+export type ComponentsStyles = {
+  [componentName: string]: ComponentStyles;
+};
+
+/**
+ * {@docCategory Theme}
  * A prepared (fully expanded) theme object.
  */
-export interface Theme extends ITheme {
-  components?: ComponentStyles;
+export interface Theme extends IScheme {
+  /**
+   * Component-level styles and token set.
+   * This is still in an experimental phase and is only applied by `ThemeProvider`.
+   */
+  components?: ComponentsStyles;
+
+  /**
+   * CSS stylesheets to be registered.
+   * This is still in an experimental phase and is only applied by `ThemeProvider`.
+   */
   stylesheets?: string[];
+
+  /**
+   * @internal
+   * Id of the theme. This is for internal use only.
+   */
   id?: string;
 
-  /** @internal
-   * This is currently only for internal use and not production-ready.
+  /**
+   * @internal
+   * Global tokens. This is for internal use only and is not production-ready.
    * */
   tokens?: RecursivePartial<Tokens>;
+
+  /**
+   * @internal
+   * The schemes property is still in an experimental phase. The intent is to have it work
+   * in conjunction with new 'schemes' prop that any component making use of Foundation can use.
+   * Alternative themes that can be referred to by name.
+   */
+  schemes?: { [P in ISchemeNames]?: IScheme };
 }
 
 /**
- * A partial theme object.
+ * {@docCategory Theme}
+ * A partial theme.
  */
-export interface PartialTheme extends IPartialTheme {
-  components?: ComponentStyles;
-  tokens?: RecursivePartial<Tokens>;
+export interface PartialTheme {
+  components?: ComponentsStyles;
   stylesheets?: string[];
+
+  palette?: Partial<IPalette>;
+  fonts?: Partial<IFontStyles>;
+  semanticColors?: Partial<ISemanticColors>;
+  isInverted?: boolean;
+  disableGlobalClassNames?: boolean;
+  rtl?: boolean;
+  spacing?: Partial<ISpacing>;
+  effects?: Partial<IEffects>;
+
+  /**
+   * Use this property to specify font property defaults.
+   */
+  defaultFontStyle?: IRawStyle;
+
+  /**
+   * @internal
+   * Global tokens. This is experimental and not production-ready.
+   * */
+  tokens?: RecursivePartial<Tokens>;
+
+  /**
+   * @internal
+   * The schemes property is still in an experimental phase. The intent is to have it work
+   * in conjunction with new 'schemes' prop that any component making use of Foundation can use.
+   * Alternative themes that can be referred to by name.
+   */
+  schemes?: { [P in ISchemeNames]?: IScheme };
 }

--- a/packages/theme/src/types/index.ts
+++ b/packages/theme/src/types/index.ts
@@ -5,5 +5,6 @@ export { ISemanticColors } from './ISemanticColors';
 export { ISemanticTextColors } from './ISemanticTextColors';
 export { ISpacing } from './ISpacing';
 export { IAnimationStyles, IAnimationVariables } from './IAnimationStyles';
-export { ITheme, IPartialTheme, IScheme, ISchemeNames } from './ITheme';
+export { IScheme, ISchemeNames } from './IScheme';
+export { ITheme, IPartialTheme } from './ITheme';
 export * from './Theme';


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Moved properties defined in `ITheme` and `IPartialTheme` to `Theme` and `PartialTheme`. Let `ITheme` and `IPartialTheme` simply equal to `Theme` and `PartialTheme`. 
- Added `docCategory` for `Theme`.

#### Focus areas to test
References on website:
http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/15480/merge/fabric-website/dist/index.html?devhost#/controls/web/references/theme

http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/15480/merge/fabric-website/dist/index.html?devhost#/controls/web/references/itheme