### PR TITLE
ResizeGroup: Improve perf by making sure resize data state change is batched.

### DIFF
--- a/change/@fluentui-react-internal-2020-10-26-14-30-54-perf-resize-group.json
+++ b/change/@fluentui-react-internal-2020-10-26-14-30-54-perf-resize-group.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "ResizeGroup: Improve perf by making sure resize data state change is batched.",
+  "packageName": "@fluentui/react-internal",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-26T21:30:54.843Z"
+}

--- a/packages/react-internal/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/react-internal/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -314,13 +314,17 @@ type ResizeDataAction = {
   value: IResizeGroupState[keyof IResizeGroupState] | IResizeGroupState;
 };
 
+/**
+ * Use useReducer instead of userState because React is not batching the state updates
+ * when state is set in callbacks of setTimeout or requestAnimationFrame.
+ * See issue: https://github.com/facebook/react/issues/14259
+ */
 function resizeDataReducer(state: IResizeGroupState, action: ResizeDataAction): IResizeGroupState {
   switch (action.type) {
     case 'resizeData':
       return { ...action.value };
-    case 'dataToMeasure': {
+    case 'dataToMeasure':
       return { ...state, dataToMeasure: action.value, resizeDirection: 'grow', measureContainer: true };
-    }
     default:
       return { ...state, [action.type]: action.value };
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`React` is not batching the state changes when states are set in callbacks like `setTimeout` or `requestAnimationFrame`. See issue: https://github.com/facebook/react/issues/14259

In `ResizeGroup`, we call `updateResizeState` from `requestAnimationFrame` callback. `updateResizeState` call different `useState` setters which causes un-batched re-renders. The fix here is to group `resize` data into a single state in `useResizeData` hook. 

Also noticed couple places where we should memoize the callbacks returned from `updateResizeState`.

#### Focus areas to test
`perf-test` results for components which uses `ResizeGroup`: `Breadcrumb`, `CommandBar`
