### PR TITLE
Major bump react-compose package

### DIFF
--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -15,7 +15,7 @@
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react": "^8.0.0-beta.0",
     "@fluentui/react-button": "^1.0.0-beta.0",
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/scripts": "^1.0.0",
     "parallel-webpack": "^2.4.0",
     "webpack-bundle-analyzer": "^3.6.0"

--- a/change/@fluentui-react-avatar-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-avatar-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-avatar",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:37:54.688Z"
+}

--- a/change/@fluentui-react-button-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-button-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-button",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:02.470Z"
+}

--- a/change/@fluentui-react-cards-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-cards-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-cards",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:05.902Z"
+}

--- a/change/@fluentui-react-checkbox-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-checkbox-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-checkbox",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:09.288Z"
+}

--- a/change/@fluentui-react-compose-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-compose-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-compose",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:11.707Z"
+}

--- a/change/@fluentui-react-flex-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-flex-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-flex",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:13.888Z"
+}

--- a/change/@fluentui-react-image-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-image-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-image",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:18.799Z"
+}

--- a/change/@fluentui-react-link-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-link-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-link",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:24.359Z"
+}

--- a/change/@fluentui-react-text-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-text-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-text",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:25.943Z"
+}

--- a/change/@fluentui-react-theme-provider-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-theme-provider-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-theme-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:27.787Z"
+}

--- a/change/@fluentui-react-toggle-2020-10-23-12-38-29-bump-compose.json
+++ b/change/@fluentui-react-toggle-2020-10-23-12-38-29-bump-compose.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Major bump react-compose package since it dependes on packages with new major.",
+  "packageName": "@fluentui/react-toggle",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T19:38:29.331Z"
+}

--- a/packages/fluentui/docs/tsconfig.json
+++ b/packages/fluentui/docs/tsconfig.json
@@ -6,7 +6,6 @@
       "@fluentui/*": ["packages/fluentui/*/src/index"],
       "@fluentui/a11y-testing": ["packages/a11y-testing/src/index"],
       "@fluentui/keyboard-key": ["packages/keyboard-key/src/index"],
-      "@fluentui/react-compose": ["packages/react-compose/src/index"],
       "@fluentui/set-version": ["packages/set-version/src"],
       "src/*": ["packages/fluentui/react-northstar/src/*"],
       "test/*": ["packages/fluentui/react-northstar/test/*"]

--- a/packages/react-avatar/package.json
+++ b/packages/react-avatar/package.json
@@ -47,7 +47,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-icons-mdl2": "^1.0.0-beta.0",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",
     "@fluentui/react-hooks": "^8.0.0-beta.0",

--- a/packages/react-button/package.json
+++ b/packages/react-button/package.json
@@ -47,7 +47,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react-icons-mdl2": "^1.0.0-beta.0",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@fluentui/keyboard-key": "^0.2.12",
     "@fluentui/react": "^8.0.0-beta.0",
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",
     "@fluentui/theme": "^2.0.0-beta.0",
     "@microsoft/load-themed-styles": "^1.10.26",

--- a/packages/react-checkbox/package.json
+++ b/packages/react-checkbox/package.json
@@ -46,7 +46,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-icons-mdl2": "^1.0.0-beta.0",
     "@fluentui/react-internal": "^8.0.0-beta.0",
     "@fluentui/react-hooks": "^8.0.0-beta.0",

--- a/packages/react-compose/package.json
+++ b/packages/react-compose/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-compose",
-  "version": "0.19.7",
+  "version": "1.0.0-beta",
   "description": "Fluent UI React component composition.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",

--- a/packages/react-flex/package.json
+++ b/packages/react-flex/package.json
@@ -34,7 +34,7 @@
     "react-dom": "16.8.6"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",
     "@fluentui/theme": "^2.0.0-beta.0",
     "@fluentui/set-version": "^8.0.0-beta.0",

--- a/packages/react-image/package.json
+++ b/packages/react-image/package.json
@@ -46,7 +46,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",
     "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/react-hooks": "^8.0.0-beta.0",

