### PR TITLE
Fix inferred type error related to ITheme (cherry-pick from 7.0)

### DIFF
--- a/change/@fluentui-react-internal-2020-10-16-18-39-16-xgao-cherry-pick-fixes.json
+++ b/change/@fluentui-react-internal-2020-10-16-18-39-16-xgao-cherry-pick-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Export getMenuStyles from ContextualMenu",
+  "packageName": "@fluentui/react-internal",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-17T01:38:58.544Z"
+}

--- a/change/@fluentui-theme-2020-10-16-18-39-16-xgao-cherry-pick-fixes.json
+++ b/change/@fluentui-theme-2020-10-16-18-39-16-xgao-cherry-pick-fixes.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix inferred type error related to ITheme.",
+  "packageName": "@fluentui/theme",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-17T01:39:16.806Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -940,6 +940,9 @@ export const getMeasurementCache: () => {
     addMeasurementToCache: (data: any, measurement: number) => void;
 };
 
+// @public (undocumented)
+export const getMenuItemStyles: (theme: ITheme) => IMenuItemStyles;
+
 // @public
 export const getNextResizeGroupStateProvider: (measurementCache?: {
     getCachedMeasurement: (data: any) => number | undefined;

--- a/packages/react-internal/src/components/ContextualMenu/index.ts
+++ b/packages/react-internal/src/components/ContextualMenu/index.ts
@@ -4,3 +4,4 @@ export * from './ContextualMenu.types';
 export * from './ContextualMenuItem';
 export * from './ContextualMenuItem.base';
 export * from './ContextualMenuItem.types';
+export { getMenuItemStyles } from './ContextualMenu.cnstyles';

--- a/packages/theme/etc/theme.api.md
+++ b/packages/theme/etc/theme.api.md
@@ -385,7 +385,8 @@ export interface IPalette {
 }
 
 // @public (undocumented)
-export type IPartialTheme = PartialTheme;
+export interface IPartialTheme extends PartialTheme {
+}
 
 // @public (undocumented)
 export interface IScheme {
@@ -545,7 +546,8 @@ export interface ISpacing {
 }
 
 // @public (undocumented)
-export type ITheme = Theme;
+export interface ITheme extends Theme {
+}
 
 // @public (undocumented)
 export namespace LocalizedFontFamilies {

--- a/packages/theme/src/types/ITheme.ts
+++ b/packages/theme/src/types/ITheme.ts
@@ -1,12 +1,13 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import { Theme, PartialTheme } from './Theme';
 export { ISchemeNames, IScheme } from './IScheme';
 
 /**
  * {@docCategory ITheme}
  */
-export type ITheme = Theme;
+export interface ITheme extends Theme {}
 
 /**
  * {@docCategory ITheme}
  */
-export type IPartialTheme = PartialTheme;
+export interface IPartialTheme extends PartialTheme {}


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick #15560.

Also noticed change from #14963 is missing. Most likely lost by code move. So adding it back.

#### Focus areas to test

(optional)
