### PR TITLE
CommandBar: fix incorrect aria role

### DIFF
--- a/change/@fluentui-react-examples-2020-10-14-15-35-39-xgao-fix-commandbar-a11y.json
+++ b/change/@fluentui-react-examples-2020-10-14-15-35-39-xgao-fix-commandbar-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update CommandBar related snanpshots after aria role update.",
+  "packageName": "@fluentui/react-examples",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-14T22:35:39.031Z"
+}

--- a/change/office-ui-fabric-react-2020-10-14-11-52-48-xgao-fix-commandbar-a11y.json
+++ b/change/office-ui-fabric-react-2020-10-14-11-52-48-xgao-fix-commandbar-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "CommandBar: fix incorrect role (WCAG 1.3.1)",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-14T18:52:48.704Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -126,6 +126,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
       >
         {/*Primary Items*/}
         <OverflowSet
+          role="none"
           componentRef={this._overflowSet}
           className={css(this._classNames.primarySet)}
           doNotContainWithinFocusZone={true}
@@ -138,6 +139,7 @@ export class CommandBarBase extends React.Component<ICommandBarProps, {}> implem
         {/*Secondary Items*/}
         {data.farItems && data.farItems.length > 0 && (
           <OverflowSet
+            role="none"
             className={css(this._classNames.secondarySet)}
             doNotContainWithinFocusZone={true}
             items={data.farItems}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`CommandBar renders commands correctly 1`] = `
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=
@@ -407,7 +407,7 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -58,7 +58,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=
@@ -998,7 +998,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=
@@ -1001,7 +1001,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.Lazy.Example.tsx.shot
@@ -57,7 +57,7 @@ exports[`Component Examples renders CommandBar.Lazy.Example.tsx correctly 1`] = 
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -58,7 +58,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -64,7 +64,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=
@@ -663,7 +663,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   flex-wrap: nowrap;
                   position: relative;
                 }
-            role="group"
+            role="none"
           >
             <div
               className=

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -56,7 +56,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=
@@ -436,7 +436,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=

--- a/packages/react-examples/src/react-next/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/react-examples/src/react-next/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -56,7 +56,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=
@@ -436,7 +436,7 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                 flex-wrap: nowrap;
                 position: relative;
               }
-          role="group"
+          role="none"
         >
           <div
             className=


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15535
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fix having incorrectly set `role="group"` in between `menubar` and `menuitem`.

#### Focus areas to test

(optional)