--- a/packages/react-link/package.json
+++ b/packages/react-link/package.json
@@ -44,7 +44,7 @@
     "react-dom": "16.8.6"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-internal": "^8.0.0-beta.0",
     "@fluentui/react-hooks": "^8.0.0-beta.0",
     "@fluentui/set-version": "^8.0.0-beta.0",

--- a/packages/react-text/package.json
+++ b/packages/react-text/package.json
@@ -45,7 +45,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-theme-provider": "^1.0.0-beta.0",
     "@fluentui/theme": "^2.0.0-beta.0",
     "@microsoft/load-themed-styles": "^1.10.26",

--- a/packages/react-theme-provider/package.json
+++ b/packages/react-theme-provider/package.json
@@ -45,7 +45,7 @@
     "react-test-renderer": "^16.3.0"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-stylesheets": "^1.0.0-beta.0",
     "@fluentui/theme": "^2.0.0-beta.0",
     "@fluentui/react-window-provider": "^2.0.0-beta.0",

--- a/packages/react-toggle/package.json
+++ b/packages/react-toggle/package.json
@@ -43,7 +43,7 @@
     "sinon": "^4.1.3"
   },
   "dependencies": {
-    "@fluentui/react-compose": "^0.19.7",
+    "@fluentui/react-compose": "^1.0.0-beta",
     "@fluentui/react-internal": "^8.0.0-beta.0",
     "@fluentui/react-hooks": "^8.0.0-beta.0",
     "@fluentui/set-version": "^8.0.0-beta.0",

--- a/scripts/lernaAliasNorthstar.js
+++ b/scripts/lernaAliasNorthstar.js
@@ -1,7 +1,7 @@
 const lernaAlias = require('lerna-alias');
 
 // northstar packages should pull these from npm, not the repo
-const excludedPackages = ['@fluentui/date-time-utilities', '@fluentui/dom-utilities'];
+const excludedPackages = ['@fluentui/date-time-utilities', '@fluentui/dom-utilities', '@fluentui/react-compose'];
 
 module.exports = {
   jest: options => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1400,6 +1400,17 @@
     "@uifabric/set-version" "^7.0.23"
     tslib "^1.10.0"
 
+"@fluentui/react-compose@^0.19.6":
+  version "0.19.6"
+  resolved "https://registry.yarnpkg.com/@fluentui/react-compose/-/react-compose-0.19.6.tgz#a49e118261096116845b2e87db0a85d3e8ffb3cd"
+  integrity sha512-+YVTIGRuYZljiHYJrnUZNelCodX+OEW6RhKvRxYsze/tve6HkidugD3W6KlZ6y8aHnTpPwnmbyfbilB3jxDKdQ==
+  dependencies:
+    "@types/classnames" "^2.2.9"
+    "@uifabric/set-version" "^7.0.23"
+    "@uifabric/utilities" "^7.32.4"
+    classnames "^2.2.6"
+    tslib "^1.10.0"
+
 "@gulp-sourcemaps/identity-map@1.X":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@gulp-sourcemaps/identity-map/-/identity-map-1.0.2.tgz#1e6fe5d8027b1f285dc0d31762f566bccd73d5a9"
@@ -4777,7 +4788,7 @@
   dependencies:
     tslib "^1.10.0"
 
-"@uifabric/utilities@^7.32.3":
+"@uifabric/utilities@^7.32.3", "@uifabric/utilities@^7.32.4":
   version "7.32.4"
   resolved "https://registry.yarnpkg.com/@uifabric/utilities/-/utilities-7.32.4.tgz#6e784c29101742196da69d0b60e63cf193c10c71"
   integrity sha512-IKZc03uyfTrgcCGSPAUWfFl9CyxzpSrxrYwAuO4NgDEySdOlkYBRwsRUh6UwWfM+sJdhg7Y3nupzNU3VSC/arg==


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Major bump react-compose package since it depends on packages with new major version.

Switch `northstar` to use real npm package of `react-compose` because they are not ready to take on the new major version yet (along with few other packages). This is also why i previously wrongfully chosen not major bumping `react-compose`.

#### Focus areas to test

(optional)
