### PR TITLE
Website: Catch JSON parsing error (7.0)

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -75,7 +75,11 @@ export class Site<TPlatforms extends string = string> extends React.Component<
       const topLevelPages = siteDefinition.pages.filter(page => !!page.platforms).map(page => page.title);
 
       // Get session storage platforms for top level pages.
-      activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
+      try {
+        activePlatforms = JSON.parse(getItem('activePlatforms') || '') || {};
+      } catch (err) {
+        // ignore parsing error
+      }
 
       // Set active platform for each top level page to local storage platform or the first platform defined for
       // that page.

--- a/change/@uifabric-fabric-website-2020-10-26-20-53-37-sessionStorage7-2.json
+++ b/change/@uifabric-fabric-website-2020-10-26-20-53-37-sessionStorage7-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Website: Fix JSON parsing error",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-27T03:53:37.816Z"
+}


### PR DESCRIPTION
Merged #15712 too fast... Catch a JSON parsing error if the session storage item doesn't exist.