### PR TITLE
Avoid using css vars for default styles applied by ThemeProvider

### DIFF
--- a/change/@fluentui-react-theme-provider-2020-10-14-17-14-36-xgao-themeprovider-ie11-safe.json
+++ b/change/@fluentui-react-theme-provider-2020-10-14-17-14-36-xgao-themeprovider-ie11-safe.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "do not use css vars for default styles applied by ThemeProvider.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T00:14:36.486Z"
+}

--- a/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
@@ -5,11 +5,6 @@ exports[`ThemeProvider can apply body theme to body 1`] = `
   class=
 
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -44,13 +39,13 @@ exports[`ThemeProvider can apply body theme to body 1`] = `
         --color-brand-secondaryContentColor: #ffffff;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: black;
+        color: white;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 />
 `;
@@ -60,11 +55,6 @@ exports[`ThemeProvider can apply body theme to body 2`] = `
   className=
       foo
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -108,11 +98,6 @@ exports[`ThemeProvider can apply body theme to none 1`] = `
   className=
       foo
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -156,13 +141,6 @@ exports[`ThemeProvider can handle a partial theme 1`] = `
   className=
 
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
-        --color-body-background: #ffffff;
-        --color-body-contentColor: #323130;
         --color-brand-background: #0078d4;
         --color-brand-borderColor: transparent;
         --color-brand-checked-background: #005a9e;
@@ -196,13 +174,13 @@ exports[`ThemeProvider can handle a partial theme 1`] = `
         --foo-background: red;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -214,13 +192,6 @@ exports[`ThemeProvider renders a div 1`] = `
   className=
 
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
-        --color-body-background: #ffffff;
-        --color-body-contentColor: #323130;
         --color-brand-background: #0078d4;
         --color-brand-borderColor: transparent;
         --color-brand-checked-background: #005a9e;
@@ -253,13 +224,13 @@ exports[`ThemeProvider renders a div 1`] = `
         --color-brand-secondaryContentColor: #ffffff;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -271,11 +242,6 @@ exports[`ThemeProvider renders a div with styling 1`] = `
   className=
 
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
         --color-body-background: white;
         --color-body-contentColor: black;
         --color-brand-background: #0078d4;
