### PR TITLE
Store website info in sessionStorage (v7)

### DIFF
--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -51,6 +51,7 @@
     "@uifabric/icons": "^7.5.12",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/theme-samples": "^7.1.34",
+    "@uifabric/utilities": "^7.32.4",
     "json-loader": "^0.5.7",
     "office-ui-fabric-core": "^11.0.0",
     "office-ui-fabric-react": "^7.148.0",

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -14,6 +14,7 @@ import {
 } from 'office-ui-fabric-react';
 import { isPageActive, hasActiveChild, INavPage, INavProps, NavSortType } from '@uifabric/example-app-base/lib/index2';
 import { theme } from '@uifabric/example-app-base/lib/styles/theme';
+import { getItem, setItem } from '@uifabric/utilities/lib/sessionStorage';
 import * as styles from './Nav.module.scss';
 
 export interface INavState {
@@ -32,12 +33,12 @@ export class Nav extends React.Component<INavProps, INavState> {
   public constructor(props: INavProps) {
     super(props);
 
-    this._localItems =
-      typeof window !== 'undefined' && window.localStorage
-        ? {
-            defaultSortState: NavSortType[localStorage.getItem('defaultSortState') as keyof typeof NavSortType],
-          }
-        : {};
+    const defaultSortState = getItem('defaultSortState');
+    this._localItems = defaultSortState
+      ? {
+          defaultSortState: NavSortType[defaultSortState as keyof typeof NavSortType],
+        }
+      : {};
 
     this.state = {
       defaultSortState: this._localItems.defaultSortState
@@ -51,7 +52,7 @@ export class Nav extends React.Component<INavProps, INavState> {
   }
 
   public componentDidMount(): void {
-    !this._localItems.defaultSortState && localStorage.setItem('defaultSortState', this.state.defaultSortState);
+    !this._localItems.defaultSortState && setItem('defaultSortState', this.state.defaultSortState);
   }
 
   public shouldComponentUpdate(nextProps: INavProps): boolean {

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -25,6 +25,7 @@ import {
 import { Nav } from '../Nav/index';
 import { AppCustomizations } from './customizations';
 import { AppCustomizationsContext, extractAnchorLink } from '@uifabric/example-app-base/lib/index';
+import { getItem, setItem } from '@uifabric/utilities/lib/sessionStorage';
 import * as styles from './Site.module.scss';
 import { appMaximumWidthLg } from '../../styles/constants';
 
@@ -73,13 +74,8 @@ export class Site<TPlatforms extends string = string> extends React.Component<
       // Get top level pages with platforms.
       const topLevelPages = siteDefinition.pages.filter(page => !!page.platforms).map(page => page.title);
 
-      // Get local storage platforms for top level pages.
-      try {
-        // Accessing localStorage can throw for various reasons
-        activePlatforms = JSON.parse(localStorage.getItem('activePlatforms') || '') || {};
-      } catch (ex) {
-        // ignore
-      }
+      // Get session storage platforms for top level pages.
+      activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
 
       // Set active platform for each top level page to local storage platform or the first platform defined for
       // that page.
@@ -448,11 +444,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<
   };
 
   private _setActivePlatforms = () => {
-    try {
-      localStorage.setItem('activePlatforms', JSON.stringify(this.state.activePlatforms));
-    } catch (ex) {
-      // ignore
-    }
+    setItem('activePlatforms', JSON.stringify(this.state.activePlatforms));
   };
 
   /**

--- a/change/@fluentui-theme-2020-10-26-17-55-23-sessionStorage.json
+++ b/change/@fluentui-theme-2020-10-26-17-55-23-sessionStorage.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update DefaultFontStyles to store language in sessionStorage not localStorage",
+  "packageName": "@fluentui/theme",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T00:55:23.270Z"
+}

--- a/change/@fluentui-utilities-2020-10-26-17-37-19-sessionStorage.json
+++ b/change/@fluentui-utilities-2020-10-26-17-37-19-sessionStorage.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add option for where to store last language setting",
+  "comment": "Add option for where to store last language setting, and use getWindow utility for getting session storage values",
   "packageName": "@uifabric/utilities",
   "email": "elcraig@microsoft.com",
   "dependentChangeType": "patch",

--- a/change/@fluentui-utilities-2020-10-26-17-37-19-sessionStorage.json
+++ b/change/@fluentui-utilities-2020-10-26-17-37-19-sessionStorage.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add option for where to store last language setting",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T00:37:19.714Z"
+}

--- a/change/@uifabric-fabric-website-2020-10-26-19-34-35-sessionStorage7.json
+++ b/change/@uifabric-fabric-website-2020-10-26-19-34-35-sessionStorage7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Store website info in sessionStorage (v7)",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T02:34:35.989Z"
+}

--- a/packages/theme/src/fonts/DefaultFontStyles.ts
+++ b/packages/theme/src/fonts/DefaultFontStyles.ts
@@ -9,7 +9,7 @@ import { IFabricConfig } from '../types/IFabricConfig';
 const DefaultBaseUrl = 'https://static2.sharepointonline.com/files/fabric/assets';
 
 // Standard font styling.
-export const DefaultFontStyles: IFontStyles = createFontStyles(getLanguage());
+export const DefaultFontStyles: IFontStyles = createFontStyles(getLanguage('sessionStorage'));
 
 function _registerFontFace(fontFamily: string, url: string, fontWeight?: IFontWeight, localFontName?: string): void {
   fontFamily = `'${fontFamily}'`;

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -331,7 +331,7 @@ export function getId(prefix?: string): string;
 export function getInitials(displayName: string | undefined | null, isRtl: boolean, allowPhoneInitials?: boolean): string;
 
 // @public
-export function getLanguage(): string | null;
+export function getLanguage(persistenceType?: 'localStorage' | 'sessionStorage' | 'none'): string | null;
 
 // @public
 export function getLastFocusable(rootElement: HTMLElement, currentElement: HTMLElement, includeElementsInFocusZones?: boolean): HTMLElement | null;
@@ -1132,6 +1132,9 @@ export function setBaseUrl(baseUrl: string): void;
 export function setFocusVisibility(enabled: boolean, target?: Element): void;
 
 // @public
+export function setLanguage(language: string, persistenceType?: 'localStorage' | 'sessionStorage' | 'none'): void;
+
+// @public @deprecated
 export function setLanguage(language: string, avoidPersisting?: boolean): void;
 
 // Warning: (ae-internal-missing-underscore) The name "setMemoizeWeakMap" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/utilities/src/language.ts
+++ b/packages/utilities/src/language.ts
@@ -1,20 +1,30 @@
 import { getDocument } from './dom/getDocument';
-import { getItem, setItem } from './localStorage';
+import * as localStorage from './localStorage';
+import * as sessionStorage from './sessionStorage';
 
 // Default to undefined so that we initialize on first read.
 let _language: string | null;
 
+const STORAGE_KEY = 'language';
+
 /**
- * Gets the rtl state of the page (returns true if in rtl.)
- *
- * @public
+ * Gets the language set for the page.
+ * @param persistenceType - Where to persist the value. Default is `localStorage` if available.
+ * (In version 8, the default will be `sessionStorage`.)
  */
-export function getLanguage(): string | null {
+export function getLanguage(
+  persistenceType: 'localStorage' | 'sessionStorage' | 'none' = 'localStorage',
+): string | null {
   if (_language === undefined) {
     let doc = getDocument();
-    const savedLanguage = getItem('language');
+    const savedLanguage =
+      persistenceType === 'localStorage'
+        ? localStorage.getItem(STORAGE_KEY)
+        : persistenceType === 'sessionStorage'
+        ? sessionStorage.getItem(STORAGE_KEY)
+        : undefined;
 
-    if (savedLanguage !== null) {
+    if (savedLanguage) {
       _language = savedLanguage;
     }
 
@@ -31,19 +41,34 @@ export function getLanguage(): string | null {
 }
 
 /**
- * Sets the rtl state of the page (by adjusting the dir attribute of the html element.)
- *
- * @public
+ * Sets the language for the page (by adjusting the lang attribute of the html element).
+ * @param language - Language to set.
+ * @param persistenceType - Where to persist the value. Default is `localStorage` if available.
+ * (In version 8, the default will be `sessionStorage`.)
  */
-export function setLanguage(language: string, avoidPersisting: boolean = false): void {
+export function setLanguage(language: string, persistenceType?: 'localStorage' | 'sessionStorage' | 'none'): void;
+/**
+ * Sets the language for the page (by adjusting the lang attribute of the html element).
+ * @deprecated Use string parameter version.
+ * @param language - Language to set.
+ * @param avoidPersisting - If true, don't store the value.
+ */
+export function setLanguage(language: string, avoidPersisting?: boolean): void;
+export function setLanguage(
+  language: string,
+  persistenceParam?: 'localStorage' | 'sessionStorage' | 'none' | boolean,
+): void {
   let doc = getDocument();
 
   if (doc) {
     doc.documentElement.setAttribute('lang', language);
   }
 
-  if (!avoidPersisting) {
-    setItem('language', language);
+  const persistenceType = persistenceParam === true ? 'none' : !persistenceParam ? 'localStorage' : persistenceParam;
+  if (persistenceType === 'localStorage') {
+    localStorage.setItem(STORAGE_KEY, language);
+  } else if (persistenceType === 'sessionStorage') {
+    sessionStorage.setItem(STORAGE_KEY, language);
   }
 
   _language = language;

--- a/packages/utilities/src/sessionStorage.ts
+++ b/packages/utilities/src/sessionStorage.ts
@@ -1,3 +1,5 @@
+import { getWindow } from './dom/getWindow';
+
 /**
  * Fetches an item from session storage without throwing an exception
  * @param key The key of the item to fetch from session storage
@@ -5,7 +7,8 @@
 export function getItem(key: string): string | null {
   let result = null;
   try {
-    result = window.sessionStorage.getItem(key);
+    const win = getWindow();
+    result = win ? win.sessionStorage.getItem(key) : null;
   } catch (e) {
     /* Eat the exception */
   }
@@ -19,7 +22,7 @@ export function getItem(key: string): string | null {
  */
 export function setItem(key: string, data: string): void {
   try {
-    window.sessionStorage.setItem(key, data);
+    getWindow()?.sessionStorage.setItem(key, data);
   } catch (e) {
     /* Eat the exception */
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Version 7 edition of #15710. 

None of the info on our website that we were putting in localStorage is actually that important to persist, so move it to sessionStorage.

One of the things being read from localStorage was the language of the page (via DefaultFontStyles). So I updated the language utility to have an option for where to store the value (still defaulting to local storage for compat), and updated DefaultFontStyles to check session storage instead. (The version 8 PR changes the `setLanguage` default storage location to session storage since this is likely to be more desirable in general.)