### PR TITLE
Fix copy when keyboard focus is on the SelectedItemsList in the UnifiedPicker

### DIFF
--- a/change/@fluentui-react-experiments-2020-10-22-14-52-53-ctrlclistfix.json
+++ b/change/@fluentui-react-experiments-2020-10-22-14-52-53-ctrlclistfix.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Fix copy when keyboard focus is in the SelectedItemsList in the UnifiedPicker",
+  "packageName": "@fluentui/react-experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-22T21:52:53.930Z"
+}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.styles.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.styles.ts
@@ -1,0 +1,14 @@
+import { ISelectedItemsListStyleProps, ISelectedItemsListStyles } from './SelectedItemsList.types';
+
+export const getStyles = (props: ISelectedItemsListStyleProps): ISelectedItemsListStyles => {
+  return {
+    copyInput: [
+      {
+        height: '0px',
+        width: '0px',
+        border: 'none',
+        outline: 'none',
+      },
+    ],
+  };
+};

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
@@ -47,7 +47,7 @@ describe('SelectedItemsList', () => {
         wrapper
           .find('div')
           .first()
-          .childAt(0)
+          .childAt(1)
           .text(),
       ).toEqual('a');
       expect(
@@ -81,7 +81,7 @@ describe('SelectedItemsList', () => {
       wrapper
         .find('div')
         .first()
-        .childAt(0)
+        .childAt(1)
         .text(),
     ).toEqual('da');
     expect(
@@ -108,7 +108,7 @@ describe('SelectedItemsList', () => {
       wrapper
         .find('div')
         .first()
-        .childAt(0)
+        .childAt(1)
         .text(),
     ).toEqual('Person A');
     expect(

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -74,6 +74,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
             // Add a zero zero size input. This is to pick up the copy command when we have
             // keyboard focus in the list
             // Focus is set to the input when the list gets focus via the _onFocus function
+            className={'ms-SelectedItemsList-copyInput'}
             ref={hiddenInput}
             style={{ height: '0px', width: '0px', border: 'none', outline: 'none' }}
             data-is-focusable={false}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -1,6 +1,16 @@
+import { css, classNamesFunction } from '@fluentui/react';
 import * as React from 'react';
+import {
+  ISelectedItemsList,
+  ISelectedItemsListProps,
+  BaseSelectedItem,
+  ISelectedItemsListStyleProps,
+  ISelectedItemsListStyles,
+} from './SelectedItemsList.types';
 
-import { ISelectedItemsList, ISelectedItemsListProps, BaseSelectedItem } from './SelectedItemsList.types';
+import { getStyles } from './SelectedItemsList.styles';
+
+const getClassNames = classNamesFunction<ISelectedItemsListStyleProps, ISelectedItemsListStyles>();
 
 const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   props: ISelectedItemsListProps<TItem>,
@@ -12,6 +22,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   const renderedItems = React.useMemo(() => items, [items]);
   const didMountRef = React.useRef(false);
   const hiddenInput = React.useRef<any>();
+  const classNames = getClassNames(getStyles);
 
   React.useEffect(() => {
     // block first call of the hook and forward each consecutive one
@@ -74,10 +85,9 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
             // Add a zero zero size input. This is to pick up the copy command when we have
             // keyboard focus in the list
             // Focus is set to the input when the list gets focus via the _onFocus function
-            className={'ms-SelectedItemsList-copyInput'}
+            className={css('ms-SelectedItemsList-copyInput', classNames.copyInput)}
             ref={hiddenInput}
             hidden={!props.getItemCopyText}
-            style={{ height: '0px', width: '0px', border: 'none', outline: 'none' }}
             data-is-focusable={false}
             aria-hidden={true}
             tabIndex={-1}

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -76,8 +76,11 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
             // Focus is set to the input when the list gets focus via the _onFocus function
             className={'ms-SelectedItemsList-copyInput'}
             ref={hiddenInput}
+            hidden={!props.getItemCopyText}
             style={{ height: '0px', width: '0px', border: 'none', outline: 'none' }}
             data-is-focusable={false}
+            aria-hidden={true}
+            tabIndex={-1}
           />
           {SelectedItem &&
             renderedItems.map((item: TItem, index: number) => (

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -11,6 +11,7 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
 
   const renderedItems = React.useMemo(() => items, [items]);
   const didMountRef = React.useRef(false);
+  const hiddenInput = React.useRef<any>();
 
   React.useEffect(() => {
     // block first call of the hook and forward each consecutive one
@@ -59,11 +60,24 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
     [items],
   );
 
+  const _onFocus = (ev: React.FocusEvent<HTMLDivElement>) => {
+    // If we have an input, set focus to it so we can pick up the copy keyboard command
+    hiddenInput.current?.focus();
+  };
+
   const SelectedItem = props.onRenderItem;
   return (
     <>
       {items.length > 0 && (
-        <div role={'list'}>
+        <div role={'list'} onFocus={_onFocus}>
+          <input
+            // Add a zero zero size input. This is to pick up the copy command when we have
+            // keyboard focus in the list
+            // Focus is set to the input when the list gets focus via the _onFocus function
+            ref={hiddenInput}
+            style={{ height: '0px', width: '0px', border: 'none', outline: 'none' }}
+            data-is-focusable={false}
+          />
           {SelectedItem &&
             renderedItems.map((item: TItem, index: number) => (
               <SelectedItem

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IPickerItemProps, ISuggestionModel, ValidationState } from '@fluentui/react/lib/Pickers';
 import { IRefObject } from '@fluentui/react/lib/Utilities';
 import { IDragDropEvents, IDragDropHelper } from '@fluentui/react/lib/DragDrop';
+import { IStyle } from '@fluentui/react/lib/Styling';
 export interface ISelectedItemsList<T> {
   /**
    * Current value of the input
@@ -140,4 +141,10 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
    * Should be used if it's possible to change some properties on items so a strict compare will fail
    */
   itemsAreEqual?: (item1?: any, item2?: any) => boolean;
+}
+
+export interface ISelectedItemsListStyleProps {}
+
+export interface ISelectedItemsListStyles {
+  copyInput: IStyle;
 }

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -8,8 +8,10 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
   role="list"
 >
   <input
+    aria-hidden={true}
     className="ms-SelectedItemsList-copyInput"
     data-is-focusable={false}
+    hidden={true}
     style={
       Object {
         "border": "none",
@@ -18,6 +20,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
         "width": "0px",
       }
     }
+    tabIndex={-1}
   />
   <div
     aria-labelledby="selectedItemPersona-id__0"
@@ -1042,8 +1045,10 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
   role="list"
 >
   <input
+    aria-hidden={true}
     className="ms-SelectedItemsList-copyInput"
     data-is-focusable={false}
+    hidden={true}
     style={
       Object {
         "border": "none",
@@ -1052,6 +1057,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
         "width": "0px",
       }
     }
+    tabIndex={-1}
   />
   <div
     aria-labelledby="selectedItemPersona-id__16"

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
   role="list"
 >
   <input
+    className="ms-SelectedItemsList-copyInput"
     data-is-focusable={false}
     style={
       Object {
@@ -1041,6 +1042,7 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
   role="list"
 >
   <input
+    className="ms-SelectedItemsList-copyInput"
     data-is-focusable={false}
     style={
       Object {

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -9,17 +9,16 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
 >
   <input
     aria-hidden={true}
-    className="ms-SelectedItemsList-copyInput"
+    className=
+        ms-SelectedItemsList-copyInput
+        {
+          border: none;
+          height: 0px;
+          outline: none;
+          width: 0px;
+        }
     data-is-focusable={false}
     hidden={true}
-    style={
-      Object {
-        "border": "none",
-        "height": "0px",
-        "outline": "none",
-        "width": "0px",
-      }
-    }
     tabIndex={-1}
   />
   <div
@@ -1046,17 +1045,16 @@ exports[`SelectedPeopleList renders personas that are passed in as default 1`] =
 >
   <input
     aria-hidden={true}
-    className="ms-SelectedItemsList-copyInput"
+    className=
+        ms-SelectedItemsList-copyInput
+        {
+          border: none;
+          height: 0px;
+          outline: none;
+          width: 0px;
+        }
     data-is-focusable={false}
     hidden={true}
-    style={
-      Object {
-        "border": "none",
-        "height": "0px",
-        "outline": "none",
-        "width": "0px",
-      }
-    }
     tabIndex={-1}
   />
   <div

--- a/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/react-experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -4,8 +4,20 @@ exports[`SelectedPeopleList renders nothing if nothing is provided 1`] = `null`;
 
 exports[`SelectedPeopleList renders personas that are passed in 1`] = `
 <div
+  onFocus={[Function]}
   role="list"
 >
+  <input
+    data-is-focusable={false}
+    style={
+      Object {
+        "border": "none",
+        "height": "0px",
+        "outline": "none",
+        "width": "0px",
+      }
+    }
+  />
   <div
     aria-labelledby="selectedItemPersona-id__0"
     className=
@@ -1025,8 +1037,20 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
 
 exports[`SelectedPeopleList renders personas that are passed in as default 1`] = `
 <div
+  onFocus={[Function]}
   role="list"
 >
+  <input
+    data-is-focusable={false}
+    style={
+      Object {
+        "border": "none",
+        "height": "0px",
+        "outline": "none",
+        "width": "0px",
+      }
+    }
+  />
   <div
     aria-labelledby="selectedItemPersona-id__16"
     className=

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
@@ -93,7 +93,7 @@ describe('UnifiedPeoplePicker', () => {
       />,
     );
 
-    const inputElement: InputElementWrapper = wrapper.find('input');
+    const inputElement: InputElementWrapper = wrapper.find('input').last();
     expect(inputElement).toHaveLength(1);
     inputElement.simulate('input', { target: { value: 'annie' } });
 

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -175,17 +175,16 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
         >
           <input
             aria-hidden={true}
-            className="ms-SelectedItemsList-copyInput"
+            className=
+                ms-SelectedItemsList-copyInput
+                {
+                  border: none;
+                  height: 0px;
+                  outline: none;
+                  width: 0px;
+                }
             data-is-focusable={false}
             hidden={false}
-            style={
-              Object {
-                "border": "none",
-                "height": "0px",
-                "outline": "none",
-                "width": "0px",
-              }
-            }
             tabIndex={-1}
           />
           <div

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
           role="list"
         >
           <input
+            className="ms-SelectedItemsList-copyInput"
             data-is-focusable={false}
             style={
               Object {

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -174,8 +174,10 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
           role="list"
         >
           <input
+            aria-hidden={true}
             className="ms-SelectedItemsList-copyInput"
             data-is-focusable={false}
+            hidden={false}
             style={
               Object {
                 "border": "none",
@@ -184,6 +186,7 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
                 "width": "0px",
               }
             }
+            tabIndex={-1}
           />
           <div
             aria-labelledby="selectedItemPersona-id__2"

--- a/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -170,8 +170,20 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
             }
       >
         <div
+          onFocus={[Function]}
           role="list"
         >
+          <input
+            data-is-focusable={false}
+            style={
+              Object {
+                "border": "none",
+                "height": "0px",
+                "outline": "none",
+                "width": "0px",
+              }
+            }
+          />
           <div
             aria-labelledby="selectedItemPersona-id__2"
             className=

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -175,17 +175,16 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
         >
           <input
             aria-hidden={true}
-            className="ms-SelectedItemsList-copyInput"
+            className=
+                ms-SelectedItemsList-copyInput
+                {
+                  border: none;
+                  height: 0px;
+                  outline: none;
+                  width: 0px;
+                }
             data-is-focusable={false}
             hidden={true}
-            style={
-              Object {
-                "border": "none",
-                "height": "0px",
-                "outline": "none",
-                "width": "0px",
-              }
-            }
             tabIndex={-1}
           />
           <div>

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -174,6 +174,7 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
           role="list"
         >
           <input
+            className="ms-SelectedItemsList-copyInput"
             data-is-focusable={false}
             style={
               Object {

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -170,8 +170,20 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
             }
       >
         <div
+          onFocus={[Function]}
           role="list"
         >
+          <input
+            data-is-focusable={false}
+            style={
+              Object {
+                "border": "none",
+                "height": "0px",
+                "outline": "none",
+                "width": "0px",
+              }
+            }
+          />
           <div>
              
             red

--- a/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/react-experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -174,8 +174,10 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
           role="list"
         >
           <input
+            aria-hidden={true}
             className="ms-SelectedItemsList-copyInput"
             data-is-focusable={false}
+            hidden={true}
             style={
               Object {
                 "border": "none",
@@ -184,6 +186,7 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
                 "width": "0px",
               }
             }
+            tabIndex={-1}
           />
           <div>
              


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The _onCopy function was not getting called  on the wrapper div in the UnifiedPicker unless focus was in the autofill input. So if you were keyboard navigating the SelectedItemsList, keyboard copy never worked. But now that we removed mouse selection, there was no way to copy multiple items.

This adds the ability to copy when keyboard navigating. onCopy only gets called if the focus is in an input. So the SelectedItemsList now has a zero size input that's not keyboard selectable, that gets focus when the list gets focus. Copy is working.

#### Focus areas to test

- Tested that we can't see the input or access it via keyboard
- Tested that backspace still works
- Tested that multiselect still works
