### PR TITLE
use the same version for codesandbox as all other dependencies

### DIFF
--- a/packages/fluentui/docs/src/components/Playground/renderConfig.ts
+++ b/packages/fluentui/docs/src/components/Playground/renderConfig.ts
@@ -11,6 +11,7 @@ import * as Classnames from 'classnames';
 const accessibilityPackageJson = require('@fluentui/accessibility/package.json');
 const docsComponentsPackageJson = require('@fluentui/docs-components/package.json');
 const projectPackageJson = require('@fluentui/react-northstar/package.json');
+const codeSandboxPackageJson = require('@fluentui/code-sandbox/package.json');
 
 export const babelConfig = {
   plugins: [
@@ -29,7 +30,7 @@ export const imports: Record<string, { version: string; module: any }> = {
   },
 
   '@fluentui/code-sandbox': {
-    version: 'latest',
+    version: codeSandboxPackageJson.version,
     module: CodeSandbox,
   },
   '@fluentui/docs-components': {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Use the same version for @fluentui/code-sandbox as other dependencies. Currently theming breaks when using latest and an older version eg. `0.47.x`

#### Focus areas to test

(optional)
