### PR TITLE
Charting: Make x axis tick count default  value to 6 for Cartesian chart and use the xAxisTickCount prop

### DIFF
--- a/change/@fluentui-react-charting-2020-10-29-23-42-16-user-v-gorraj-Tsk_4604077.json
+++ b/change/@fluentui-react-charting-2020-10-29-23-42-16-user-v-gorraj-Tsk_4604077.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "Charting: Make x axis tick count default  value to 6 for Cartesian chart and use the xAxisTickCount prop",
+  "packageName": "@fluentui/react-charting",
+  "email": "v-gorraj@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-10-29T18:12:16.475Z"
+}

--- a/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
+++ b/packages/react-charting/src/components/CommonComponents/CartesianChart.types.ts
@@ -224,7 +224,7 @@ export interface ICartesianChartProps {
 
   /**
    * defines the number of ticks on the x-axis
-   * @default 10
+   * @default 6
    */
   xAxisTickCount?: number;
 

--- a/packages/react-charting/src/utilities/utilities.ts
+++ b/packages/react-charting/src/utilities/utilities.ts
@@ -133,9 +133,9 @@ export function createNumericXAxis(xAxisParams: IXAxisParams, isRtl: boolean) {
   const {
     domainNRangeValues,
     showRoundOffXTickValues = false,
-    xAxistickSize = 10,
+    xAxistickSize = 6,
     tickPadding = 10,
-    xAxisCount = 10,
+    xAxisCount = 6,
     xAxisElement,
   } = xAxisParams;
   const xAxisScale = d3ScaleLinear()
@@ -164,13 +164,14 @@ export function createNumericXAxis(xAxisParams: IXAxisParams, isRtl: boolean) {
  * @param {boolean} isRtl
  */
 export function createDateXAxis(xAxisParams: IXAxisParams, tickParams: ITickParams, isRtl: boolean) {
-  const { domainNRangeValues, xAxisElement } = xAxisParams;
+  const { domainNRangeValues, xAxisElement, xAxistickSize = 6, xAxisCount = 6 } = xAxisParams;
   const xAxisScale = d3ScaleTime()
     .domain([domainNRangeValues.dStartValue, domainNRangeValues.dEndValue])
     .range([domainNRangeValues.rStartValue, domainNRangeValues.rEndValue]);
   const xAxis = d3AxisBottom(xAxisScale)
-    .tickSize(10)
-    .tickPadding(10);
+    .tickSize(xAxistickSize)
+    .tickPadding(10)
+    .ticks(xAxisCount);
   tickParams.tickValues ? xAxis.tickValues(tickParams.tickValues) : '';
   tickParams.tickFormat ? xAxis.tickFormat(d3TimeFormat.timeFormat(tickParams.tickFormat)) : '';
   if (xAxisElement) {
@@ -192,7 +193,7 @@ export function createDateXAxis(xAxisParams: IXAxisParams, tickParams: ITickPara
  * @returns
  */
 export function createStringXAxis(xAxisParams: IXAxisParams, tickParams: ITickParams, dataset: string[]) {
-  const { domainNRangeValues, xAxisCount = 10, xAxistickSize = 10, tickPadding = 10, xAxisPadding = 0.1 } = xAxisParams;
+  const { domainNRangeValues, xAxisCount = 6, xAxistickSize = 6, tickPadding = 10, xAxisPadding = 0.1 } = xAxisParams;
   const xAxisScale = d3ScaleBand()
     .domain(dataset!)
     .range([domainNRangeValues.rStartValue, domainNRangeValues.rEndValue])


### PR DESCRIPTION

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Charting: Make x axis tick count default  value to 6 for Cartesian chart and to enable to use xAxisTickCount prop

#### Focus areas to test

chart x axis

#### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/13463251/97615000-b9a8ab00-1a40-11eb-820f-b29de6853a56.png)
**After**
![image](https://user-images.githubusercontent.com/13463251/97615031-c4634000-1a40-11eb-8e71-805a37775af4.png)


