### PR TITLE
Port TextField reveal password feature to master

### DIFF
--- a/change/@fluentui-react-internal-2020-10-27-10-31-14-reveal-password.json
+++ b/change/@fluentui-react-internal-2020-10-27-10-31-14-reveal-password.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Port TextField reveal password feature to master",
+  "packageName": "@fluentui/react-internal",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T17:30:53.672Z"
+}

--- a/change/@fluentui-utilities-2020-10-27-10-31-14-reveal-password.json
+++ b/change/@fluentui-utilities-2020-10-27-10-31-14-reveal-password.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "isIE11 utility should use getWindow to get the window",
+  "packageName": "@fluentui/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T17:31:14.305Z"
+}

--- a/packages/react-conformance/src/defaultTests.tsx
+++ b/packages/react-conformance/src/defaultTests.tsx
@@ -99,9 +99,9 @@ export const defaultTests: TestObject = {
             ? customMount(<Component {...mergedProps} />).find(targetComponent)
             : customMount(<Component {...mergedProps} />);
 
-          expect(rootRef.current).toBeDefined();
+          expect(rootRef.current).toBeTruthy();
           // Ref should resolve to an HTML element.
-          expect(rootRef.current?.getAttribute).toBeDefined();
+          expect(rootRef.current?.getAttribute).toBeTruthy();
         });
       } catch (e) {
         defaultErrorMessages['component-handles-ref'](componentInfo, testInfo, e);

--- a/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/react/TextField/TextField.Basic.Example.tsx
@@ -26,6 +26,7 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
+        <TextField label="Password with reveal button" type="password" canRevealPassword />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -1930,6 +1930,256 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
         </div>
       </div>
     </div>
+    <div
+      className=
+          ms-TextField
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+    >
+      <div
+        className="ms-TextField-wrapper"
+      >
+        <label
+          className=
+              ms-Label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #323130;
+                display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow-wrap: break-word;
+                padding-bottom: 5px;
+                padding-left: 0;
+                padding-right: 0;
+                padding-top: 5px;
+                word-wrap: break-word;
+              }
+          htmlFor="TextField30"
+          id="TextFieldLabel32"
+        >
+          Password with reveal button
+        </label>
+        <div
+          className=
+              ms-TextField-fieldGroup
+              {
+                align-items: stretch;
+                background: #ffffff;
+                border-radius: 2px;
+                border: 1px solid #605e5c;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: text;
+                display: flex;
+                flex-direction: row;
+                height: 32px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+              &:hover {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover {
+                border-color: Highlight;
+              }
+              @media screen and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
+        >
+          <input
+            aria-invalid={false}
+            aria-labelledby="TextFieldLabel32"
+            className=
+                ms-TextField-field
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: transparent;
+                  background: none;
+                  border-radius: 0px;
+                  border: none;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #323130;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-width: 0px;
+                  outline: 0px;
+                  padding-bottom: 0;
+                  padding-left: 8px;
+                  padding-right: 8px;
+                  padding-top: 0;
+                  text-overflow: ellipsis;
+                  width: 100%;
+                }
+                &:active {
+                  outline: 0px;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+                &:hover {
+                  outline: 0px;
+                }
+                &::-ms-clear {
+                  display: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                &::placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
+                }
+                &:-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
+                &::-ms-input-placeholder {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
+                }
+            id="TextField30"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onInput={[Function]}
+            type="password"
+            value=""
+          />
+          <button
+            className=
+                ms-TextField-reveal
+                ms-Button
+                ms-Button--icon
+                {
+                  background-color: transparent;
+                  border: none;
+                  color: #0078d4;
+                  height: 30px;
+                  padding-bottom: 0px;
+                  padding-left: 4px;
+                  padding-right: 4px;
+                  padding-top: 0px;
+                  width: 32px;
+                }
+                &:hover {
+                  background-color: #f3f2f1;
+                  color: #106ebe;
+                  outline: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:focus {
+                  outline: 0px;
+                }
+            onClick={[Function]}
+          >
+            <span
+              className=
+
+                  {
+                    align-items: center;
+                    display: flex;
+                    height: 100%;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      bottom: 6px;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons-1";
+                      font-size: 16px;
+                      font-style: normal;
+                      font-weight: normal;
+                      line-height: 18px;
+                      margin-bottom: 0px;
+                      margin-left: 4px;
+                      margin-right: 4px;
+                      margin-top: 0px;
+                      pointer-events: none;
+                      right: 8px;
+                      speak: none;
+                      top: auto;
+                    }
+                data-icon-name="RedEye"
+              >
+                
+              </i>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;

--- a/packages/react-internal/etc/react-internal.api.md
+++ b/packages/react-internal/etc/react-internal.api.md
@@ -5156,6 +5156,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     autoAdjustHeight?: boolean;
     autoComplete?: string;
     borderless?: boolean;
+    canRevealPassword?: boolean;
     className?: string;
     componentRef?: IRefObject<ITextField>;
     defaultValue?: string;
@@ -5202,6 +5203,7 @@ export interface ITextFieldSnapshot {
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
     isFocused?: boolean;
+    isRevealingPassword?: boolean;
     uncontrolledValue: string | undefined;
 }
 
@@ -5211,6 +5213,7 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> & Pi
     hasIcon?: boolean;
     hasLabel?: boolean;
     focused?: boolean;
+    hasRevealButton?: boolean;
 };
 
 // @public (undocumented)
@@ -5221,6 +5224,9 @@ export interface ITextFieldStyles {
     fieldGroup: IStyle;
     icon: IStyle;
     prefix: IStyle;
+    revealButton: IStyle;
+    revealIcon: IStyle;
+    revealSpan: IStyle;
     root: IStyle;
     subComponentStyles: ITextFieldSubComponentStyles;
     suffix: IStyle;

--- a/packages/react-internal/src/components/TextField/TextField.styles.tsx
+++ b/packages/react-internal/src/components/TextField/TextField.styles.tsx
@@ -22,6 +22,7 @@ const globalClassNames = {
   prefix: 'ms-TextField-prefix',
   suffix: 'ms-TextField-suffix',
   wrapper: 'ms-TextField-wrapper',
+  revealButton: 'ms-TextField-reveal',
 
   multiline: 'ms-TextField--multiline',
   borderless: 'ms-TextField--borderless',
@@ -79,6 +80,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     hasErrorMessage,
     inputClassName,
     autoAdjustHeight,
+    hasRevealButton,
   } = props;
 
   const { semanticColors, effects, fonts } = theme;
@@ -336,9 +338,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         autoAdjustHeight && {
           overflow: 'hidden',
         },
-      hasIcon && {
-        paddingRight: 24,
-      },
+      hasIcon &&
+        !hasRevealButton && {
+          paddingRight: 24,
+        },
       multiline &&
         hasIcon && {
           paddingRight: 40,
@@ -413,6 +416,50 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     ],
     prefix: [classNames.prefix, fieldPrefixSuffix],
     suffix: [classNames.suffix, fieldPrefixSuffix],
+    revealButton: [
+      classNames.revealButton,
+      'ms-Button',
+      'ms-Button--icon',
+      {
+        height: 30,
+        width: 32,
+        border: 'none',
+        padding: '0px 4px',
+        backgroundColor: 'transparent',
+        color: semanticColors.link,
+        selectors: {
+          ':hover': {
+            outline: 0,
+            color: semanticColors.primaryButtonBackgroundHovered,
+            backgroundColor: semanticColors.buttonBackgroundHovered,
+            selectors: {
+              [HighContrastSelector]: {
+                borderColor: 'Highlight',
+                color: 'Highlight',
+              },
+            },
+          },
+          ':focus': { outline: 0 },
+        },
+      },
+      hasIcon && {
+        marginRight: 28,
+      },
+    ],
+    revealSpan: {
+      display: 'flex',
+      height: '100%',
+      alignItems: 'center',
+    },
+    revealIcon: {
+      margin: '0px 4px',
+      pointerEvents: 'none',
+      bottom: 6,
+      right: 8,
+      top: 'auto',
+      fontSize: IconFontSizes.medium,
+      lineHeight: 18,
+    },
     subComponentStyles: {
       label: getLabelStyles(props),
     },

--- a/packages/react-internal/src/components/TextField/TextField.test.tsx
+++ b/packages/react-internal/src/components/TextField/TextField.test.tsx
@@ -124,11 +124,16 @@ describe('TextField snapshots', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with reveal password button', () => {
+    const component = create(<TextField type="password" canRevealPassword />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 }); // end snapshots
 
-describe('TextField rendering values from props', () => {
+describe('TextField', () => {
   beforeEach(sharedBeforeEach);
-  afterEach(sharedAfterEach);
 
   isConformant({
     Component: TextField,
@@ -136,6 +141,11 @@ describe('TextField rendering values from props', () => {
     componentPath: path.join(__dirname, 'TextField.ts'),
     elementRefName: 'elementRef',
   });
+});
+
+describe('TextField rendering values from props', () => {
+  beforeEach(sharedBeforeEach);
+  afterEach(sharedAfterEach);
 
   it('can render a value', () => {
     const testText = 'initial value';
@@ -235,6 +245,39 @@ describe('TextField basic props', () => {
     const suffixDOM: Element = wrapper.getDOMNode().getElementsByClassName('ms-TextField-suffix')[0];
     expect(prefixDOM.textContent).toEqual(examplePrefix);
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
+  });
+
+  it('should not render reveal password button by default', () => {
+    wrapper = mount(<TextField type="password" />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+  });
+
+  it('should render reveal password button if canRevealPassword=true', () => {
+    wrapper = mount(<TextField type="password" canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(1);
+  });
+
+  it('ignores canRevealPassword if type is unspecified', () => {
+    wrapper = mount(<TextField canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+  });
+
+  it('ignores canRevealPassword if type is not password', () => {
+    wrapper = mount(<TextField type="text" canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+  });
+
+  it('should toggle reveal password on reveal button click', () => {
+    wrapper = mount(<TextField type="password" canRevealPassword={true} />);
+    const input = wrapper.find('input');
+    const reveal = wrapper.find('.ms-TextField-reveal');
+
+    input.simulate('input', mockEvent('Password123$'));
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
+    reveal.simulate('click');
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('text');
+    reveal.simulate('click');
+    expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');
   });
 
   it('should not give an aria-labelledby if no label is provided', () => {

--- a/packages/react-internal/src/components/TextField/TextField.types.ts
+++ b/packages/react-internal/src/components/TextField/TextField.types.ts
@@ -256,6 +256,12 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
    * https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill
    */
   autoComplete?: string;
+
+  /**
+   * Whether to show the reveal password button for input type `'password'` (will be ignored unless
+   * the `type` prop is set to `'password'`).
+   */
+  canRevealPassword?: boolean;
 }
 
 /**
@@ -282,6 +288,8 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> &
     hasLabel?: boolean;
     /** Element has focus. */
     focused?: boolean;
+    /** Element has a peek button for passwords */
+    hasRevealButton?: boolean;
   };
 
 /**
@@ -349,6 +357,21 @@ export interface ITextFieldStyles {
    * Styling for subcomponents.
    */
   subComponentStyles: ITextFieldSubComponentStyles;
+
+  /**
+   * Styling for reveal password button
+   */
+  revealButton: IStyle;
+
+  /**
+   * Styling for reveal password span
+   */
+  revealSpan: IStyle;
+
+  /**
+   * Styling for reveal password icon
+   */
+  revealIcon: IStyle;
 }
 
 /**

--- a/packages/react-internal/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/react-internal/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1312,6 +1312,229 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
 </div>
 `;
 
+exports[`TextField snapshots renders with reveal password button 1`] = `
+<div
+  className=
+      ms-TextField
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          @media screen and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
+    >
+      <input
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: 0px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        type="password"
+        value=""
+      />
+      <button
+        className=
+            ms-TextField-reveal
+            ms-Button
+            ms-Button--icon
+            {
+              background-color: transparent;
+              border: none;
+              color: #0078d4;
+              height: 30px;
+              padding-bottom: 0px;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0px;
+              width: 32px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #106ebe;
+              outline: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:focus {
+              outline: 0px;
+            }
+        onClick={[Function]}
+      >
+        <span
+          className=
+
+              {
+                align-items: center;
+                display: flex;
+                height: 100%;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  bottom: 6px;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 18px;
+                  margin-bottom: 0px;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0px;
+                  pointer-events: none;
+                  right: 8px;
+                  speak: none;
+                  top: auto;
+                }
+            data-icon-name="RedEye"
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`TextField snapshots should respect user component and subcomponent styling 1`] = `
 <div
   className=

--- a/packages/utilities/src/ie11Detector.ts
+++ b/packages/utilities/src/ie11Detector.ts
@@ -1,7 +1,11 @@
+import { getWindow } from './dom/getWindow';
+
 export const isIE11 = (): boolean => {
-  if (typeof window === 'undefined' || !window.navigator || !window.navigator.userAgent) {
+  const win = getWindow();
+
+  if (!win?.navigator?.userAgent) {
     return false;
   }
 
-  return window.navigator.userAgent.indexOf('rv:11.0') > -1;
+  return win.navigator.userAgent.indexOf('rv:11.0') > -1;
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Port the reveal password feature added in #15021 (and the fix from #15673) to master. This is not a straight cherry-pick; in addition to copying the changes I simplified some of the logic and made some minor fixes: simplifying logic for when to show the button, using the shared `isIE11()` utility, using semantic colors not palette colors, and improving tests.

For a better idea of how this differs from the original v7 version, see #15722 where I'm porting the fixes from here back to 7.

(cc @hutchcodes since it won't let me add you as a reviewer)