### PR TITLE
TextField: reveal password fixes (v7)

### DIFF
--- a/change/@fluentui-react-examples-2020-10-27-15-21-30-reveal-password-7.json
+++ b/change/@fluentui-react-examples-2020-10-27-15-21-30-reveal-password-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: reveal password fixes",
+  "packageName": "@fluentui/react-examples",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T22:21:30.911Z"
+}

--- a/change/@fluentui-react-internal-2020-10-27-10-31-14-reveal-password.json
+++ b/change/@fluentui-react-internal-2020-10-27-10-31-14-reveal-password.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField reveal password fixes",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T17:30:53.672Z"
+}

--- a/change/@fluentui-utilities-2020-10-27-10-31-14-reveal-password.json
+++ b/change/@fluentui-utilities-2020-10-27-10-31-14-reveal-password.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "isIE11 utility should use getWindow to get the window",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T17:31:14.305Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8069,6 +8069,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     iconProps?: IIconProps;
     inputClassName?: string;
     label?: string;
+    // @deprecated (undocumented)
+    mask?: string;
+    // @deprecated (undocumented)
+    maskChar?: string;
+    // @deprecated (undocumented)
+    maskFormat?: {
+        [key: string]: RegExp;
+    };
     multiline?: boolean;
     onChange?: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8069,14 +8069,6 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     iconProps?: IIconProps;
     inputClassName?: string;
     label?: string;
-    // @deprecated (undocumented)
-    mask?: string;
-    // @deprecated (undocumented)
-    maskChar?: string;
-    // @deprecated (undocumented)
-    maskFormat?: {
-        [key: string]: RegExp;
-    };
     multiline?: boolean;
     onChange?: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;
@@ -8111,7 +8103,7 @@ export interface ITextFieldSnapshot {
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
     isFocused?: boolean;
-    type: string;
+    isRevealingPassword?: boolean;
     uncontrolledValue: string | undefined;
 }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { IProcessedStyleSet } from '../../Styling';
 import { Label, ILabelStyleProps, ILabelStyles } from '../../Label';
