### PR TITLE
Operate Dialog in open mode to ensure accessible focus behavior

### DIFF
--- a/change/@fluentui-web-components-2020-10-13-15-51-52-users-chhol-reset-dialog-to-open-mode.json
+++ b/change/@fluentui-web-components-2020-10-13-15-51-52-users-chhol-reset-dialog-to-open-mode.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "operate dialog in open mode to ensure accessible focus behavior is supported",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-13T22:51:52.037Z"
+}

--- a/packages/web-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/src/dialog/dialog.stories.ts
@@ -1,5 +1,6 @@
 import { FluentDesignSystemProvider } from '../design-system-provider';
 import DialogTemplate from './fixtures/dialog.html';
+import DialogFastButtonsTemplate from './fixtures/dialog-button-test.html';
 import { FluentDialog } from './';
 
 // Prevent tree-shaking
@@ -11,3 +12,4 @@ export default {
 };
 
 export const Dialog = (): string => DialogTemplate;
+export const DialogButtonTest = (): string => DialogFastButtonsTemplate;

--- a/packages/web-components/src/dialog/fixtures/dialog-button-test.html
+++ b/packages/web-components/src/dialog/fixtures/dialog-button-test.html
@@ -1,0 +1,7 @@
+<fluent-design-system-provider use-defaults>
+  <fluent-dialog id="foo" aria-label="Simple dialog" modal="true">
+    <h2>Dialog with text and fluent buttons. The first button should receive focus</h2>
+    <fluent-button tabindex="0" id="element">Button Text</fluent-button>
+    <fluent-button tabindex="0" id="element">Button Text</fluent-button>
+  </fluent-dialog>
+</fluent-design-system-provider>

--- a/packages/web-components/src/dialog/index.ts
+++ b/packages/web-components/src/dialog/index.ts
@@ -15,9 +15,6 @@ import { DialogStyles as styles } from './dialog.styles';
   name: 'fluent-dialog',
   template,
   styles,
-  shadowOptions: {
-    mode: 'closed',
-  },
 })
 export class FluentDialog extends Dialog {}
 


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Due to issues with slotted content on the dialog this PR returns the dialog back to open mode to ensure accessible focus behavior can be achieved and works as expected.

#### Focus areas to test

(optional)
