### PR TITLE
Avoid using css vars for default styles applied by ThemeProvider

### DIFF
--- a/change/@fluentui-react-button-2020-10-19-17-48-56-xgao-themeprovider-ie11-safe.json
+++ b/change/@fluentui-react-button-2020-10-19-17-48-56-xgao-themeprovider-ie11-safe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "packageName": "@fluentui/react-button",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T00:48:56.143Z"
+}

--- a/change/@fluentui-react-button-2020-10-19-17-49-34-xgao-themeprovider-ie11-safe.json
+++ b/change/@fluentui-react-button-2020-10-19-17-49-34-xgao-themeprovider-ie11-safe.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update ThemeProvider snapshots.",
+  "packageName": "@fluentui/react-button",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-20T00:49:34.679Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-10-14-17-14-36-xgao-themeprovider-ie11-safe.json
+++ b/change/@fluentui-react-theme-provider-2020-10-14-17-14-36-xgao-themeprovider-ie11-safe.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "do not use css vars for default styles applied by ThemeProvider.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-15T00:14:36.486Z"
+}

--- a/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/react-button/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`Button renders a default state 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   <button
@@ -356,13 +356,13 @@ exports[`Button renders anchor when href prop is provided 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   <a

--- a/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
+++ b/packages/react-theme-provider/src/__snapshots__/ThemeProvider.test.tsx.snap
@@ -73,13 +73,13 @@ exports[`ThemeProvider can apply body theme to body 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: black;
+        color: white;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 />
 `;
@@ -312,13 +312,13 @@ exports[`ThemeProvider can handle a partial theme 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -398,13 +398,13 @@ exports[`ThemeProvider renders a div 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #ffffff;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -484,13 +484,13 @@ exports[`ThemeProvider renders a div with styling 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: white;
+        color: black;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   Hello
@@ -570,13 +570,13 @@ exports[`ThemeProvider renders nested themes 1`] = `
         --text-variant-title3-lineHeight: 32px;
       }
       {
-        -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-        -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-        background: var(--color-body-background);
-        color: var(--color-body-contentColor);
-        font-family: var(--body-fontFamily);
-        font-size: var(--body-fontSize);
-        font-weight: var(--body-fontWeight);
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: white;
+        color: black;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
       }
 >
   <div>
@@ -654,13 +654,13 @@ exports[`ThemeProvider renders nested themes 1`] = `
           --text-variant-title3-lineHeight: 32px;
         }
         {
-          -moz-osx-font-smoothing: var(--body-mozOsxFontSmoothing);
-          -webkit-font-smoothing: var(--body-webkitFontSmoothing);
-          background: var(--color-body-background);
-          color: var(--color-body-contentColor);
-          font-family: var(--body-fontFamily);
-          font-size: var(--body-fontSize);
-          font-weight: var(--body-fontWeight);
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background: black;
+          color: white;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
         }
   >
     <div>

--- a/packages/react-theme-provider/src/useThemeProviderClasses.tsx
+++ b/packages/react-theme-provider/src/useThemeProviderClasses.tsx
@@ -14,13 +14,13 @@ const useThemeProviderStyles = makeStyles((theme: Theme) => {
     root: tokenStyles,
     body: [
       {
-        color: 'var(--color-body-contentColor)',
-        background: 'var(--color-body-background)',
-        fontFamily: 'var(--body-fontFamily)',
-        fontWeight: 'var(--body-fontWeight)',
-        fontSize: 'var(--body-fontSize)',
-        MozOsxFontSmoothing: 'var(--body-mozOsxFontSmoothing)',
-        WebkitFontSmoothing: 'var(--body-webkitFontSmoothing)',
+        color: tokens?.color?.body?.contentColor,
+        background: tokens?.color?.body?.background,
+        fontFamily: tokens?.body?.fontFamily,
+        fontWeight: tokens?.body?.fontWeight,
+        fontSize: tokens?.body?.fontSize,
+        MozOsxFontSmoothing: tokens?.body?.mozOsxFontSmoothing,
+        WebkitFontSmoothing: tokens?.body?.webkitFontSmoothing,
       },
     ],
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
avoid using css vars for default styles applied by ThemeProvider (ie11 safe)

#### Focus areas to test

(optional)
