### PR TITLE
Store website info in sessionStorage (v6)

### DIFF
--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -53,6 +53,7 @@
     "@uifabric/icons": "^6.5.5",
     "@uifabric/set-version": "^1.1.3",
     "@uifabric/theme-samples": "^0.1.10",
+    "@uifabric/utilities": "^6.45.2",
     "react-app-polyfill": "~1.0.1",
     "json-loader": "^0.5.7",
     "office-ui-fabric-react": "^6.214.1",

--- a/apps/fabric-website/src/components/Nav/Nav.tsx
+++ b/apps/fabric-website/src/components/Nav/Nav.tsx
@@ -14,6 +14,7 @@ import {
 } from 'office-ui-fabric-react';
 import { isPageActive, hasActiveChild, INavPage, INavProps, NavSortType } from '@uifabric/example-app-base/lib/index2';
 import { theme } from '@uifabric/example-app-base/lib/styles/theme';
+import { getItem, setItem } from '@uifabric/utilities/lib/sessionStorage';
 import * as styles from './Nav.module.scss';
 
 export interface INavState {
@@ -32,9 +33,10 @@ export class Nav extends React.Component<INavProps, INavState> {
   public constructor(props: INavProps) {
     super(props);
 
-    this._localItems = !!window.localStorage
+    const defaultSortState = getItem('defaultSortState');
+    this._localItems = defaultSortState
       ? {
-          defaultSortState: NavSortType[localStorage.getItem('defaultSortState') as keyof typeof NavSortType]
+          defaultSortState: NavSortType[defaultSortState as keyof typeof NavSortType],
         }
       : {};
 
@@ -46,7 +48,7 @@ export class Nav extends React.Component<INavProps, INavState> {
   }
 
   public componentDidMount(): void {
-    !this._localItems.defaultSortState && localStorage.setItem('defaultSortState', this.state.defaultSortState);
+    !this._localItems.defaultSortState && setItem('defaultSortState', this.state.defaultSortState);
   }
 
   public shouldComponentUpdate(nextProps: INavProps): boolean {

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -75,7 +75,11 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
       const topLevelPages = siteDefinition.pages.filter(page => !!page.platforms).map(page => page.title);
 
       // Get session storage platforms for top level pages.
-      activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
+      try {
+        activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
+      } catch (err) {
+        // ignore parsing error
+      }
 
       // Set active platform for each top level page to local storage platform or the first platform defined for that page.
       topLevelPages.forEach(item => {

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -24,6 +24,7 @@ import {
 import { Nav } from '../Nav/index';
 import { AppCustomizations } from './customizations';
 import { AppCustomizationsContext, extractAnchorLink } from '@uifabric/example-app-base/lib/index';
+import { getItem, setItem } from '@uifabric/utilities/lib/sessionStorage';
 import * as styles from './Site.module.scss';
 import { appMaximumWidthLg } from '../../styles/constants';
 
@@ -73,13 +74,8 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
       // Get top level pages with platforms.
       const topLevelPages = siteDefinition.pages.filter(page => !!page.platforms).map(page => page.title);
 
-      // Get local storage platforms for top level pages.
-      try {
-        // Accessing localStorage can throw for various reasons
-        activePlatforms = JSON.parse(localStorage.getItem('activePlatforms') || '') || {};
-      } catch (ex) {
-        // ignore
-      }
+      // Get session storage platforms for top level pages.
+      activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
 
       // Set active platform for each top level page to local storage platform or the first platform defined for that page.
       topLevelPages.forEach(item => {
@@ -432,11 +428,7 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
   };
 
   private _setActivePlatforms = () => {
-    try {
-      localStorage.setItem('activePlatforms', JSON.stringify(this.state.activePlatforms));
-    } catch (ex) {
-      // ignore
-    }
+    setItem('activePlatforms', JSON.stringify(this.state.activePlatforms));
   };
 
   /**

--- a/change/@uifabric-fabric-website-2020-10-26-19-42-57-sessionStorage6.json
+++ b/change/@uifabric-fabric-website-2020-10-26-19-42-57-sessionStorage6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Store website info in sessionStorage",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "79fc7157c509f39dcba3b5377e9e63addb88407e",
+  "date": "2020-10-27T02:42:57.631Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Version 6 edition of #15710.

None of the info on our website that we were putting in localStorage is actually that important to persist, so move it to sessionStorage.

In the interest of keeping the change minimal since this is an old version, this PR does NOT include any of the changes to the language utility, which is probably okay since the helper only appears to be reading not writing the way it's used in the website.