### PR TITLE
Charting: Adding support for bar gaps and rounded corners in VerticalStackedBarChart

### DIFF
--- a/change/@fluentui-react-charting-2020-10-26-16-15-46-verticalStackedBarChartBarStyling.json
+++ b/change/@fluentui-react-charting-2020-10-26-16-15-46-verticalStackedBarChartBarStyling.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Charting: Adding support for bar gaps and rounded corners in VerticalStackedBarChart.",
+  "packageName": "@fluentui/react-charting",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-26T23:15:45.984Z"
+}

--- a/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
+++ b/packages/react-charting/src/components/VerticalStackedBarChart/VerticalStackedBarChart.types.ts
@@ -21,6 +21,21 @@ export interface IVerticalStackedBarChartProps extends ICartesianChartProps {
   barWidth?: number;
 
   /**
+   * Gap (max) between bars in a stack. When non-zero, the bars in a stack will
+   * be separated by gaps. The actual size of each gap is calculated as 20% of
+   * the height of that stack, with a minimum size of 1px and a maximum given by
+   * this prop.
+   * @default 0
+   */
+  barGapMax?: number;
+
+  /**
+   * Corner radius of the bars
+   * @default 0
+   */
+  barCornerRadius?: number;
+
+  /**
    * Colors from which to select the color of each bar.
    * @deprecated Not using this prop. DIrectly taking color from given data.
    */

--- a/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
+++ b/packages/react-examples/src/react-charting/VerticalStackedBarChart/VerticalStackedBarChart.Styled.Example.tsx
@@ -7,11 +7,19 @@ import {
   IVerticalStackedBarChartProps,
 } from '@fluentui/react-charting';
 import { DefaultPalette, IStyle, DefaultFontStyles } from '@fluentui/react/lib/Styling';
-import { DirectionalHint } from '@fluentui/react';
+import { ChoiceGroup, DirectionalHint, IChoiceGroupOption } from '@fluentui/react';
+
+const options: IChoiceGroupOption[] = [
+  { key: 'singleCallout', text: 'Single callout' },
+  { key: 'MultiCallout', text: 'Stack callout' },
+];
 
 interface IVerticalStackedBarState {
   width: number;
   height: number;
+  barGapMax: number;
+  barCornerRadius: number;
+  selectedCallout: string;
 }
 
 export class VerticalStackedBarChartStyledExample extends React.Component<{}, IVerticalStackedBarState> {
@@ -20,23 +28,19 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
     this.state = {
       width: 650,
       height: 350,
+      barGapMax: 2,
+      barCornerRadius: 2,
+      selectedCallout: 'MultiCallout',
     };
   }
   public render(): JSX.Element {
     return <div>{this._basicExample()}</div>;
   }
 
-  private _onWidthChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ width: parseInt(e.target.value, 10) });
-  };
-  private _onHeightChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ height: parseInt(e.target.value, 10) });
-  };
-
   private _basicExample(): JSX.Element {
     const firstChartPoints: IVSChartDataPoint[] = [
-      { legend: 'Metadata1', data: 40, color: DefaultPalette.accent },
-      { legend: 'Metadata2', data: 5, color: DefaultPalette.blueMid },
+      { legend: 'Metadata1', data: 2, color: DefaultPalette.accent },
+      { legend: 'Metadata2', data: 1, color: DefaultPalette.blueMid },
       { legend: 'Metadata3', data: 0, color: DefaultPalette.blueLight },
     ];
 
@@ -76,7 +80,7 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
       return {
         xAxis: {
           selectors: {
-            text: { fill: 'black', fontSize: '8px' },
+            text: { fill: 'black', fontSize: '10px' },
           },
         },
         chart: {
@@ -94,15 +98,53 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
 
     return (
       <>
-        <label>change Width:</label>
-        <input type="range" value={this.state.width} min={200} max={1000} onChange={this._onWidthChange} />
-        <label>change Height:</label>
-        <input type="range" value={this.state.height} min={200} max={1000} onChange={this._onHeightChange} />
+        <div>
+          <label>Width:</label>
+          <input
+            type="range"
+            value={this.state.width}
+            min={200}
+            max={1000}
+            onChange={e => this.setState({ width: +e.target.value })}
+          />
+          <label>Height:</label>
+          <input
+            type="range"
+            value={this.state.height}
+            min={200}
+            max={1000}
+            onChange={e => this.setState({ height: +e.target.value })}
+          />
+        </div>
+        <div>
+          <label>BarGapMax:</label>
+          <input
+            type="range"
+            value={this.state.barGapMax}
+            min={0}
+            max={10}
+            onChange={e => this.setState({ barGapMax: +e.target.value })}
+          />
+          <label>BarCornerRadius:</label>
+          <input
+            type="range"
+            value={this.state.barCornerRadius}
+            min={0}
+            max={10}
+            onChange={e => this.setState({ barCornerRadius: +e.target.value })}
+          />
+          <ChoiceGroup
+            options={options}
+            defaultSelectedKey="MultiCallout"
+            // eslint-disable-next-line react/jsx-no-bind
+            onChange={(_ev, option) => option && this.setState({ selectedCallout: option.key })}
+            label="Pick one"
+          />
+        </div>
         <div style={rootStyle}>
           <VerticalStackedBarChart
             data={data}
-            height={this.state.height}
-            width={this.state.width}
+            {...this.state}
             yAxisTickCount={10}
             // Just test link
             href={'www.google.com'}
@@ -110,15 +152,16 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
             styles={customStyles}
             yMaxValue={120}
             yMinValue={10}
+            isCalloutForStack={this.state.selectedCallout === 'MultiCallout'}
             calloutProps={{
               directionalHint: DirectionalHint.topCenter,
             }}
             // eslint-disable-next-line react/jsx-no-bind
             yAxisTickFormat={(x: number | string) => `${x} h`}
             margins={{
-              bottom: 0,
-              top: 0,
-              left: 0,
+              bottom: 35,
+              top: 10,
+              left: 35,
               right: 0,
             }}
             legendProps={{
@@ -129,8 +172,8 @@ export class VerticalStackedBarChartStyledExample extends React.Component<{}, IV
                 },
               },
             }}
-            // eslint-disable-next-line react/jsx-no-bind, @typescript-eslint/no-explicit-any
-            onRenderCalloutPerDataPoint={(props: any) =>
+            // eslint-disable-next-line react/jsx-no-bind
+            onRenderCalloutPerDataPoint={props =>
               props ? (
                 <ChartHoverCard
                   XValue={props.xAxisCalloutData}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Part of #15285
- [x] Include a change request file using `$ yarn change`

#### Description of changes

_Cherry-pick of #15606._

_Original PR description:_

Add support for two styling parameters for vertical stacked bar chart:

- rounded top corners (border radius)
- spacing between bars (bar gap); given as a maximum gap in pixels

![image](https://user-images.githubusercontent.com/1230364/96540766-5efa9c80-1253-11eb-8e5c-80ee75351639.png)