### PR TITLE
Update theme instances to contain components (scopedSettings)

### DIFF
--- a/change/@uifabric-azure-themes-2020-10-12-13-37-09-xgao-theme-packages.json
+++ b/change/@uifabric-azure-themes-2020-10-12-13-37-09-xgao-theme-packages.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Theme instances to contain components/scopedSettings.",
+  "packageName": "@uifabric/azure-themes",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T20:37:00.499Z"
+}

--- a/change/@uifabric-mdl2-theme-2020-10-12-13-37-09-xgao-theme-packages.json
+++ b/change/@uifabric-mdl2-theme-2020-10-12-13-37-09-xgao-theme-packages.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Theme instances to contain components/scopedSettings",
+  "packageName": "@uifabric/mdl2-theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T20:37:07.538Z"
+}

--- a/change/@uifabric-theme-samples-2020-10-12-13-37-09-xgao-theme-packages.json
+++ b/change/@uifabric-theme-samples-2020-10-12-13-37-09-xgao-theme-packages.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Theme instances to contain components/scopedSettings",
+  "packageName": "@uifabric/theme-samples",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-12T20:37:09.681Z"
+}

--- a/packages/azure-themes/README.md
+++ b/packages/azure-themes/README.md
@@ -6,17 +6,34 @@
 The Azure themes require the following import statements:
 
 ```js
-import { Fabric, Customizer } from '@fluentui/react';
-import { AzureCustomizationsLight, AzureCustomizationsDark } from '@uifabric/azure-themes';
+import {
+  AzureThemeDark,
+  AzureThemeLight,
+  AzureCustomizationsLight,
+  AzureCustomizationsDark,
+} from '@uifabric/azure-themes';
 ```
 
-The theme may subsequently be set to either the Azure or Azure-Dark themes
+The theme may subsequently be set to either the Azure or Azure-Dark themes.
+
+In case of applying theme using `Customizer`:
 
 ```jsx
-  const customizations = AzureCustomizationsDark // or alternatively AzureCustomizationsLight
+  import { Customizer } from '@fluentui/react';
+  const customizations = AzureCustomizationsDark; // or alternatively AzureCustomizationsLight
+
   <Customizer {...customizations}>
-    <Fabric>
-        <div>{child component}</div>
-    </Fabric>
+    <div>{child component}</div>
   </Customizer>
+```
+
+In case of applying theme using `ThemeProvider`:
+
+```jsx
+  import { ThemeProvider } from '@fluentui/react-theme-provider';
+  const theme = AzureThemeDark; // or alternatively AzureThemeLight
+
+  <ThemeProvider theme={theme}>
+    <div>{child component}</div>
+  </ThemeProvider>
 ```

--- a/packages/azure-themes/package.json
+++ b/packages/azure-themes/package.json
@@ -30,6 +30,7 @@
     "react": "16.8.6"
   },
   "dependencies": {
+    "@fluentui/theme": "^1.4.0",
     "@uifabric/merge-styles": "^7.19.1",
     "@uifabric/set-version": "^7.0.23",
     "office-ui-fabric-react": "^7.146.1",

--- a/packages/azure-themes/src/AzureCustomizations.ts
+++ b/packages/azure-themes/src/AzureCustomizations.ts
@@ -3,32 +3,36 @@ import { AzureThemeDark } from './azure/AzureThemeDark';
 import { AzureThemeLight } from './azure/AzureThemeLight';
 import { AzureThemeHighContrastLight } from './azure/AzureThemeHighContrastLight';
 import { AzureThemeHighContrastDark } from './azure/AzureThemeHighContrastDark';
-import { AzureStyleSettings } from './azure/AzureStyleSettings';
+
+const { components: darkScopedSettings, ...darkThemeSettings } = AzureThemeDark;
+const { components: lightScopedSettings, ...lightThemeSettings } = AzureThemeLight;
+const { components: hcLightScopedSettings, ...hcLightThemeSettings } = AzureThemeHighContrastLight;
+const { components: hcDarkScopedSettings, ...hcDarkThemeSettings } = AzureThemeHighContrastDark;
 
 export const AzureCustomizationsDark: ICustomizations = {
   settings: {
-    theme: { ...AzureThemeDark },
+    theme: darkThemeSettings,
   },
-  scopedSettings: { ...AzureStyleSettings(AzureThemeDark) },
+  scopedSettings: { ...darkScopedSettings },
 };
 
 export const AzureCustomizationsLight: ICustomizations = {
   settings: {
-    theme: { ...AzureThemeLight },
+    theme: lightThemeSettings,
   },
-  scopedSettings: { ...AzureStyleSettings(AzureThemeLight) },
+  scopedSettings: { ...lightScopedSettings },
 };
 
 export const AzureCustomizationsHighContrastLight: ICustomizations = {
   settings: {
-    theme: { ...AzureThemeHighContrastLight },
+    theme: hcLightThemeSettings,
   },
-  scopedSettings: { ...AzureStyleSettings(AzureThemeHighContrastLight) },
+  scopedSettings: { ...hcLightScopedSettings },
 };
 
 export const AzureCustomizationsHighContrastDark: ICustomizations = {
   settings: {
-    theme: { ...AzureThemeHighContrastDark },
+    theme: hcDarkThemeSettings,
   },
-  scopedSettings: { ...AzureStyleSettings(AzureThemeHighContrastDark) },
+  scopedSettings: { ...hcDarkScopedSettings },
 };

--- a/packages/azure-themes/src/azure/AzureThemeDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeDark.ts
@@ -1,8 +1,9 @@
-import { createTheme, ITheme } from 'office-ui-fabric-react';
+import { createTheme, Theme } from '@fluentui/theme';
 import { CommonSemanticColors, DarkSemanticColors } from './AzureColors';
 import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
+import { AzureStyleSettings } from './AzureStyleSettings';
 
 const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: DarkSemanticColors.background,
@@ -125,7 +126,7 @@ const darkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   linkBorderStyle: 'dashed',
 };
 
