### PR TITLE
Major bump react-window-provider and export from OUFR

### DIFF
--- a/change/@fluentui-react-window-provider-2020-10-27-16-24-37-export-window-provider-7.json
+++ b/change/@fluentui-react-window-provider-2020-10-27-16-24-37-export-window-provider-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Major bump version to 1.0.0 to avoid package duplication.",
+  "packageName": "@fluentui/react-window-provider",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T23:24:37.914Z"
+}

--- a/change/@uifabric-react-hooks-2020-10-27-16-24-37-export-window-provider-7.json
+++ b/change/@uifabric-react-hooks-2020-10-27-16-24-37-export-window-provider-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Update react-window-provider package version.",
+  "packageName": "@uifabric/react-hooks",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "none",
+  "date": "2020-10-27T23:24:10.823Z"
+}

--- a/change/office-ui-fabric-react-2020-10-27-16-24-37-export-window-provider-7.json
+++ b/change/office-ui-fabric-react-2020-10-27-16-24-37-export-window-provider-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export react-window-provider.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-27T23:23:34.819Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -10108,6 +10108,7 @@ export class VirtualizedComboBox extends React.Component<IComboBoxProps, {}> imp
 
 
 export * from "@fluentui/react-focus";
+export * from "@fluentui/react-window-provider";
 export * from "@uifabric/icons";
 export * from "@uifabric/styling";
 export * from "@uifabric/utilities";

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -66,9 +66,10 @@
     "storybook-addon-performance": "^0.9.0"
   },
   "dependencies": {
-    "@fluentui/react-focus": "^7.16.15",
-    "@microsoft/load-themed-styles": "^1.10.26",
     "@fluentui/date-time-utilities": "^7.9.0",
+    "@fluentui/react-focus": "^7.16.15",
+    "@fluentui/react-window-provider": "^1.0.0",
+    "@microsoft/load-themed-styles": "^1.10.26",
     "@uifabric/foundation": "^7.9.16",
     "@uifabric/icons": "^7.5.14",
     "@uifabric/merge-styles": "^7.19.1",
@@ -76,7 +77,6 @@
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/styling": "^7.16.15",
     "@uifabric/utilities": "^7.33.1",
-    "@fluentui/react-window-provider": "^0.3.3",
     "prop-types": "^15.7.2",
     "tslib": "^1.10.0"
   },

--- a/packages/office-ui-fabric-react/src/Utilities.ts
+++ b/packages/office-ui-fabric-react/src/Utilities.ts
@@ -1,3 +1,2 @@
 import './version';
 export * from '@uifabric/utilities';
-export * from '@fluentui/react-window-provider';

--- a/packages/office-ui-fabric-react/src/Utilities.ts
+++ b/packages/office-ui-fabric-react/src/Utilities.ts
@@ -1,2 +1,3 @@
 import './version';
 export * from '@uifabric/utilities';
+export * from '@fluentui/react-window-provider';

--- a/packages/office-ui-fabric-react/src/WindowProvider.ts
+++ b/packages/office-ui-fabric-react/src/WindowProvider.ts
@@ -1,0 +1,2 @@
+import './version';
+export * from '@fluentui/react-window-provider';

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -83,5 +83,6 @@ export * from './ThemeGenerator';
 export * from './Toggle';
 export * from './Tooltip';
 export * from './Utilities';
+export * from './WindowProvider';
 
 import './version';

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { BaseDecorator } from './BaseDecorator';
 import { getWindow, hoistStatics, EventGroup } from '../../Utilities';
-import { WindowContext } from '@fluentui/react-window-provider';
+import { WindowContext } from '../../WindowProvider';
 
 export interface IWithResponsiveModeState {
   responsiveMode?: ResponsiveMode;

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -40,7 +40,7 @@
     "react-dom": "16.8.6"
   },
   "dependencies": {
-    "@fluentui/react-window-provider": "^0.3.3",
+    "@fluentui/react-window-provider": "^1.0.0",
     "@uifabric/set-version": "^7.0.23",
     "@uifabric/utilities": "^7.33.1",
     "tslib": "^1.10.0"

--- a/packages/react-window-provider/package.json
+++ b/packages/react-window-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fluentui/react-window-provider",
-  "version": "0.3.3",
+  "version": "1.0.0",
   "description": "Utilities for providing and consuming the window/document objects even across portal/iframe/child-window boundaries.",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Related issue: #15727

- Major bump `react-window-provider` to `1.0.0` since it's used by other in-production packages. From [versioning perspective](https://semver.org/spec/v1.0.0.html#how-do-i-know-when-to-release-100), it's more correct to be versioned as `v1` instead of `v0`. Having versioned `v1` can also help avoid package duplications:
![image](https://user-images.githubusercontent.com/1207059/97372931-f7a3a480-1871-11eb-818b-4636cf0f1fac.png)

- export all from `@fluentui/react-window-provider` from OUFR (under `lib/WindowProvider`).
#### Focus areas to test

(optional)
