### PR TITLE
Fix inferred type error related to ITheme

### DIFF
--- a/change/@fluentui-theme-2020-10-16-13-18-01-fix-weird-typing-error.json
+++ b/change/@fluentui-theme-2020-10-16-13-18-01-fix-weird-typing-error.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix ITheme inferred typing error.",
+  "packageName": "@fluentui/theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T20:18:01.657Z"
+}

--- a/change/office-ui-fabric-react-2020-10-16-13-18-01-fix-weird-typing-error.json
+++ b/change/office-ui-fabric-react-2020-10-16-13-18-01-fix-weird-typing-error.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix ITheme inferred typing error.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-16T20:17:43.663Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1322,7 +1322,7 @@ export const getMeasurementCache: () => {
 };
 
 // @public (undocumented)
-export const getMenuItemStyles: (theme: import("@fluentui/theme/lib/types").Theme) => IMenuItemStyles;
+export const getMenuItemStyles: (theme: ITheme) => IMenuItemStyles;
 
 // @public
 export const getNextResizeGroupStateProvider: (measurementCache?: {

--- a/packages/theme/etc/theme.api.md
+++ b/packages/theme/etc/theme.api.md
@@ -385,7 +385,8 @@ export interface IPalette {
 }
 
 // @public (undocumented)
-export type IPartialTheme = PartialTheme;
+export interface IPartialTheme extends PartialTheme {
+}
 
 // @public (undocumented)
 export interface IScheme {
@@ -545,7 +546,8 @@ export interface ISpacing {
 }
 
 // @public (undocumented)
-export type ITheme = Theme;
+export interface ITheme extends Theme {
+}
 
 // @public (undocumented)
 export namespace LocalizedFontFamilies {

--- a/packages/theme/src/types/ITheme.ts
+++ b/packages/theme/src/types/ITheme.ts
@@ -1,12 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Theme, PartialTheme } from './Theme';
 export { ISchemeNames, IScheme } from './IScheme';
 
 /**
  * {@docCategory ITheme}
  */
-export type ITheme = Theme;
+export interface ITheme extends Theme {}
 
 /**
  * {@docCategory ITheme}
  */
-export type IPartialTheme = PartialTheme;
+export interface IPartialTheme extends PartialTheme {}


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Run into a report of following typing error related to `ITheme`.
```
 error TS2742: The inferred type of 'navGroupDividerStyle' cannot be named without a reference to '../../../../../common/temp/node_modules/.registry.npmjs.org/@uifabric/styling/7.16.12_8fbe4bd393535fec5ef0af7d5e2846e1/node_modules/@fluentui/theme/lib/types'. This is likely not portable. A type annotation is necessary.
35 export const navGroupDividerStyle = (theme: ITheme): IStyle => {
```

the issue can only be fixed in user's code by adding explicit type definition:
```
export const navGroupDividerStyle: (theme: ITheme) => IStyle = (theme: ITheme): IStyle => {
```

Changing `type` to `interface ... extends ...` fixed the issue. However I am still puzzled by why
#### Focus areas to test

(optional)
