### PR TITLE
Use type from state iff canRevealPassword is true

### DIFF
--- a/change/office-ui-fabric-react-2020-10-24-10-42-39-7.0.json
+++ b/change/office-ui-fabric-react-2020-10-24-10-42-39-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: Use type from state iff canRevealPassword is true",
+  "packageName": "office-ui-fabric-react",
+  "email": "fahasanw@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-24T05:12:39.137Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -484,13 +484,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       'defaultValue',
     ]);
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
-    const inputType = this.props.canRevealPassword ? this.state.type : this.props.type ?? 'text';
+    const type = this.props.canRevealPassword ? this.state.type : this.props.type ?? 'text';
     return (
       <input
         id={this._id}
         aria-labelledby={ariaLabelledBy}
         {...inputProps}
-        type={inputType}
+        type={type}
         ref={this._textElement as React.RefObject<HTMLInputElement>}
         value={this.value || ''}
         onInput={this._onInputChange}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -360,7 +360,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       this._hasWarnedNullValue = true;
       warn(
         `Warning: 'value' prop on '${COMPONENT_NAME}' should not be null. Consider using an ` +
-        'empty string to clear the component or undefined to indicate an uncontrolled component.',
+          'empty string to clear the component or undefined to indicate an uncontrolled component.',
       );
     }
   }
@@ -484,7 +484,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       'defaultValue',
     ]);
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
-    const inputType = this.props.canRevealPassword ? this.state.type : (inputProps.type ?? 'text');
+    const inputType = this.props.canRevealPassword ? this.state.type : this.props.type ?? 'text';
     return (
       <input
         id={this._id}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -360,7 +360,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       this._hasWarnedNullValue = true;
       warn(
         `Warning: 'value' prop on '${COMPONENT_NAME}' should not be null. Consider using an ` +
-          'empty string to clear the component or undefined to indicate an uncontrolled component.',
+        'empty string to clear the component or undefined to indicate an uncontrolled component.',
       );
     }
   }
@@ -484,12 +484,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       'defaultValue',
     ]);
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
+    const inputType = this.props.canRevealPassword ? this.state.type : (inputProps.type ?? 'text');
     return (
       <input
         id={this._id}
         aria-labelledby={ariaLabelledBy}
         {...inputProps}
-        type={this.state.type}
+        type={inputType}
         ref={this._textElement as React.RefObject<HTMLInputElement>}
         value={this.value || ''}
         onInput={this._onInputChange}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #15670
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Set the type of TextField based on below priority list:
1. `this.state.type` iff `this.props.canRevealPassword` is set to `true`.
2. Use `type` from props.
3. Default to `text`.

#### Note:
`$ yarn change`: Command created no file.