### PR TITLE
Fixed doc generation for icon shorthand prop with hack

### DIFF
--- a/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
+++ b/packages/fluentui/react-northstar/src/components/Icon/Icon.tsx
@@ -229,6 +229,15 @@ const iconPatchedShorthandFactory: ShorthandFactory<IconProps> = (value, options
   return iconOriginalShorthandFactory(value, options);
 };
 
+// The mappedShorthandProp in docs will not generate correctly
+// unless an explicit call to `createShorthandFactory`is present
+// Absence of this shorthand property in componentInfo will crash multiple docs pages
+Icon.create = createShorthandFactory({
+  Component: Icon,
+  mappedProp: 'name',
+  allowsJSX: false,
+});
+
 Icon.create = iconPatchedShorthandFactory;
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The change made in #14404 broke the doc generation for the `name` shorthand prop in the icon's componentInfo.

This will crash the following doc pages for 0.47.x:

* Alert
* Attachment
* Button
* Input
* Label
* Reaction
* Status

because they can use the `Icon` component as shorthand. But if there is no mappedProp in the componentInfo, the typegenerator in the docsite will crash

#### Focus areas to test

(optional)
