### PR TITLE
Fixing variants typings in makeVariantClasses

### DIFF
--- a/change/@fluentui-react-button-2020-10-14-18-35-40-buttonTypings.json
+++ b/change/@fluentui-react-button-2020-10-14-18-35-40-buttonTypings.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Updating use of makeVariantClasses and fixing typing bugs.",
+  "packageName": "@fluentui/react-button",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T01:34:35.537Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-10-14-18-35-40-buttonTypings.json
+++ b/change/@fluentui-react-theme-provider-2020-10-14-18-35-40-buttonTypings.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Expanding type of MakeVariantClassesOptions to take into account user provided Variants.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T01:35:10.859Z"
+}

--- a/change/@fluentui-theme-2020-10-14-18-35-40-buttonTypings.json
+++ b/change/@fluentui-theme-2020-10-14-18-35-40-buttonTypings.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fixing and expanding token typings.",
+  "packageName": "@fluentui/theme",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T01:35:40.353Z"
+}

--- a/packages/react-button/etc/react-button.api.md
+++ b/packages/react-button/etc/react-button.api.md
@@ -78,17 +78,17 @@ export interface ButtonState extends ButtonProps {
 
 // @public (undocumented)
 export type ButtonTokens = ColorTokens & FontTokens & {
-    paddingLeft?: string;
-    paddingRight?: string;
-    paddingTop?: string;
-    paddingBottom?: string;
+    paddingLeft?: string | number;
+    paddingRight?: string | number;
+    paddingTop?: string | number;
+    paddingBottom?: string | number;
     margin?: string;
     height?: string;
-    minWidth?: string;
-    maxWidth?: string;
+    minWidth?: string | number;
+    maxWidth?: string | number;
     minHeight?: string;
     contentGap?: string;
-    iconSize?: string;
+    iconSize?: string | number;
     borderRadius?: string;
     borderTopLeftRadius?: string;
     borderTopRightRadius?: string;
@@ -96,7 +96,8 @@ export type ButtonTokens = ColorTokens & FontTokens & {
     borderBottomRightRadius?: string;
     borderWidth?: string;
     boxShadow?: string;
-    width?: string;
+    width?: string | number;
+    forcedColorAdjust?: string;
     transform?: string;
     transition?: string;
     size?: {
@@ -116,11 +117,13 @@ export type ButtonTokens = ColorTokens & FontTokens & {
 
 // @public (undocumented)
 export type ButtonVariants<TTokens = ButtonTokens> = {
-    base?: TTokens;
-    primary?: TTokens;
-    iconOnly?: TTokens;
-    circular?: TTokens;
+    root?: TTokens;
     block?: TTokens;
+    circular?: TTokens;
+    iconOnly?: TTokens;
+    ghost?: TTokens;
+    primary?: TTokens;
+    transparent?: TTokens;
 };
 
 // @public (undocumented)
@@ -157,10 +160,10 @@ export interface CompoundButtonState extends CompoundButtonProps {
 
 // @public (undocumented)
 export type CompoundButtonTokens = ButtonTokens & {
-    secondaryContentColor: string;
-    secondaryContentFontSize: string;
-    secondaryContentFontWeight: string;
-    secondaryContentGap: string;
+    secondaryContentColor?: string;
+    secondaryContentFontSize?: string | number;
+    secondaryContentFontWeight?: string;
+    secondaryContentGap?: string;
 };
 
 // @public (undocumented)
@@ -204,7 +207,13 @@ export interface MenuButtonState extends MenuButtonProps, Omit<ButtonState, 'ico
 }
 
 // @public (undocumented)
-export type MenuButtonTokens = ButtonTokens;
+export type MenuButtonTokens = ButtonTokens & {
+    menuIconColor?: string;
+    menuIconSize?: string | number;
+};
+
+// @public (undocumented)
+export type MenuButtonVariants = ButtonVariants<MenuButtonTokens>;
 
 // @public (undocumented)
 export const SplitButton: React.ForwardRefExoticComponent<Pick<SplitButtonProps, string | number> & React.RefAttributes<HTMLElement>>;
@@ -226,7 +235,13 @@ export interface SplitButtonState extends Omit<SplitButtonProps, 'menu'>, MenuBu
 }
 
 // @public (undocumented)
-export type SplitButtonTokens = MenuButtonTokens;
+export type SplitButtonTokens = MenuButtonTokens & {
+    dividerColor?: string;
+    dividerThickness?: string | number;
+};
+
+// @public (undocumented)
+export type SplitButtonVariants = ButtonVariants<SplitButtonTokens>;
 
 // @public
 export const ToggleButton: React.ForwardRefExoticComponent<Pick<ToggleButtonProps, string | number> & React.RefAttributes<HTMLElement>>;
@@ -240,6 +255,12 @@ export interface ToggleButtonProps extends ButtonProps {
 // @public (undocumented)
 export interface ToggleButtonState extends ToggleButtonProps {
 }
+
+// @public (undocumented)
+export type ToggleButtonTokens = ButtonTokens;
+
+// @public (undocumented)
+export type ToggleButtonVariants = ButtonVariants<ToggleButtonTokens>;
 
 // @public
 export const useButton: (props: ButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: ButtonProps | undefined) => {
@@ -278,7 +299,7 @@ export const useMenuButton: (props: MenuButtonProps, ref: React.Ref<HTMLElement>
 };
 
 // @public (undocumented)
-export const useMenuButtonClasses: (state: {}, theme?: Theme | undefined, renderer?: import("@fluentui/react-theme-provider").StyleRenderer | undefined) => void;
+export const useMenuButtonClasses: (state: MenuButtonState, theme?: Theme | undefined, renderer?: import("@fluentui/react-theme-provider").StyleRenderer | undefined) => void;
 
 // @public (undocumented)
 export const useMenuButtonState: (state: MenuButtonState) => void;
@@ -290,7 +311,7 @@ export const useSplitButton: (props: SplitButtonProps, ref: React.Ref<HTMLElemen
 };
 
 // @public (undocumented)
-export const useSplitButtonClasses: (state: {}, theme?: Theme | undefined, renderer?: import("@fluentui/react-theme-provider").StyleRenderer | undefined) => void;
+export const useSplitButtonClasses: (state: SplitButtonState, theme?: Theme | undefined, renderer?: import("@fluentui/react-theme-provider").StyleRenderer | undefined) => void;
 
 // @public (undocumented)
 export const useToggleButton: (props: ToggleButtonProps, ref: React.Ref<HTMLElement>, defaultProps?: ToggleButtonProps | undefined) => {

--- a/packages/react-button/src/components/Button/Button.types.ts
+++ b/packages/react-button/src/components/Button/Button.types.ts
@@ -102,17 +102,17 @@ export interface ButtonState extends ButtonProps {
 export type ButtonTokens = ColorTokens &
   FontTokens & {
     /* sizing */
-    paddingLeft?: string;
-    paddingRight?: string;
-    paddingTop?: string;
-    paddingBottom?: string;
+    paddingLeft?: string | number;
+    paddingRight?: string | number;
+    paddingTop?: string | number;
+    paddingBottom?: string | number;
     margin?: string;
     height?: string;
-    minWidth?: string;
-    maxWidth?: string;
+    minWidth?: string | number;
+    maxWidth?: string | number;
     minHeight?: string;
     contentGap?: string;
-    iconSize?: string;
+    iconSize?: string | number;
     borderRadius?: string;
     borderTopLeftRadius?: string;
     borderTopRightRadius?: string;
@@ -120,7 +120,9 @@ export type ButtonTokens = ColorTokens &
     borderBottomRightRadius?: string;
     borderWidth?: string;
     boxShadow?: string;
-    width?: string;
+    width?: string | number;
+
+    forcedColorAdjust?: string;
 
     transform?: string;
     transition?: string;
@@ -142,9 +144,11 @@ export type ButtonTokens = ColorTokens &
   };
 
 export type ButtonVariants<TTokens = ButtonTokens> = {
-  base?: TTokens;
-  primary?: TTokens;
-  iconOnly?: TTokens;
-  circular?: TTokens;
+  root?: TTokens;
   block?: TTokens;
+  circular?: TTokens;
+  iconOnly?: TTokens;
+  ghost?: TTokens;
+  primary?: TTokens;
+  transparent?: TTokens;
 };

--- a/packages/react-button/src/components/Button/useButtonClasses.ts
+++ b/packages/react-button/src/components/Button/useButtonClasses.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { makeVariantClasses, Theme } from '@fluentui/react-theme-provider';
 import { EdgeChromiumHighContrastSelector } from '@uifabric/styling';
-import { ButtonState } from './Button.types';
+import { ButtonState, ButtonVariants } from './Button.types';
 
 const GlobalClassNames = {
   root: 'ms-Button',
@@ -40,7 +40,7 @@ export const ButtonSizeVariants = {
   },
 };
 
-export const useButtonClasses = makeVariantClasses<ButtonState>({
+export const useButtonClasses = makeVariantClasses<ButtonState, ButtonVariants>({
   name: 'Button',
   prefix: '--button',
 
@@ -233,7 +233,7 @@ export const useButtonClasses = makeVariantClasses<ButtonState>({
     },
   },
 
-  variants: (theme: Theme) => {
+  variants: (theme: Theme): ButtonVariants => {
     const { fonts, effects, palette, semanticColors } = theme;
 
     return {
@@ -268,7 +268,6 @@ export const useButtonClasses = makeVariantClasses<ButtonState>({
         fontWeight: '600',
         fontSize: fonts?.medium?.fontSize,
         fontFamily: fonts?.medium?.fontFamily,
-        secondaryContentFontSize: fonts?.small.fontSize,
 
         // Color tokens
         focusColor: palette?.black,
@@ -399,7 +398,6 @@ export const useButtonClasses = makeVariantClasses<ButtonState>({
         contentColor: palette?.neutralPrimary,
         fontWeight: 'normal',
         iconColor: palette?.themeDarkAlt,
-        menuIconColor: palette?.neutralSecondary,
         secondaryContentColor: palette?.neutralPrimary,
         forcedColorAdjust: 'none',
 

--- a/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
+++ b/packages/react-button/src/components/CompoundButton/CompoundButton.types.ts
@@ -16,10 +16,10 @@ export interface CompoundButtonProps extends ButtonProps {
 export interface CompoundButtonState extends CompoundButtonProps {}
 
 export type CompoundButtonTokens = ButtonTokens & {
-  secondaryContentColor: string;
-  secondaryContentFontSize: string;
-  secondaryContentFontWeight: string;
-  secondaryContentGap: string;
+  secondaryContentColor?: string;
+  secondaryContentFontSize?: string | number;
+  secondaryContentFontWeight?: string;
+  secondaryContentGap?: string;
 };
 
 export type CompoundButtonVariants = ButtonVariants<CompoundButtonTokens>;

--- a/packages/react-button/src/components/CompoundButton/useCompoundButtonClasses.ts
+++ b/packages/react-button/src/components/CompoundButton/useCompoundButtonClasses.ts
@@ -1,5 +1,5 @@
 import { makeVariantClasses, Theme } from '@fluentui/react-theme-provider';
-import { CompoundButtonState } from './CompoundButton.types';
+import { CompoundButtonState, CompoundButtonVariants } from './CompoundButton.types';
 import { useButtonClasses } from '../Button/useButtonClasses';
 
 const GlobalClassNames = {
@@ -8,7 +8,7 @@ const GlobalClassNames = {
   secondaryContent: 'ms-CompoundButton-secondaryContent',
 };
 
-export const useClasses = makeVariantClasses<CompoundButtonState>({
+export const useClasses = makeVariantClasses<CompoundButtonState, CompoundButtonVariants>({
   name: 'CompoundButton',
   prefix: '--button',
   styles: {
@@ -78,8 +78,8 @@ export const useClasses = makeVariantClasses<CompoundButtonState>({
     ],
   },
 
-  variants: (theme: Theme) => {
-    const { palette, semanticColors } = theme;
+  variants: (theme: Theme): CompoundButtonVariants => {
+    const { fonts, palette, semanticColors } = theme;
 
     return {
       root: {
@@ -93,6 +93,7 @@ export const useClasses = makeVariantClasses<CompoundButtonState>({
         iconSize: '28px',
         secondaryContentColor: palette.neutralSecondary,
         secondaryContentGap: '4px',
+        secondaryContentFontSize: fonts?.small.fontSize,
         secondaryContentFontWeight: 'normal',
 
         hovered: {

--- a/packages/react-button/src/components/MenuButton/MenuButton.types.ts
+++ b/packages/react-button/src/components/MenuButton/MenuButton.types.ts
@@ -1,5 +1,5 @@
 import { ShorthandProps } from '@fluentui/react-compose/lib/next/index';
-import { ButtonProps, ButtonState, ButtonTokens } from '../Button/Button.types';
+import { ButtonProps, ButtonState, ButtonTokens, ButtonVariants } from '../Button/Button.types';
 import { ExpandedState } from './useExpanded';
 
 export type MenuButtonProps = Omit<ButtonProps, 'iconPosition' | 'loader'> & {
@@ -37,4 +37,9 @@ export interface MenuButtonState extends MenuButtonProps, Omit<ButtonState, 'ico
   menu: ExpandedState['menu'];
 }
 
-export type MenuButtonTokens = ButtonTokens;
+export type MenuButtonTokens = ButtonTokens & {
+  menuIconColor?: string;
+  menuIconSize?: string | number;
+};
+
+export type MenuButtonVariants = ButtonVariants<MenuButtonTokens>;

--- a/packages/react-button/src/components/MenuButton/useMenuButtonClasses.ts
+++ b/packages/react-button/src/components/MenuButton/useMenuButtonClasses.ts
@@ -1,4 +1,5 @@
 import { makeVariantClasses, Theme } from '@fluentui/react-theme-provider';
+import { MenuButtonState, MenuButtonVariants } from './MenuButton.types';
 
 const GlobalClassNames = {
   root: 'ms-Button-root',
@@ -8,7 +9,7 @@ const GlobalClassNames = {
   _expanded: 'ms-Button--expanded',
 };
 
-export const useMenuButtonClasses = makeVariantClasses({
+export const useMenuButtonClasses = makeVariantClasses<MenuButtonState, MenuButtonVariants>({
   name: 'MenuButton',
   prefix: '--button',
   styles: {
@@ -50,13 +51,17 @@ export const useMenuButtonClasses = makeVariantClasses({
     _disabled: [GlobalClassNames._disabled],
   },
 
-  variants: (theme: Theme) => {
+  variants: (theme: Theme): MenuButtonVariants => {
     const { palette } = theme;
 
     return {
       root: {
         menuIconSize: '12px',
         menuIconColor: 'var(--body-menuIconColor)',
+      },
+
+      ghost: {
+        menuIconColor: palette?.neutralSecondary,
       },
 
       transparent: {

--- a/packages/react-button/src/components/SplitButton/SplitButton.types.ts
+++ b/packages/react-button/src/components/SplitButton/SplitButton.types.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { ShorthandProps } from '@fluentui/react-compose/lib/next/index';
-import { ButtonProps } from '../Button/Button.types';
+import { ButtonProps, ButtonVariants } from '../Button/Button.types';
 import { MenuButtonProps, MenuButtonState, MenuButtonTokens } from '../MenuButton/MenuButton.types';
 
 export interface SplitButtonProps extends ButtonProps, MenuButtonProps {
@@ -24,4 +24,9 @@ export interface SplitButtonState extends Omit<SplitButtonProps, 'menu'>, MenuBu
   menuButtonRef?: React.RefObject<HTMLButtonElement>;
 }
 
-export type SplitButtonTokens = MenuButtonTokens;
+export type SplitButtonTokens = MenuButtonTokens & {
+  dividerColor?: string;
+  dividerThickness?: string | number;
+};
+
+export type SplitButtonVariants = ButtonVariants<SplitButtonTokens>;

--- a/packages/react-button/src/components/SplitButton/useSplitButtonClasses.tsx
+++ b/packages/react-button/src/components/SplitButton/useSplitButtonClasses.tsx
@@ -1,6 +1,7 @@
 import { makeVariantClasses, Theme } from '@fluentui/react-theme-provider';
 import { EdgeChromiumHighContrastSelector } from '@uifabric/styling';
 import { ButtonSizeVariants } from '../Button/index';
+import { SplitButtonState, SplitButtonVariants } from './SplitButton.types';
 
 const GlobalClassNames = {
   root: 'ms-SplitButton',
@@ -10,7 +11,7 @@ const GlobalClassNames = {
 
 const menuButtonWidth = '32px';
 
-export const useSplitButtonClasses = makeVariantClasses({
+export const useSplitButtonClasses = makeVariantClasses<SplitButtonState, SplitButtonVariants>({
   name: 'SplitButton',
   prefix: '--button',
 
@@ -87,7 +88,7 @@ export const useSplitButtonClasses = makeVariantClasses({
       },
     },
   },
-  variants: (theme: Theme) => {
+  variants: (theme: Theme): SplitButtonVariants => {
     const { palette, semanticColors } = theme;
 
     return {

--- a/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
+++ b/packages/react-button/src/components/ToggleButton/ToggleButton.types.ts
@@ -1,4 +1,4 @@
-import { ButtonProps } from '../Button/Button.types';
+import { ButtonProps, ButtonTokens, ButtonVariants } from '../Button/Button.types';
 
 export interface ToggleButtonProps extends ButtonProps {
   /**
@@ -17,3 +17,7 @@ export interface ToggleButtonProps extends ButtonProps {
 }
 
 export interface ToggleButtonState extends ToggleButtonProps {}
+
+export type ToggleButtonTokens = ButtonTokens;
+
+export type ToggleButtonVariants = ButtonVariants<ToggleButtonTokens>;

--- a/packages/react-button/src/components/ToggleButton/useToggleButtonClasses.tsx
+++ b/packages/react-button/src/components/ToggleButton/useToggleButtonClasses.tsx
@@ -1,8 +1,8 @@
 import { EdgeChromiumHighContrastSelector } from '@uifabric/styling';
 import { makeVariantClasses, Theme } from '@fluentui/react-theme-provider';
-import { ToggleButtonState } from './ToggleButton.types';
+import { ToggleButtonState, ToggleButtonVariants } from './ToggleButton.types';
 
-export const useToggleButtonClasses = makeVariantClasses<ToggleButtonState>({
+export const useToggleButtonClasses = makeVariantClasses<ToggleButtonState, ToggleButtonVariants>({
   name: 'ToggleButton',
   prefix: '--button',
 
@@ -68,7 +68,7 @@ export const useToggleButtonClasses = makeVariantClasses<ToggleButtonState>({
     },
   },
 
-  variants: (theme: Theme) => {
+  variants: (theme: Theme): ToggleButtonVariants => {
     const { palette, semanticColors } = theme;
 
     return {

--- a/packages/react-theme-provider/etc/react-theme-provider.api.md
+++ b/packages/react-theme-provider/etc/react-theme-provider.api.md
@@ -46,14 +46,14 @@ export function makeStyles<TStyleSet extends {
 };
 
 // @public
-export const makeVariantClasses: <TState = {}>(options: MakeVariantClassesOptions) => (state: TState, theme?: Theme | undefined, renderer?: import(".").StyleRenderer | undefined) => void;
+export const makeVariantClasses: <TState = {}, TVariants = Record<string, any>>(options: MakeVariantClassesOptions<TVariants>) => (state: TState, theme?: Theme | undefined, renderer?: import(".").StyleRenderer | undefined) => void;
 
 // @public
-export type MakeVariantClassesOptions = {
+export type MakeVariantClassesOptions<TVariants = Variants> = {
     name?: string;
     prefix?: string;
     styles?: Record<string, IStyle> | ((theme: Theme) => Record<string, IStyle>);
-    variants?: Variants | ((theme: Theme) => Variants);
+    variants?: TVariants | ((theme: Theme) => TVariants);
 };
 
 // @public (undocumented)

--- a/packages/react-theme-provider/src/makeVariantClasses.ts
+++ b/packages/react-theme-provider/src/makeVariantClasses.ts
@@ -40,7 +40,7 @@ const processVariants = (variants: Variants | undefined, theme: Theme, name?: st
 /**
  * Options for makeVariantClasses.
  */
-export type MakeVariantClassesOptions = {
+export type MakeVariantClassesOptions<TVariants = Variants> = {
   /**
    * Name of the component to use for fetching variants from the theme.
    */
@@ -60,7 +60,7 @@ export type MakeVariantClassesOptions = {
    * Variants for the styles. A variant defines token values when a particular prop is present, or the
    * variant prop matches.
    */
-  variants?: Variants | ((theme: Theme) => Variants);
+  variants?: TVariants | ((theme: Theme) => TVariants);
 };
 
 /**
@@ -68,7 +68,9 @@ export type MakeVariantClassesOptions = {
  * token values mapped to modifiers on the component. A variant can also be referenced using
  * a variant string. Variants can be overridden through the theme of the component.
  */
-export const makeVariantClasses = <TState = {}>(options: MakeVariantClassesOptions) => {
+export const makeVariantClasses = <TState = {}, TVariants = Variants>(
+  options: MakeVariantClassesOptions<TVariants>,
+) => {
   const { styles, variants, name, prefix } = options;
 
   // This function will only be called when styles have not been evaluated for this set for

--- a/packages/theme/etc/theme.api.md
+++ b/packages/theme/etc/theme.api.md
@@ -16,12 +16,14 @@ export const AnimationVariables: IAnimationVariables;
 
 // @public
 export type ColorTokens = ColorTokenSet & {
-    hovered?: ColorTokenSet;
-    pressed?: ColorTokenSet;
-    disabled?: ColorTokenSet;
     checked?: ColorTokenSet;
     checkedHovered?: ColorTokenSet;
     checkedPressed?: ColorTokenSet;
+    disabled?: ColorTokenSet;
+    expanded?: ColorTokenSet;
+    focused?: ColorTokenSet;
+    hovered?: ColorTokenSet;
+    pressed?: ColorTokenSet;
 };
 
 // @public
@@ -36,6 +38,7 @@ export type ColorTokenSet = {
     focusColor?: string;
     focusInnerColor?: string;
     opacity?: string;
+    highContrast?: ColorTokens;
 };
 
 // @public (undocumented)
@@ -163,7 +166,7 @@ export namespace FontSizes {
 // @public (undocumented)
 export type FontTokens = Partial<{
     fontFamily: string;
-    fontSize: string;
+    fontSize: string | number;
     fontWeight: string;
 }>;
 

--- a/packages/theme/src/types/Theme.ts
+++ b/packages/theme/src/types/Theme.ts
@@ -26,6 +26,8 @@ export type ColorTokenSet = {
   focusColor?: string;
   focusInnerColor?: string;
   opacity?: string;
+
+  highContrast?: ColorTokens;
 };
 
 /**
@@ -49,17 +51,19 @@ export type ColorTokenSet = {
  * to "pressed".
  */
 export type ColorTokens = ColorTokenSet & {
-  hovered?: ColorTokenSet;
-  pressed?: ColorTokenSet;
-  disabled?: ColorTokenSet;
   checked?: ColorTokenSet;
   checkedHovered?: ColorTokenSet;
   checkedPressed?: ColorTokenSet;
+  disabled?: ColorTokenSet;
+  expanded?: ColorTokenSet;
+  focused?: ColorTokenSet;
+  hovered?: ColorTokenSet;
+  pressed?: ColorTokenSet;
 };
 
 export type FontTokens = Partial<{
   fontFamily: string;
-  fontSize: string;
+  fontSize: string | number;
   fontWeight: string;
 }>;
 


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #15483
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes the typings for the `variants` when using `makeVariantClasses` to restrict what can be sent as a value to that parameter in the function.


#### Focus areas to test

(optional)
