### PR TITLE
[Ref-Conformance] Adding a forwardRef to react-internal VerticalDivider

### DIFF
--- a/change/@fluentui-react-internal-2020-10-22-14-40-18-fix-ref-conformance-react-internal-vertical-divider.json
+++ b/change/@fluentui-react-internal-2020-10-22-14-40-18-fix-ref-conformance-react-internal-vertical-divider.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Adding a forwardRef to VerticalDivider within react-internal.",
+  "packageName": "@fluentui/react-internal",
+  "email": "czearing@outlook.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T21:40:18.564Z"
+}

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -5602,7 +5602,7 @@ export interface IVerticalDividerClassNames {
 }
 
 // @public
-export interface IVerticalDividerProps {
+export interface IVerticalDividerProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLDivElement> {
     className?: string;
     // @deprecated (undocumented)
     getClassNames?: (theme: ITheme) => IVerticalDividerClassNames;

--- a/packages/react-internal/src/components/Divider/VerticalDivider.base.tsx
+++ b/packages/react-internal/src/components/Divider/VerticalDivider.base.tsx
@@ -3,14 +3,17 @@ import { IVerticalDividerProps, IVerticalDividerPropsStyles, IVerticalDividerSty
 import { classNamesFunction } from '../../Utilities';
 const getClassNames = classNamesFunction<IVerticalDividerPropsStyles, IVerticalDividerStyles>();
 
-export const VerticalDividerBase = (props: IVerticalDividerProps) => {
+export const VerticalDividerBase: React.FunctionComponent<IVerticalDividerProps> = React.forwardRef<
+  HTMLDivElement,
+  IVerticalDividerProps
+>((props, ref) => {
   // eslint-disable-next-line deprecation/deprecation
   const { styles, theme, getClassNames: deprecatedGetClassNames, className } = props;
   const classNames = getClassNames(styles, { theme: theme, getClassNames: deprecatedGetClassNames, className });
   return (
-    <span className={classNames.wrapper}>
+    <span className={classNames.wrapper} ref={ref}>
       <span className={classNames.divider} />
     </span>
   );
-};
+});
 VerticalDividerBase.displayName = 'VerticalDividerBase';

--- a/packages/react-internal/src/components/Divider/VerticalDivider.test.tsx
+++ b/packages/react-internal/src/components/Divider/VerticalDivider.test.tsx
@@ -5,8 +5,6 @@ describe('VerticalDivider', () => {
   isConformant({
     Component: VerticalDivider,
     displayName: 'VerticalDivider',
-    // Problem: Doesn’t handle ref.
-    // Solution: Add a ref to the root element.
-    disabledTests: ['has-top-level-file', 'component-handles-ref', 'component-has-root-ref'],
+    disabledTests: ['has-top-level-file'],
   });
 });

--- a/packages/react-internal/src/components/Divider/VerticalDivider.types.ts
+++ b/packages/react-internal/src/components/Divider/VerticalDivider.types.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ITheme, IStyle } from '../../Styling';
 import { IStyleFunctionOrObject } from '../../Utilities';
 
@@ -5,7 +6,7 @@ import { IStyleFunctionOrObject } from '../../Utilities';
  * {@docCategory VerticalDivider}
  * Props for the Vertical Divider
  */
-export interface IVerticalDividerProps {
+export interface IVerticalDividerProps extends React.HTMLAttributes<HTMLElement>, React.RefAttributes<HTMLDivElement> {
   /**
    * @deprecated Use styles instead.
    * Optional function to generate the class names for the divider for custom styling


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

- Adding a forwardRef to `VerticalDivider`
- Appling the ref to the root element.
- Extending IVerticalDividerProps to `React.RefAttributes<HTMLDivElement>`
- Removing **component-handles-ref** and  **component-has-root-ref** `disabledTests` from VerticalDivider.test.tsx

#### Focus areas to test

`VerticalDivider`
