### PR TITLE
Charting: Adding customized callout support to AreaChart and LineChart

### DIFF
--- a/change/@fluentui-react-charting-2020-10-23-16-37-48-customCalloutForCharts.json
+++ b/change/@fluentui-react-charting-2020-10-23-16-37-48-customCalloutForCharts.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Charting: Adding customized callout support to AreaChart and LineChart.",
+  "packageName": "@fluentui/react-charting",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-23T23:37:48.170Z"
+}

--- a/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.base.tsx
@@ -7,6 +7,7 @@ import { find, getId, memoizeFunction } from '@fluentui/react/lib/Utilities';
 import {
   CartesianChart,
   IChartProps,
+  ICustomizedCalloutData,
   IAreaChartProps,
   IChildProps,
   IRefArrayData,
@@ -37,6 +38,8 @@ export interface IAreaChartState extends IBasestate {
   displayOfLine: string;
   activeCircleId: string;
   isCircleClicked: boolean;
+  dataPointCalloutProps?: ICustomizedCalloutData;
+  stackCalloutProps?: ICustomizedCalloutData;
 }
 
 export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartState> {
@@ -116,6 +119,7 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
         tickParams={tickParams}
         maxOfYVal={stackedInfo.maxOfYVal}
         getGraphData={this._getGraphData}
+        customizedCallout={this._getCustomizedCallout()}
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
         children={(props: IChildProps) => {
@@ -199,6 +203,14 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       stackedInfo,
       calloutPoints,
     };
+  };
+
+  private _getCustomizedCallout = () => {
+    return this.props.onRenderCalloutPerStack
+      ? this.props.onRenderCalloutPerStack(this.state.stackCalloutProps)
+      : this.props.onRenderCalloutPerDataPoint
+      ? this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
+      : null;
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -316,6 +328,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
       displayOfLine: 'visibility',
       activeCircleId: circleId,
       isCircleClicked: false,
+      stackCalloutProps: found!,
+      dataPointCalloutProps: found!,
     });
   };
 
@@ -349,6 +363,8 @@ export class AreaChartBase extends React.Component<IAreaChartProps, IAreaChartSt
           displayOfLine: 'visibility',
           activeCircleId: circleId,
           isCircleClicked: false,
+          stackCalloutProps: found!,
+          dataPointCalloutProps: found!,
         });
       }
     });

