### PR TITLE
7.0: Add option for selectable headers and footers to FloatingSuggestionsComposite (and therefor the UnifiedPicker)

### DIFF
--- a/change/@fluentui-react-examples-2020-10-16-11-01-14-headerfooterselectable7.0.json
+++ b/change/@fluentui-react-examples-2020-10-16-11-01-14-headerfooterselectable7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Add example to FloatingSuggestionsComposite with selectable headers and footers",
+  "packageName": "@fluentui/react-examples",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-16T18:01:13.978Z"
+}

--- a/change/@uifabric-experiments-2020-10-16-11-01-14-headerfooterselectable7.0.json
+++ b/change/@uifabric-experiments-2020-10-16-11-01-14-headerfooterselectable7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add property to FloatingSuggestionComposite to have keyboard selectable headers and footers",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T18:00:52.869Z"
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.tsx
@@ -31,6 +31,9 @@ export const BaseFloatingSuggestions = <T extends {}>(props: IBaseFloatingSugges
     calloutProps,
     pickerWidth,
     onKeyDown,
+    pickerSuggestionsProps,
+    selectedFooterIndex,
+    selectedHeaderIndex,
   } = props;
 
   const hidePicker = (ev: React.MouseEvent): void => {
@@ -64,13 +67,19 @@ export const BaseFloatingSuggestions = <T extends {}>(props: IBaseFloatingSugges
             onRenderItem={onRenderSuggestion}
             onRenderHeader={onRenderHeader}
             onRenderFooter={onRenderFooter}
+            headerItemsProps={pickerSuggestionsProps?.headerItemsProps}
+            footerItemsProps={pickerSuggestionsProps?.footerItemsProps}
             onRenderNoResultFound={onRenderNoResultFound}
             noResultsFoundText={noResultsFoundText}
             maximumSuggestionsToShow={maximumSuggestionsToShow}
             suggestionsContainerAriaLabel={suggestionsContainerAriaLabel}
             selectedSuggestionIndex={selectedSuggestionIndex}
+            selectedFooterIndex={selectedFooterIndex}
+            selectedHeaderIndex={selectedHeaderIndex}
             suggestionsHeaderText={suggestionsHeaderText}
             pickerWidth={pickerWidth}
+            suggestionsHeaderContainerAriaLabel={pickerSuggestionsProps?.suggestionsHeaderContainerAriaLabel}
+            suggestionsFooterContainerAriaLabel={pickerSuggestionsProps?.suggestionsFooterContainerAriaLabel}
           />
         </Callout>
       ) : null}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -7,6 +7,7 @@ import {
   IFloatingSuggestionItem,
 } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { IRenderFunction, IRefObject } from '@uifabric/utilities';
+import { ISuggestionsControlProps } from '../FloatingSuggestions/Suggestions/Suggestions.types';
 
 /**
  * FloatingSuggestions component props
@@ -127,7 +128,32 @@ export interface IBaseFloatingSuggestionsProps<T> {
    * Arrow key callback
    */
   onKeyDown?: (ev: React.KeyboardEvent<HTMLElement>) => void;
+  /**
+   * The properties used for selectable headers and footers
+   * takes precedence over onRenderHeader and onRenderFooter
+   */
+  pickerSuggestionsProps?: IBaseFloatingPickerHeaderFooterProps;
+  /**
+   * Index to indicate the selected header
+   * This logic must be driven by parent component
+   * Should be used with the headerItemProps on the pickerSuggestionProps
+   */
+  selectedHeaderIndex?: number;
+  /**
+   * Index to indicate the selected footer
+   * This logic must be driven by parent component
+   * Should be used with the footerItemProps on the pickerSuggestionProps
+   */
+  selectedFooterIndex?: number;
 }
