### PR TITLE
Mark Fabric and Customizer deprecated

### DIFF
--- a/apps/theming-designer/src/components/Header.tsx
+++ b/apps/theming-designer/src/components/Header.tsx
@@ -58,20 +58,18 @@ const codepenHeader = `const {
   Checkbox,
   DefaultButton,
   Fabric,
-  loadTheme,
   Pivot,
   PivotItem,
   PrimaryButton,
   Stack,
   Toggle,
+  ThemeProvider
 } = FluentUIReact;\n\n`;
 const codepenSamples = `\n\n
 
-loadTheme(myTheme);\n
-
 const Content = () => {
     return (
-      <Fabric applyThemeToBody>
+      <ThemeProvider applyTo='body' theme={myTheme}>
         <Stack tokens={{childrenGap: 8, maxWidth: 300}}>
           <Pivot>
             <PivotItem headerText="Home" />
@@ -88,7 +86,7 @@ const Content = () => {
           <Checkbox label="Checkbox"/>
           <Checkbox checked label="Checkbox Checked" />
         </Stack>
-      </Fabric>
+      </ThemeProvider>
     );
 }
 ReactDOM.render(<Content />,document.getElementById('content'));`;

--- a/change/@fluentui-react-internal-2020-10-15-20-49-39-xgao-theme-deprecations.json
+++ b/change/@fluentui-react-internal-2020-10-15-20-49-39-xgao-theme-deprecations.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Deprecate Fabric.",
+  "packageName": "@fluentui/react-internal",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T03:49:20.752Z"
+}

--- a/change/@uifabric-tsx-editor-2020-10-15-20-49-39-xgao-theme-deprecations.json
+++ b/change/@uifabric-tsx-editor-2020-10-15-20-49-39-xgao-theme-deprecations.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update codepen to use ThemeProvider instead of Fabric.",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T03:49:32.538Z"
+}

