### PR TITLE
Area chart data memoized

### DIFF
--- a/change/@fluentui-react-charting-2020-10-22-11-56-11-areaChartDataMemoized.json
+++ b/change/@fluentui-react-charting-2020-10-22-11-56-11-areaChartDataMemoized.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Charting: Resolving redraw issue after data change in AreaChart and implementing memoization.",
+  "packageName": "@fluentui/react-charting",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T18:56:11.003Z"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { max as d3Max } from 'd3-array';
 import { select as d3Select } from 'd3-selection';
 import { area as d3Area, stack as d3Stack, curveMonotoneX as d3CurveBasis } from 'd3-shape';
-import { getId, find } from '@fluentui/react/lib/Utilities';
 import { IPalette } from '@fluentui/react/lib/Styling';
+import { find, getId, memoizeFunction } from '@fluentui/react/lib/Utilities';
 import {
   CartesianChart,
+  IChartProps,
   IAreaChartProps,
   IChildProps,
   IRefArrayData,
@@ -41,27 +42,21 @@ export interface IAreaChartState extends IBasestate {
 export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartState> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _calloutPoints: any;
-  private _points: ILineChartPoints[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private dataSet: any;
+  private _createSet: (data: IChartProps) => { colors: string[]; stackedInfo: any; calloutPoints: any };
   private _colors: string[];
-  private _keys: string[];
   private _refArray: IRefArrayData[];
   private _uniqueIdForGraph: string;
   private _verticalLineId: string;
   private _circleId: string;
   private _uniqueCallOutID: string;
-  private containerHeight: number;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _stackedData: any;
   private _chart: JSX.Element[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _xAxisScale: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private _yAxisScale: any;
 
   public constructor(props: IAreaChartProps) {
     super(props);
+    this._createSet = memoizeFunction((data: IChartProps) => this._createDataSet(data.lineChartData!));
     this.state = {
       activeLegend: '',
       hoverXValue: '',
@@ -79,34 +74,18 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       showYAxisGridLines: 'Dont use this property. Lines are drawn by default',
     });
     this._refArray = [];
-    this._points = this.props.data.lineChartData ? this.props.data.lineChartData : [];
     this._uniqueIdForGraph = getId('areaChart_');
     this._verticalLineId = getId('verticalLine_');
     this._circleId = getId('circle');
-    this._calloutPoints = this.props.data.lineChartData ? calloutData(this.props.data.lineChartData!) : [];
-    this.dataSet = this._createDataSet();
-  }
-
-  public componentDidUpdate(prevProps: IAreaChartProps): void {
-    if (
-      prevProps.data !== this.props.data ||
-      prevProps.height !== this.props.height ||
-      prevProps.width !== this.props.width
-    ) {
-      this._points = this.props.data.lineChartData ? this.props.data.lineChartData : [];
-      this.dataSet = this._createDataSet();
-      this._calloutPoints = this.props.data.lineChartData ? calloutData(this.props.data.lineChartData!) : [];
-      this._drawGraph(this.containerHeight, this._xAxisScale, this._yAxisScale);
-    }
   }
 
   public render(): JSX.Element {
-    const isXAxisDateType = getXAxisType(this._points);
-    this._keys = this._createKeys();
-    this._colors = this._getColors();
-    const stackedInfo = this._getStackedData();
+    const { colors, stackedInfo, calloutPoints } = this._createSet(this.props.data);
+    this._calloutPoints = calloutPoints;
+    const isXAxisDateType = getXAxisType(this.props.data.lineChartData!);
+    this._colors = colors;
     this._stackedData = stackedInfo.stackedData;
-    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette);
+    const legends: JSX.Element = this._getLegendData(this.props.theme!.palette, this.props.data.lineChartData!);
 
     const tickParams = {
       tickValues: this.props.tickValues,
@@ -128,7 +107,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     return (
       <CartesianChart
         {...this.props}
-        points={this._points}
+        points={this.props.data.lineChartData!}
         chartType={ChartTypes.AreaChart}
         calloutProps={calloutProps}
         legendBars={legends}
@@ -140,20 +119,45 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
         children={(props: IChildProps) => {
-          this.containerHeight = props.containerHeight!;
-          this._xAxisScale = props.xScale!;
-          this._yAxisScale = props.yScale!;
           return <g>{this._chart}</g>;
         }}
       />
     );
   }
 
-  private _createDataSet = () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private _getStackedData = (keys: string[], dataSet: any) => {
+    const stackedValues = d3Stack().keys(keys)(dataSet);
+    const maxOfYVal = d3Max(stackedValues[stackedValues.length - 1], dp => dp[1])!;
+    const stackedData: Array<IAreaChartDataSetPoint[]> = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    stackedValues.forEach((layer: any) => {
+      const currentStack: IAreaChartDataSetPoint[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      layer.forEach((d: any) => {
+        currentStack.push({
+          values: d,
+          xVal: d.data.xVal,
+        });
+      });
+      stackedData.push(currentStack);
+    });
+    return {
+      stackedData,
+      maxOfYVal,
+    };
+  };
+
+  private _createDataSet = (points: ILineChartPoints[]) => {
     const allChartPoints: ILineChartDataPoint[] = [];
     const dataSet: IAreaChartDataSetPoint[] = [];
-    this._points.length &&
-      this._points.forEach((singleChartPoint: ILineChartPoints) => {
+    const colors: string[] = [];
+    const calloutPoints = calloutData(points!);
+
+    points &&
+      points.length &&
+      points.forEach((singleChartPoint: ILineChartPoints) => {
+        colors.push(singleChartPoint.color);
         allChartPoints.push(...singleChartPoint.data);
       });
 
@@ -177,42 +181,23 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         (point: ILineChartDataPoint) => (point.x instanceof Date ? point.x.toLocaleDateString() : point.x) !== val,
       );
     }
-    return dataSet;
-  };
 
-  private _getColors = (): string[] => {
-    return this._points.map((singlePoint: ILineChartPoints) => singlePoint.color);
-  };
-
-  private _createKeys = (): string[] => {
-    const keysLength: number = Object.keys(this.dataSet[0]).length;
+    // get keys from dataset, used to create stacked data
+    const keysLength: number = dataSet && Object.keys(dataSet[0])!.length;
     const keys: string[] = [];
     for (let i = 0; i < keysLength - 1; i++) {
       const keyVal = `chart${i}`;
       keys.push(keyVal);
     }
-    return keys;
-  };
 
-  private _getStackedData = () => {
-    const stackedValues = d3Stack().keys(this._keys)(this.dataSet);
-    const maxOfYVal = d3Max(stackedValues[stackedValues.length - 1], dp => dp[1])!;
-    const stackedData: Array<IAreaChartDataSetPoint[]> = [];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    stackedValues.forEach((layer: any) => {
-      const currentStack: IAreaChartDataSetPoint[] = [];
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      layer.forEach((d: any) => {
-        currentStack.push({
-          values: d,
-          xVal: d.data.xVal,
-        });
-      });
-      stackedData.push(currentStack);
-    });
+    // Stacked Info used to draw graph
+    const stackedInfo = this._getStackedData(keys, dataSet);
+
     return {
-      stackedData,
-      maxOfYVal,
+      colors,
+      keys,
+      stackedInfo,
+      calloutPoints,
     };
   };
 
@@ -259,8 +244,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
     }
   }
 
-  private _getLegendData = (palette: IPalette): JSX.Element => {
-    const data = this._points;
+  private _getLegendData = (palette: IPalette, points: ILineChartPoints[]): JSX.Element => {
+    const data = points;
     const defaultPalette: string[] = [palette.blueLight, palette.blue, palette.blueMid, palette.red, palette.black];
     const actions: ILegend[] = [];
 
@@ -402,6 +387,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private _drawGraph = (containerHeight: number, xScale: any, yScale: any): JSX.Element[] => {
+    const points = this.props.data.lineChartData!;
     const area = d3Area()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .x((d: any) => xScale(d.xVal))
@@ -421,7 +407,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
           key={`${index}-graph-${this._uniqueIdForGraph}`}
           d={area(singleStackedData)!}
           fill={this._colors[index]}
-          fillOpacity={this._getOpacity(this._points[index].legend)}
+          fillOpacity={this._getOpacity(points[index]!.legend)}
           strokeWidth={3}
         />,
       );
@@ -434,8 +420,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
           {singleStackedData.map((singlePoint: IDPointType, pointIndex: number) => {
             const circleId = `${this._circleId}_${index * this._stackedData[0].length + pointIndex}`;
             const xLineVal = xScale(singlePoint.xVal);
-            const xAxisCalloutData = this._points[index].data[index].xAxisCalloutData!;
-            lineColor = this._points[index].color;
+            const xAxisCalloutData = points[index]!.data[index].xAxisCalloutData!;
+            lineColor = points[index]!.color;
             return (
               <circle
                 key={circleId}
@@ -446,7 +432,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
                 r={this.state.activeCircleId === circleId ? 8 : 0.01}
                 stroke={lineColor}
                 strokeWidth={3}
-                visibility={this._getOpacityOfCircle(this._points[index].legend)}
+                visibility={this._getOpacityOfCircle(points[index]!.legend)}
                 fill={this._updateCircleFillColor(circleId, lineColor)}
                 ref={(e: SVGCircleElement | null) => {
                   this._refCallback(e!, circleId);
@@ -457,7 +443,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
                 onBlur={this._mouseOutAction}
                 onClick={this._onDataPointClick.bind(
                   this,
-                  this._points[index].data[pointIndex].onDataPointClick!,
+                  points[index]!.data[pointIndex].onDataPointClick!,
                   circleId,
                   lineColor,
                 )}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -6,7 +6,169 @@ import { DefaultPalette } from '@fluentui/react/lib/Styling';
 interface IAreaChartBasicState {
   width: number;
   height: number;
+  chartData: any;
 }
+
+const chart1Points = [
+  {
+    x: 20,
+    y: 7000,
+    xAxisCalloutData: '2018/01/01',
+    yAxisCalloutData: '10%',
+  },
+  {
+    x: 25,
+    y: 9000,
+    xAxisCalloutData: '2018/01/15',
+    yAxisCalloutData: '18%',
+  },
+  {
+    x: 30,
+    y: 13000,
+    xAxisCalloutData: '2018/01/28',
+    yAxisCalloutData: '24%',
+  },
+  {
+    x: 35,
+    y: 15000,
+    xAxisCalloutData: '2018/02/01',
+    yAxisCalloutData: '25%',
+  },
+  {
+    x: 40,
+    y: 11000,
+    xAxisCalloutData: '2018/03/01',
+    yAxisCalloutData: '15%',
+  },
+  {
+    x: 45,
+    y: 8760,
+    xAxisCalloutData: '2018/03/15',
+    yAxisCalloutData: '30%',
+  },
+  {
+    x: 50,
+    y: 3500,
+    xAxisCalloutData: '2018/03/28',
+    yAxisCalloutData: '18%',
+  },
+  {
+    x: 55,
+    y: 20000,
+    xAxisCalloutData: '2018/04/04',
+    yAxisCalloutData: '32%',
+  },
+  {
+    x: 60,
+    y: 17000,
+    xAxisCalloutData: '2018/04/15',
+    yAxisCalloutData: '29%',
+  },
+  {
+    x: 65,
+    y: 1000,
+    xAxisCalloutData: '2018/05/05',
+    yAxisCalloutData: '43%',
+  },
+  {
+    x: 70,
+    y: 12000,
+    xAxisCalloutData: '2018/06/01',
+    yAxisCalloutData: '45%',
+  },
+  {
+    x: 75,
+    y: 6876,
+    xAxisCalloutData: '2018/01/15',
+    yAxisCalloutData: '18%',
+  },
+  {
+    x: 80,
+    y: 12000,
+    xAxisCalloutData: '2018/04/30',
+    yAxisCalloutData: '55%',
+  },
+  {
+    x: 85,
+    y: 7000,
+    xAxisCalloutData: '2018/05/04',
+    yAxisCalloutData: '12%',
+  },
+  {
+    x: 90,
+    y: 10000,
+    xAxisCalloutData: '2018/06/01',
+    yAxisCalloutData: '45%',
+  },
+];
+
+const chart2Points = [
+  {
+    x: 50,
+    y: 3500,
+    xAxisCalloutData: '2018/03/28',
+    yAxisCalloutData: '18%',
+  },
+  {
+    x: 55,
+    y: 20000,
+    xAxisCalloutData: '2018/04/04',
+    yAxisCalloutData: '32%',
+  },
+  {
+    x: 60,
+    y: 17000,
+    xAxisCalloutData: '2018/04/15',
+    yAxisCalloutData: '29%',
+  },
+
+  {
+    x: 70,
+    y: 12000,
+    xAxisCalloutData: '2018/06/01',
+    yAxisCalloutData: '45%',
+  },
+  {
+    x: 75,
+    y: 6876,
+    xAxisCalloutData: '2018/01/15',
+    yAxisCalloutData: '18%',
+  },
+  {
+    x: 80,
+    y: 12000,
+    xAxisCalloutData: '2018/04/30',
+    yAxisCalloutData: '55%',
+  },
+  {
+    x: 85,
+    y: 7000,
+    xAxisCalloutData: '2018/05/04',
+    yAxisCalloutData: '12%',
+  },
+  {
+    x: 90,
+    y: 10000,
+    xAxisCalloutData: '2018/06/01',
+    yAxisCalloutData: '45%',
+  },
+];
+
+const chartPoints1 = [
+  {
+    legend: 'legend1',
+    data: chart1Points,
+    color: DefaultPalette.accent,
+  },
+];
+
+const chartPoints2 = [
+  {
+    legend: 'legend1',
+    data: chart2Points,
+    color: 'red',
+  },
+];
 
 export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicState> {
   constructor(props: ILineChartProps) {
@@ -14,6 +176,7 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
     this.state = {
       width: 700,
       height: 300,
+      chartData: chartPoints1,
     };
   }
 
@@ -25,115 +188,17 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
     this.setState({ width: parseInt(e.target.value, 10) });
   };
   private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('height change');
     this.setState({ height: parseInt(e.target.value, 10) });
   };
 
+  private _onDataChange = () => {
+    this.setState({ chartData: chartPoints2 });
+  };
+
   private _basicExample(): JSX.Element {
-    const chart1Points = [
-      {
-        x: 20,
-        y: 7000,
-        xAxisCalloutData: '2018/01/01',
-        yAxisCalloutData: '10%',
-      },
-      {
-        x: 25,
-        y: 9000,
-        xAxisCalloutData: '2018/01/15',
-        yAxisCalloutData: '18%',
-      },
-      {
-        x: 30,
-        y: 13000,
-        xAxisCalloutData: '2018/01/28',
-        yAxisCalloutData: '24%',
-      },
-      {
-        x: 35,
-        y: 15000,
-        xAxisCalloutData: '2018/02/01',
-        yAxisCalloutData: '25%',
-      },
-      {
-        x: 40,
-        y: 11000,
-        xAxisCalloutData: '2018/03/01',
-        yAxisCalloutData: '15%',
-      },
-      {
-        x: 45,
-        y: 8760,
-        xAxisCalloutData: '2018/03/15',
-        yAxisCalloutData: '30%',
-      },
-      {
-        x: 50,
-        y: 3500,
-        xAxisCalloutData: '2018/03/28',
-        yAxisCalloutData: '18%',
-      },
-      {
-        x: 55,
-        y: 20000,
-        xAxisCalloutData: '2018/04/04',
-        yAxisCalloutData: '32%',
-      },
-      {
-        x: 60,
-        y: 17000,
-        xAxisCalloutData: '2018/04/15',
-        yAxisCalloutData: '29%',
-      },
-      {
-        x: 65,
-        y: 1000,
-        xAxisCalloutData: '2018/05/05',
-        yAxisCalloutData: '43%',
-      },
-      {
-        x: 70,
-        y: 12000,
-        xAxisCalloutData: '2018/06/01',
-        yAxisCalloutData: '45%',
-      },
-      {
-        x: 75,
-        y: 6876,
-        xAxisCalloutData: '2018/01/15',
-        yAxisCalloutData: '18%',
-      },
-      {
-        x: 80,
-        y: 12000,
-        xAxisCalloutData: '2018/04/30',
-        yAxisCalloutData: '55%',
-      },
-      {
-        x: 85,
-        y: 7000,
-        xAxisCalloutData: '2018/05/04',
-        yAxisCalloutData: '12%',
-      },
-      {
-        x: 90,
-        y: 10000,
-        xAxisCalloutData: '2018/06/01',
-        yAxisCalloutData: '45%',
-      },
-    ];
-
-    const chartPoints = [
-      {
-        legend: 'legend1',
-        data: chart1Points,
-        color: DefaultPalette.accent,
-      },
-    ];
-
     const chartData = {
       chartTitle: 'Area chart basic example',
-      lineChartData: chartPoints,
+      lineChartData: this.state.chartData,
     };
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
@@ -144,6 +209,13 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <button
+          onClick={() => {
+            this._onDataChange();
+          }}
+        >
+          Update data
+        </button>
         <div style={rootStyle}>
           <AreaChart height={this.state.height} width={this.state.width} data={chartData} showYAxisGridLines={true} />
         </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #15285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherry-pick of #15299._

_Original PR description:_

After props data updated, need to update stackedValues and CalloutPoints which are using to redraw the graph. These data updated.

Memoize concept implemented - Previously, calculating stacked data, getting keys, colors, creating dataset all these will be calculated for every render which is not required and take time. Now all these will be calculated only when prop changes. 

#### Focus areas to test

Area chart

#### Before Fix, After clicking on update data (Graph is same as previous)
![image](https://user-images.githubusercontent.com/20105532/94231324-644d1b80-ff21-11ea-9509-09a1b6d584d3.png)

#### After fix, Updated graph.
![image](https://user-images.githubusercontent.com/20105532/94231304-5ac3b380-ff21-11ea-8104-49711424f318.png)

Test link: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/15235/merge/charting/dist/index.html#/examples/areachart
