### PR TITLE
Add versioning to generate-package-manifest (master)

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -134,17 +134,17 @@ steps:
     displayName: 'Publish Artifact: Fabric Website Resources'
 
   - script: |
-      yarn workspace @fluentui/scripts just generate-package-manifest
+      node ./scripts/generate-package-manifest
     displayName: 'Generates a package manifest'
 
   - task: AzureUpload@2
     displayName: Upload Package Manifest
     inputs:
-      SourcePath: 'package-manifest.json'
+      SourcePath: 'package-manifest'
       azureSubscription: 'UI Fabric (private)'
       storage: fabricweb
       ContainerName: 'fabric'
-      BlobPrefix: 'package-manifest/latest'
+      BlobPrefix: ''
       Gzip: false
 
   - template: .devops/templates/cleanup.yml

--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -144,7 +144,7 @@ steps:
       azureSubscription: 'UI Fabric (private)'
       storage: fabricweb
       ContainerName: 'fabric'
-      BlobPrefix: ''
+      BlobPrefix: 'package-manifest'
       Gzip: false
 
   - template: .devops/templates/cleanup.yml

--- a/scripts/generate-package-manifest.js
+++ b/scripts/generate-package-manifest.js
@@ -1,0 +1,20 @@
+// @ts-check
+const path = require('path');
+const fs = require('fs-extra');
+const semver = require('semver');
+const { getAllPackageInfo, findGitRoot } = require('./monorepo/index');
+
+// Generate "manifest" file with package.jsons of all the monorepo packages (mainly for ODSP)
+
+const allPackageInfo = getAllPackageInfo();
+const fuirVersion = allPackageInfo['@fluentui/react'].packageJson.version;
+const packageInfoString = JSON.stringify(allPackageInfo, null, 2);
+
+const manifestRoot = path.join(findGitRoot(), 'package-manifest');
+const dests = [fuirVersion, path.join('latest', String(semver.major(fuirVersion)))];
+
+for (const dest of dests) {
+  const destFolder = path.join(manifestRoot, dest);
+  fs.mkdirpSync(destFolder);
+  fs.writeFileSync(path.join(destFolder, 'package-manifest.json'), packageInfoString);
+}

--- a/scripts/just.config.ts
+++ b/scripts/just.config.ts
@@ -15,7 +15,6 @@ import { lintImports } from './tasks/lint-imports';
 import { prettier } from './tasks/prettier';
 import { checkForModifiedFiles } from './tasks/check-for-modified-files';
 import { generateVersionFiles } from './tasks/generate-version-files';
-import { generatePackageManifestTask } from './tasks/generate-package-manifest';
 import { postprocessTask } from './tasks/postprocess';
 import { postprocessAmdTask } from './tasks/postprocess-amd';
 import { postprocessCommonjsTask } from './tasks/postprocess-commonjs';
@@ -82,7 +81,6 @@ export function preset() {
   task('prettier', prettier);
   task('check-for-modified-files', checkForModifiedFiles);
   task('generate-version-files', generateVersionFiles);
-  task('generate-package-manifest', generatePackageManifestTask);
   task('storybook:start', startStorybookTask());
   task('storybook:build', buildStorybookTask());
 

--- a/scripts/tasks/generate-package-manifest.ts
+++ b/scripts/tasks/generate-package-manifest.ts
@@ -1,9 +1,0 @@
-import * as path from 'path';
-import * as fs from 'fs';
-import { getAllPackageInfo, findGitRoot } from '../monorepo/index';
-
-export function generatePackageManifestTask() {
-  const allPackageInfo = getAllPackageInfo();
-  const root = findGitRoot();
-  fs.writeFileSync(path.join(root, 'package-manifest.json'), JSON.stringify(allPackageInfo, null, 2));
-}


### PR DESCRIPTION
Instead of only saving the latest manifest version, put them in a versioned structure (in the blob storage container).
```
package-manifest/
  latest/
    7/package-manifest.json
    8/package-manifest.json
  x.y.z/package-manifest.json
```

cc @dmichon-msft 