--- a/change/@uifabric-tsx-editor-2020-10-15-20-49-39-xgao-theme-deprecations.json
+++ b/change/@uifabric-tsx-editor-2020-10-15-20-49-39-xgao-theme-deprecations.json
@@ -1,7 +1,7 @@
 {
   "type": "patch",
   "comment": "Update codepen to use ThemeProvider instead of Fabric.",
-  "packageName": "@uifabric/tsx-editor",
+  "packageName": "@fluentui/react-monaco-editor",
   "email": "xgao@microsoft.com",
   "dependentChangeType": "patch",
   "date": "2020-10-16T03:49:32.538Z"

--- a/change/@uifabric-utilities-2020-10-15-20-49-39-xgao-theme-deprecations.json
+++ b/change/@uifabric-utilities-2020-10-15-20-49-39-xgao-theme-deprecations.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Deprecate Customizer.",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T03:49:39.835Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -732,7 +732,7 @@ export class ExtendedSelectedItem extends React.Component<ISelectedPeopleItemPro
     render(): JSX.Element;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export const Fabric: React.FunctionComponent<IFabricProps>;
 
 // @public (undocumented)

--- a/packages/react-internal/src/components/Fabric/Fabric.tsx
+++ b/packages/react-internal/src/components/Fabric/Fabric.tsx
@@ -4,6 +4,9 @@ import { FabricBase } from './Fabric.base';
 import { getStyles } from './Fabric.styles';
 import { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric.types';
 
+/**
+ * @deprecated This component is deprecated as of `fluentui/react` version 8. Use `ThemeProvider` instead.
+ */
 export const Fabric: React.FunctionComponent<IFabricProps> = styled<IFabricProps, IFabricStyleProps, IFabricStyles>(
   FabricBase,
   getStyles,

--- a/packages/react-internal/src/components/Fabric/Fabric.tsx
+++ b/packages/react-internal/src/components/Fabric/Fabric.tsx
@@ -5,7 +5,7 @@ import { getStyles } from './Fabric.styles';
 import { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric.types';
 
 /**
- * @deprecated This component is deprecated as of `fluentui/react` version 8. Use `ThemeProvider` instead.
+ * @deprecated This component is deprecated as of `@fluentui/react` version 8. Use `ThemeProvider` instead.
  */
 export const Fabric: React.FunctionComponent<IFabricProps> = styled<IFabricProps, IFabricStyleProps, IFabricStyles>(
   FabricBase,

--- a/packages/react-monaco-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/react-monaco-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`example transform can return component 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.FluentUIReact;
+const { Label, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -16,7 +16,7 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(ThemeProvider, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -25,7 +25,7 @@ return LabelBasicExampleWrapper;
 exports[`example transform can return component with transpiled example 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.FluentUIReact;
+const { Label, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -35,7 +35,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(ThemeProvider, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -43,7 +43,7 @@ return LabelBasicExampleWrapper;
 
 exports[`example transform handles examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.FluentUIReact;
+  "output": "const { SpinButton, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -67,7 +67,7 @@ class SpinButtonBasicExample extends React.Component<any, any> {
   }
 }
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <ThemeProvider><SpinButtonBasicExample /></ThemeProvider>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
@@ -105,7 +105,7 @@ ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 
 exports[`example transform handles examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.FluentUIReact;
+  "output": "const { Label, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -118,14 +118,14 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <ThemeProvider><LabelBasicExample /></ThemeProvider>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.FluentUIReact;
+  "output": "const { SpinButton, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -158,14 +158,14 @@ var SpinButtonBasicExample = /** @class */ (function (_super) {
 }(React.Component));
 { SpinButtonBasicExample };
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <ThemeProvider><SpinButtonBasicExample /></ThemeProvider>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.FluentUIReact;
+  "output": "const { Label, ThemeProvider, initializeIcons } = window.FluentUIReact;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -175,7 +175,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <ThemeProvider><LabelBasicExample /></ThemeProvider>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;

--- a/packages/react-monaco-editor/src/transpiler/exampleTransform.ts
+++ b/packages/react-monaco-editor/src/transpiler/exampleTransform.ts
@@ -95,12 +95,12 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
 
     // If eval-ing the code, the component can't use JSX format
     const wrapperCode = returnFunction
-      ? `React.createElement(Fabric, null, React.createElement(${component}, null))`
-      : `<Fabric><${component} /></Fabric>`;
+      ? `React.createElement(ThemeProvider, null, React.createElement(${component}, null))`
+      : `<ThemeProvider><${component} /></ThemeProvider>`;
     lines.push('', `const ${finalComponent} = () => ${wrapperCode};`);
 
-    if (identifiersByGlobal.FluentUIReact.indexOf('Fabric') === -1) {
-      identifiersByGlobal.FluentUIReact.push('Fabric');
+    if (identifiersByGlobal.FluentUIReact.indexOf('ThemeProvider') === -1) {
+      identifiersByGlobal.FluentUIReact.push('ThemeProvider');
     }
 
     if (identifiersByGlobal.FluentUIReact.indexOf('initializeIcons') === -1) {

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -172,7 +172,7 @@ export class Customizations {
     static unobserve(onChange: () => void): void;
 }
 
-// @public
+// @public @deprecated
 export class Customizer extends React.Component<ICustomizerProps> {
     // (undocumented)
     componentDidMount(): void;

--- a/packages/utilities/src/customizations/Customizer.tsx
+++ b/packages/utilities/src/customizations/Customizer.tsx
@@ -18,7 +18,7 @@ import { ICustomizerProps } from './Customizer.types';
  *
  * @public
  *
- * @deprecated This component is deprecated as of `fluentui/react` version 8. Use `ThemeProvider` instead.
+ * @deprecated This component is deprecated as of `@fluentui/react` version 8. Use `ThemeProvider` instead.
  */
 export class Customizer extends React.Component<ICustomizerProps> {
   public componentDidMount(): void {

--- a/packages/utilities/src/customizations/Customizer.tsx
+++ b/packages/utilities/src/customizations/Customizer.tsx
@@ -17,6 +17,8 @@ import { ICustomizerProps } from './Customizer.types';
  * - A function that receives the current settings and returns the new ones that apply to the scope
  *
  * @public
+ *
+ * @deprecated This component is deprecated as of `fluentui/react` version 8. Use `ThemeProvider` instead.
  */
 export class Customizer extends React.Component<ICustomizerProps> {
   public componentDidMount(): void {


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
- Mark `Fabric` and `Customizer` as deprecated
- Update codepens to use `ThemeProvider`

Related issue: #14740

#### Focus areas to test

(optional)