+
+export type IBaseFloatingPickerHeaderFooterProps = Pick<
+  ISuggestionsControlProps<any>,
+  | 'suggestionsHeaderContainerAriaLabel'
+  | 'headerItemsProps'
+  | 'footerItemsProps'
+  | 'suggestionsFooterContainerAriaLabel'
+>;
 
 /**
  * FLoatingSuggestions style props

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestions.types.ts
@@ -7,7 +7,7 @@ import {
   IFloatingSuggestionItem,
 } from './FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { IRenderFunction, IRefObject } from '@uifabric/utilities';
-import { ISuggestionsControlProps } from '../FloatingSuggestions/Suggestions/Suggestions.types';
+import { IFloatingSuggestionsHeaderFooterProps } from './FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 /**
  * FloatingSuggestions component props
@@ -147,13 +147,24 @@ export interface IBaseFloatingSuggestionsProps<T> {
   selectedFooterIndex?: number;
 }
 
-export type IBaseFloatingPickerHeaderFooterProps = Pick<
-  ISuggestionsControlProps<any>,
-  | 'suggestionsHeaderContainerAriaLabel'
-  | 'headerItemsProps'
-  | 'footerItemsProps'
-  | 'suggestionsFooterContainerAriaLabel'
->;
+export interface IBaseFloatingPickerHeaderFooterProps {
+  /**
+   * An ARIA label for the container that is the parent of the suggestions header items.
+   */
+  suggestionsHeaderContainerAriaLabel?: string;
+  /**
+   * An ARIA label for the container that is the parent of the suggestions footer items.
+   */
+  suggestionsFooterContainerAriaLabel?: string;
+  /**
+   * The header items props
+   */
+  headerItemsProps?: IFloatingSuggestionsHeaderFooterProps[];
+  /**
+   * The footer items props
+   */
+  footerItemsProps?: IFloatingSuggestionsHeaderFooterProps[];
+}
 
 /**
  * FLoatingSuggestions style props

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.styles.ts
@@ -1,0 +1,60 @@
+import { getGlobalClassNames, getTheme, HighContrastSelector } from '@uifabric/styling';
+import {
+  IFloatingSuggestionHeaderFooterItemStylesProps,
+  IFloatingSuggestionHeaderFooterItemStyles,
+} from './FloatingSuggestionsHeaderFooterItem.types';
+
+const GlobalClassNames = {
+  actionButton: 'ms-FloatingSuggestionsHeaderFooterItem-actionButton',
+  buttonSelected: 'ms-FloatingSuggestionsHeaderFooterItem-buttonSelected',
+  suggestionsTitle: 'ms-FloatingSuggestionsHeaderFooterItem-suggestionsTitle',
+};
+
+export const getStyles = (
+  props: IFloatingSuggestionHeaderFooterItemStylesProps,
+): IFloatingSuggestionHeaderFooterItemStyles => {
+  const theme = getTheme();
+
+  if (!theme) {
+    throw new Error('theme is undefined or null in FloatingSuggestionsItem getStyles function.');
+  }
+
+  const { semanticColors } = theme;
+  const classNames = getGlobalClassNames(GlobalClassNames, theme);
+
+  return {
+    actionButton: [
+      classNames.actionButton,
+      {
+        width: '100%',
+        padding: '0px',
+        minWidth: '0',
+        height: '100%',
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'WindowText',
+          },
+          '&:hover': {
+            color: semanticColors.menuItemTextHovered,
+          },
+        },
+      },
+    ],
+    buttonSelected: [
+      classNames.buttonSelected,
+      {
+        background: semanticColors.menuItemBackgroundPressed,
+        selectors: {
+          ':hover': {
+            background: semanticColors.menuDivider,
+          },
+          [HighContrastSelector]: {
+            background: 'Highlight',
+            color: 'HighlightText',
+            MsHighContrastAdjust: 'none',
+          },
+        },
+      },
+    ],
+  };
+};

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { classNamesFunction, css } from '../../../Utilities';
+import {
+  IFloatingSuggestionsHeaderFooterItemProps,
+  IFloatingSuggestionHeaderFooterItemStylesProps,
+  IFloatingSuggestionHeaderFooterItemStyles,
+} from './FloatingSuggestionsHeaderFooterItem.types';
+import { getStyles } from './FloatingSuggestionsHeaderFooterItem.styles';
+
+const getClassNames = classNamesFunction<
+  IFloatingSuggestionHeaderFooterItemStylesProps,
+  IFloatingSuggestionHeaderFooterItemStyles
+>();
+
+export const FloatingSuggestionsHeaderFooterItem = (props: IFloatingSuggestionsHeaderFooterItemProps): JSX.Element => {
+  const { renderItem, onExecute, isSelected, id, className } = props;
+  const classNames = getClassNames(getStyles);
+
+  return onExecute ? (
+    <div
+      id={id}
+      onClick={onExecute}
+      className={css('ms-Suggestions-sectionButton', className, classNames.actionButton, {
+        ['is-selected ' + classNames.buttonSelected]: isSelected,
+      })}
+    >
+      {renderItem()}
+    </div>
+  ) : (
+    <div id={id} className={css('ms-Suggestions-section', className, classNames.actionButton)}>
+      {renderItem()}
+    </div>
+  );
+};

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, css } from '../../../Utilities';
+import { classNamesFunction, css } from 'office-ui-fabric-react/lib/Utilities';
 import {
   IFloatingSuggestionsHeaderFooterItemProps,
   IFloatingSuggestionHeaderFooterItemStylesProps,

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types.ts
@@ -1,0 +1,25 @@
+import { ITheme, IStyle } from '@uifabric/styling';
+
+export interface IFloatingSuggestionsHeaderFooterProps {
+  renderItem: () => JSX.Element;
+  onExecute?: () => void;
+  className?: string;
+  ariaLabel?: string;
+  shouldShow: () => boolean;
+}
+
+export interface IFloatingSuggestionsHeaderFooterItemProps {
+  renderItem: () => JSX.Element;
+  onExecute?: () => void;
+  isSelected: boolean;
+  id: string;
+  className: string | undefined;
+  theme?: ITheme;
+}
+
+export interface IFloatingSuggestionHeaderFooterItemStylesProps {}
+
+export interface IFloatingSuggestionHeaderFooterItemStyles {
+  actionButton: IStyle;
+  buttonSelected: IStyle;
+}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
@@ -7,6 +7,7 @@ import {
 } from './FloatingSuggestionsList.types';
 import { FloatingSuggestionsItemMemo } from '../FloatingSuggestionsItem/FloatingSuggestionsItem';
 import { getStyles } from './FloatingSuggestionsList.styles';
+import { ISuggestionsHeaderFooterProps, SuggestionsHeaderFooterItem } from 'office-ui-fabric-react/lib/FloatingPicker';
 
 const getClassNames = classNamesFunction<IFloatingSuggestionsListStyleProps, IFloatingSuggestionsListStyle>();
 
@@ -20,8 +21,44 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
   };
 
   const renderHeader = (): JSX.Element | null => {
-    const { onRenderHeader, suggestionsHeaderText } = props;
+    const {
+      onRenderHeader,
+      suggestionsHeaderText,
+      headerItemsProps,
+      selectedHeaderIndex,
+      suggestionsHeaderContainerAriaLabel,
+    } = props;
 
+    if (headerItemsProps) {
+      return (
+        <div
+          className={css('ms-Suggestions-headerContainer', classNames.suggestionsContainer)}
+          id="suggestionHeader-list"
+          role="list"
+          aria-label={suggestionsHeaderContainerAriaLabel}
+        >
+          {headerItemsProps.map((headerItemProps: ISuggestionsHeaderFooterProps, index: number) => {
+            const isSelected = selectedHeaderIndex !== -1 && selectedHeaderIndex === index;
+            return headerItemProps.shouldShow() ? (
+              <div
+                id={'sug-header' + index}
+                key={'sug-header' + index}
+                role="listitem"
+                aria-label={headerItemProps.ariaLabel}
+              >
+                <SuggestionsHeaderFooterItem
+                  id={'sug-header-item' + index}
+                  isSelected={isSelected}
+                  renderItem={headerItemProps.renderItem}
+                  onExecute={headerItemProps.onExecute}
+                  className={headerItemProps.className}
+                />
+              </div>
+            ) : null;
+          })}
+        </div>
+      );
+    }
     if (onRenderHeader) {
       return onRenderHeader(suggestionItems);
     }
@@ -29,7 +66,38 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
   };
 
   const renderFooter = (): JSX.Element | null => {
-    const { onRenderFooter } = props;
+    const { onRenderFooter, footerItemsProps, selectedFooterIndex, suggestionsFooterContainerAriaLabel } = props;
+
+    if (footerItemsProps) {
+      return (
+        <div
+          className={css('ms-Suggestions-footerContainer', classNames.suggestionsContainer)}
+          id="suggestionFooter-list"
+          role="list"
+          aria-label={suggestionsFooterContainerAriaLabel}
+        >
+          {footerItemsProps.map((footerItemProps: ISuggestionsHeaderFooterProps, index: number) => {
+            const isSelected = selectedFooterIndex !== -1 && selectedFooterIndex === index;
+            return footerItemProps.shouldShow() ? (
+              <div
+                id={'sug-footer' + index}
+                key={'sug-footer' + index}
+                role="listitem"
+                aria-label={footerItemProps.ariaLabel}
+              >
+                <SuggestionsHeaderFooterItem
+                  id={'sug-footer-item' + index}
+                  isSelected={isSelected}
+                  renderItem={footerItemProps.renderItem}
+                  onExecute={footerItemProps.onExecute}
+                  className={footerItemProps.className}
+                />
+              </div>
+            ) : null;
+          })}
+        </div>
+      );
+    }
     if (onRenderFooter) {
       return onRenderFooter(suggestionItems);
     }

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.tsx
@@ -7,7 +7,8 @@ import {
 } from './FloatingSuggestionsList.types';
 import { FloatingSuggestionsItemMemo } from '../FloatingSuggestionsItem/FloatingSuggestionsItem';
 import { getStyles } from './FloatingSuggestionsList.styles';
-import { ISuggestionsHeaderFooterProps, SuggestionsHeaderFooterItem } from 'office-ui-fabric-react/lib/FloatingPicker';
+import { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
+import { FloatingSuggestionsHeaderFooterItem } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem';
 
 const getClassNames = classNamesFunction<IFloatingSuggestionsListStyleProps, IFloatingSuggestionsListStyle>();
 
@@ -37,7 +38,7 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
           role="list"
           aria-label={suggestionsHeaderContainerAriaLabel}
         >
-          {headerItemsProps.map((headerItemProps: ISuggestionsHeaderFooterProps, index: number) => {
+          {headerItemsProps.map((headerItemProps: IFloatingSuggestionsHeaderFooterProps, index: number) => {
             const isSelected = selectedHeaderIndex !== -1 && selectedHeaderIndex === index;
             return headerItemProps.shouldShow() ? (
               <div
@@ -46,7 +47,7 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
                 role="listitem"
                 aria-label={headerItemProps.ariaLabel}
               >
-                <SuggestionsHeaderFooterItem
+                <FloatingSuggestionsHeaderFooterItem
                   id={'sug-header-item' + index}
                   isSelected={isSelected}
                   renderItem={headerItemProps.renderItem}
@@ -76,7 +77,7 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
           role="list"
           aria-label={suggestionsFooterContainerAriaLabel}
         >
-          {footerItemsProps.map((footerItemProps: ISuggestionsHeaderFooterProps, index: number) => {
+          {footerItemsProps.map((footerItemProps: IFloatingSuggestionsHeaderFooterProps, index: number) => {
             const isSelected = selectedFooterIndex !== -1 && selectedFooterIndex === index;
             return footerItemProps.shouldShow() ? (
               <div
@@ -85,7 +86,7 @@ export const FloatingSuggestionsList = <T extends {}>(props: IFloatingSuggestion
                 role="listitem"
                 aria-label={footerItemProps.ariaLabel}
               >
-                <SuggestionsHeaderFooterItem
+                <FloatingSuggestionsHeaderFooterItem
                   id={'sug-footer-item' + index}
                   isSelected={isSelected}
                   renderItem={footerItemProps.renderItem}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
@@ -6,6 +6,7 @@ import {
 } from '../FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { IRenderFunction } from '@uifabric/utilities';
 import { IStyle } from '@uifabric/styling';
+import { ISuggestionsHeaderFooterProps } from 'office-ui-fabric-react/lib/FloatingPicker';
 
 export interface IFloatingSuggestionsListProps<T> {
   suggestionItems: IFloatingSuggestionItem<T>[];
@@ -27,6 +28,12 @@ export interface IFloatingSuggestionsListProps<T> {
   suggestionsContainerAriaLabel?: string;
   selectedSuggestionIndex?: number;
   pickerWidth?: string;
+  headerItemsProps?: ISuggestionsHeaderFooterProps[];
+  selectedHeaderIndex?: number;
+  suggestionsHeaderContainerAriaLabel?: string;
+  footerItemsProps?: ISuggestionsHeaderFooterProps[];
+  selectedFooterIndex?: number;
+  suggestionsFooterContainerAriaLabel?: string;
 }
 
 export interface IFloatingSuggestionsListStyleProps {}

--- a/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
+++ b/packages/experiments/src/components/FloatingSuggestionsComposite/FloatingSuggestionsList/FloatingSuggestionsList.types.ts
@@ -6,7 +6,7 @@ import {
 } from '../FloatingSuggestionsItem/FloatingSuggestionsItem.types';
 import { IRenderFunction } from '@uifabric/utilities';
 import { IStyle } from '@uifabric/styling';
-import { ISuggestionsHeaderFooterProps } from 'office-ui-fabric-react/lib/FloatingPicker';
+import { IFloatingSuggestionsHeaderFooterProps } from '../FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 export interface IFloatingSuggestionsListProps<T> {
   suggestionItems: IFloatingSuggestionItem<T>[];
@@ -28,10 +28,10 @@ export interface IFloatingSuggestionsListProps<T> {
   suggestionsContainerAriaLabel?: string;
   selectedSuggestionIndex?: number;
   pickerWidth?: string;
-  headerItemsProps?: ISuggestionsHeaderFooterProps[];
+  headerItemsProps?: IFloatingSuggestionsHeaderFooterProps[];
   selectedHeaderIndex?: number;
   suggestionsHeaderContainerAriaLabel?: string;
-  footerItemsProps?: ISuggestionsHeaderFooterProps[];
+  footerItemsProps?: IFloatingSuggestionsHeaderFooterProps[];
   selectedFooterIndex?: number;
   suggestionsFooterContainerAriaLabel?: string;
 }

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -30,7 +30,14 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const { setQueryString } = useQueryString('');
   const [selection, setSelection] = React.useState(new Selection({ onSelectionChanged: () => _onSelectionChanged() }));
   const [focusedItemIndices, setFocusedItemIndices] = React.useState(selection.getSelectedIndices() || []);
-  const { suggestions, selectedSuggestionIndex, isSuggestionsVisible } = props.floatingSuggestionProps;
+  const {
+    suggestions,
+    selectedSuggestionIndex,
+    selectedFooterIndex,
+    selectedHeaderIndex,
+    pickerSuggestionsProps,
+    isSuggestionsVisible,
+  } = props.floatingSuggestionProps;
   const [draggedIndex, setDraggedIndex] = React.useState<number>(-1);
   const dragDropHelper = new DragDropHelper({
     selection: selection,
@@ -39,11 +46,23 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
   const {
     focusItemIndex,
     suggestionItems,
+    footerItemIndex,
+    footerItems,
+    headerItemIndex,
+    headerItems,
     isSuggestionsShown,
     showPicker,
     selectPreviousSuggestion,
     selectNextSuggestion,
-  } = useFloatingSuggestionItems(suggestions, selectedSuggestionIndex, isSuggestionsVisible);
+  } = useFloatingSuggestionItems(
+    suggestions,
+    selectedSuggestionIndex,
+    selectedFooterIndex,
+    pickerSuggestionsProps?.footerItemsProps,
+    selectedHeaderIndex,
+    pickerSuggestionsProps?.headerItemsProps,
+    isSuggestionsVisible,
+  );
 
   const {
     selectedItems,
@@ -228,12 +247,20 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
           break;
         case KeyCodes.enter:
         case KeyCodes.tab:
-          if (!ev.shiftKey && !ev.ctrlKey && focusItemIndex >= 0) {
+          if (!ev.shiftKey && !ev.ctrlKey && (focusItemIndex >= 0 || footerItemIndex >= 0 || headerItemIndex >= 0)) {
             ev.preventDefault();
             ev.stopPropagation();
-            // Get the focused element and add it to selectedItemsList
-            showPicker(false);
-            _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+            if (focusItemIndex >= 0) {
+              // Get the focused element and add it to selectedItemsList
+              showPicker(false);
+              _onSuggestionSelected(ev, suggestionItems[focusItemIndex]);
+            } else if (footerItemIndex >= 0) {
+              // execute the footer action
+              footerItems![footerItemIndex].onExecute!();
+            } else if (headerItemIndex >= 0) {
+              // execute the header action
+              headerItems![headerItemIndex].onExecute!();
+            }
           }
           break;
         case KeyCodes.up:
@@ -338,6 +365,9 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
       isSuggestionsVisible: isSuggestionsShown,
       suggestions: suggestionItems,
       selectedSuggestionIndex: focusItemIndex,
+      selectedFooterIndex: footerItemIndex,
+      selectedHeaderIndex: headerItemIndex,
+      pickerSuggestionsProps: pickerSuggestionsProps,
       onFloatingSuggestionsDismiss: _onFloatingSuggestionsDismiss,
       onSuggestionSelected: _onSuggestionSelected,
       onKeyDown: _onInputKeyDown,

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ISuggestionsHeaderFooterProps } from 'office-ui-fabric-react';
+import { IFloatingSuggestionsHeaderFooterProps } from '../../FloatingSuggestionsComposite/FloatingSuggestionsHeaderFooterItem/FloatingSuggestionsHeaderFooterItem.types';
 
 export interface IUseFloatingSuggestionItems<T> {
   focusItemIndex: number;
@@ -8,12 +8,12 @@ export interface IUseFloatingSuggestionItems<T> {
   setSuggestionItems: React.Dispatch<React.SetStateAction<T[]>>;
   footerItemIndex: number;
   setfooterItemIndex: React.Dispatch<React.SetStateAction<number>>;
-  footerItems: ISuggestionsHeaderFooterProps[];
-  setFooterItems: React.Dispatch<React.SetStateAction<ISuggestionsHeaderFooterProps[]>>;
+  footerItems: IFloatingSuggestionsHeaderFooterProps[];
+  setFooterItems: React.Dispatch<React.SetStateAction<IFloatingSuggestionsHeaderFooterProps[]>>;
   headerItemIndex: number;
   setHeaderItemIndex: React.Dispatch<React.SetStateAction<number>>;
-  headerItems: ISuggestionsHeaderFooterProps[];
-  setHeaderItems: React.Dispatch<React.SetStateAction<ISuggestionsHeaderFooterProps[]>>;
+  headerItems: IFloatingSuggestionsHeaderFooterProps[];
+  setHeaderItems: React.Dispatch<React.SetStateAction<IFloatingSuggestionsHeaderFooterProps[]>>;
   isSuggestionsShown: boolean;
   showPicker: (show: boolean) => void;
   selectNextSuggestion: () => void;
@@ -27,9 +27,9 @@ export const useFloatingSuggestionItems = <T extends {}>(
   floatingSuggestionItems: T[],
   focusSuggestionIndex?: number,
   focusFooterIndex?: number,
-  footerSuggestionItems?: ISuggestionsHeaderFooterProps[],
+  footerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   focusHeaderIndex?: number,
-  headerSuggestionItems?: ISuggestionsHeaderFooterProps[],
+  headerSuggestionItems?: IFloatingSuggestionsHeaderFooterProps[],
   isSuggestionsVisible?: boolean,
 ) => {
   const [focusItemIndex, setFocusItemIndex] = React.useState(focusSuggestionIndex || -1);
@@ -44,7 +44,7 @@ export const useFloatingSuggestionItems = <T extends {}>(
     setSuggestionItems(floatingSuggestionItems);
   }, [floatingSuggestionItems]);
 
-  const headerFooterItemsHaveExecute = (items: ISuggestionsHeaderFooterProps[]): boolean => {
+  const headerFooterItemsHaveExecute = (items: IFloatingSuggestionsHeaderFooterProps[]): boolean => {
     let haveExecute = false;
     items!.forEach(item => {
       if (item.onExecute !== undefined) {
@@ -57,7 +57,10 @@ export const useFloatingSuggestionItems = <T extends {}>(
   const hasSelectableFooters = footerItems ? headerFooterItemsHaveExecute(footerItems) : false;
   const hasSelectableHeaders = headerItems ? headerFooterItemsHaveExecute(headerItems) : false;
 
-  const getNextSelectableHeaderOrFooter = (items: ISuggestionsHeaderFooterProps[], itemIndex: number): number => {
+  const getNextSelectableHeaderOrFooter = (
+    items: IFloatingSuggestionsHeaderFooterProps[],
+    itemIndex: number,
+  ): number => {
     let nextIndex = -1;
     if (items) {
       let i = itemIndex + 1;
@@ -72,7 +75,10 @@ export const useFloatingSuggestionItems = <T extends {}>(
     return nextIndex;
   };
 
-  const getPreviousSelectableHeaderOrFooter = (items: ISuggestionsHeaderFooterProps[], itemIndex: number): number => {
+  const getPreviousSelectableHeaderOrFooter = (
+    items: IFloatingSuggestionsHeaderFooterProps[],
+    itemIndex: number,
+  ): number => {
     let nextIndex = -1;
     if (items) {
       let i = itemIndex !== -1 ? itemIndex - 1 : items.length - 1;

--- a/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
+++ b/packages/experiments/src/components/UnifiedPicker/hooks/useFloatingSuggestionItems.ts
@@ -1,10 +1,19 @@
 import * as React from 'react';
+import { ISuggestionsHeaderFooterProps } from 'office-ui-fabric-react';
 
 export interface IUseFloatingSuggestionItems<T> {
   focusItemIndex: number;
   setFocusItemIndex: React.Dispatch<React.SetStateAction<number>>;
   suggestionItems: T[];
   setSuggestionItems: React.Dispatch<React.SetStateAction<T[]>>;
+  footerItemIndex: number;
+  setfooterItemIndex: React.Dispatch<React.SetStateAction<number>>;
+  footerItems: ISuggestionsHeaderFooterProps[];
+  setFooterItems: React.Dispatch<React.SetStateAction<ISuggestionsHeaderFooterProps[]>>;
+  headerItemIndex: number;
+  setHeaderItemIndex: React.Dispatch<React.SetStateAction<number>>;
+  headerItems: ISuggestionsHeaderFooterProps[];
+  setHeaderItems: React.Dispatch<React.SetStateAction<ISuggestionsHeaderFooterProps[]>>;
   isSuggestionsShown: boolean;
   showPicker: (show: boolean) => void;
   selectNextSuggestion: () => void;
@@ -17,45 +26,200 @@ export interface IUseFloatingSuggestionItems<T> {
 export const useFloatingSuggestionItems = <T extends {}>(
   floatingSuggestionItems: T[],
   focusSuggestionIndex?: number,
+  focusFooterIndex?: number,
+  footerSuggestionItems?: ISuggestionsHeaderFooterProps[],
+  focusHeaderIndex?: number,
+  headerSuggestionItems?: ISuggestionsHeaderFooterProps[],
   isSuggestionsVisible?: boolean,
 ) => {
   const [focusItemIndex, setFocusItemIndex] = React.useState(focusSuggestionIndex || -1);
   const [suggestionItems, setSuggestionItems] = React.useState(floatingSuggestionItems);
+  const [footerItemIndex, setFooterItemIndex] = React.useState(focusFooterIndex || -1);
+  const [footerItems, setFooterItems] = React.useState(footerSuggestionItems);
+  const [headerItemIndex, setHeaderItemIndex] = React.useState(focusHeaderIndex || -1);
+  const [headerItems, setHeaderItems] = React.useState(headerSuggestionItems);
   const [isSuggestionsShown, setIsSuggestionsShown] = React.useState(isSuggestionsVisible || false);
 
   React.useEffect(() => {
     setSuggestionItems(floatingSuggestionItems);
   }, [floatingSuggestionItems]);
 
+  const headerFooterItemsHaveExecute = (items: ISuggestionsHeaderFooterProps[]): boolean => {
+    let haveExecute = false;
+    items!.forEach(item => {
+      if (item.onExecute !== undefined) {
+        haveExecute = true;
+      }
+    });
+    return haveExecute;
+  };
+
+  const hasSelectableFooters = footerItems ? headerFooterItemsHaveExecute(footerItems) : false;
+  const hasSelectableHeaders = headerItems ? headerFooterItemsHaveExecute(headerItems) : false;
+
+  const getNextSelectableHeaderOrFooter = (items: ISuggestionsHeaderFooterProps[], itemIndex: number): number => {
+    let nextIndex = -1;
+    if (items) {
+      let i = itemIndex + 1;
+      while (i < items.length) {
+        if (items[i].onExecute && items[i].shouldShow()) {
+          nextIndex = i;
+          i = items.length;
+        }
+        i++;
+      }
+    }
+    return nextIndex;
+  };
+
+  const getPreviousSelectableHeaderOrFooter = (items: ISuggestionsHeaderFooterProps[], itemIndex: number): number => {
+    let nextIndex = -1;
+    if (items) {
+      let i = itemIndex !== -1 ? itemIndex - 1 : items.length - 1;
+      while (i > -1) {
+        if (items[i].onExecute && items[i].shouldShow()) {
+          nextIndex = i;
+          i = -1;
+        }
+        i--;
+      }
+    }
+    return nextIndex;
+  };
+
   const showPicker = (show: boolean) => {
     setFocusItemIndex(-1);
+    setFooterItemIndex(-1);
+    setHeaderItemIndex(-1);
     setIsSuggestionsShown(show);
   };
 
   const selectNextSuggestion = (): void => {
-    if (suggestionItems && suggestionItems.length > 0) {
-      if (focusItemIndex === -1) {
-        setFocusItemIndex(0);
-      } else if (focusItemIndex < suggestionItems.length - 1) {
-        setFocusItemIndex(focusItemIndex + 1);
-      } else if (focusItemIndex === suggestionItems.length - 1) {
-        setFocusItemIndex(0);
+    // We're currently selected on a header
+    if (headerItemIndex > -1) {
+      // First, try and find another header
+      const nextHeaderIndex = getNextSelectableHeaderOrFooter(headerItems!, headerItemIndex);
+      if (nextHeaderIndex !== -1) {
+        setHeaderItemIndex(nextHeaderIndex);
+      } else {
+        // select the first suggestion item
+        setHeaderItemIndex(-1);
+        if (suggestionItems && suggestionItems.length > 0) {
+          // select the first suggestion item
+          setFocusItemIndex(0);
+        } else if (hasSelectableFooters) {
+          setFooterItemIndex(getNextSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+        }
       }
     }
-    if (suggestionItems.length > focusItemIndex + 1) {
-      setFocusItemIndex(focusItemIndex + 1);
+    // We're currently selected on a selected item
+    else if (focusItemIndex > -1) {
+      // If we're at the end of the list
+      if (focusItemIndex === suggestionItems.length - 1) {
+        if (hasSelectableFooters) {
+          setFooterItemIndex(getNextSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+          setFocusItemIndex(-1);
+        } else if (hasSelectableHeaders) {
+          setHeaderItemIndex(getNextSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+          setFocusItemIndex(-1);
+        } else {
+          setFocusItemIndex(0);
+        }
+      } else {
+        setFocusItemIndex(focusItemIndex + 1);
+      }
+    }
+    // We're currently selected on a footer
+    else if (footerItemIndex > -1) {
+      // First, try and find another footer
+      const nextFooterIndex = getNextSelectableHeaderOrFooter(footerItems!, footerItemIndex);
+      if (nextFooterIndex !== -1) {
+        setFooterItemIndex(nextFooterIndex);
+      } else {
+        setFooterItemIndex(-1);
+        if (hasSelectableHeaders) {
+          setHeaderItemIndex(getNextSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+        } else if (suggestionItems && suggestionItems.length > 0) {
+          // select the first suggestion item
+          setFocusItemIndex(0);
+        }
+      }
+    }
+    // else, we have no items selected, so select the first one available
+    else {
+      if (hasSelectableHeaders) {
+        setHeaderItemIndex(getNextSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+      } else if (suggestionItems && suggestionItems.length > 0) {
+        // select the first suggestion item
+        setFocusItemIndex(0);
+      } else if (hasSelectableFooters) {
+        setFooterItemIndex(getNextSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+      }
+      // else, we stay in the state with nothing selected
     }
   };
 
   const selectPreviousSuggestion = (): void => {
-    if (suggestionItems && suggestionItems.length > 0) {
-      if (focusItemIndex === -1) {
-        setFocusItemIndex(suggestionItems.length - 1);
-      } else if (focusItemIndex > 0) {
-        setFocusItemIndex(focusItemIndex - 1);
-      } else if (focusItemIndex === 0) {
-        setFocusItemIndex(suggestionItems.length - 1);
+    // We're currently selected on a footer
+    if (footerItemIndex > -1) {
+      // First, try and find another footer
+      const previousFooterIndex = getPreviousSelectableHeaderOrFooter(footerItems!, footerItemIndex);
+      if (previousFooterIndex !== -1) {
+        setFooterItemIndex(previousFooterIndex);
+      } else {
+        setFooterItemIndex(-1);
+        if (suggestionItems && suggestionItems.length > 0) {
+          // select the first suggestion item
+          setFocusItemIndex(suggestionItems.length - 1);
+        } else if (hasSelectableHeaders) {
+          setHeaderItemIndex(getPreviousSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+        }
       }
+    }
+    // We're currently selected on a selected item
+    else if (focusItemIndex > -1) {
+      // If we're at the beginning of the list
+      if (focusItemIndex === 0) {
+        setFocusItemIndex(-1);
+        if (hasSelectableHeaders) {
+          setHeaderItemIndex(getPreviousSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+        } else if (hasSelectableFooters) {
+          setFooterItemIndex(getPreviousSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+        } else {
+          setFocusItemIndex(suggestionItems.length - 1);
+        }
+      } else {
+        setFocusItemIndex(focusItemIndex - 1);
+      }
+    }
+    // We're currently selected on a header
+    else if (headerItemIndex > -1) {
+      // First, try and find another header
+      const nextHeaderIndex = getPreviousSelectableHeaderOrFooter(headerItems!, headerItemIndex);
+      if (nextHeaderIndex !== -1) {
+        setHeaderItemIndex(nextHeaderIndex);
+      } else {
+        // select the first suggestion item
+        setHeaderItemIndex(-1);
+        if (hasSelectableFooters) {
+          setFooterItemIndex(getPreviousSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+        } else if (suggestionItems && suggestionItems.length > 0) {
+          // select the first suggestion item
+          setFocusItemIndex(suggestionItems.length - 1);
+        }
+      }
+    }
+    // else, we have no items selected, so select the last one available
+    else {
+      if (hasSelectableFooters) {
+        setFooterItemIndex(getPreviousSelectableHeaderOrFooter(footerItems!, footerItemIndex));
+      } else if (suggestionItems && suggestionItems.length > 0) {
+        // select the last suggestion item
+        setFocusItemIndex(suggestionItems.length - 1);
+      } else if (hasSelectableHeaders) {
+        setHeaderItemIndex(getPreviousSelectableHeaderOrFooter(headerItems!, headerItemIndex));
+      }
+      // else, we stay in the state with nothing selected
     }
   };
 
@@ -78,6 +242,14 @@ export const useFloatingSuggestionItems = <T extends {}>(
     setFocusItemIndex: setFocusItemIndex,
     suggestionItems: suggestionItems,
     setSuggestionItems: setSuggestionItems,
+    footerItemIndex: footerItemIndex,
+    setFooterItemIndex: setFooterItemIndex,
+    footerItems: footerItems,
+    setFooterItems: setFooterItems,
+    headerItemIndex: headerItemIndex,
+    setHeaderItemIndex: setHeaderItemIndex,
+    headerItems: headerItems,
+    setHeaderItems: setHeaderItems,
     isSuggestionsShown: isSuggestionsShown,
     showPicker: showPicker,
     selectNextSuggestion: selectNextSuggestion,

--- a/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
+++ b/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
@@ -3,12 +3,11 @@ import {
   IFloatingSuggestionItemProps,
   FloatingPeopleSuggestions,
   IFloatingSuggestionItem,
-  IBaseFloatingPickerHeaderFooterProps,
 } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
-import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { mru } from '@uifabric/example-data';
 import { useConst } from '@uifabric/react-hooks';
-import { Autofill } from '@fluentui/react';
+import { Autofill } from 'office-ui-fabric-react';
 import { KeyCodes } from '@uifabric/experiments/lib/Utilities';
 
 const _suggestions = [
@@ -64,7 +63,7 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
 
   const input = React.useRef<Autofill>(null);
 
-  const suggestionProps: IBaseFloatingPickerHeaderFooterProps = useConst(() => {
+  const suggestionProps = useConst(() => {
     return {
       headerItemsProps: [
         {
@@ -103,6 +102,8 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
           ariaLabel: 'Select to log out to console',
         },
       ],
+      suggestionsFooterContainerAriaLabel: 'Footer container',
+      suggestionsHeaderContainerAriaLabel: 'Header container',
     };
   });
 
@@ -227,8 +228,6 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
           selectedSuggestionIndex={selectedSuggestionIndex}
           selectedFooterIndex={selectedFooterIndex}
           selectedHeaderIndex={selectedHeaderIndex}
-          suggestionsFooterContainerAriaLabel={'Footer container'}
-          suggestionsHeaderContainerAriaLabel={'Header container'}
         />
       </>
     );
@@ -244,15 +243,9 @@ export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
           flex: '1 1 auto',
           height: '34px',
           border: 'none',
-          flexGrow: '1',
           outline: 'none',
           padding: '0 6px 0px',
           margin: '1px',
-          selectors: {
-            '&::-ms-clear': {
-              display: 'none',
-            },
-          },
         }}
         // eslint-disable-next-line react/jsx-no-bind
         onKeyDown={_onInputKeyDown}

--- a/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
+++ b/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingPeopleSuggestions.HeaderFooter.Example.tsx
@@ -1,0 +1,263 @@
+import * as React from 'react';
+import {
+  IFloatingSuggestionItemProps,
+  FloatingPeopleSuggestions,
+  IFloatingSuggestionItem,
+  IBaseFloatingPickerHeaderFooterProps,
+} from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
+import { IPersonaProps } from '@fluentui/react/lib/Persona';
+import { mru } from '@uifabric/example-data';
+import { useConst } from '@uifabric/react-hooks';
+import { Autofill } from '@fluentui/react';
+import { KeyCodes } from '@uifabric/experiments/lib/Utilities';
+
+const _suggestions = [
+  {
+    key: '1',
+    id: '1',
+    displayText: 'Suggestion 1',
+    item: mru[0],
+    isSelected: true,
+    showRemoveButton: true,
+  },
+  {
+    key: '2',
+    id: '2',
+    displayText: 'Suggestion 2',
+    item: mru[1],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '3',
+    id: '3',
+    displayText: 'Suggestion 3',
+    item: mru[2],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '4',
+    id: '4',
+    displayText: 'Suggestion 4',
+    item: mru[3],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+  {
+    key: '5',
+    id: '5',
+    displayText: 'Suggestion 5',
+    item: mru[4],
+    isSelected: false,
+    showRemoveButton: true,
+  },
+] as IFloatingSuggestionItem<IPersonaProps>[];
+
+export const FloatingPeopleSuggestionsHeaderFooterExample = (): JSX.Element => {
+  const [peopleSuggestions, setPeopleSuggestions] = React.useState<IFloatingSuggestionItemProps<IPersonaProps>[]>([
+    ..._suggestions,
+  ]);
+  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = React.useState<number>(0);
+  const [selectedFooterIndex, setSelectedFooterIndex] = React.useState<number>(-1);
+  const selectedHeaderIndex = -1;
+
+  const input = React.useRef<Autofill>(null);
+
+  const suggestionProps: IBaseFloatingPickerHeaderFooterProps = useConst(() => {
+    return {
+      headerItemsProps: [
+        {
+          renderItem: () => {
+            return <>People Suggestions</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          ariaLabel: 'People suggestions header',
+        },
+      ],
+      footerItemsProps: [
+        {
+          renderItem: () => {
+            return <>Showing {peopleSuggestions.length} results</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            alert('You selected people suggestions');
+          },
+          ariaLabel: 'Showing results',
+        },
+        {
+          renderItem: () => {
+            return <>Select to log out to console</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            console.log(peopleSuggestions);
+          },
+          ariaLabel: 'Select to log out to console',
+        },
+      ],
+    };
+  });
+
+  const _onSuggestionSelected = (
+    ev: React.MouseEvent<HTMLElement, MouseEvent>,
+    item: IFloatingSuggestionItemProps<IPersonaProps>,
+  ) => {
+    _markSuggestionSelected(item);
+  };
+
+  const _onSuggestionRemoved = (
+    ev: React.MouseEvent<HTMLElement, MouseEvent>,
+    suggestionToRemove: IFloatingSuggestionItemProps<IPersonaProps>,
+  ) => {
+    setPeopleSuggestions(suggestions => {
+      const modifiedSuggestions = suggestions.filter(item => item.id !== suggestionToRemove.id);
+      return modifiedSuggestions;
+    });
+  };
+
+  const _markSuggestionSelected = (selectedSuggestion: IFloatingSuggestionItemProps<IPersonaProps>) => {
+    setPeopleSuggestions(suggestions => {
+      const modifiedSuggestions = suggestions.map(suggestion =>
+        suggestion.id === selectedSuggestion.id
+          ? { ...suggestion, isSelected: true }
+          : { ...suggestion, isSelected: false },
+      );
+      return modifiedSuggestions;
+    });
+  };
+
+  const selectPreviousItem = () => {
+    // Headers are not selectable in this example
+    // Suggestions
+    if (selectedSuggestionIndex > -1) {
+      if (selectedSuggestionIndex === 0) {
+        setSelectedSuggestionIndex(-1);
+      }
+      // otherwise, move up one
+      else {
+        setSelectedSuggestionIndex(selectedSuggestionIndex - 1);
+      }
+    }
+    // footers
+    else if (selectedFooterIndex > -1) {
+      if (selectedFooterIndex === 0) {
+        // move to suggestions
+        setSelectedFooterIndex(-1);
+        setSelectedSuggestionIndex(peopleSuggestions.length - 1);
+      } else {
+        setSelectedFooterIndex(selectedFooterIndex - 1);
+      }
+    }
+  };
+
+  const selectNextItem = () => {
+    // Headers are not selectable in this example
+    // Suggestions
+    if (selectedSuggestionIndex === -1 && selectedFooterIndex === -1) {
+      setSelectedSuggestionIndex(0);
+    } else if (selectedSuggestionIndex > -1) {
+      // if we're at the end of the suggestions, move to the footer
+      if (selectedSuggestionIndex === peopleSuggestions.length - 1) {
+        setSelectedSuggestionIndex(-1);
+        setSelectedFooterIndex(0);
+      }
+      // otherwise, move down one
+      else {
+        setSelectedSuggestionIndex(selectedSuggestionIndex + 1);
+      }
+    }
+    // footers
+    else if (selectedFooterIndex > -1) {
+      if (selectedFooterIndex === suggestionProps.footerItemsProps!.length - 1) {
+        // if we're at the end, stay there
+      } else {
+        setSelectedFooterIndex(selectedFooterIndex + 1);
+      }
+    }
+  };
+
+  const _onInputKeyDown = (ev: React.KeyboardEvent<Autofill | HTMLElement>) => {
+    const keyCode = ev.which;
+    switch (keyCode) {
+      case KeyCodes.enter:
+      case KeyCodes.tab:
+        if (selectedSuggestionIndex > -1) {
+          alert('an item was selected');
+        }
+        if (selectedFooterIndex > -1) {
+          suggestionProps.footerItemsProps![selectedFooterIndex]!.onExecute!();
+        }
+        break;
+      case KeyCodes.up:
+        ev.preventDefault();
+        ev.stopPropagation();
+        selectPreviousItem();
+        break;
+      case KeyCodes.down:
+        ev.preventDefault();
+        ev.stopPropagation();
+        selectNextItem();
+        break;
+    }
+  };
+
+  const _renderExtendedPicker = () => {
+    return (
+      <>
+        <FloatingPeopleSuggestions
+          suggestions={[...peopleSuggestions]}
+          isSuggestionsVisible={true}
+          targetElement={input.current?.inputElement}
+          /* eslint-disable react/jsx-no-bind */
+          onSuggestionSelected={_onSuggestionSelected}
+          onRemoveSuggestion={_onSuggestionRemoved}
+          /* eslint-enable react/jsx-no-bind */
+          noResultsFoundText={'No suggestions'}
+          onFloatingSuggestionsDismiss={undefined}
+          showSuggestionRemoveButton={true}
+          pickerSuggestionsProps={suggestionProps}
+          selectedSuggestionIndex={selectedSuggestionIndex}
+          selectedFooterIndex={selectedFooterIndex}
+          selectedHeaderIndex={selectedHeaderIndex}
+          suggestionsFooterContainerAriaLabel={'Footer container'}
+          suggestionsHeaderContainerAriaLabel={'Header container'}
+        />
+      </>
+    );
+  };
+
+  return (
+    <div className={'ms-BasePicker-text'}>
+      <Autofill
+        ref={input}
+        aria-label={'input'}
+        style={{
+          display: 'flex',
+          flex: '1 1 auto',
+          height: '34px',
+          border: 'none',
+          flexGrow: '1',
+          outline: 'none',
+          padding: '0 6px 0px',
+          margin: '1px',
+          selectors: {
+            '&::-ms-clear': {
+              display: 'none',
+            },
+          },
+        }}
+        // eslint-disable-next-line react/jsx-no-bind
+        onKeyDown={_onInputKeyDown}
+      />
+      {_renderExtendedPicker()}
+    </div>
+  );
+};

