### PR TITLE
Charting: Fixing uncaught type error in VerticalStackedBarChart and made minor edits to margins

### DIFF
--- a/change/@fluentui-react-charting-2020-10-26-12-32-58-verticalStackedBarChartMinorChanges.json
+++ b/change/@fluentui-react-charting-2020-10-26-12-32-58-verticalStackedBarChartMinorChanges.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Charting: Fixing uncaught type error in VerticalStackedBarChart and made minor edits to margins.",
+  "packageName": "@fluentui/react-charting",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-26T19:32:58.064Z"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.base.tsx
@@ -15,7 +15,6 @@ import {
   createDateXAxis,
   createYAxis,
   createStringYAxis,
-  additionalMarginRight,
   IMargins,
   getMinMaxOfYAxis,
   XAxisTypes,
@@ -60,11 +59,17 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
       _height: this.props.height || 350,
     };
     this.idForGraph = getId('chart_');
+    /**
+     * In RTL mode, Only graph will be rendered left/right. We need to provide left and right margins manually.
+     * So that, in RTL, left margins becomes right margins and viceversa.
+     * As graph needs to be drawn perfecty, these values consider as default values.
+     * Same margins using for all other cartesian charts. Can be accessible through 'getMargins' call back method.
+     */
     this.margins = {
-      top: this.props.margins?.top || 20,
-      right: this.props.margins?.right || 20,
-      bottom: this.props.margins?.bottom || 35,
-      left: this.props.margins?.left || 40,
+      top: this.props.margins?.top ?? 20,
+      bottom: this.props.margins?.bottom ?? 35,
+      right: this._isRtl ? this.props.margins?.left ?? 40 : this.props.margins?.right ?? 20,
+      left: this._isRtl ? this.props.margins?.right ?? 20 : this.props.margins?.left ?? 40,
     };
   }
 
@@ -200,7 +205,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
                 this.xAxisElement = e;
               }}
               id={`xAxisGElement${this.idForGraph}`}
-              transform={`translate(0, ${svgDimensions.height - 35})`}
+              transform={`translate(0, ${svgDimensions.height - this.margins.bottom!})`}
               className={this._classNames.xAxis}
             />
             <g
