### PR TITLE
Fix React as external config

### DIFF
--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -205,8 +205,16 @@ module.exports = {
               : output,
 
           externals: {
-            react: 'React',
-            'react-dom': 'ReactDOM',
+            react: {
+              commonjs: 'react',
+              amd: 'react',
+              root: 'React',
+            },
+            'react-dom': {
+              commonjs: 'react-dom',
+              amd: 'react-dom',
+              root: 'ReactDOM',
+            },
           },
 
           resolve: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10349
- [x] Include a change request file using `$ yarn change`

#### Description of changes

As mentioned in the #10349, fluentui-react's build is configured to be able to use React as an external but *only* as a global. This change fixes that by using the proper config that will allow using external React as a global as well as with other methodologies (such as with SystemJS for in-browser module resolution).

#### Focus areas to test

- Inspect the output bundle and verify that:
  - `require("React"),require("ReactDOM")` is no longer present
  -  the correct casing `require("react"),require("react-dom")` is included
- Verify that it still works with React as a global (eg. react provided via a CDN)

### Notes

I wasn't able to find how to actually build the final bundle to be able to test these changes as I've described above.