--- a/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
+++ b/packages/react-examples/src/experiments/FloatingPeopleSuggestions/FloatingSuggestionsPage.tsx
@@ -4,6 +4,8 @@ import { FloatingPeopleSuggestionsExample } from './FloatingPeopleSuggestions.Ex
 const FloatingPeoplePickerSuggestionsExampleCode = require('!raw-loader!./FloatingPeopleSuggestions.Example') as string;
 import { FloatingPeopleSuggestionsCustomRenderExample } from './FloatingPeopleSuggestions.CustomRender.Example';
 const FloatingPeoplePickerSuggestionsCustomRenderCode = require('!raw-loader!./FloatingPeopleSuggestions.CustomRender.Example') as string;
+import { FloatingPeopleSuggestionsHeaderFooterExample } from './FloatingPeopleSuggestions.HeaderFooter.Example';
+const FloatingPeoplePickerSuggestionsHeaderFooterCode = require('!raw-loader!./FloatingPeopleSuggestions.HeaderFooter.Example') as string;
 
 export class FloatingSuggestionPage extends React.Component<IComponentDemoPageProps, {}> {
   public render(): JSX.Element {
@@ -18,6 +20,9 @@ export class FloatingSuggestionPage extends React.Component<IComponentDemoPagePr
             </ExampleCard>
             <ExampleCard title="Basic" isOptIn={true} code={FloatingPeoplePickerSuggestionsCustomRenderCode}>
               <FloatingPeopleSuggestionsCustomRenderExample />
+            </ExampleCard>
+            <ExampleCard title="Basic" isOptIn={true} code={FloatingPeoplePickerSuggestionsHeaderFooterCode}>
+              <FloatingPeopleSuggestionsHeaderFooterExample />
             </ExampleCard>
           </div>
         }

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -3,12 +3,14 @@ import {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,
   IFloatingPeopleSuggestionsProps,
+  IBaseFloatingPickerHeaderFooterProps,
 } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePicker';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
 import { mru, people } from '@uifabric/example-data';
 import { ISelectedPeopleListProps } from '@uifabric/experiments/lib/SelectedItemsList';
 import { IInputProps } from 'office-ui-fabric-react';
+import { useConst } from '@uifabric/react-hooks';
 
 const _suggestions = [
   {
@@ -61,6 +63,48 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
   const [peopleSelectedItems, setPeopleSelectedItems] = React.useState<IPersonaProps[]>([]);
 
   const ref = React.useRef<any>();
+
+  const suggestionProps: IBaseFloatingPickerHeaderFooterProps = useConst(() => {
+    return {
+      /*headerItemsProps: [
+        {
+          renderItem: () => {
+            return <>People Suggestions</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            alert('People suggestions selected');
+          },
+        },
+      ],*/
+      footerItemsProps: [
+        {
+          renderItem: () => {
+            return <>Showing {peopleSuggestions.length} results</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          /*onExecute: () => {
+            alert('Showing people suggestions executed');
+          },*/
+        },
+        {
+          renderItem: () => {
+            return <>Select to log out to console</>;
+          },
+          shouldShow: () => {
+            return peopleSuggestions.length > 0;
+          },
+          onExecute: () => {
+            console.log(peopleSuggestions);
+          },
+        },
+      ],
+    };
+  });
 
   const _onSuggestionSelected = (
     ev: React.MouseEvent<HTMLElement, MouseEvent>,
@@ -194,6 +238,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
     onFloatingSuggestionsDismiss: undefined,
     showSuggestionRemoveButton: true,
     pickerWidth: '300px',
+    pickerSuggestionsProps: suggestionProps,
   } as IFloatingPeopleSuggestionsProps;
 
   const selectedPeopleListProps = {

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -66,6 +66,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const suggestionProps: IBaseFloatingPickerHeaderFooterProps = useConst(() => {
     return {
+      // uncomment below section to see any example of a selectable header item
       /*headerItemsProps: [
         {
           renderItem: () => {
@@ -87,6 +88,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
           shouldShow: () => {
             return peopleSuggestions.length > 0;
           },
+          // uncomment to see an example of multiple selectable footer items
           /*onExecute: () => {
             alert('Showing people suggestions executed');
           },*/

--- a/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
+++ b/packages/react-examples/src/experiments/UnifiedPeoplePicker/UnifiedPeoplePicker.Example.tsx
@@ -3,7 +3,6 @@ import {
   IFloatingSuggestionItemProps,
   IFloatingSuggestionItem,
   IFloatingPeopleSuggestionsProps,
-  IBaseFloatingPickerHeaderFooterProps,
 } from '@uifabric/experiments/lib/FloatingPeopleSuggestionsComposite';
 import { UnifiedPeoplePicker } from '@uifabric/experiments/lib/UnifiedPeoplePicker';
 import { IPersonaProps } from 'office-ui-fabric-react/lib/Persona';
@@ -64,7 +63,7 @@ export const UnifiedPeoplePickerExample = (): JSX.Element => {
 
   const ref = React.useRef<any>();
 
-  const suggestionProps: IBaseFloatingPickerHeaderFooterProps = useConst(() => {
+  const suggestionProps = useConst(() => {
     return {
       // uncomment below section to see any example of a selectable header item
       /*headerItemsProps: [


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
v8 PR - https://github.com/microsoft/fluentui/pull/15432

Adding a property so that consumers can add selectable footers and headers to the floating picker. It wasn't possible to keyboard navigate to headers or footers previously. This property takes precedence over the old render functions, but I've kept them, so this change is backwards compatible.

I added keyboard navigation to the UnifiedPicker as well.

I added an example for the floating suggestions composite and I modified the UPP single example so that the picker has headers and footers.

#### Focus areas to test

I have checked that keyboard navigation works properly when:
- no headers or footers
- non selectable headers and footers
- non selectable header, selectable footers
- non selectable header, one selectable footer
- selectable header, one selectable footer