### PR TITLE
7.0: Fix copy when keyboard focus is on the SelectedItemsList in the UnifiedPicker

### DIFF
--- a/change/@uifabric-experiments-2020-10-23-13-07-05-ctrlclistfix7.0.json
+++ b/change/@uifabric-experiments-2020-10-23-13-07-05-ctrlclistfix7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix copy when keyboard focus is in the SelectedItemsList in the UnifiedPicker",
+  "packageName": "@uifabric/experiments",
+  "email": "elvonspa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T20:07:05.274Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.styles.ts
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.styles.ts
@@ -1,0 +1,14 @@
+import { ISelectedItemsListStyleProps, ISelectedItemsListStyles } from './SelectedItemsList.types';
+
+export const getStyles = (props: ISelectedItemsListStyleProps): ISelectedItemsListStyles => {
+  return {
+    copyInput: [
+      {
+        height: '0px',
+        width: '0px',
+        border: 'none',
+        outline: 'none',
+      },
+    ],
+  };
+};

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.test.tsx
@@ -47,7 +47,7 @@ describe('SelectedItemsList', () => {
         wrapper
           .find('div')
           .first()
-          .childAt(0)
+          .childAt(1)
           .text(),
       ).toEqual('a');
       expect(
@@ -81,7 +81,7 @@ describe('SelectedItemsList', () => {
       wrapper
         .find('div')
         .first()
-        .childAt(0)
+        .childAt(1)
         .text(),
     ).toEqual('da');
     expect(
@@ -108,7 +108,7 @@ describe('SelectedItemsList', () => {
       wrapper
         .find('div')
         .first()
-        .childAt(0)
+        .childAt(1)
         .text(),
     ).toEqual('Person A');
     expect(

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
+import { css, classNamesFunction } from 'office-ui-fabric-react';
+import {
+  ISelectedItemsList,
+  ISelectedItemsListProps,
+  BaseSelectedItem,
+  ISelectedItemsListStyleProps,
+  ISelectedItemsListStyles,
+} from './SelectedItemsList.types';
+import { getStyles } from './SelectedItemsList.styles';
 
-import { ISelectedItemsList, ISelectedItemsListProps, BaseSelectedItem } from './SelectedItemsList.types';
+const getClassNames = classNamesFunction<ISelectedItemsListStyleProps, ISelectedItemsListStyles>();
 
 const _SelectedItemsList = <TItem extends BaseSelectedItem>(
   props: ISelectedItemsListProps<TItem>,
@@ -11,6 +20,8 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
 
   const renderedItems = React.useMemo(() => items, [items]);
   const didMountRef = React.useRef(false);
+  const hiddenInput = React.useRef<any>();
+  const classNames = getClassNames(getStyles);
 
   React.useEffect(() => {
     // block first call of the hook and forward each consecutive one
@@ -59,11 +70,27 @@ const _SelectedItemsList = <TItem extends BaseSelectedItem>(
     [items],
   );
 
+  const _onFocus = (ev: React.FocusEvent<HTMLDivElement>) => {
+    // If we have an input, set focus to it so we can pick up the copy keyboard command
+    hiddenInput.current?.focus();
+  };
+
   const SelectedItem = props.onRenderItem;
   return (
     <>
       {items.length > 0 && (
-        <div role={'list'}>
+        <div role={'list'} onFocus={_onFocus}>
+          <input
+            // Add a zero zero size input. This is to pick up the copy command when we have
+            // keyboard focus in the list
+            // Focus is set to the input when the list gets focus via the _onFocus function
+            className={css('ms-SelectedItemsList-copyInput', classNames.copyInput)}
+            ref={hiddenInput}
+            hidden={!props.getItemCopyText}
+            data-is-focusable={false}
+            aria-hidden={true}
+            tabIndex={-1}
+          />
           {SelectedItem &&
             renderedItems.map((item: TItem, index: number) => (
               <SelectedItem

--- a/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedItemsList.types.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { IPickerItemProps, ISuggestionModel, ValidationState } from 'office-ui-fabric-react/lib/Pickers';
 import { IRefObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IDragDropEvents, IDragDropHelper } from 'office-ui-fabric-react/lib/utilities/dragdrop/index';
+import { IStyle } from 'office-ui-fabric-react/lib/Styling';
 export interface ISelectedItemsList<T> {
   /**
    * Current value of the input
@@ -140,4 +141,10 @@ export interface ISelectedItemsListProps<T> extends React.ClassAttributes<any> {
    * Should be used if it's possible to change some properties on items so a strict compare will fail
    */
   itemsAreEqual?: (item1?: any, item2?: any) => boolean;
+}
+
+export interface ISelectedItemsListStyleProps {}
+
+export interface ISelectedItemsListStyles {
+  copyInput: IStyle;
 }

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -4,8 +4,23 @@ exports[`SelectedPeopleList renders nothing if nothing is provided 1`] = `null`;
 
 exports[`SelectedPeopleList renders personas that are passed in 1`] = `
 <div
+  onFocus={[Function]}
   role="list"
 >
+  <input
+    aria-hidden={true}
+    className=
+        ms-SelectedItemsList-copyInput
+        {
+          border: none;
+          height: 0px;
+          outline: none;
+          width: 0px;
+        }
+    data-is-focusable={false}
+    hidden={true}
+    tabIndex={-1}
+  />
   <div
     aria-labelledby="selectedItemPersona-id__0"
     className=
@@ -1025,8 +1040,23 @@ exports[`SelectedPeopleList renders personas that are passed in 1`] = `
 
 exports[`SelectedPeopleList renders personas that are passed in as default 1`] = `
 <div
+  onFocus={[Function]}
   role="list"
 >
+  <input
+    aria-hidden={true}
+    className=
+        ms-SelectedItemsList-copyInput
+        {
+          border: none;
+          height: 0px;
+          outline: none;
+          width: 0px;
+        }
+    data-is-focusable={false}
+    hidden={true}
+    tabIndex={-1}
+  />
   <div
     aria-labelledby="selectedItemPersona-id__16"
     className=

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/UnifiedPeoplePicker.test.tsx
@@ -93,7 +93,7 @@ describe('UnifiedPeoplePicker', () => {
       />,
     );
 
-    const inputElement: InputElementWrapper = wrapper.find('input');
+    const inputElement: InputElementWrapper = wrapper.find('input').last();
     expect(inputElement).toHaveLength(1);
     inputElement.simulate('input', { target: { value: 'annie' } });
 

--- a/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
+++ b/packages/experiments/src/components/UnifiedPicker/UnifiedPeoplePicker/__snapshots__/UnifiedPeoplePicker.test.tsx.snap
@@ -170,8 +170,23 @@ exports[`UnifiedPeoplePicker renders correctly with selected and suggested items
             }
       >
         <div
+          onFocus={[Function]}
           role="list"
         >
+          <input
+            aria-hidden={true}
+            className=
+                ms-SelectedItemsList-copyInput
+                {
+                  border: none;
+                  height: 0px;
+                  outline: none;
+                  width: 0px;
+                }
+            data-is-focusable={false}
+            hidden={false}
+            tabIndex={-1}
+          />
           <div
             aria-labelledby="selectedItemPersona-id__2"
             className=

--- a/packages/experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
+++ b/packages/experiments/src/components/UnifiedPicker/__snapshots__/UnifiedPicker.test.tsx.snap
@@ -170,8 +170,23 @@ exports[`UnifiedPicker renders correctly with selected and suggested items 1`] =
             }
       >
         <div
+          onFocus={[Function]}
           role="list"
         >
+          <input
+            aria-hidden={true}
+            className=
+                ms-SelectedItemsList-copyInput
+                {
+                  border: none;
+                  height: 0px;
+                  outline: none;
+                  width: 0px;
+                }
+            data-is-focusable={false}
+            hidden={true}
+            tabIndex={-1}
+          />
           <div>
              
             red


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

v8 - https://github.com/microsoft/fluentui/pull/15655

The _onCopy function was not getting called on the wrapper div in the UnifiedPicker unless focus was in the autofill input. So if you were keyboard navigating the SelectedItemsList, keyboard copy never worked. But now that we removed mouse selection, there was no way to copy multiple items.

This adds the ability to copy when keyboard navigating. onCopy only gets called if the focus is in an input. So the SelectedItemsList now has a zero size input that's not keyboard selectable, that gets focus when the list gets focus. Copy is working.

#### Focus areas to test

- Tested that we can't see the input or access it via keyboard
- Tested that backspace still works
- Tested that multiselect still works