--- a/packages/react-charting/src/components/AreaChart/AreaChart.types.ts
+++ b/packages/react-charting/src/components/AreaChart/AreaChart.types.ts
@@ -1,10 +1,11 @@
-import { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
+import { IRenderFunction, IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
 import {
   IChartProps,
   IRefArrayData,
   IBasestate,
   ILineChartDataPoint,
   ILineChartPoints,
+  ICustomizedCalloutData,
   IMargins,
 } from '../../types/index';
 import {
@@ -32,6 +33,16 @@ export interface IAreaChartProps extends ICartesianChartProps {
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<ICartesianChartStyleProps, ICartesianChartStyles>;
+
+  /**
+   * Define a custom callout renderer for a data point
+   */
+  onRenderCalloutPerDataPoint?: IRenderFunction<ICustomizedCalloutData>;
+
+  /**
+   * Define a custom callout renderer for a stack; default is to render per data point
+   */
+  onRenderCalloutPerStack?: IRenderFunction<ICustomizedCalloutData>;
 }
 
 export interface IAreaChartStyles extends ICartesianChartStyles {}

--- a/packages/react-charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/react-charting/src/components/LineChart/LineChart.base.tsx
@@ -9,6 +9,7 @@ import {
   IChildProps,
   ILineChartProps,
   ILineChartPoints,
+  ICustomizedCalloutData,
   IMargins,
   IRefArrayData,
   IColorFillBarsProps,
@@ -33,6 +34,10 @@ export interface ILineChartState extends IBasestate {
   // This is a boolean value which is set to true
   // when at least one legend is selected
   isSelectedLegend: boolean;
+  // This value will be used as customized callout props - point callout.
+  dataPointCalloutProps?: ICustomizedCalloutData;
+  // This value will be used as Customized callout props - For stack callout.
+  stackCalloutProps?: ICustomizedCalloutData;
 }
 
 export class LineChartBase extends React.Component<ILineChartProps, ILineChartState> {
@@ -137,6 +142,7 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
         getmargins={this._getMargins}
         getGraphData={this._initializeLineChartData}
         xAxisType={isXAxisDateType ? XAxisTypes.DateAxis : XAxisTypes.NumericAxis}
+        customizedCallout={this._getCustomizedCallout()}
         /* eslint-disable react/jsx-no-bind */
         // eslint-disable-next-line react/no-children-prop
         children={(props: IChildProps) => {
@@ -174,6 +180,14 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       />
     );
   }
+
+  private _getCustomizedCallout = () => {
+    return this.props.onRenderCalloutPerStack
+      ? this.props.onRenderCalloutPerStack(this.state.stackCalloutProps)
+      : this.props.onRenderCalloutPerDataPoint
+      ? this.props.onRenderCalloutPerDataPoint(this.state.dataPointCalloutProps)
+      : null;
+  };
 
   private _getMargins = (margins: IMargins) => {
     this.margins = margins;
@@ -498,6 +512,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
           refSelected: obj.refElement,
           hoverXValue: xAxisCalloutData ? xAxisCalloutData : '' + formattedData,
           YValueHover: found.values,
+          stackCalloutProps: found!,
+          dataPointCalloutProps: found!,
         });
       }
     });
@@ -528,6 +544,8 @@ export class LineChartBase extends React.Component<ILineChartProps, ILineChartSt
       refSelected: mouseEvent,
       hoverXValue: xAxisCalloutData ? xAxisCalloutData : '' + formattedData,
       YValueHover: found.values,
+      stackCalloutProps: found!,
+      dataPointCalloutProps: found!,
     });
   };
 