@@ -209,7 +214,7 @@ export class CartesianChartBase extends React.Component<IModifiedCartesianChartP
               }}
               id={`yAxisGElement${this.idForGraph}`}
               transform={`translate(${
-                this._isRtl ? svgDimensions.width - this.margins.right! - additionalMarginRight : 40
+                this._isRtl ? svgDimensions.width - this.margins.right! : this.margins.left!
               }, 0)`}
               className={this._classNames.yAxis}
             />

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -157,6 +157,8 @@ export interface ICartesianChartProps {
 
   /**
    * Margins for the chart
+   * @default `{ top: 20, bottom: 35, left: 40, right: 20 }`
+   * To avoid edge cuttings to the chart, we recommend you use default values or greater then default values
    */
   margins?: IMargins;
 

--- a/packages/react-charting/src/components/Legends/Legends.base.tsx
+++ b/packages/react-charting/src/components/Legends/Legends.base.tsx
@@ -298,7 +298,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       >
         <div
           className={classNames.overflowIndicationTextStyle}
-          // eslint-disable-next-line react/jsx-no-bind
           ref={(rootElem: HTMLDivElement) => (this._hoverCardRef = rootElem)}
           {...(allowFocusOnLegends && {
             'aria-expanded': this.state.isHoverCardVisible,
@@ -378,7 +377,6 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
         {...(data.nativeButtonProps && { ...data.nativeButtonProps })}
         key={index}
         className={classNames.legend}
-        /* eslint-disable react/jsx-no-bind */
         onClick={onClickHandler}
         onMouseOver={onHoverHandler}
         onMouseOut={onMouseOut}

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -46,18 +46,22 @@ export interface IWrapLabelProps {
 export interface IMargins {
   /**
    * left margin for the chart.
+   * @default 40
    */
   left?: number;
   /**
    * Right margin for the chart.
+   * @default 20
    */
   right?: number;
   /**
    * Top margin for the chart.
+   * @default 20
    */
   top?: number;
   /**
    * Bottom margin for the chart.
+   * @default 35
    */
   bottom?: number;
 }
@@ -118,7 +122,6 @@ export interface IFitContainerParams {
   legendContainer: HTMLDivElement;
   container: HTMLDivElement | null | HTMLElement;
 }
-export const additionalMarginRight: number = 20;
 
 /**
  * Create Numeric X axis
@@ -530,7 +533,7 @@ export function domainRangeOfDateForAreaChart(
   });
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rEndValue = width - margins.right!;
 
   return isRTL
     ? { dStartValue: lDate, dEndValue: sDate, rStartValue, rEndValue }
@@ -564,7 +567,7 @@ export function domainRangeOfNumericForAreaChart(
   })!;
 
   const rStartValue = margins.left!;
-  const rEndValue = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rEndValue = width - margins.right!;
 
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue, rEndValue }
@@ -584,7 +587,7 @@ export function domainRangeOfNumericForAreaChart(
  */
 export function domainRangeOfStrForVSBC(margins: IMargins, width: number, isRTL: boolean): IDomainNRange {
   const rMin = margins.left!;
-  const rMax = width - margins.right! - (isRTL ? additionalMarginRight : 0);
+  const rMax = width - margins.right!;
 
   return isRTL
     ? { dStartValue: 0, dEndValue: 0, rStartValue: rMax, rEndValue: rMin }
@@ -628,7 +631,7 @@ export function domainRangeOfVSBCNumeric(
   const xMax = d3Max(points, (point: IDataPoint) => point.x as number)!;
   // barWidth / 2 - for to get tick middle of the bar
   const rMax = margins.left! + barWidth / 2;
-  const rMin = width - margins.right! - barWidth / 2 - (isRTL ? additionalMarginRight : 0);
+  const rMin = width - margins.right! - barWidth / 2;
   return isRTL
     ? { dStartValue: xMax, dEndValue: xMin, rStartValue: rMax, rEndValue: rMin }
     : { dStartValue: xMin, dEndValue: xMax, rStartValue: rMax, rEndValue: rMin };

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -37,7 +37,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
     const firstChartPoints: IVSChartDataPoint[] = [
       { legend: 'Metadata1', data: 40, color: DefaultPalette.accent },
       { legend: 'Metadata2', data: 5, color: DefaultPalette.blueMid },
-      { legend: 'Metadata3', data: 15, color: DefaultPalette.blueLight },
+      { legend: 'Metadata3', data: 0, color: DefaultPalette.blueLight },
     ];
 
     const secondChartPoints: IVSChartDataPoint[] = [
@@ -74,6 +74,11 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
 
     const customStyles: IVerticalStackedBarChartProps['styles'] = () => {
       return {
+        xAxis: {
+          selectors: {
+            text: { fill: 'black', fontSize: '8px' },
+          },
+        },
         chart: {
           paddingBottom: '45px',
         },
@@ -99,6 +104,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             height={this.state.height}
             width={this.state.width}
             yAxisTickCount={10}
+            // Just test link
             href={'www.google.com'}
             // eslint-disable-next-line react/jsx-no-bind
             styles={customStyles}
@@ -109,7 +115,12 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             }}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisTickFormat={(x: number | string) => `${x} h`}
-            margins={{ left: 50 }}
+            margins={{
+              bottom: 0,
+              top: 0,
+              left: 0,
+              right: 0,
+            }}
             legendProps={{
               allowFocusOnLegends: true,
               styles: {
@@ -118,8 +129,8 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 },
               },
             }}
-            // eslint-disable-next-line react/jsx-no-bind
-            onRenderCalloutPerDataPoint={props =>
+            // eslint-disable-next-line react/jsx-no-bind, @typescript-eslint/no-explicit-any
+            onRenderCalloutPerDataPoint={(props: any) =>
               props ? (
                 <ChartHoverCard
                   XValue={props.xAxisCalloutData}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #15285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherry-pick of #15447._

_Original PR description:_

Vertical stacked bar chart.

1. 'Uncaught type error' issue fixed when click event triggers on bars.
2. Adjusted margin props to the cartesian/specific charts.
3. Updated below conditions as like previous PR:  https://github.com/microsoft/fluentui/pull/14912/
     -  Non zero bars condition added
     - Changed 'data-is-focusable' param to undefined instead of false.
    - Ref's data updated.
4. Margins condition updated. Now 0 value can be accepted.
5. Added description(default prop values) to the margins prop

Note: As Cartesian component consumed by other charts, Due to small change in cartesian, cross checked all other charts and added screenshots.

#### Focus areas to test

Vertical stacked bar chart
Vertical bar chart
Area chart
Line chart

### After fix
 ```
margins: {
left: 45,
right: 30
}
```
#### Vertical stacked bar chart
![image](https://user-images.githubusercontent.com/20105532/95721574-6f79a880-0c90-11eb-9d95-e8d83f772044.png)

#### Vertical stacked bar chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95722889-24f92b80-0c92-11eb-978b-ca85cd544f73.png)

```
margins: {{
left: 45,
right: 30
}}
```
#### Vertical bar chart 
![image](https://user-images.githubusercontent.com/20105532/95722624-ccc22980-0c91-11eb-866e-824e72322e7c.png)

#### Vertical bar chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95722710-e95e6180-0c91-11eb-8acc-5e8c5901a33b.png)

#### No margins given - It can take default values  ``` left:40, right: 20 ```
#### Area chart
![image](https://user-images.githubusercontent.com/20105532/95723508-db5d1080-0c92-11eb-9edf-11d77d00cd06.png)

#### Area chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95723183-7d302d80-0c92-11eb-9b7b-b3794cff8534.png)

#### Line chart
![image](https://user-images.githubusercontent.com/20105532/95723730-165f4400-0c93-11eb-9488-ac0696a13249.png)

#### Line chart with RTL
![image](https://user-images.githubusercontent.com/20105532/95723775-2414c980-0c93-11eb-8c19-47ce185c4f91.png)