### PR TITLE
Fix syncpack for northstar packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,13 +134,35 @@
       {
         "packages": [
           "@fluentui/accessibility",
+          "@fluentui/code-sandbox",
+          "@fluentui/docs-components",
+          "@fluentui/docs",
+          "@fluentui/e2e",
+          "@fluentui/perf",
+          "@fluentui/perf-test",
+          "@fluentui/react-component-event-listener",
+          "@fluentui/react-component-nesting-registry",
+          "@fluentui/react-component-ref",
+          "@fluentui/react-context-selector",
+          "@fluentui/react-icons-northstar",
+          "@fluentui/react-northstar-emotion-renderer",
+          "@fluentui/react-northstar-fela-renderer",
+          "@fluentui/react-northstar-styles-renderer",
+          "@fluentui/react-proptypes",
+          "@fluentui/react-telemetry",
           "@fluentui/react-bindings",
-          "@fluentui/react-northstar"
+          "@fluentui/react-builder",
+          "@fluentui/react-northstar",
+          "@fluentui/state",
+          "@fluentui/styles"
         ],
         "dependencies": [
           "@uifabric/utilities",
           "@fluentui/dom-utilities",
-          "@fluentui/date-time-utilities"
+          "@fluentui/date-time-utilities",
+          "@fluentui/eslint-plugin",
+          "@fluentui/react",
+          "@fluentui/react-compose"
         ]
       }
     ]

--- a/package.json
+++ b/package.json
@@ -157,7 +157,6 @@
           "@fluentui/styles"
         ],
         "dependencies": [
-          "@uifabric/utilities",
           "@fluentui/dom-utilities",
           "@fluentui/date-time-utilities",
           "@fluentui/eslint-plugin",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
This change is to fix [syncpack failures](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=144925&view=results) happens after beachball applies package updates.

Context: beachball no longer bump dependencies for out-of-scope packages. The dependencies will need to be manually bumped from now on for each northstar releases. 

#### Focus areas to test

(optional)