--- a/packages/react-charting/src/components/LineChart/LineChart.types.ts
+++ b/packages/react-charting/src/components/LineChart/LineChart.types.ts
@@ -1,5 +1,12 @@
-import { IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
-import { IChartProps, ILineChartPoints, IMargins, IBasestate, IRefArrayData } from '../../types/index';
+import { IRenderFunction, IStyleFunctionOrObject } from '@fluentui/react/lib/Utilities';
+import {
+  IChartProps,
+  ILineChartPoints,
+  IMargins,
+  IBasestate,
+  IRefArrayData,
+  ICustomizedCalloutData,
+} from '../../types/index';
 import { IEventAnnotation } from '../../types/IEventAnnotation';
 import {
   ICartesianChartProps,
@@ -24,6 +31,16 @@ export interface ILineChartProps extends ICartesianChartProps {
    * Show event annotation
    */
   eventAnnotationProps?: IEventsAnnotationProps;
+
+  /**
+   * Define a custom callout renderer for a data point
+   */
+  onRenderCalloutPerDataPoint?: IRenderFunction<ICustomizedCalloutData>;
+
+  /**
+   * Define a custom callout renderer for a stack; default is to render per data point
+   */
+  onRenderCalloutPerStack?: IRenderFunction<ICustomizedCalloutData>;
 
   /*
    * Color fill bars for the chart,

--- a/packages/react-charting/src/types/IDataPoint.ts
+++ b/packages/react-charting/src/types/IDataPoint.ts
@@ -372,3 +372,20 @@ export interface IHeatMapChartData {
    */
   value: number;
 }
+
+export interface ICustomizedCalloutDataPoint {
+  legend: string;
+  y: number;
+  color: string;
+  xAxisCalloutData?: string;
+  yAxisCalloutData?: string | { [id: string]: number };
+}
+
+/**
+ * Used for custom callout data interface. As Area chart callout data will be prepared from given props.data,
+ * Those required data passing to onRenderCalloutPerDataPoint and onRenderCalloutPerStack.
+ */
+export interface ICustomizedCalloutData {
+  x: number | string | Date;
+  values: ICustomizedCalloutDataPoint[];
+}

--- a/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
+++ b/packages/react-examples/src/react-charting/AreaChart/AreaChart.Basic.Example.tsx
@@ -1,182 +1,27 @@
 import * as React from 'react';
-import { AreaChart } from '@fluentui/react-charting';
-import { ILineChartProps } from '@fluentui/react-charting';
+import { AreaChart, ICustomizedCalloutData } from '@fluentui/react-charting';
+import { IAreaChartProps, ChartHoverCard } from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
+import { ChoiceGroup, IChoiceGroupOption } from '@fluentui/react/lib/ChoiceGroup';
 
 interface IAreaChartBasicState {
   width: number;
   height: number;
-  chartData: any;
+  isCalloutselected: boolean;
 }
 
-const chart1Points = [
-  {
-    x: 20,
-    y: 7000,
-    xAxisCalloutData: '2018/01/01',
-    yAxisCalloutData: '10%',
-  },
-  {
-    x: 25,
-    y: 9000,
-    xAxisCalloutData: '2018/01/15',
-    yAxisCalloutData: '18%',
-  },
-  {
-    x: 30,
-    y: 13000,
-    xAxisCalloutData: '2018/01/28',
-    yAxisCalloutData: '24%',
-  },
-  {
-    x: 35,
-    y: 15000,
-    xAxisCalloutData: '2018/02/01',
-    yAxisCalloutData: '25%',
-  },
-  {
-    x: 40,
-    y: 11000,
-    xAxisCalloutData: '2018/03/01',
-    yAxisCalloutData: '15%',
-  },
-  {
-    x: 45,
-    y: 8760,
-    xAxisCalloutData: '2018/03/15',
-    yAxisCalloutData: '30%',
-  },
-  {
-    x: 50,
-    y: 3500,
-    xAxisCalloutData: '2018/03/28',
-    yAxisCalloutData: '18%',
-  },
-  {
-    x: 55,
-    y: 20000,
-    xAxisCalloutData: '2018/04/04',
-    yAxisCalloutData: '32%',
-  },
-  {
-    x: 60,
-    y: 17000,
-    xAxisCalloutData: '2018/04/15',
-    yAxisCalloutData: '29%',
-  },
-  {
-    x: 65,
-    y: 1000,
-    xAxisCalloutData: '2018/05/05',
-    yAxisCalloutData: '43%',
-  },
-  {
-    x: 70,
-    y: 12000,
-    xAxisCalloutData: '2018/06/01',
-    yAxisCalloutData: '45%',
-  },
-  {
-    x: 75,
-    y: 6876,
-    xAxisCalloutData: '2018/01/15',
-    yAxisCalloutData: '18%',
-  },
-  {
-    x: 80,
-    y: 12000,
-    xAxisCalloutData: '2018/04/30',
-    yAxisCalloutData: '55%',
-  },
-  {
-    x: 85,
-    y: 7000,
-    xAxisCalloutData: '2018/05/04',
-    yAxisCalloutData: '12%',
-  },
-  {
-    x: 90,
-    y: 10000,
-    xAxisCalloutData: '2018/06/01',
-    yAxisCalloutData: '45%',
-  },
-];
-
-const chart2Points = [
-  {
-    x: 50,
-    y: 3500,
-    xAxisCalloutData: '2018/03/28',
-    yAxisCalloutData: '18%',
-  },
-  {
-    x: 55,
-    y: 20000,
-    xAxisCalloutData: '2018/04/04',
-    yAxisCalloutData: '32%',
-  },
-  {
-    x: 60,
-    y: 17000,
-    xAxisCalloutData: '2018/04/15',
-    yAxisCalloutData: '29%',
-  },
-
-  {
-    x: 70,
-    y: 12000,
-    xAxisCalloutData: '2018/06/01',
-    yAxisCalloutData: '45%',
-  },
-  {
-    x: 75,
-    y: 6876,
-    xAxisCalloutData: '2018/01/15',
-    yAxisCalloutData: '18%',
-  },
-  {
-    x: 80,
-    y: 12000,
-    xAxisCalloutData: '2018/04/30',
-    yAxisCalloutData: '55%',
-  },
-  {
-    x: 85,
-    y: 7000,
-    xAxisCalloutData: '2018/05/04',
-    yAxisCalloutData: '12%',
-  },
-  {
-    x: 90,
-    y: 10000,
-    xAxisCalloutData: '2018/06/01',
-    yAxisCalloutData: '45%',
-  },
-];
-
-const chartPoints1 = [
-  {
-    legend: 'legend1',
-    data: chart1Points,
-    color: DefaultPalette.accent,
-  },
-];
-
-const chartPoints2 = [
-  {
-    legend: 'legend1',
-    data: chart2Points,
-    color: 'red',
-  },
+const options: IChoiceGroupOption[] = [
+  { key: 'basicExample', text: 'Basic Example' },
+  { key: 'calloutExample', text: 'Custom Callout Example' },
 ];
 
 export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicState> {
-  constructor(props: ILineChartProps) {
+  constructor(props: IAreaChartProps) {
     super(props);
     this.state = {
       width: 700,
       height: 300,
-      chartData: chartPoints1,
+      isCalloutselected: false,
     };
   }
 
@@ -191,14 +36,119 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
     this.setState({ height: parseInt(e.target.value, 10) });
   };
 
-  private _onDataChange = () => {
-    this.setState({ chartData: chartPoints2 });
+  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void => {
+    if (this.state.isCalloutselected) {
+      this.setState({ isCalloutselected: false });
+    } else {
+      this.setState({ isCalloutselected: true });
+    }
   };
 
   private _basicExample(): JSX.Element {
+    const chart1Points = [
+      {
+        x: 20,
+        y: 7000,
+        xAxisCalloutData: '2018/01/01',
+        yAxisCalloutData: '10%',
+      },
+      {
+        x: 25,
+        y: 9000,
+        xAxisCalloutData: '2018/01/15',
+        yAxisCalloutData: '18%',
+      },
+      {
+        x: 30,
+        y: 13000,
+        xAxisCalloutData: '2018/01/28',
+        yAxisCalloutData: '24%',
+      },
+      {
+        x: 35,
+        y: 15000,
+        xAxisCalloutData: '2018/02/01',
+        yAxisCalloutData: '25%',
+      },
+      {
+        x: 40,
+        y: 11000,
+        xAxisCalloutData: '2018/03/01',
+        yAxisCalloutData: '15%',
+      },
+      {
+        x: 45,
+        y: 8760,
+        xAxisCalloutData: '2018/03/15',
+        yAxisCalloutData: '30%',
+      },
+      {
+        x: 50,
+        y: 3500,
+        xAxisCalloutData: '2018/03/28',
+        yAxisCalloutData: '18%',
+      },
+      {
+        x: 55,
+        y: 20000,
+        xAxisCalloutData: '2018/04/04',
+        yAxisCalloutData: '32%',
+      },
+      {
+        x: 60,
+        y: 17000,
+        xAxisCalloutData: '2018/04/15',
+        yAxisCalloutData: '29%',
+      },
+      {
+        x: 65,
+        y: 1000,
+        xAxisCalloutData: '2018/05/05',
+        yAxisCalloutData: '43%',
+      },
+      {
+        x: 70,
+        y: 12000,
+        xAxisCalloutData: '2018/06/01',
+        yAxisCalloutData: '45%',
+      },
+      {
+        x: 75,
+        y: 6876,
+        xAxisCalloutData: '2018/01/15',
+        yAxisCalloutData: '18%',
+      },
+      {
+        x: 80,
+        y: 12000,
+        xAxisCalloutData: '2018/04/30',
+        yAxisCalloutData: '55%',
+      },
+      {
+        x: 85,
+        y: 7000,
+        xAxisCalloutData: '2018/05/04',
+        yAxisCalloutData: '12%',
+      },
+      {
+        x: 90,
+        y: 10000,
+        xAxisCalloutData: '2018/06/01',
+        yAxisCalloutData: '45%',
+      },
+    ];
+
+    const chartPoints = [
+      {
+        legend: 'legend1',
+        data: chart1Points,
+        color: DefaultPalette.accent,
+      },
+    ];
+
     const chartData = {
       chartTitle: 'Area chart basic example',
-      lineChartData: this.state.chartData,
+      lineChartData: chartPoints,
     };
 
     const rootStyle = { width: `${this.state.width}px`, height: `${this.state.height}px` };
@@ -209,15 +159,25 @@ export class AreaChartBasicExample extends React.Component<{}, IAreaChartBasicSt
         <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
         <label>change Height:</label>
         <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
-        <button
-          onClick={() => {
-            this._onDataChange();
-          }}
-        >
-          Update data
-        </button>
+        <ChoiceGroup options={options} defaultSelectedKey="basicExample" onChange={this._onChange} label="Pick one" />
         <div style={rootStyle}>
-          <AreaChart height={this.state.height} width={this.state.width} data={chartData} showYAxisGridLines={true} />
+          <AreaChart
+            height={this.state.height}
+            width={this.state.width}
+            data={chartData}
+            showYAxisGridLines={true}
+            // eslint-disable-next-line react/jsx-no-bind
+            onRenderCalloutPerDataPoint={(props: ICustomizedCalloutData) =>
+              props && this.state.isCalloutselected ? (
+                <ChartHoverCard
+                  XValue={props.x.toString()}
+                  Legend={'Custom Legend'}
+                  YValue={`${props.values[0].yAxisCalloutData || props.values[0].y} h`}
+                  color={'red'}
+                />
+              ) : null
+            }
+          />
         </div>
       </>
     );

--- a/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/LineChart/LineChart.Styled.Example.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '@fluentui/react-charting';
+import {
+  IChartProps,
+  ILineChartPoints,
+  ILineChartProps,
+  LineChart,
+  ChartHoverCard,
+  ICustomizedCalloutData,
+} from '@fluentui/react-charting';
 import { DefaultPalette } from '@fluentui/react/lib/Styling';
 
 interface IStyledLineChartExampleState {
@@ -65,6 +72,17 @@ export class LineChartStyledExample extends React.Component<{}, IStyledLineChart
             hideLegend={true}
             height={this.state.height}
             width={this.state.width}
+            // eslint-disable-next-line react/jsx-no-bind
+            onRenderCalloutPerDataPoint={(props: ICustomizedCalloutData) =>
+              props ? (
+                <ChartHoverCard
+                  XValue={'Custom XVal'}
+                  Legend={'Custom Legend'}
+                  YValue={`${props.values[0].yAxisCalloutData || props.values[0].y} h`}
+                  color={'red'}
+                />
+              ) : null
+            }
           />
         </div>
       </>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #15285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherry-pick of #15361._

_Original PR description:_

Custom callout support added to Area chart and line chart.

To add this, Exposed callout props and added a new callback method prop to the chart props. As a callback, below details will be available.
![image](https://user-images.githubusercontent.com/13463251/95055800-7002c400-0711-11eb-9f47-077434dc580f.png)


Implementing custom callout feature, Need to implement own callout component and need to pass props like below ( See Examples file for better understanding.

#### Focus areas to test
Area chart
Line chart


#### Screenshots
### Area Chart

**Default behavior**

![image](https://user-images.githubusercontent.com/13463251/95055976-accebb00-0711-11eb-936b-908ad1784fc1.png)

**Custom callout**
![image](https://user-images.githubusercontent.com/13463251/95056112-db4c9600-0711-11eb-9224-42097e2ac7a0.png)

### Line chart
**Default behavior**
![image](https://user-images.githubusercontent.com/13463251/95056199-fddeaf00-0711-11eb-806c-4fa6c89c7ed2.png)


**Custom callout**
![image](https://user-images.githubusercontent.com/13463251/95056221-046d2680-0712-11eb-8a5c-e086989b8fb5.png)


Test link: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/15361/merge/charting/dist/index.html#/examples/areachart
 

