### PR TITLE
[Ref-Conformance] Adding a forwardRef to react-internal ContextualMenu

### DIFF
--- a/change/@fluentui-react-conformance-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
+++ b/change/@fluentui-react-conformance-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Adding a forwardRef to ContextualMenu (ref-conformance)",
+  "comment": "Adding support to targetComponent in component-handles-ref defaultTest.",
   "packageName": "@fluentui/react-conformance",
   "email": "czearing@outlook.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-react-conformance-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
+++ b/change/@fluentui-react-conformance-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding a forwardRef to ContextualMenu (ref-conformance)",
+  "packageName": "@fluentui/react-conformance",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T23:10:35.736Z"
+}

--- a/change/@fluentui-react-internal-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
+++ b/change/@fluentui-react-internal-2020-10-20-16-10-52-fix-ref-conformance-react-internal-contextual-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding a forwardRef to ContextualMenu (ref-conformance)",
+  "packageName": "@fluentui/react-internal",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-20T23:10:52.644Z"
+}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -87,14 +87,18 @@ export const defaultTests: TestObject = {
   'component-handles-ref': (componentInfo: ComponentDoc, testInfo: IsConformantOptions) => {
     it(`handles ref`, () => {
       try {
-        const { Component, requiredProps, elementRefName = 'ref' } = testInfo;
+        const { Component, requiredProps, elementRefName = 'ref', targetComponent, customMount = mount } = testInfo;
         const rootRef = React.createRef<HTMLDivElement>();
         const mergedProps: Partial<{}> = {
           ...requiredProps,
           [elementRefName]: rootRef,
         };
+
         act(() => {
-          mount(<Component {...mergedProps} />);
+          targetComponent
+            ? customMount(<Component {...mergedProps} />).find(targetComponent)
+            : customMount(<Component {...mergedProps} />);
+
           expect(rootRef.current).toBeDefined();
           // Ref should resolve to an HTML element.
           expect(rootRef.current?.getAttribute).toBeDefined();

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -2156,7 +2156,7 @@ export interface IContextualMenuListProps {
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
-export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
+export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, React.RefAttributes<HTMLDivElement>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
     ariaLabel?: string;
     beakWidth?: number;

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -528,10 +528,7 @@ export function constructKeytip(configMap: IKeytipConfigMap, parentSequence: str
 export const ContextualMenu: React.FunctionComponent<IContextualMenuProps>;
 
 // @public (undocumented)
-export const ContextualMenuBase: {
-    (propsWithoutDefaults: IContextualMenuProps): JSX.Element;
-    displayName: string;
-};
+export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps>;
 
 // @public
 export const ContextualMenuItem: React.FunctionComponent<IContextualMenuItemProps>;

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -47,7 +47,7 @@ import {
 import { IProcessedStyleSet, concatStyleSetsWithProps } from '../../Styling';
 import { IContextualMenuItemStyleProps, IContextualMenuItemStyles } from './ContextualMenuItem.types';
 import { getItemStyles } from './ContextualMenu.classNames';
-import { useTarget, usePrevious, useOnEvent } from '@uifabric/react-hooks';
+import { useTarget, usePrevious, useOnEvent, useMergedRefs } from '@uifabric/react-hooks';
 import { useResponsiveMode } from '../../utilities/hooks/useResponsiveMode';
 import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 
@@ -188,10 +188,15 @@ function useShouldUpdateFocusOnMouseMove({ delayUpdateFocusOnHover, hidden }: IC
   return [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] as const;
 }
 
-export const ContextualMenuBase = (propsWithoutDefaults: IContextualMenuProps) => {
-  const props = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> = React.forwardRef<
+  HTMLDivElement,
+  IContextualMenuProps
+>((propsWithoutDefaults, forwardedRef) => {
+  const { ...props } = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+  const rootRef = React.useRef<HTMLDivElement>(null);
 
-  const hostElement = React.useRef<HTMLDivElement>(null);
+  const hostElement: React.RefObject<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
+
   const [targetRef, targetWindow] = useTarget(hostElement);
   const [expandedMenuItemKey, submenuTarget, expandedByMouseClick, openSubMenu, closeSubMenu] = useSubMenuState(props);
   const [shouldUpdateFocusOnMouseEvent, gotMouseMove, onMenuFocusCapture] = useShouldUpdateFocusOnMouseMove(props);
@@ -219,7 +224,7 @@ export const ContextualMenuBase = (propsWithoutDefaults: IContextualMenuProps) =
       responsiveMode={responsiveMode}
     />
   );
-};
+});
 ContextualMenuBase.displayName = 'ContextualMenuBase';
 
 interface IContextualMenuInternalProps extends IContextualMenuProps {

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -345,7 +345,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       focusZoneProps,
       // eslint-disable-next-line deprecation/deprecation
       getMenuClassNames,
-      hoisted: { expandedMenuItemKey, targetRef, onMenuFocusCapture },
+      hoisted: { expandedMenuItemKey, targetRef, onMenuFocusCapture, hostElement },
     } = this.props;
 
     this._classNames = getMenuClassNames

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -192,7 +192,7 @@ export const ContextualMenuBase: React.FunctionComponent<IContextualMenuProps> =
   HTMLDivElement,
   IContextualMenuProps
 >((propsWithoutDefaults, forwardedRef) => {
-  const { ...props } = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
+  const { ref, ...props } = getPropsWithDefaults(DEFAULT_PROPS, propsWithoutDefaults);
   const rootRef = React.useRef<HTMLDivElement>(null);
 
   const hostElement: React.RefObject<HTMLDivElement> = useMergedRefs(rootRef, forwardedRef);
@@ -345,7 +345,7 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
       focusZoneProps,
       // eslint-disable-next-line deprecation/deprecation
       getMenuClassNames,
-      hoisted: { expandedMenuItemKey, targetRef, hostElement, onMenuFocusCapture },
+      hoisted: { expandedMenuItemKey, targetRef, onMenuFocusCapture },
     } = this.props;
 
     this._classNames = getMenuClassNames
@@ -439,12 +439,12 @@ class ContextualMenuInternal extends React.Component<IContextualMenuInternalProp
           directionalHintFixed={directionalHintFixed}
           alignTargetEdge={alignTargetEdge}
           hidden={this.props.hidden}
+          ref={hostElement}
         >
           <div
             aria-label={ariaLabel}
             aria-labelledby={labelElementId}
             style={contextMenuStyle}
-            ref={hostElement}
             id={id}
             className={this._classNames.container}
             tabIndex={shouldFocusOnContainer ? 0 : -1}

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -31,10 +31,7 @@ describe('ContextualMenu', () => {
   isConformant({
     Component: ContextualMenu,
     displayName: 'ContextualMenu',
-    // Priority: High
-    // Problem: Is FunctionComponent but missing `forwardRef`
-    // Solution: add forwardRef and ref typing
-    disabledTests: ['component-has-root-ref', 'component-handles-ref'],
+    requiredProps: { items: { text: 'Later Today', key: 'Today', secondaryText: '7:00 PM', ariaLabel: 'foo' } },
   });
 
   it('allows setting aria-label per ContextualMenuItem', () => {

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -5,6 +5,8 @@ import { FocusZoneDirection } from '../../FocusZone';
 import * as renderer from 'react-test-renderer';
 
 import { IContextualMenuProps, IContextualMenuStyles, IContextualMenu } from './ContextualMenu.types';
+
+import { CalloutContent } from '../Callout/CalloutContent';
 import { ContextualMenu } from './ContextualMenu';
 import { canAnyMenuItemsCheck } from './ContextualMenu.base';
 import { IContextualMenuItem, ContextualMenuItemType, IContextualMenuListProps } from './ContextualMenu.types';
@@ -31,7 +33,17 @@ describe('ContextualMenu', () => {
   isConformant({
     Component: ContextualMenu,
     displayName: 'ContextualMenu',
-    requiredProps: { items: { text: 'Later Today', key: 'Today', secondaryText: '7:00 PM', ariaLabel: 'foo' } },
+    targetComponent: CalloutContent,
+    requiredProps: {
+      hidden: false,
+      items: [{ text: 'test', key: 'Today', secondaryText: '7:00 PM', ariaLabel: 'foo' }],
+    },
+    // TODO: ContextualMenu handles ref but doesn't pass:
+    // expect(rootRef.current?.getAttribute).toBeDefined();
+    //
+    // This test failure likely stems from Callout as it experiences the same error. The failing test should be
+    // further investigated and re-enabled in a future pull request.
+    disabledTests: ['component-handles-ref'],
   });
 
   it('allows setting aria-label per ContextualMenuItem', () => {

--- a/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/react-internal/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -39,7 +39,10 @@ export interface IContextualMenu {}
 /**
  * {@docCategory ContextualMenu}
  */
-export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
+export interface IContextualMenuProps
+  extends IBaseProps<IContextualMenu>,
+    React.RefAttributes<HTMLDivElement>,
+    IWithResponsiveModeState {
   /**
    * Optional callback to access the IContextualMenu interface. Use this instead of ref for accessing
    * the public methods and properties of the component.


### PR DESCRIPTION
#### Pull request checklist
- [X] Include a change request file using `$ yarn change`

#### Description of changes

- Adding a forwardRef to `ContextualMenu`
- Apply ref to the root element
- Adding `targetComponent` support to **component-handles-ref** `defaultTest`
- Removing **component-has-root-ref** `disabledTests` from ContextualMenu.test.tsx

#### Focus areas to test

 `ContextualMenu`
