### PR TITLE
UPP: Add onKeyDown prop

### DIFF
--- a/change/@fluentui-react-experiments-2020-10-20-14-54-31-addkeydownprop.json
+++ b/change/@fluentui-react-experiments-2020-10-20-14-54-31-addkeydownprop.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add onKeyDown prop to UnifiedPicker",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T21:54:31.804Z"
+}

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -176,7 +176,13 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     onDragEnd: _onDragEnd,
   };
 
-  const _onBackspace = (ev: React.KeyboardEvent<HTMLDivElement>) => {
+  const _onKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
+    // Allow the caller to handle the key down
+    if (props.onKeyDown) {
+      props.onKeyDown(ev);
+    }
+
+    // Handle delete of items via backspace
     if (ev.which !== KeyCodes.backspace) {
       return;
     }
@@ -339,7 +345,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     <div
       ref={rootRef}
       className={css('ms-BasePicker ms-BaseExtendedPicker', className ? className : '')}
-      onKeyDown={_onBackspace}
+      onKeyDown={_onKeyDown}
       onCopy={_onCopy}
     >
       <FocusZone

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.tsx
@@ -183,11 +183,7 @@ export const UnifiedPicker = <T extends {}>(props: IUnifiedPickerProps<T>): JSX.
     }
 
     // Handle delete of items via backspace
-    if (ev.which !== KeyCodes.backspace) {
-      return;
-    }
-
-    if (selectedItems.length) {
+    if (ev.which === KeyCodes.backspace && selectedItems.length) {
       if (
         focusedItemIndices.length === 0 &&
         input &&

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPicker.types.ts
@@ -84,6 +84,11 @@ export interface IUnifiedPickerProps<T> {
   onInputChange?: (filter: string) => void;
 
   /**
+   * Callback for when a key is pressed
+   */
+  onKeyDown?: (ev: React.KeyboardEvent<HTMLDivElement>) => void;
+
+  /**
    * Drag drop events callback interface
    */
   dragDropEvents?: IDragDropEvents;


### PR DESCRIPTION
<!--
!!!!!!! IMPORTANT !!!!!!!

Due to work we're currently doing to prepare master branch for our version 8 beta release,
please hold-off submitting the PR until around October 12 if it's not urgent.
If it is urgent, please submit the PR targeting the 7.0 branch.

This change does not apply to react-northstar contributors.

See https://github.com/microsoft/fluentui/issues/15222 for more details. Sorry for the inconvenience and short notice.
-->

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a prop for onKeyDown so the consumer has the ability to modify that

I did test that this works by adding the overload to an example, but didn't feel like it added to the example to check it in