@@ -310,13 +276,13 @@ exports[`ThemeProvider renders a div with styling 1`] = `
         --color-brand-secondaryContentColor: #ffffff;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: white;
+        color: black;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -328,11 +294,6 @@ exports[`ThemeProvider renders nested themes 1`] = `
   className=
 
       {
-        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        --body-fontSize: 14px;
-        --body-fontWeight: 400;
-        --body-mozOsxFontSmoothing: grayscale;
-        --body-webkitFontSmoothing: antialiased;
         --color-body-background: white;
         --color-body-contentColor: black;
         --color-brand-background: #0078d4;
@@ -367,13 +328,13 @@ exports[`ThemeProvider renders nested themes 1`] = `
         --color-brand-secondaryContentColor: #ffffff;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: white;
+        color: black;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   <div>
@@ -383,11 +344,6 @@ exports[`ThemeProvider renders nested themes 1`] = `
     className=
 
         {
-          --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          --body-fontSize: 14px;
-          --body-fontWeight: 400;
-          --body-mozOsxFontSmoothing: grayscale;
-          --body-webkitFontSmoothing: antialiased;
           --color-body-background: black;
           --color-body-contentColor: white;
           --color-brand-background: #0078d4;
@@ -422,13 +378,13 @@ exports[`ThemeProvider renders nested themes 1`] = `
           --color-brand-secondaryContentColor: #ffffff;
         }
         {
-          -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-          -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-          background: var(--color-body-background);
-          color: var(--color-body-contentColor);
-          font-family: var(--body-fontFamily);
-          font-size: var(--body-fontSize);
-          font-weight: var(--body-fontWeight);
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: black;
+          color: white;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
         }
   >
     <div>

--- a/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
@@ -5,6 +5,11 @@ exports[`ThemeProvider can apply body theme to body 1`] = `
   class=
 
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -55,6 +60,11 @@ exports[`ThemeProvider can apply body theme to body 2`] = `
   className=
       foo
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -98,6 +108,11 @@ exports[`ThemeProvider can apply body theme to none 1`] = `
   className=
       foo
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
         --color-body-background: black;
         --color-body-contentColor: white;
         --color-brand-background: #0078d4;
@@ -141,6 +156,13 @@ exports[`ThemeProvider can handle a partial theme 1`] = `
   className=
 
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
+        --color-body-background: #ffffff;
+        --color-body-contentColor: #323130;
         --color-brand-background: #0078d4;
         --color-brand-borderColor: transparent;
         --color-brand-checked-background: #005a9e;
@@ -192,6 +214,13 @@ exports[`ThemeProvider renders a div 1`] = `
   className=
 
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
+        --color-body-background: #ffffff;
+        --color-body-contentColor: #323130;
         --color-brand-background: #0078d4;
         --color-brand-borderColor: transparent;
         --color-brand-checked-background: #005a9e;
@@ -242,6 +271,11 @@ exports[`ThemeProvider renders a div with styling 1`] = `
   className=
 
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
         --color-body-background: white;
         --color-body-contentColor: black;
         --color-brand-background: #0078d4;
@@ -294,6 +328,11 @@ exports[`ThemeProvider renders nested themes 1`] = `
   className=
 
       {
+        --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        --body-fontSize: 14px;
+        --body-fontWeight: 400;
+        --body-mozOsxFontSmoothing: grayscale;
+        --body-webkitFontSmoothing: antialiased;
         --color-body-background: white;
         --color-body-contentColor: black;
         --color-brand-background: #0078d4;
@@ -344,6 +383,11 @@ exports[`ThemeProvider renders nested themes 1`] = `
     className=
 
         {
+          --body-fontFamily: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          --body-fontSize: 14px;
+          --body-fontWeight: 400;
+          --body-mozOsxFontSmoothing: grayscale;
+          --body-webkitFontSmoothing: antialiased;
           --color-body-background: black;
           --color-body-contentColor: white;
           --color-brand-background: #0078d4;

--- a/packages/react-theme-provider/src/getTokens.ts
+++ b/packages/react-theme-provider/src/getTokens.ts
@@ -5,17 +5,11 @@ import { merge } from '@uifabric/utilities';
  * Get tokens from theme object.
  */
 export function getTokens(theme: Theme, userTokens?: RecursivePartial<Tokens>): RecursivePartial<Tokens> {
-  const { fonts } = theme;
   const { palette, semanticColors } = theme;
 
   const preparedTokens = merge<RecursivePartial<Tokens>>(
     {
       color: {
-        body: {
-          background: semanticColors.bodyBackground,
-          contentColor: semanticColors.bodyText,
-        },
-
         // accent is currently only mapped for primary button to use.
         brand: {
           background: semanticColors.primaryButtonBackground,
@@ -67,14 +61,6 @@ export function getTokens(theme: Theme, userTokens?: RecursivePartial<Tokens>): 
             contentColor: semanticColors.primaryButtonTextPressed,
           },
         },
-      },
-
-      body: {
-        fontFamily: fonts.medium.fontFamily,
-        fontWeight: fonts.medium.fontWeight,
-        fontSize: fonts.medium.fontSize,
-        mozOsxFontSmoothing: fonts.medium.MozOsxFontSmoothing,
-        webkitFontSmoothing: fonts.medium.WebkitFontSmoothing,
       },
     },
 

--- a/packages/react-theme-provider/src/getTokens.ts
+++ b/packages/react-theme-provider/src/getTokens.ts
@@ -5,11 +5,17 @@ import { merge } from '@uifabric/utilities';
  * Get tokens from theme object.
  */
 export function getTokens(theme: Theme, userTokens?: RecursivePartial<Tokens>): RecursivePartial<Tokens> {
+  const { fonts } = theme;
   const { palette, semanticColors } = theme;
 
   const preparedTokens = merge<RecursivePartial<Tokens>>(
     {
       color: {
+        body: {
+          background: semanticColors.bodyBackground,
+          contentColor: semanticColors.bodyText,
+        },
+
         // accent is currently only mapped for primary button to use.
         brand: {
           background: semanticColors.primaryButtonBackground,
@@ -61,6 +67,14 @@ export function getTokens(theme: Theme, userTokens?: RecursivePartial<Tokens>): 
             contentColor: semanticColors.primaryButtonTextPressed,
           },
         },
+      },
+
+      body: {
+        fontFamily: fonts.medium.fontFamily,
+        fontWeight: fonts.medium.fontWeight,
+        fontSize: fonts.medium.fontSize,
+        mozOsxFontSmoothing: fonts.medium.MozOsxFontSmoothing,
+        webkitFontSmoothing: fonts.medium.WebkitFontSmoothing,
       },
     },
 

--- a/packages/react-theme-provider/src/useThemeProviderClasses.tsx
+++ b/packages/react-theme-provider/src/useThemeProviderClasses.tsx
@@ -9,18 +9,19 @@ import { Theme } from './types';
 const useThemeProviderStyles = makeStyles((theme: Theme) => {
   const { tokens } = theme;
   const tokenStyles = tokensToStyleObject(tokens);
+  const { fonts, semanticColors } = theme;
 
   return {
     root: tokenStyles,
     body: [
       {
-        color: 'var(--color-body-contentColor)',
-        background: 'var(--color-body-background)',
-        fontFamily: 'var(--body-fontFamily)',
-        fontWeight: 'var(--body-fontWeight)',
-        fontSize: 'var(--body-fontSize)',
-        MozOsxFontSmoothing: 'var(--body-mozOsxFontSmoothing)',
-        WebkitFontSmoothing: 'var(--body-webkitFontSmoothing)',
+        color: tokens?.color?.body?.contentColor || semanticColors.bodyText,
+        background: tokens?.color?.body?.background || semanticColors.bodyBackground,
+        fontFamily: tokens?.body?.fontFamily || fonts.medium.fontFamily,
+        fontWeight: tokens?.body?.fontWeight || fonts.medium.fontWeight,
+        fontSize: tokens?.body?.fontSize || fonts.medium.fontSize,
+        MozOsxFontSmoothing: tokens?.body?.MozOsxFontSmoothing || fonts.medium.MozOsxFontSmoothing,
+        WebkitFontSmoothing: tokens?.body?.WebkitFontSmoothing || fonts.medium.WebkitFontSmoothing,
       },
     ],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-theme-provider/src/useThemeProviderClasses.tsx
+++ b/packages/react-theme-provider/src/useThemeProviderClasses.tsx
@@ -9,19 +9,18 @@ import { Theme } from './types';
 const useThemeProviderStyles = makeStyles((theme: Theme) => {
   const { tokens } = theme;
   const tokenStyles = tokensToStyleObject(tokens);
-  const { fonts, semanticColors } = theme;
 
   return {
     root: tokenStyles,
     body: [
       {
-        color: tokens?.color?.body?.contentColor || semanticColors.bodyText,
-        background: tokens?.color?.body?.background || semanticColors.bodyBackground,
-        fontFamily: tokens?.body?.fontFamily || fonts.medium.fontFamily,
-        fontWeight: tokens?.body?.fontWeight || fonts.medium.fontWeight,
-        fontSize: tokens?.body?.fontSize || fonts.medium.fontSize,
-        MozOsxFontSmoothing: tokens?.body?.MozOsxFontSmoothing || fonts.medium.MozOsxFontSmoothing,
-        WebkitFontSmoothing: tokens?.body?.WebkitFontSmoothing || fonts.medium.WebkitFontSmoothing,
+        color: tokens?.color?.body?.contentColor,
+        background: tokens?.color?.body?.background,
+        fontFamily: tokens?.body?.fontFamily,
+        fontWeight: tokens?.body?.fontWeight,
+        fontSize: tokens?.body?.fontSize,
+        MozOsxFontSmoothing: tokens?.body?.mozOsxFontSmoothing,
+        WebkitFontSmoothing: tokens?.body?.webkitFontSmoothing,
       },
     ],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
avoid using css vars for default styles applied by ThemeProvider (ie11 safe)

#### Focus areas to test

(optional)
