### PR TITLE
ensure elevated-corner-radius is applied to dialog

### DIFF
--- a/change/@fluentui-web-components-2020-10-15-19-45-35-users-chhol-fix-dialog-corner-radius.json
+++ b/change/@fluentui-web-components-2020-10-15-19-45-35-users-chhol-fix-dialog-corner-radius.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ensure elevated-corner-radius is applied to dialog",
+  "packageName": "@fluentui/web-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T02:45:35.324Z"
+}

--- a/packages/web-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/src/dialog/dialog.styles.ts
@@ -38,7 +38,7 @@ export const DialogStyles = css`
     ${elevation}
     margin-top: auto;
     margin-bottom: auto;
-    border-radius: calc(var(--elevated-corner-radius));
+    border-radius: calc(var(--elevated-corner-radius) * 1px);
     width: var(--dialog-width);
     height: var(--dialog-height);
     background: var(--background-color);


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes a bug where the elevated corner radius was not being applied due to a missing calculation to pixels.

#### Focus areas to test

(optional)
