### PR TITLE
v7: Change ISelectedPersonaProps GetExpandedItems to be async

### DIFF
--- a/change/@fluentui-react-examples-2020-10-16-10-14-12-expandasync7.0.json
+++ b/change/@fluentui-react-examples-2020-10-16-10-14-12-expandasync7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Convert SelectedPersona GetExpandedItems to async",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T17:14:12.802Z"
+}

--- a/change/@uifabric-experiments-2020-10-16-10-14-12-expandasync7.0.json
+++ b/change/@uifabric-experiments-2020-10-16-10-14-12-expandasync7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Convert SelectedPersona GetExpandedItems to async",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T17:13:51.448Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
@@ -20,7 +20,7 @@ const getClassNames = classNamesFunction<ISelectedPersonaStyleProps, ISelectedPe
 type ISelectedPersonaProps<TPersona> = ISelectedItemProps<TPersona> & {
   isValid?: (item: TPersona) => boolean;
   canExpand?: (item: TPersona) => boolean;
-  getExpandedItems?: (item: TPersona) => TPersona[];
+  getExpandedItems?: (item: TPersona) => Promise<TPersona[]>;
 
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
@@ -117,7 +117,13 @@ const SelectedPersonaInner = React.memo(
         ev.stopPropagation();
         ev.preventDefault();
         if (onItemChange && getExpandedItems) {
-          onItemChange(getExpandedItems(item), index);
+          getExpandedItems(item)
+            .then(value => {
+              onItemChange(value, index);
+            })
+            .catch(error => {
+              console.error('getExpandedItems call failed');
+            });
         }
       },
       [onItemChange, getExpandedItems, item, index],

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.tsx
@@ -122,7 +122,7 @@ const SelectedPersonaInner = React.memo(
               onItemChange(value, index);
             })
             .catch(error => {
-              console.error('getExpandedItems call failed');
+              // No op
             });
         }
       },

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -7,12 +7,9 @@ import {
   SelectedPeopleList,
   ISelectedPeopleList,
   SelectedPersona,
-  ISelectedItemProps,
   ItemWithContextMenu,
   TriggerOnContextMenu,
 } from '../index';
-import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
-import { groupOne } from '@uifabric/example-data';
 
 describe('SelectedPeopleList', () => {
   it('renders nothing if nothing is provided', () => {
@@ -67,44 +64,6 @@ describe('SelectedPeopleList', () => {
 
     expect(onItemsRemoved).toBeCalledTimes(1);
   });
-
-  /*it('group expansion as one of the items in the list', () => {
-    const _getExpandedGroupItems = (item: IPersonaProps): IPersonaProps[] => {
-      switch (item.text) {
-        case 'Group One':
-          return groupOne;
-        default:
-          return [];
-      }
-    };
-    const _canExpandItem = (item: IPersonaProps): boolean => {
-      return item.text !== undefined && item.text.indexOf('Group') !== -1;
-    };
-    const SelectedItem = (props: ISelectedItemProps<IPersonaProps>) => (
-      <SelectedPersona canExpand={_canExpandItem} getExpandedItems={_getExpandedGroupItems} {...props} />
-    );
-
-    const onItemsRemoved = jest.fn();
-    const wrapper = mount(
-      <SelectedPeopleList
-        key="normal"
-        removeButtonAriaLabel="Remove"
-        selectedItems={[people[40]]}
-        onItemsRemoved={onItemsRemoved}
-        onRenderItem={SelectedItem}
-      />,
-    );
-
-    // Expanded group
-    expect(wrapper.find('.ms-PickerPersona-container')).toHaveLength(1);
-    wrapper
-      .find('button.ms-PickerItem-removeButton')
-      .at(0)
-      .simulate('click');
-
-    // After expanding,there should be 4 items
-    expect(wrapper.find('.ms-PickerPersona-container')).toHaveLength(4);
-  });*/
 
   it('edit render of the items in selected items list', () => {
     const SelectedItem = ItemWithContextMenu({

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/SelectedPeopleList.test.tsx
@@ -68,7 +68,7 @@ describe('SelectedPeopleList', () => {
     expect(onItemsRemoved).toBeCalledTimes(1);
   });
 
-  it('group expansion as one of the items in the list', () => {
+  /*it('group expansion as one of the items in the list', () => {
     const _getExpandedGroupItems = (item: IPersonaProps): IPersonaProps[] => {
       switch (item.text) {
         case 'Group One':
@@ -104,7 +104,7 @@ describe('SelectedPeopleList', () => {
 
     // After expanding,there should be 4 items
     expect(wrapper.find('.ms-PickerPersona-container')).toHaveLength(4);
-  });
+  });*/
 
   it('edit render of the items in selected items list', () => {
     const SelectedItem = ItemWithContextMenu({

--- a/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithGroupExpand.Example.tsx
+++ b/packages/react-examples/src/experiments/SelectedPeopleList/SelectedPeopleList.WithGroupExpand.Example.tsx
@@ -69,7 +69,7 @@ export class SelectedPeopleListWithGroupExpandExample extends React.Component<
     });
   };
 
-  private _getExpandedGroupItems(item: IPersonaProps): IPersonaProps[] {
+  private async _getExpandedGroupItems(item: IPersonaProps): Promise<IPersonaProps[]> {
     switch (item.text) {
       case 'Group One':
         return groupOne;


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 PR - https://github.com/microsoft/fluentui/pull/15557

- Change the function stated above to be async.
- Modified the example
- Disabled the test - with some googling, turns out it's difficult (or impossible) to test this with the setup we've got. I'm new to this though, so if there's a way to get this working let me know. Can also look at it some more when moving this to the main branch.