-import { Icon, IIconProps } from '../../Icon';
+import { Icon } from '../../Icon';
 import {
   Async,
   DelayedRender,
@@ -9,9 +9,11 @@ import {
   classNamesFunction,
   getId,
   getNativeProps,
+  getWindow,
   initializeComponentRef,
   inputProperties,
   isControlled,
+  isIE11,
   textAreaProperties,
   warn,
   warnControlledUsage,
@@ -35,10 +37,10 @@ export interface ITextFieldState {
   errorMessage: string | JSX.Element;
 
   /**
-   * The type of the textfield
-   * Password by default, text when revealing the password
+   * Whether this field has `type='password'` and `canRevealPassword=true`, and the password is
+   * currently being revealed.
    */
-  type: string;
+  isRevealingPassword?: boolean;
 }
 
 /** @internal */
@@ -52,6 +54,9 @@ export interface ITextFieldSnapshot {
 
 const DEFAULT_STATE_VALUE = '';
 const COMPONENT_NAME = 'TextField';
+
+const REVEAL_ICON_NAME = 'RedEye';
+const HIDE_ICON_NAME = 'Hide';
 
 export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldState, ITextFieldSnapshot>
   implements ITextField {
@@ -75,11 +80,6 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   private _async: Async;
   /** Most recent value from a change or input event, to help avoid processing events twice */
   private _lastChangeValue: string | undefined;
-
-  private _isPassword = false;
-  private _showRevealButton = false;
-  private _revealIconProps: IIconProps = { iconName: 'RedEye' };
-  private _hideIconProps: IIconProps = { iconName: 'Hide' };
 
   public constructor(props: ITextFieldProps) {
     super(props);
@@ -107,11 +107,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       uncontrolledValue: this._isControlled ? undefined : defaultValue,
       isFocused: false,
       errorMessage: '',
-      type: this.props.type ?? 'text',
     };
-
-    this._isPassword = this.props.type === 'password';
-    this._showRevealButton = this._shouldShowRevealButton();
 
     this._delayedValidate = this._async.debounce(this._validate, this.props.deferredValidationTime);
     this._lastValidation = 0;
@@ -204,15 +200,19 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       theme,
       styles,
       autoAdjustHeight,
+      canRevealPassword,
+      type,
       onRenderPrefix = this._onRenderPrefix,
       onRenderSuffix = this._onRenderSuffix,
       onRenderLabel = this._onRenderLabel,
       onRenderDescription = this._onRenderDescription,
     } = this.props;
-    const { isFocused } = this.state;
+    const { isFocused, isRevealingPassword } = this.state;
     const errorMessage = this._errorMessage;
 
-    this._classNames = getClassNames(styles!, {
+    const hasRevealButton = !!canRevealPassword && type === 'password' && _browserNeedsRevealButton();
+
+    const classNames = (this._classNames = getClassNames(styles!, {
       theme: theme!,
       className,
       disabled,
@@ -227,31 +227,31 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       underlined,
       inputClassName,
       autoAdjustHeight,
-      hasRevealButton: this._isPassword,
-    });
+      hasRevealButton,
+    }));
 
     return (
-      <div className={this._classNames.root}>
-        <div className={this._classNames.wrapper}>
+      <div className={classNames.root}>
+        <div className={classNames.wrapper}>
           {onRenderLabel(this.props, this._onRenderLabel)}
-          <div className={this._classNames.fieldGroup}>
+          <div className={classNames.fieldGroup}>
             {(prefix !== undefined || this.props.onRenderPrefix) && (
-              <div className={this._classNames.prefix}>{onRenderPrefix(this.props, this._onRenderPrefix)}</div>
+              <div className={classNames.prefix}>{onRenderPrefix(this.props, this._onRenderPrefix)}</div>
             )}
             {multiline ? this._renderTextArea() : this._renderInput()}
-            {iconProps && <Icon className={this._classNames.icon} {...iconProps} />}
-            {this._isPassword && this._showRevealButton && (
-              <button className={this._classNames.revealButton} onClick={this._onRevealButtonClick}>
-                <span className={this._classNames.revealSpan} data-automationid="splitbuttonprimary">
+            {iconProps && <Icon className={classNames.icon} {...iconProps} />}
+            {hasRevealButton && (
+              <button className={classNames.revealButton} onClick={this._onRevealButtonClick}>
+                <span className={classNames.revealSpan}>
                   <Icon
-                    className={this._classNames.revealIcon}
-                    {...(this.state.type === 'password' ? this._revealIconProps : this._hideIconProps)}
+                    className={classNames.revealIcon}
+                    iconName={isRevealingPassword ? HIDE_ICON_NAME : REVEAL_ICON_NAME}
                   />
                 </span>
               </button>
             )}
             {(suffix !== undefined || this.props.onRenderSuffix) && (
-              <div className={this._classNames.suffix}>{onRenderSuffix(this.props, this._onRenderSuffix)}</div>
+              <div className={classNames.suffix}>{onRenderSuffix(this.props, this._onRenderSuffix)}</div>
             )}
           </div>
         </div>
@@ -261,7 +261,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
             {errorMessage && (
               <div role="alert">
                 <DelayedRender>
-                  <p className={this._classNames.errorMessage}>
+                  <p className={classNames.errorMessage}>
                     <span data-automation-id="error-message">{errorMessage}</span>
                   </p>
                 </DelayedRender>
@@ -482,15 +482,16 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
     const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, [
       'defaultValue',
+      'type',
     ]);
     const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
-    const type = this.props.canRevealPassword ? this.state.type : this.props.type ?? 'text';
+    const type = this.state.isRevealingPassword ? 'text' : this.props.type ?? 'text';
     return (
       <input
+        type={type}
         id={this._id}
         aria-labelledby={ariaLabelledBy}
         {...inputProps}
-        type={type}
         ref={this._textElement as React.RefObject<HTMLInputElement>}
         value={this.value || ''}
         onInput={this._onInputChange}
@@ -507,12 +508,9 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   }
 
   private _onRevealButtonClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
-    if (this.state.type === 'password') {
-      this.setState({ type: 'text' });
-    } else {
-      this.setState({ type: 'password' });
-    }
+    this.setState(prevState => ({ isRevealingPassword: !prevState.isRevealingPassword }));
   };
+
   private _onInputChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
     // Previously, we needed to call both onInput and onChange due to some weird IE/React issues,
     // which have *probably* been fixed now:
@@ -600,29 +598,6 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       textField.style.height = textField.scrollHeight + 'px';
     }
   }
-
-  private _shouldShowRevealButton = (): boolean => {
-    if (typeof window === 'undefined' || !window.navigator || !window.navigator.userAgent) {
-      return false;
-    }
-
-    if (this.props.canRevealPassword) {
-      const userAgent = window.navigator.userAgent;
-
-      //IE
-      const isIE = /rv:11.0/.test(userAgent);
-
-      //Edge
-      //Chromium Edge
-      const isEdge = /Edg/.test(userAgent);
-
-      if (isIE || isEdge) {
-        return false;
-      }
-      return true;
-    }
-    return false;
-  };
 }
 
 /** Get the value from the given state and props (converting from number to string if needed) */
@@ -641,4 +616,23 @@ function _getValue(props: ITextFieldProps, state: ITextFieldState): string | und
  */
 function _shouldValidateAllChanges(props: ITextFieldProps): boolean {
   return !(props.validateOnFocusIn || props.validateOnFocusOut);
+}
+
+// Only calculate this once across all TextFields, since will stay the same
+let __browserNeedsRevealButton: boolean | undefined;
+
+function _browserNeedsRevealButton() {
+  if (typeof __browserNeedsRevealButton !== 'boolean') {
+    const win = getWindow();
+
+    if (win?.navigator) {
+      // Edge, Chromium Edge
+      const isEdge = /Edg/.test(win.navigator.userAgent || '');
+
+      __browserNeedsRevealButton = !(isIE11() || isEdge);
+    } else {
+      __browserNeedsRevealButton = true;
+    }
+  }
+  return __browserNeedsRevealButton;
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -22,7 +22,7 @@ const globalClassNames = {
   prefix: 'ms-TextField-prefix',
   suffix: 'ms-TextField-suffix',
   wrapper: 'ms-TextField-wrapper',
-  reveal: 'ms-TextField-reveal',
+  revealButton: 'ms-TextField-reveal',
 
   multiline: 'ms-TextField--multiline',
   borderless: 'ms-TextField--borderless',
@@ -83,7 +83,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     hasRevealButton,
   } = props;
 
-  const { semanticColors, effects, fonts, palette } = theme;
+  const { semanticColors, effects, fonts } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
@@ -416,11 +416,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     ],
     prefix: [classNames.prefix, fieldPrefixSuffix],
     suffix: [classNames.suffix, fieldPrefixSuffix],
-    subComponentStyles: {
-      label: getLabelStyles(props),
-    },
     revealButton: [
-      classNames.reveal,
+      classNames.revealButton,
       'ms-Button',
       'ms-Button--icon',
       {
@@ -433,8 +430,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         selectors: {
           ':hover': {
             outline: 0,
-            color: palette.themeDarkAlt,
-            backgroundColor: palette.neutralLighter,
+            color: semanticColors.primaryButtonBackgroundHovered,
+            backgroundColor: semanticColors.buttonBackgroundHovered,
             selectors: {
               [HighContrastSelector]: {
                 borderColor: 'Highlight',
@@ -449,23 +446,22 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         marginRight: 28,
       },
     ],
-    revealSpan: [
-      {
-        display: 'flex',
-        height: '100%',
-        alignItems: 'center',
-      },
-    ],
-    revealIcon: [
-      {
-        margin: '0px 4px',
-        pointerEvents: 'none',
-        bottom: 6,
-        right: 8,
-        top: 'auto',
-        fontSize: IconFontSizes.medium,
-        lineHeight: 18,
-      },
-    ],
+    revealSpan: {
+      display: 'flex',
+      height: '100%',
+      alignItems: 'center',
+    },
+    revealIcon: {
+      margin: '0px 4px',
+      pointerEvents: 'none',
+      bottom: 6,
+      right: 8,
+      top: 'auto',
+      fontSize: IconFontSizes.medium,
+      lineHeight: 18,
+    },
+    subComponentStyles: {
+      label: getLabelStyles(props),
+    },
   };
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -124,6 +124,12 @@ describe('TextField snapshots', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders with reveal password button', () => {
+    const component = renderer.create(<TextField type="password" canRevealPassword />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 }); // end snapshots
 
 describe('TextField rendering values from props', () => {
@@ -230,28 +236,30 @@ describe('TextField basic props', () => {
     expect(suffixDOM.textContent).toEqual(exampleSuffix);
   });
 
-  it('should render reveal password button if showRevealPassword=true', () => {
-    const component = renderer.create(<TextField type="password" canRevealPassword={true} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  it('should not render reveal password button by default', () => {
+    wrapper = mount(<TextField type="password" />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
   });
 
-  it('should not render reveal password button if showRevealPassword=false', () => {
-    const component = renderer.create(<TextField type="password" canRevealPassword={false} />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  it('should render reveal password button if canRevealPassword=true', () => {
+    wrapper = mount(<TextField type="password" canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(1);
   });
 
-  it('should not render reveal password button if showRevealPassword is not set', () => {
-    const component = renderer.create(<TextField type="password" />);
-    const tree = component.toJSON();
-    expect(tree).toMatchSnapshot();
+  it('ignores canRevealPassword if type is unspecified', () => {
+    wrapper = mount(<TextField canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
+  });
+
+  it('ignores canRevealPassword if type is not password', () => {
+    wrapper = mount(<TextField type="text" canRevealPassword />);
+    expect(wrapper.find('.ms-TextField-reveal')).toHaveLength(0);
   });
 
   it('should toggle reveal password on reveal button click', () => {
     wrapper = mount(<TextField type="password" canRevealPassword={true} />);
     const input = wrapper.find('input');
-    const reveal = wrapper.find('button');
+    const reveal = wrapper.find('.ms-TextField-reveal');
 
     input.simulate('input', mockEvent('Password123$'));
     expect((input.getDOMNode() as HTMLInputElement).type).toEqual('password');

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -252,8 +252,8 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   autoComplete?: string;
 
   /**
-   * Whether to show the reveal password button for input type 'password'
-   * @defaultvalue true
+   * Whether to show the reveal password button for input type `'password'` (will be ignored unless
+   * the `type` prop is set to `'password'`).
    */
   canRevealPassword?: boolean;
 
@@ -297,7 +297,7 @@ export type ITextFieldStyleProps = Required<Pick<ITextFieldProps, 'theme'>> &
     hasLabel?: boolean;
     /** Element has focus. */
     focused?: boolean;
-    /** Element has a peek button for Passwords */
+    /** Element has a peek button for passwords */
     hasRevealButton?: boolean;
   };
 

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -1,539 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TextField basic props should not render reveal password button if showRevealPassword is not set 1`] = `
-<div
-  className=
-      ms-TextField
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
-  <div
-    className="ms-TextField-wrapper"
-  >
-    <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
-            forced-color-adjust: none;
-          }
-    >
-      <input
-        aria-invalid={false}
-        className=
-            ms-TextField-field
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
-            }
-            &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="password"
-        value=""
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`TextField basic props should not render reveal password button if showRevealPassword=false 1`] = `
-<div
-  className=
-      ms-TextField
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
-  <div
-    className="ms-TextField-wrapper"
-  >
-    <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
-            forced-color-adjust: none;
-          }
-    >
-      <input
-        aria-invalid={false}
-        className=
-            ms-TextField-field
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
-            }
-            &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="password"
-        value=""
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`TextField basic props should render reveal password button if showRevealPassword=true 1`] = `
-<div
-  className=
-      ms-TextField
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        box-shadow: none;
-        box-sizing: border-box;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        margin-bottom: 0px;
-        margin-left: 0px;
-        margin-right: 0px;
-        margin-top: 0px;
-        padding-bottom: 0px;
-        padding-left: 0px;
-        padding-right: 0px;
-        padding-top: 0px;
-        position: relative;
-      }
->
-  <div
-    className="ms-TextField-wrapper"
-  >
-    <div
-      className=
-          ms-TextField-fieldGroup
-          {
-            align-items: stretch;
-            background: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
-            box-shadow: none;
-            box-sizing: border-box;
-            cursor: text;
-            display: flex;
-            flex-direction: row;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-          }
-          &:hover {
-            border-color: #323130;
-          }
-          @media screen and (-ms-high-contrast: active){&:hover {
-            border-color: Highlight;
-          }
-          @media screen and (forced-colors: active){&:hover {
-            forced-color-adjust: none;
-          }
-    >
-      <input
-        aria-invalid={false}
-        className=
-            ms-TextField-field
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              background: none;
-              border-radius: 0px;
-              border: none;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              min-width: 0px;
-              outline: 0px;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              text-overflow: ellipsis;
-              width: 100%;
-            }
-            &:active {
-              outline: 0px;
-            }
-            &:focus {
-              outline: 0px;
-            }
-            &:hover {
-              outline: 0px;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: Window;
-              color: WindowText;
-            }
-            &::placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::placeholder {
-              color: GrayText;
-            }
-            &:-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
-              color: GrayText;
-            }
-            &::-ms-input-placeholder {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #605e5c;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              opacity: 1;
-            }
-            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
-              color: GrayText;
-            }
-        id="TextField0"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onInput={[Function]}
-        type="password"
-        value=""
-      />
-      <button
-        className=
-            ms-TextField-reveal
-            ms-Button
-            ms-Button--icon
-            {
-              background-color: transparent;
-              border: none;
-              color: #0078d4;
-              height: 30px;
-              padding-bottom: 0px;
-              padding-left: 4px;
-              padding-right: 4px;
-              padding-top: 0px;
-              width: 32px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #106ebe;
-              outline: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:focus {
-              outline: 0px;
-            }
-        onClick={[Function]}
-      >
-        <span
-          className=
-
-              {
-                align-items: center;
-                display: flex;
-                height: 100%;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <i
-            aria-hidden={true}
-            className=
-
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  bottom: 6px;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons-1";
-                  font-size: 16px;
-                  font-style: normal;
-                  font-weight: normal;
-                  line-height: 18px;
-                  margin-bottom: 0px;
-                  margin-left: 4px;
-                  margin-right: 4px;
-                  margin-top: 0px;
-                  pointer-events: none;
-                  right: 8px;
-                  speak: none;
-                  top: auto;
-                }
-            data-icon-name="RedEye"
-          >
-            
-          </i>
-        </span>
-      </button>
-    </div>
-  </div>
-</div>
-`;
-
 exports[`TextField snapshots renders correctly 1`] = `
 <div
   className=
@@ -1841,6 +1307,229 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
         placeholder="test placeholder"
         value=""
       />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TextField snapshots renders with reveal password button 1`] = `
+<div
+  className=
+      ms-TextField
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        box-shadow: none;
+        box-sizing: border-box;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        margin-bottom: 0px;
+        margin-left: 0px;
+        margin-right: 0px;
+        margin-top: 0px;
+        padding-bottom: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        padding-top: 0px;
+        position: relative;
+      }
+>
+  <div
+    className="ms-TextField-wrapper"
+  >
+    <div
+      className=
+          ms-TextField-fieldGroup
+          {
+            align-items: stretch;
+            background: #ffffff;
+            border-radius: 2px;
+            border: 1px solid #605e5c;
+            box-shadow: none;
+            box-sizing: border-box;
+            cursor: text;
+            display: flex;
+            flex-direction: row;
+            height: 32px;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            padding-bottom: 0px;
+            padding-left: 0px;
+            padding-right: 0px;
+            padding-top: 0px;
+            position: relative;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            border-color: Highlight;
+          }
+          @media screen and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
+    >
+      <input
+        aria-invalid={false}
+        className=
+            ms-TextField-field
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              background: none;
+              border-radius: 0px;
+              border: none;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              min-width: 0px;
+              outline: 0px;
+              padding-bottom: 0;
+              padding-left: 8px;
+              padding-right: 8px;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &:active {
+              outline: 0px;
+            }
+            &:focus {
+              outline: 0px;
+            }
+            &:hover {
+              outline: 0px;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            &::placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
+            }
+            &:-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
+            &::-ms-input-placeholder {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
+            }
+        id="TextField0"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        type="password"
+        value=""
+      />
+      <button
+        className=
+            ms-TextField-reveal
+            ms-Button
+            ms-Button--icon
+            {
+              background-color: transparent;
+              border: none;
+              color: #0078d4;
+              height: 30px;
+              padding-bottom: 0px;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0px;
+              width: 32px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #106ebe;
+              outline: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:focus {
+              outline: 0px;
+            }
+        onClick={[Function]}
+      >
+        <span
+          className=
+
+              {
+                align-items: center;
+                display: flex;
+                height: 100%;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  bottom: 6px;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons-1";
+                  font-size: 16px;
+                  font-style: normal;
+                  font-weight: normal;
+                  line-height: 18px;
+                  margin-bottom: 0px;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0px;
+                  pointer-events: none;
+                  right: 8px;
+                  speak: none;
+                  top: auto;
+                }
+            data-icon-name="RedEye"
+          >
+            
+          </i>
+        </span>
+      </button>
     </div>
   </div>
 </div>

--- a/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
+++ b/packages/react-examples/src/office-ui-fabric-react/TextField/TextField.Basic.Example.tsx
@@ -26,7 +26,7 @@ export const TextFieldBasicExample: React.FunctionComponent = () => {
         <TextField label="With an icon" iconProps={iconProps} />
         <TextField label="With placeholder" placeholder="Please enter text here" />
         <TextField label="Disabled with placeholder" disabled placeholder="I am disabled" />
-        <TextField label="Password with Reveal Button" type="password" canRevealPassword={true} />
+        <TextField label="Password with reveal button" type="password" canRevealPassword />
       </Stack>
     </Stack>
   );

--- a/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/office-ui-fabric-react/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -1982,7 +1982,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
           htmlFor="TextField30"
           id="TextFieldLabel32"
         >
-          Password with Reveal Button
+          Password with reveal button
         </label>
         <div
           className=
@@ -2147,7 +2147,6 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                     display: flex;
                     height: 100%;
                   }
-              data-automationid="splitbuttonprimary"
             >
               <i
                 aria-hidden={true}

--- a/packages/utilities/src/ie11Detector.ts
+++ b/packages/utilities/src/ie11Detector.ts
@@ -1,7 +1,11 @@
+import { getWindow } from './dom/getWindow';
+
 export const isIE11 = (): boolean => {
-  if (typeof window === 'undefined' || !window.navigator || !window.navigator.userAgent) {
+  const win = getWindow();
+
+  if (!win?.navigator?.userAgent) {
     return false;
   }
 
-  return window.navigator.userAgent.indexOf('rv:11.0') > -1;
+  return win.navigator.userAgent.indexOf('rv:11.0') > -1;
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

While porting the original reveal password change back to master (see #15720) I noticed some fixes or optimizations that could be made:
- Simplify logic for when to show the button/how to determine the type of the field
- Use shared utilities `getWindow` and `isIE11` when determining whether the button is needed (and cache the result)
- Use semantic colors not palette colors (I verified that these colors map to the same values by default)
- Improving tests: while we should have a snapshot test for the field with a button, it's good to also have tests that explicitly check for the button. Also good to verify that canRevealPassword is only respected for type=password.
- Fix docs: they incorrectly stated that canRevealPassword defaults to true (looks like it did in the original implementation), and clarify that it's only respected for type=password

I also noticed that the `isIE11` utility wasn't using `getWindow` internally, so I fixed that.

(cc @hutchcodes since it won't let me add you as a reviewer)