### PR TITLE
Rename UMD global for scheme-utilities

### DIFF
--- a/change/@fluentui-scheme-utilities-2020-10-23-16-12-26-scheme-global.json
+++ b/change/@fluentui-scheme-utilities-2020-10-23-16-12-26-scheme-global.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Rename UMD global to FluentUISchemeUtilities",
+  "packageName": "@fluentui/scheme-utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T23:12:26.107Z"
+}

--- a/packages/scheme-utilities/webpack.config.js
+++ b/packages/scheme-utilities/webpack.config.js
@@ -9,6 +9,6 @@ module.exports = resources.createConfig(BUNDLE_NAME, true, {
 
   output: {
     libraryTarget: 'var',
-    library: 'Variants',
+    library: 'FluentUISchemeUtilities',
   },
 });


### PR DESCRIPTION
To follow conventions, the UMD global for scheme-utilities should be called `FluentUISchemeUtilities` not `Variants` now.