-export const AzureThemeDark: ITheme = createTheme({
+export const AzureThemeDark: Theme = createTheme({
   fonts: {
     medium: {
       fontFamily: StyleConstants.fontFamily,
@@ -148,3 +149,5 @@ export const AzureThemeDark: ITheme = createTheme({
   },
   semanticColors: darkExtendedSemanticColors,
 });
+
+AzureThemeDark.components = AzureStyleSettings(AzureThemeDark);

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastDark.ts
@@ -1,8 +1,9 @@
-import { createTheme, ITheme } from 'office-ui-fabric-react';
+import { createTheme, Theme } from '@fluentui/theme';
 import { CommonSemanticColors, HighContrastDarkSemanticColors } from './AzureColors';
 import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
+import { AzureStyleSettings } from './AzureStyleSettings';
 
 const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: HighContrastDarkSemanticColors.background,
@@ -125,7 +126,7 @@ const highContrastDarkExtendedSemanticColors: Partial<IExtendedSemanticColors> =
   linkBorderStyle: 'dashed',
 };
 
-export const AzureThemeHighContrastDark: ITheme = createTheme({
+export const AzureThemeHighContrastDark: Theme = createTheme({
   fonts: {
     medium: {
       fontFamily: StyleConstants.fontFamily,
@@ -148,3 +149,5 @@ export const AzureThemeHighContrastDark: ITheme = createTheme({
   },
   semanticColors: highContrastDarkExtendedSemanticColors,
 });
+
+AzureThemeHighContrastDark.components = AzureStyleSettings(AzureThemeHighContrastDark);

--- a/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeHighContrastLight.ts
@@ -1,8 +1,9 @@
-import { createTheme, ITheme } from 'office-ui-fabric-react';
+import { createTheme, Theme } from '@fluentui/theme';
 import { CommonSemanticColors, HighContrastLightSemanticColors } from './AzureColors';
 import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
+import { AzureStyleSettings } from './AzureStyleSettings';
 
 const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: HighContrastLightSemanticColors.background,
@@ -126,7 +127,7 @@ const highContrastLightExtendedSemanticColors: Partial<IExtendedSemanticColors> 
   linkBorderStyle: 'dashed',
 };
 
-export const AzureThemeHighContrastLight: ITheme = createTheme({
+export const AzureThemeHighContrastLight: Theme = createTheme({
   fonts: {
     medium: {
       fontFamily: StyleConstants.fontFamily,
@@ -149,3 +150,5 @@ export const AzureThemeHighContrastLight: ITheme = createTheme({
   },
   semanticColors: highContrastLightExtendedSemanticColors,
 });
+
+AzureThemeHighContrastLight.components = AzureStyleSettings(AzureThemeHighContrastLight);

--- a/packages/azure-themes/src/azure/AzureThemeLight.ts
+++ b/packages/azure-themes/src/azure/AzureThemeLight.ts
@@ -1,8 +1,9 @@
-import { createTheme, ITheme } from 'office-ui-fabric-react';
+import { createTheme, Theme } from '@fluentui/theme';
 import { CommonSemanticColors, LightSemanticColors } from './AzureColors';
 import { IExtendedSemanticColors } from './IExtendedSemanticColors';
 import { FontSizes } from './AzureType';
 import * as StyleConstants from './Constants';
+import { AzureStyleSettings } from './AzureStyleSettings';
 
 const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   bodyBackground: LightSemanticColors.background,
@@ -125,7 +126,7 @@ const lightExtendedSemanticColors: Partial<IExtendedSemanticColors> = {
   linkBorderStyle: 'dashed',
 };
 
-export const AzureThemeLight: ITheme = createTheme({
+export const AzureThemeLight: Theme = createTheme({
   fonts: {
     medium: {
       fontFamily: StyleConstants.fontFamily,
@@ -148,3 +149,5 @@ export const AzureThemeLight: ITheme = createTheme({
   },
   semanticColors: lightExtendedSemanticColors,
 });
+
+AzureThemeLight.components = AzureStyleSettings(AzureThemeLight);

--- a/packages/mdl2-theme/README.md
+++ b/packages/mdl2-theme/README.md
@@ -8,5 +8,25 @@ This package contains MDL2 coloring, theming and styling for use with Fluent UI 
 To import MDL2 theme:
 
 ```js
-import { MDL2Customizations } from '@uifabric/mdl2-theme';
+import { MDL2Theme, MDL2Customizations } from '@uifabric/mdl2-theme';
+```
+
+In case of applying theme using `Customizer`:
+
+```jsx
+  import { Customizer } from '@fluentui/react';
+
+  <Customizer {...MDL2Customizations}>
+    <div>{child component}</div>
+  </Customizer>
+```
+
+In case of applying theme using `ThemeProvider`:
+
+```jsx
+  import { ThemeProvider } from '@fluentui/react-theme-provider';
+
+  <ThemeProvider theme={MDL2Theme}>
+    <div>{child component}</div>
+  </ThemeProvider>
 ```

--- a/packages/mdl2-theme/package.json
+++ b/packages/mdl2-theme/package.json
@@ -26,6 +26,7 @@
     "@uifabric/build": "^7.0.0"
   },
   "dependencies": {
+    "@fluentui/theme": "^1.4.0",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.11",
     "@uifabric/variants": "^7.2.24",

--- a/packages/mdl2-theme/src/MDL2Customizations.ts
+++ b/packages/mdl2-theme/src/MDL2Customizations.ts
@@ -1,13 +1,14 @@
 import { MDL2Theme } from './mdl2/MDL2Theme';
-import { MDL2Styles } from './mdl2/MDL2Styles';
 import { ICustomizations } from 'office-ui-fabric-react';
 import { addVariants } from '@uifabric/variants';
 
+const { components: scopedSettings, ...theme } = MDL2Theme;
+
 export const MDL2Customizations: ICustomizations = {
   settings: {
-    theme: { ...MDL2Theme },
+    theme,
   },
-  scopedSettings: { ...MDL2Styles },
+  scopedSettings: { ...scopedSettings },
 };
 
 addVariants(MDL2Customizations.settings.theme);

--- a/packages/mdl2-theme/src/mdl2/MDL2Theme.ts
+++ b/packages/mdl2-theme/src/mdl2/MDL2Theme.ts
@@ -1,7 +1,8 @@
-import { createTheme, ITheme, FontWeights } from '@uifabric/styling';
+import { createTheme, Theme, FontWeights } from '@fluentui/theme';
+import { MDL2Styles } from './MDL2Styles';
 import { FontSizes } from './MDL2Type';
 
-export const MDL2Theme: ITheme = createTheme({
+export const MDL2Theme: Theme = createTheme({
   palette: {
     neutralDark: '#212121',
     neutralPrimary: '#333333',
@@ -79,6 +80,7 @@ export const MDL2Theme: ITheme = createTheme({
       fontWeight: FontWeights.light,
     },
   },
+  components: MDL2Styles,
 });
 
 export default MDL2Theme;

--- a/packages/mdl2-theme/src/mdl2/styles/Label.styles.ts
+++ b/packages/mdl2-theme/src/mdl2/styles/Label.styles.ts
@@ -1,4 +1,4 @@
-import { FontWeights } from '@uifabric/styling';
+import { FontWeights } from '@fluentui/theme';
 
 export const LabelStyles = {
   root: {

--- a/packages/theme-samples/package.json
+++ b/packages/theme-samples/package.json
@@ -26,6 +26,7 @@
     "@uifabric/build": "^7.0.0"
   },
   "dependencies": {
+    "@fluentui/theme": "^1.4.0",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/variants": "^7.2.24",
     "office-ui-fabric-react": "^7.146.1",

--- a/packages/theme-samples/src/DarkCustomizations/DarkCustomizations.ts
+++ b/packages/theme-samples/src/DarkCustomizations/DarkCustomizations.ts
@@ -1,11 +1,5 @@
-import {
-  createTheme,
-  ICustomizations,
-  IPalette,
-  ITheme,
-  IPersonaCoinStyleProps,
-  IPersonaCoinStyles,
-} from 'office-ui-fabric-react';
+import { ICustomizations, IPalette, IPersonaCoinStyleProps, IPersonaCoinStyles } from 'office-ui-fabric-react';
+import { createTheme, Theme } from '@fluentui/theme';
 import { DatePickerStyles } from './styles/DatePickerStyles';
 import { PeoplePickerItemStyles } from './styles/PeoplePickerStyles';
 import { addVariants } from '@uifabric/variants';
@@ -37,7 +31,15 @@ const DarkDefaultPalette: Partial<IPalette> = {
   redDark: '#F1707B',
 };
 
-export const DarkTheme: ITheme = createTheme({
+export const PersonaCoinStyles = (props: IPersonaCoinStyleProps): Partial<IPersonaCoinStyles> => {
+  return {
+    initials: {
+      color: props.showUnknownPersonaCoin ? DarkTheme.palette.redDark : DarkTheme.palette.black,
+    },
+  };
+};
+
+export const DarkTheme: Theme = createTheme({
   palette: DarkDefaultPalette,
   semanticColors: {
     buttonText: DarkDefaultPalette.black,
@@ -57,156 +59,151 @@ export const DarkTheme: ITheme = createTheme({
   isInverted: true,
 });
 
-export const PersonaCoinStyles = (props: IPersonaCoinStyleProps): Partial<IPersonaCoinStyles> => {
-  return {
-    initials: {
-      color: props.showUnknownPersonaCoin ? DarkTheme.palette.redDark : DarkTheme.palette.black,
+const componentStyles = {
+  Card: {
+    styles: {
+      root: {
+        background: DarkTheme.palette.neutralLighter,
+      },
     },
-  };
+  },
+  DatePicker: {
+    styles: DatePickerStyles,
+  },
+  DetailsList: {
+    styles: {
+      headerWrapper: {
+        selectors: {
+          '.ms-DetailsHeader': {
+            borderColor: DarkTheme.palette.neutralQuaternary,
+          },
+        },
+      },
+    },
+  },
+  ActionButton: {
+    styles: {
+      root: {
+        backgroundColor: DarkTheme.palette.white,
+      },
+      rootDisabled: {
+        backgroundColor: DarkTheme.palette.neutralLighter,
+      },
+      rootHovered: {
+        backgroundColor: DarkTheme.palette.neutralLight,
+      },
+      rootPressed: {
+        backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
+      },
+    },
+  },
+  DetailsRow: {
+    styles: {
+      root: {
+        selectors: {
+          ':hover': {
+            background: DarkTheme.palette.neutralLighter,
+          },
+        },
+        borderColor: DarkTheme.palette.neutralQuaternaryAlt,
+      },
+    },
+  },
+  Modal: {
+    styles: {
+      main: {
+        backgroundColor: DarkTheme.palette.neutralLighter,
+      },
+    },
+  },
+  Overlay: {
+    styles: {
+      root: {
+        background: DarkTheme.palette.blackTranslucent40,
+      },
+    },
+  },
+  VerticalDivider: {
+    styles: {
+      divider: {
+        backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
+      },
+      wrapper: {
+        Backgroundcolor: DarkTheme.palette.green,
+      },
+    },
+  },
+  DocumentCard: {
+    styles: {
+      root: {
+        border: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
+        selectors: {
+          '.ms-DocumentCardPreview': {
+            borderRight: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
+          },
+        },
+      },
+    },
+  },
+  DocumentCardPreview: {
+    styles: {
+      root: {
+        borderBottom: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
+        borderRight: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
+      },
+    },
+  },
+  Panel: {
+    styles: {
+      main: {
+        backgroundColor: DarkTheme.palette.neutralLighter,
+      },
+      closeButton: {
+        color: DarkTheme.palette.neutralSecondary,
+        selectors: {
+          ':hover': {
+            color: DarkTheme.palette.neutralPrimary,
+          },
+        },
+      },
+    },
+  },
+  PeoplePickerItem: {
+    styles: PeoplePickerItemStyles,
+  },
+  PersonaCoin: {
+    styles: PersonaCoinStyles,
+  },
+  Separator: {
+    styles: {
+      root: {
+        selectors: {
+          ':before': {
+            backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
+          },
+          ':after': {
+            backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
+          },
+        },
+      },
+    },
+  },
+  SpinButton: {
+    styles: {
+      inputTextSelected: {
+        color: DarkTheme.palette.black,
+        background: DarkTheme.palette.themePrimary,
+      },
+    },
+  },
 };
+
+DarkTheme.components = componentStyles;
+addVariants(DarkTheme);
 
 export const DarkCustomizations: ICustomizations = {
   settings: {
     theme: DarkTheme,
   },
-  scopedSettings: {
-    Card: {
-      styles: {
-        root: {
-          background: DarkTheme.palette.neutralLighter,
-        },
-      },
-    },
-    DatePicker: {
-      styles: DatePickerStyles,
-    },
-    DetailsList: {
-      styles: {
-        headerWrapper: {
-          selectors: {
-            '.ms-DetailsHeader': {
-              borderColor: DarkTheme.palette.neutralQuaternary,
-            },
-          },
-        },
-      },
-    },
-    ActionButton: {
-      styles: {
-        root: {
-          backgroundColor: DarkTheme.palette.white,
-        },
-        rootDisabled: {
-          backgroundColor: DarkTheme.palette.neutralLighter,
-        },
-        rootHovered: {
-          backgroundColor: DarkTheme.palette.neutralLight,
-        },
-        rootPressed: {
-          backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
-        },
-      },
-    },
-    DetailsRow: {
-      styles: {
-        root: {
-          selectors: {
-            ':hover': {
-              background: DarkTheme.palette.neutralLighter,
-            },
-          },
-          borderColor: DarkTheme.palette.neutralQuaternaryAlt,
-        },
-      },
-    },
-    Modal: {
-      styles: {
-        main: {
-          backgroundColor: DarkTheme.palette.neutralLighter,
-        },
-      },
-    },
-    Overlay: {
-      styles: {
-        root: {
-          background: DarkTheme.palette.blackTranslucent40,
-        },
-      },
-    },
-    VerticalDivider: {
-      styles: {
-        divider: {
-          backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
-        },
-        wrapper: {
-          Backgroundcolor: DarkTheme.palette.green,
-        },
-      },
-    },
-    DocumentCard: {
-      styles: {
-        root: {
-          border: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
-          selectors: {
-            '.ms-DocumentCardPreview': {
-              borderRight: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
-            },
-          },
-        },
-      },
-    },
-    DocumentCardPreview: {
-      styles: {
-        root: {
-          borderBottom: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
-          borderRight: `1px solid ${DarkTheme.palette.neutralQuaternaryAlt}`,
-        },
-      },
-    },
-    Panel: {
-      styles: {
-        main: {
-          backgroundColor: DarkTheme.palette.neutralLighter,
-        },
-        closeButton: {
-          color: DarkTheme.palette.neutralSecondary,
-          selectors: {
-            ':hover': {
-              color: DarkTheme.palette.neutralPrimary,
-            },
-          },
-        },
-      },
-    },
-    PeoplePickerItem: {
-      styles: PeoplePickerItemStyles,
-    },
-    PersonaCoin: {
-      styles: PersonaCoinStyles,
-    },
-    Separator: {
-      styles: {
-        root: {
-          selectors: {
-            ':before': {
-              backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
-            },
-            ':after': {
-              backgroundColor: DarkTheme.palette.neutralQuaternaryAlt,
-            },
-          },
-        },
-      },
-    },
-    SpinButton: {
-      styles: {
-        inputTextSelected: {
-          color: DarkTheme.palette.black,
-          background: DarkTheme.palette.themePrimary,
-        },
-      },
-    },
-  },
+  scopedSettings: componentStyles,
 };
-
-addVariants(DarkCustomizations.settings.theme);

--- a/packages/theme-samples/src/DefaultCustomizations.ts
+++ b/packages/theme-samples/src/DefaultCustomizations.ts
@@ -1,11 +1,12 @@
 import { createTheme, ICustomizations } from 'office-ui-fabric-react';
 import { addVariants } from '@uifabric/variants';
 
+export const DefaultTheme = createTheme();
+addVariants(DefaultTheme);
+
 export const DefaultCustomizations: ICustomizations = {
   settings: {
-    theme: createTheme({}),
+    theme: DefaultTheme,
   },
   scopedSettings: {},
 };
-
-addVariants(DefaultCustomizations.settings.theme);

--- a/packages/theme-samples/src/TeamsCustomizations.ts
+++ b/packages/theme-samples/src/TeamsCustomizations.ts
@@ -1,90 +1,50 @@
 import { createTheme, ICustomizations } from 'office-ui-fabric-react';
 import { addVariants } from '@uifabric/variants';
+import { Theme } from '@fluentui/theme';
+
+export const TeamsTheme: Theme = createTheme({
+  palette: {
+    themePrimary: '#6061aa',
+    themeLighterAlt: '#f7f7fc',
+    themeLighter: '#e1e1f2',
+    themeLight: '#c7c8e6',
+    themeTertiary: '#9797cd',
+    themeSecondary: '#6f70b5',
+    themeDarkAlt: '#56579a',
+    themeDark: '#494a82',
+    themeDarker: '#363660',
+    neutralLighterAlt: '#f8f8f8',
+    neutralLighter: '#f4f4f4',
+    neutralLight: '#eaeaea',
+    neutralQuaternaryAlt: '#dadada',
+    neutralQuaternary: '#d0d0d0',
+    neutralTertiaryAlt: '#c8c8c8',
+    neutralTertiary: '#b6b0b0',
+    neutralSecondary: '#9f9797',
+    neutralPrimaryAlt: '#877f7f',
+    neutralPrimary: '#282424',
+    neutralDark: '#585151',
+    black: '#403b3b',
+    white: '#fff',
+  },
+  semanticColors: {
+    buttonBackground: 'transparent',
+    buttonBackgroundHovered: '#bdbdbd',
+    buttonBackgroundPressed: '#a7a7a7',
+
+    buttonText: '#252424',
+    buttonTextPressed: '#252424',
+    buttonTextHovered: '#252424',
+
+    buttonBorder: '#bdbdbd',
+  },
+});
+
+addVariants(TeamsTheme);
 
 export const TeamsCustomizations: ICustomizations = {
   settings: {
-    theme: createTheme({
-      palette: {
-        themePrimary: '#6061aa',
-        themeLighterAlt: '#f7f7fc',
-        themeLighter: '#e1e1f2',
-        themeLight: '#c7c8e6',
-        themeTertiary: '#9797cd',
-        themeSecondary: '#6f70b5',
-        themeDarkAlt: '#56579a',
-        themeDark: '#494a82',
-        themeDarker: '#363660',
-        neutralLighterAlt: '#f8f8f8',
-        neutralLighter: '#f4f4f4',
-        neutralLight: '#eaeaea',
-        neutralQuaternaryAlt: '#dadada',
-        neutralQuaternary: '#d0d0d0',
-        neutralTertiaryAlt: '#c8c8c8',
-        neutralTertiary: '#b6b0b0',
-        neutralSecondary: '#9f9797',
-        neutralPrimaryAlt: '#877f7f',
-        neutralPrimary: '#282424',
-        neutralDark: '#585151',
-        black: '#403b3b',
-        white: '#fff',
-      },
-      semanticColors: {
-        buttonBackground: 'transparent',
-        buttonBackgroundHovered: '#bdbdbd',
-        buttonBackgroundPressed: '#a7a7a7',
-
-        buttonText: '#252424',
-        buttonTextPressed: '#252424',
-        buttonTextHovered: '#252424',
-
-        buttonBorder: '#bdbdbd',
-      },
-    }),
+    theme: TeamsTheme,
   },
-
-  scopedSettings: {
-    Button: {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      tokens: (props: any) => {
-        return [
-          {
-            iconSize: 16,
-            iconWeight: 700,
-            textWeight: 400,
-          },
-          !props.circular && {
-            borderRadius: 3,
-            borderWidth: 2,
-            contentPadding: '4px 32px',
-          },
-          props.circular && {
-            borderWidth: 1,
-          },
-          !props.disabled && {
-            iconColor: '#252424', // this hardcoding doesn't work well with variants
-            borderColorHovered: 'transparent',
-            borderColorPressed: 'transparent',
-          },
-          props.expanded && {
-            borderColor: 'transparent',
-          },
-          props.circular &&
-            !props.disabled && {
-              backgroundColorHovered: '#464775', // this hardcoding doesn't work well with variants
-              backgroundColorPressed: '#464775', // this hardcoding doesn't work well with variants
-              textColorHovered: '#fff',
-              textColorPressed: '#fff',
-              iconColorHovered: '#fff',
-              iconColorPressed: '#fff',
-            },
-          props.primary &&
-            !props.disabled && {
-              iconColor: 'white',
-            },
-        ];
-      },
-    },
-  },
+  scopedSettings: {},
 };
-
-addVariants(TeamsCustomizations.settings.theme);

--- a/packages/theme-samples/src/WordCustomizations.ts
+++ b/packages/theme-samples/src/WordCustomizations.ts
@@ -8,7 +8,7 @@ export const WordTheme: Theme = createTheme({
     themeSecondary: '#366ec2',
   },
   semanticColors: {
-    buttonBackground: 'white',
+    buttonBackground: '#FFF',
     buttonBackgroundHovered: 'rgb(240, 240, 240)',
     buttonBackgroundPressed: 'rgb(240, 240, 240)',
     buttonText: 'rgb(43, 87, 154)',

--- a/packages/theme-samples/src/WordCustomizations.ts
+++ b/packages/theme-samples/src/WordCustomizations.ts
@@ -1,42 +1,27 @@
 import { createTheme, ICustomizations } from 'office-ui-fabric-react';
 import { addVariants } from '@uifabric/variants';
+import { Theme } from '@fluentui/theme';
+
+export const WordTheme: Theme = createTheme({
+  palette: {
+    themePrimary: '#2b579a',
+    themeSecondary: '#366ec2',
+  },
+  semanticColors: {
+    buttonBackground: 'white',
+    buttonBackgroundHovered: 'rgb(240, 240, 240)',
+    buttonBackgroundPressed: 'rgb(240, 240, 240)',
+    buttonText: 'rgb(43, 87, 154)',
+    buttonBorder: 'rgb(237, 235, 233)',
+  },
+});
+
+addVariants(WordTheme);
 
 export const WordCustomizations: ICustomizations = {
   settings: {
-    theme: createTheme({
-      palette: {
-        themePrimary: '#2b579a',
-        themeSecondary: '#366ec2',
-      },
-      semanticColors: {
-        buttonBackground: 'white',
-        buttonBackgroundHovered: 'rgb(240, 240, 240)',
-        buttonBackgroundPressed: 'rgb(240, 240, 240)',
-        buttonText: 'rgb(43, 87, 154)',
-        buttonBorder: 'rgb(237, 235, 233)',
-      },
-    }),
+    theme: WordTheme,
   },
 
-  scopedSettings: {
-    Button: {
-      /* eslint-disable @typescript-eslint/no-explicit-any */
-      tokens: (props: any) => {
-        return [
-          {
-            borderWidth: 1,
-            textSize: 13.5,
-            textWeight: 600,
-            iconSize: 12,
-            contentPadding: '0px 6px',
-          },
-          !props.circular && {
-            minHeight: 26,
-          },
-        ];
-      },
-    },
-  },
+  scopedSettings: {},
 };
-
-addVariants(WordCustomizations.settings.theme);


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
We recently added new typings for  theme and partial theme (`Theme` and `PartialTheme` without prefix `I`), which support a new property `components`. It's essentially the same as `scopedSettings`. This PR updates the theme instances we have in `azure-theme`, `mdl2-theme` and `theme-samples` packages to use the new typing and populate `components` property with scoped settings.
That way, when user uses `ThemeProvider`, they can simply pass these theme instances to `ThemeProvider` -> `theme` prop.

#### Focus areas to test

(optional)
