### PR TITLE
Update Image examples

### DIFF
--- a/packages/react-examples/src/react/Image/Image.Center.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Center.Example.tsx
@@ -1,32 +1,33 @@
 import * as React from 'react';
 import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: IImageProps = {
+  imageFit: ImageFit.center,
+  width: 350,
+  height: 150,
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageCenterExample = () => {
-  const imageProps: IImageProps = {
-    src: 'http://placehold.it/800x300',
-    imageFit: ImageFit.center,
-    width: 350,
-    height: 150,
-    onLoad: ev => console.log('image loaded', ev),
-  };
   return (
     <div>
       <p>
-        Setting the imageFit property to "center" behaves the same as "none", while centering the image within the
-        frame.
+        Setting the <code>imageFit</code> property to <code>ImageFit.center</code> behaves the same as{' '}
+        <code>ImageFit.none</code>, while centering the image within the frame.
       </p>
-      <Label>The image is larger than the frame, so all sides are cropped to center the image.</Label>
+      <p>This image is larger than the frame, so all sides are cropped to center the image.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/800x300"
         alt='Example of the image fit value "center" on an image larger than the frame.'
       />
-      <br />
-      <Label>
-        The image is smaller than the frame, so there is empty space within the frame. The image is centered in the
+      <p>
+        This image is smaller than the frame, so there is empty space within the frame. The image is centered in the
         available space.
-      </Label>
+      </p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x100"

--- a/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterContain.Example.tsx
@@ -1,47 +1,49 @@
-import { IImageProps, Image, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
 import * as React from 'react';
+import { IImageProps, Image, ImageFit } from '@fluentui/react/lib/Image';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: Partial<IImageProps> = {
+  imageFit: ImageFit.centerContain,
+  width: 200,
+  height: 200,
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageCenterContainExample = () => {
-  const imageProps: Partial<IImageProps> = {
-    imageFit: ImageFit.centerContain,
-    width: 200,
-    height: 200,
-  };
   return (
     <div>
       <p>
-        Setting the imageFit property to "centerContain" will cause the image to scale up or down proportionally. Images
-        smaller than their frame will be rendered as "ImageFit.center", while images larger than both either frame's
-        height or width will render as "ImageFit.contain".
+        Setting the <code>imageFit</code> property to <code>ImageFit.centerContain</code> will cause the image to scale
+        up or down proportionally. Images smaller than their frame will be rendered as <code>ImageFit.center</code>,
+        while images larger than either frame's height or width will render as <code>ImageFit.contain</code>.
       </p>
-      <Label>The image is smaller than the frame, so it's centered and rendered at its natural size.</Label>
+      <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x150"
         alt='Example of the image fit value "centerContain" on an image smaller than the frame.'
       />
-      <br />
-      <Label>The image has a wider width than the frame so it's contained.</Label>
+      <p>This image is wider than the frame, so it's contained.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/300x100"
         alt='Example of the image fit value "centerContain" on an image wider than the frame.'
       />
-      <br />
-      <Label>The image is taller than the frame so it's contained.</Label>
+      <p>This image is taller than the frame, so it's contained.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x300"
         alt='Example of the image fit value "centerContain" on an image taller than the frame.'
       />
-      <br />
-      <Label>These images are taller and wider than the frame and so they are contained.</Label>
+      <p>These images are taller and wider than the frame, so they are contained.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/400x500"
         alt='Example of the image fit value "centerContain" on an image taller and wider than the frame.'
       />
+      <br />
       <br />
       <Image
         {...imageProps}

--- a/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.CenterCover.Example.tsx
@@ -1,56 +1,55 @@
 import { IImageProps, Image, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
 import * as React from 'react';
 
-export const ImageCenterCoverExample = () => {
-  const imageProps: Partial<IImageProps> = {
-    imageFit: ImageFit.centerCover,
-    width: 200,
-    height: 200,
-  };
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: Partial<IImageProps> = {
+  imageFit: ImageFit.centerCover,
+  width: 200,
+  height: 200,
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
+export const ImageCenterCoverExample = () => {
   return (
     <div>
       <p>
-        Setting the imageFit property to "centerCover" will cause the image to scale up or down proportionally. Images
-        smaller than their frame will be rendered as "ImageFit.center", while images larger than both the frame's height
-        and width will render as "ImageFit.cover".
+        Setting the <code>imageFit</code> property to <code>ImageFit.centerCover</code> will cause the image to scale up
+        or down proportionally. Images smaller than their frame will be rendered as <code>ImageFit.center</code>, while
+        images larger than either frame's height or width will render as <code>ImageFit.cover</code>.
       </p>
-      <Label>The image is smaller than the frame, so it's centered and rendered at its natural size.</Label>
+      <p>This image is smaller than the frame, so it's centered and rendered at its natural size.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x150"
         alt='Example of the image fit value "centerCover" on an image smaller than the frame.'
       />
-      <br />
-      <Label>
-        The image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's
+      <p>
+        This image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's
         rendered at its natural size while cropping the sides.
-      </Label>
+      </p>
       <Image
         {...imageProps}
         src="http://placehold.it/300x100"
         alt='Example of the image fit value "centerCover" on an image wider than the frame.'
       />
-      <br />
-      <Label>
-        The image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's
+      <p>
+        This image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's
         rendered at its natural size while cropping the top and bottom.
-      </Label>
+      </p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x300"
         alt='Example of the image fit value "centerCover" on an image taller than the frame.'
       />
-      <br />
-      <Label>
-        These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.
-      </Label>
+      <p>These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.</p>
       <Image
         {...imageProps}
         src="http://placehold.it/400x500"
         alt='Example of the image fit value "centerCover" on an image taller and wider than the frame.'
       />
+      <br />
       <br />
       <Image
         {...imageProps}

--- a/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Contain.Example.tsx
@@ -1,33 +1,36 @@
 import * as React from 'react';
 import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: IImageProps = {
+  imageFit: ImageFit.contain,
+  src: 'http://placehold.it/700x300',
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageContainExample = () => {
-  const imageProps: IImageProps = {
-    src: 'http://placehold.it/700x300',
-    imageFit: ImageFit.contain,
-  };
   return (
     <div>
       <p>
-        Setting the imageFit property to "contain" will scale the image up or down to fit the frame, while maintaining
-        its natural aspect ratio and without cropping the image.
+        Setting the <code>imageFit</code> property to <code>ImageFit.contain</code> will scale the image up or down to
+        fit the frame, while maintaining its natural aspect ratio and without cropping the image.
       </p>
-      <Label>
-        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and
+      <p>
+        This image has a wider aspect ratio (more landscape) than the frame, so it's scaled to fit the width and
         centered in the available vertical space.
-      </Label>
+      </p>
       <Image
         {...imageProps}
         alt='Example of the image fit value "contain" on an image wider than the frame.'
         width={200}
         height={200}
       />
-      <br />
-      <Label>
-        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and
+      <p>
+        This image has a taller aspect ratio (more portrait) than the frame, so it's scaled to fit the height and
         centered in the available horizontal space.
-      </Label>
+      </p>
       <Image
         {...imageProps}
         alt='Example of the image fit value "contain" on an image taller than the frame.'

--- a/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Cover.Example.tsx
@@ -1,33 +1,36 @@
 import * as React from 'react';
 import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: IImageProps = {
+  imageFit: ImageFit.cover,
+  src: 'http://placehold.it/500x500',
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageCoverExample = () => {
-  const imageProps: IImageProps = {
-    src: 'http://placehold.it/500x500',
-    imageFit: ImageFit.cover,
-  };
   return (
     <div>
       <p>
-        Setting the imageFit property to "cover" will cause the image to scale up or down proportionally, while cropping
-        from either the top and bottom or sides to completely fill the frame.
+        Setting the <code>imageFit</code> property to <code>ImageFit.cover</code> will cause the image to scale up or
+        down proportionally, while cropping from either the top and bottom or sides to completely fill the frame.
       </p>
-      <Label>
-        The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and
-        the sides are cropped evenly.
-      </Label>
+      <p>
+        This image has a wider aspect ratio (more landscape) than the frame, so it's scaled to fit the height and the
+        sides are cropped evenly.
+      </p>
       <Image
         {...imageProps}
         alt='Example of the image fit value "cover" on an image wider than the frame.'
         width={150}
         height={250}
       />
-      <br />
-      <Label>
-        The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and
-        the top and bottom are cropped evenly.
-      </Label>
+      <p>
+        This image has a taller aspect ratio (more portrait) than the frame, so it's scaled to fit the width and the top
+        and bottom are cropped evenly.
+      </p>
       <Image
         {...imageProps}
         alt='Example of the image fit value "cover" on an image taller than the frame.'

--- a/packages/react-examples/src/react/Image/Image.Default.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.Default.Example.tsx
@@ -1,47 +1,41 @@
 import * as React from 'react';
-import { Image } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+import { Image, IImageProps } from '@fluentui/react/lib/Image';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: Partial<IImageProps> = {
+  src: 'http://placehold.it/350x150',
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageDefaultExample = () => (
   <div>
     <p>
-      With no imageFit property set, the width and height props control the size of the frame. Depending on which of
-      those props is used, the image may scale to fit the frame.
+      With no <code>imageFit</code> property set, the <code>width</code> and <code>height</code> props control the size
+      of the frame. Depending on which of those props is used, the image may scale to fit the frame.
     </p>
-    <Label>
-      Without a width or height specified, the frame remains at its natural size and the image will not be scaled.
-    </Label>
-    <Image
-      src="http://placehold.it/350x150"
-      alt="Example with no image fit value and no height or width is specified."
-    />
-    <br />
-    <Label>
+    <p>
+      Without a <code>width</code> or <code>height</code> specified, the frame remains at its natural size and the image
+      will not be scaled.
+    </p>
+    <Image {...imageProps} alt="Example with no image fit value and no height or width is specified." />
+    <p>
       If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the
       available width.
-    </Label>
-    <Image
-      src="http://placehold.it/350x150"
-      alt="Example with no image fit value and only width is specified."
-      width={600}
-    />
-    <br />
-    <Label>
+    </p>
+    <Image {...imageProps} alt="Example with no image fit value and only width is specified." width={600} />
+    <p>
       If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill
       the available height.
-    </Label>
-    <Image
-      src="http://placehold.it/350x150"
-      alt="Example with no image fit value and only height is specified."
-      height={100}
-    />
-    <br />
-    <Label>
+    </p>
+    <Image {...imageProps} alt="Example with no image fit value and only height is specified." height={100} />
+    <p>
       If both width and height are provided, the frame will be set to that width and height. The image will scale to
       fill both the available width and height. <strong>This may result in a distorted image.</strong>
-    </Label>
+    </p>
     <Image
-      src="http://placehold.it/350x150"
+      {...imageProps}
       alt="Example with no image fit value and height or width is specified."
       width={100}
       height={100}

--- a/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.MaximizeFrame.Example.tsx
@@ -1,25 +1,28 @@
 import * as React from 'react';
 import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: IImageProps = {
+  maximizeFrame: true,
+  imageFit: ImageFit.cover,
+  src: 'http://placehold.it/500x500',
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageMaximizeFrameExample = () => {
-  const imageProps: IImageProps = {
-    src: 'http://placehold.it/500x500',
-    imageFit: ImageFit.cover,
-    maximizeFrame: true,
-  };
   return (
     <div>
       <p>
-        Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage
-        of its parent, you can use the "maximizeFrame" prop to expand the frame to fill the parent element.
+        Where the exact width or height of the image's frame is not known, such as when sizing an image as a percentage
+        of its parent, you can use the <code>maximizeFrame</code> prop to expand the frame to fill the parent element.
       </p>
-      <Label>The image is placed within a landscape container.</Label>
+      <p>This image is placed within a landscape container.</p>
       <div style={{ width: '200px', height: '100px' }}>
         <Image {...imageProps} alt="Example of the maximizeFrame property with a landscape container." />
       </div>
-      <br />
-      <Label>The image is placed within a portrait container.</Label>
+      <p>This image is placed within a portrait container.</p>
       <div style={{ width: '100px', height: '200px' }}>
         <Image {...imageProps} alt="Example of the maximizeFrame property with a portrait container" />
       </div>

--- a/packages/react-examples/src/react/Image/Image.None.Example.tsx
+++ b/packages/react-examples/src/react/Image/Image.None.Example.tsx
@@ -1,30 +1,33 @@
 import * as React from 'react';
 import { Image, IImageProps, ImageFit } from '@fluentui/react/lib/Image';
-import { Label } from '@fluentui/react/lib/Label';
+
+// These props are defined up here so they can easily be applied to multiple Images.
+// Normally specifying them inline would be fine.
+const imageProps: IImageProps = {
+  imageFit: ImageFit.none,
+  width: 350,
+  height: 150,
+  // Show a border around the image (just for demonstration purposes)
+  styles: props => ({ root: { border: '1px solid ' + props.theme.palette.neutralSecondary } }),
+};
 
 export const ImageNoneExample = () => {
-  const imageProps: IImageProps = {
-    src: 'http://placehold.it/500x250',
-    imageFit: ImageFit.none,
-    width: 350,
-    height: 150,
-  };
   return (
     <div>
       <p>
-        By setting the imageFit property to "none", the image will remain at its natural size, even if the frame is made
-        larger or smaller by setting the width and height props.
+        By setting the <code>imageFit</code> property to <code>ImageFit.none</code>, the image will remain at its
+        natural size, even if the frame is made larger or smaller by setting the width or height props.
       </p>
-      <Label>
-        The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the
-        frame.
-      </Label>
-      <Image {...imageProps} alt='Example of the image fit value "none" on an image larger than the frame.' />
-      <br />
-      <Label>
-        The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the
-        upper left of the frame.
-      </Label>
+      <p>This image is larger than the frame, so it's cropped to fit and positioned at the upper left.</p>
+      <Image
+        {...imageProps}
+        src="http://placehold.it/500x250"
+        alt='Example of the image fit value "none" on an image larger than the frame.'
+      />
+      <p>
+        This image is smaller than the frame, so there's empty space within the frame and the image is positioned at the
+        upper left.
+      </p>
       <Image
         {...imageProps}
         src="http://placehold.it/100x100"

--- a/packages/react-examples/src/react/__snapshots__/Image.Center.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.Center.Example.tsx.shot
@@ -3,41 +3,31 @@
 exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Setting the imageFit property to "center" behaves the same as "none", while centering the image within the frame.
+    Setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.center
+    </code>
+     behaves the same as
+     
+    <code>
+      ImageFit.none
+    </code>
+    , while centering the image within the frame.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is larger than the frame, so all sides are cropped to center the image.
-  </label>
+  <p>
+    This image is larger than the frame, so all sides are cropped to center the image.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -72,40 +62,16 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
       src="http://placehold.it/800x300"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.
-  </label>
+  <p>
+    This image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.CenterContain.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.CenterContain.Example.tsx.shot
@@ -3,41 +3,34 @@
 exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Setting the imageFit property to "centerContain" will cause the image to scale up or down proportionally. Images smaller than their frame will be rendered as "ImageFit.center", while images larger than both either frame's height or width will render as "ImageFit.contain".
+    Setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.centerContain
+    </code>
+     will cause the image to scale up or down proportionally. Images smaller than their frame will be rendered as 
+    <code>
+      ImageFit.center
+    </code>
+    , while images larger than either frame's height or width will render as 
+    <code>
+      ImageFit.contain
+    </code>
+    .
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is smaller than the frame, so it's centered and rendered at its natural size.
-  </label>
+  <p>
+    This image is smaller than the frame, so it's centered and rendered at its natural size.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -73,40 +66,16 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
       src="http://placehold.it/100x150"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a wider width than the frame so it's contained.
-  </label>
+  <p>
+    This image is wider than the frame, so it's contained.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -142,40 +111,16 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
       src="http://placehold.it/300x100"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is taller than the frame so it's contained.
-  </label>
+  <p>
+    This image is taller than the frame, so it's contained.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -211,40 +156,16 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
       src="http://placehold.it/100x300"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    These images are taller and wider than the frame and so they are contained.
-  </label>
+  <p>
+    These images are taller and wider than the frame, so they are contained.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -281,12 +202,14 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
     />
   </div>
   <br />
+  <br />
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.CenterCover.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.CenterCover.Example.tsx.shot
@@ -3,41 +3,34 @@
 exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Setting the imageFit property to "centerCover" will cause the image to scale up or down proportionally. Images smaller than their frame will be rendered as "ImageFit.center", while images larger than both the frame's height and width will render as "ImageFit.cover".
+    Setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.centerCover
+    </code>
+     will cause the image to scale up or down proportionally. Images smaller than their frame will be rendered as 
+    <code>
+      ImageFit.center
+    </code>
+    , while images larger than either frame's height or width will render as 
+    <code>
+      ImageFit.cover
+    </code>
+    .
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is smaller than the frame, so it's centered and rendered at its natural size.
-  </label>
+  <p>
+    This image is smaller than the frame, so it's centered and rendered at its natural size.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -73,40 +66,16 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
       src="http://placehold.it/100x150"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's rendered at its natural size while cropping the sides.
-  </label>
+  <p>
+    This image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's rendered at its natural size while cropping the sides.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -142,40 +111,16 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
       src="http://placehold.it/300x100"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's rendered at its natural size while cropping the top and bottom.
-  </label>
+  <p>
+    This image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's rendered at its natural size while cropping the top and bottom.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -211,40 +156,16 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
       src="http://placehold.it/100x300"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
+  <p>
     These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.
-  </label>
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -281,12 +202,14 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
     />
   </div>
   <br />
+  <br />
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.Contain.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.Contain.Example.tsx.shot
@@ -3,41 +3,26 @@
 exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Setting the imageFit property to "contain" will scale the image up or down to fit the frame, while maintaining its natural aspect ratio and without cropping the image.
+    Setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.contain
+    </code>
+     will scale the image up or down to fit the frame, while maintaining its natural aspect ratio and without cropping the image.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and centered in the available vertical space.
-  </label>
+  <p>
+    This image has a wider aspect ratio (more landscape) than the frame, so it's scaled to fit the width and centered in the available vertical space.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -75,40 +60,16 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
       src="http://placehold.it/700x300"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and centered in the available horizontal space.
-  </label>
+  <p>
+    This image has a taller aspect ratio (more portrait) than the frame, so it's scaled to fit the height and centered in the available horizontal space.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.Cover.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.Cover.Example.tsx.shot
@@ -3,41 +3,26 @@
 exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Setting the imageFit property to "cover" will cause the image to scale up or down proportionally, while cropping from either the top and bottom or sides to completely fill the frame.
+    Setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.cover
+    </code>
+     will cause the image to scale up or down proportionally, while cropping from either the top and bottom or sides to completely fill the frame.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and the sides are cropped evenly.
-  </label>
+  <p>
+    This image has a wider aspect ratio (more landscape) than the frame, so it's scaled to fit the height and the sides are cropped evenly.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -75,40 +60,16 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
       src="http://placehold.it/500x500"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and the top and bottom are cropped evenly.
-  </label>
+  <p>
+    This image has a taller aspect ratio (more portrait) than the frame, so it's scaled to fit the width and the top and bottom are cropped evenly.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.Default.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.Default.Example.tsx.shot
@@ -3,41 +3,38 @@
 exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
 <div>
   <p>
-    With no imageFit property set, the width and height props control the size of the frame. Depending on which of those props is used, the image may scale to fit the frame.
+    With no 
+    <code>
+      imageFit
+    </code>
+     property set, the 
+    <code>
+      width
+    </code>
+     and 
+    <code>
+      height
+    </code>
+     props control the size of the frame. Depending on which of those props is used, the image may scale to fit the frame.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    Without a width or height specified, the frame remains at its natural size and the image will not be scaled.
-  </label>
+  <p>
+    Without a 
+    <code>
+      width
+    </code>
+     or 
+    <code>
+      height
+    </code>
+     specified, the frame remains at its natural size and the image will not be scaled.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -66,40 +63,16 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
       src="http://placehold.it/350x150"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
+  <p>
     If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the available width.
-  </label>
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -130,40 +103,16 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
       src="http://placehold.it/350x150"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
+  <p>
     If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill the available height.
-  </label>
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -194,43 +143,19 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
       src="http://placehold.it/350x150"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
+  <p>
     If both width and height are provided, the frame will be set to that width and height. The image will scale to fill both the available width and height. 
     <strong>
       This may result in a distorted image.
     </strong>
-  </label>
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
@@ -3,35 +3,15 @@
 exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`] = `
 <div>
   <p>
-    Where the exact width and height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the "maximizeFrame" prop to expand the frame to fill the parent element.
+    Where the exact width or height of the image's frame is not known, such as when sizing an image as a percentage of its parent, you can use the 
+    <code>
+      maximizeFrame
+    </code>
+     prop to expand the frame to fill the parent element.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is placed within a landscape container.
-  </label>
+  <p>
+    This image is placed within a landscape container.
+  </p>
   <div
     style={
       Object {
@@ -47,6 +27,7 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            border: 1px solid #605e5c;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
@@ -87,34 +68,9 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
       />
     </div>
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is placed within a portrait container.
-  </label>
+  <p>
+    This image is placed within a portrait container.
+  </p>
   <div
     style={
       Object {
@@ -130,6 +86,7 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            border: 1px solid #605e5c;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;

--- a/packages/react-examples/src/react/__snapshots__/Image.None.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Image.None.Example.tsx.shot
@@ -3,41 +3,26 @@
 exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
 <div>
   <p>
-    By setting the imageFit property to "none", the image will remain at its natural size, even if the frame is made larger or smaller by setting the width and height props.
+    By setting the 
+    <code>
+      imageFit
+    </code>
+     property to 
+    <code>
+      ImageFit.none
+    </code>
+    , the image will remain at its natural size, even if the frame is made larger or smaller by setting the width or height props.
   </p>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the frame.
-  </label>
+  <p>
+    This image is larger than the frame, so it's cropped to fit and positioned at the upper left.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;
@@ -69,40 +54,16 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
       src="http://placehold.it/500x250"
     />
   </div>
-  <br />
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 0px;
-          margin-left: 0px;
-          margin-right: 0px;
-          margin-top: 0px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-  >
-    The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the upper left of the frame.
-  </label>
+  <p>
+    This image is smaller than the frame, so there's empty space within the frame and the image is positioned at the upper left.
+  </p>
   <div
     className=
         ms-Image
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          border: 1px solid #605e5c;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
           font-weight: 400;


### PR DESCRIPTION
Minor cleanup change that I started awhile back and never pushed... 
- Add back outline to image frames to help better demonstrate the ImageFit values' behavior (this was lost when we got rid of `ImagePage.global.scss` awhile back)
- Use normal paragraphs (not Label) to describe the image examples. Label is specifically for form components.
- Minor wording cleanup