### PR TITLE
Add preventDefault logic for toggle button label area

### DIFF
--- a/change/@fluentui-react-toggle-2020-11-02-09-54-50-t-xinywa-fix-clicking-issue-for-toggle-button-label-area.json
+++ b/change/@fluentui-react-toggle-2020-11-02-09-54-50-t-xinywa-fix-clicking-issue-for-toggle-button-label-area.json
@@ -1,0 +1,8 @@
+{
+  "type": "prerelease",
+  "comment": "update change file",
+  "packageName": "@fluentui/react-toggle",
+  "email": "t-xinywa@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-11-02T01:54:50.494Z"
+}

--- a/packages/react-examples/src/react-tabs/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Pivot.AlwaysRender.Example.tsx.shot
@@ -46,6 +46,7 @@ exports[`Component Examples renders Pivot.AlwaysRender.Example.tsx correctly 1`]
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Always render children
     </label>

--- a/packages/react-examples/src/react-tabs/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
+++ b/packages/react-examples/src/react-tabs/__snapshots__/Pivot.OverflowMenu.Example.tsx.shot
@@ -50,6 +50,7 @@ Array [
             }
         htmlFor="Toggle0"
         id="Toggle0-label"
+        onClick={[Function]}
       >
         overflow
       </label>
@@ -229,6 +230,7 @@ Array [
             }
         htmlFor="Toggle1"
         id="Toggle1-label"
+        onClick={[Function]}
       >
         linkFormat
       </label>
@@ -400,6 +402,7 @@ Array [
             }
         htmlFor="Toggle2"
         id="Toggle2-label"
+        onClick={[Function]}
       >
         direction
       </label>

--- a/packages/react-examples/src/react-toggle/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react-toggle/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -63,6 +63,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Enabled and checked
     </label>
@@ -241,6 +242,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle1"
       id="Toggle1-label"
+      onClick={[Function]}
     >
       Enabled and unchecked
     </label>
@@ -415,6 +417,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
+      onClick={[Function]}
     >
       Disabled and checked
     </label>
@@ -584,6 +587,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle3"
       id="Toggle3-label"
+      onClick={[Function]}
     >
       Disabled and unchecked
     </label>
@@ -751,6 +755,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle4"
       id="Toggle4-label"
+      onClick={[Function]}
     >
       With inline label
     </label>
@@ -927,6 +932,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle5"
       id="Toggle5-label"
+      onClick={[Function]}
     >
       Disabled with inline label
     </label>
@@ -1095,6 +1101,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle6"
       id="Toggle6-label"
+      onClick={[Function]}
     >
       With inline label and without onText and offText
     </label>
@@ -1230,6 +1237,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle7"
       id="Toggle7-label"
+      onClick={[Function]}
     >
       Disabled with inline label and without onText and offText
     </label>
@@ -1349,6 +1357,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle8"
       id="Toggle8-label"
+      onClick={[Function]}
     >
       Enabled and checked (ARIA 1.0 compatible)
     </label>

--- a/packages/react-examples/src/react-toggle/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/react-examples/src/react-toggle/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -62,6 +62,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       <div>
         Custom label
@@ -268,6 +269,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
+      onClick={[Function]}
     >
       <div>
         Custom inline label

--- a/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -1279,6 +1279,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
             }
         htmlFor="Toggle16"
         id="Toggle16-label"
+        onClick={[Function]}
       >
         Show preview box
       </label>

--- a/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -462,6 +462,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           }
       htmlFor="Toggle4"
       id="Toggle4-label"
+      onClick={[Function]}
     >
       Allow freeform
     </label>
@@ -599,6 +600,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           }
       htmlFor="Toggle5"
       id="Toggle5-label"
+      onClick={[Function]}
     >
       Auto-complete
     </label>

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
             }
         htmlFor="Toggle0"
         id="Toggle0-label"
+        onClick={[Function]}
       >
         Enable compact mode
       </label>
@@ -249,6 +250,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
             }
         htmlFor="Toggle1"
         id="Toggle1-label"
+        onClick={[Function]}
       >
         Enable modal selection
       </label>

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -54,6 +54,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
             }
         htmlFor="Toggle0"
         id="Toggle0-label"
+        onClick={[Function]}
       >
         Enable column reorder
       </label>

--- a/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -176,6 +176,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             }
         htmlFor="Toggle3"
         id="Toggle3-label"
+        onClick={[Function]}
       >
         Compact mode
       </label>
@@ -312,6 +313,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             }
         htmlFor="Toggle4"
         id="Toggle4-label"
+        onClick={[Function]}
       >
         Show index of first item in view when unmounting
       </label>

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -42,6 +42,7 @@ Array [
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
+      onClick={[Function]}
     >
       Is draggable
     </label>

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -42,6 +42,7 @@ Array [
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Is draggable
     </label>

--- a/packages/react-examples/src/react/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -47,6 +47,7 @@ Array [
             }
         htmlFor="Toggle0"
         id="Toggle0-label"
+        onClick={[Function]}
       >
         Is draggable
       </label>

--- a/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -63,6 +63,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Show error message
     </label>

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -85,6 +85,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
             }
         htmlFor="Toggle1"
         id="Toggle1-label"
+        onClick={[Function]}
       >
         Use trap zone
       </label>

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -267,6 +267,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
               }
           htmlFor="Toggle4"
           id="Toggle4-label"
+          onClick={[Function]}
         >
           Use trap zone
         </label>

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -267,6 +267,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
               }
           htmlFor="Toggle4"
           id="Toggle4-label"
+          onClick={[Function]}
         >
           Use trap zone
         </label>

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -85,6 +85,7 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
             }
         htmlFor="Toggle1"
         id="Toggle1-label"
+        onClick={[Function]}
       >
         Use trap zone
       </label>

--- a/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -86,6 +86,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               }
           htmlFor="Toggle1"
           id="Toggle1-label"
+          onClick={[Function]}
         >
           Enable trap zone 1
         </label>
@@ -417,6 +418,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   }
               htmlFor="Toggle6"
               id="Toggle6-label"
+              onClick={[Function]}
             >
               Enable trap zone 2
             </label>
@@ -748,6 +750,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       }
                   htmlFor="Toggle11"
                   id="Toggle11-label"
+                  onClick={[Function]}
                 >
                   Enable trap zone 3
                 </label>
@@ -1093,6 +1096,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       }
                   htmlFor="Toggle16"
                   id="Toggle16-label"
+                  onClick={[Function]}
                 >
                   Enable trap zone 4
                 </label>
@@ -1451,6 +1455,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   }
               htmlFor="Toggle21"
               id="Toggle21-label"
+              onClick={[Function]}
             >
               Enable trap zone 5
             </label>

--- a/packages/react-examples/src/react/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -46,6 +46,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Wrap the content box below in a Layer
     </label>

--- a/packages/react-examples/src/react/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -61,6 +61,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           }
       htmlFor="Toggle1"
       id="Toggle1-label"
+      onClick={[Function]}
     >
       Show panel
     </label>
@@ -194,6 +195,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
+      onClick={[Function]}
     >
       Trap panel
     </label>

--- a/packages/react-examples/src/react/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -53,6 +53,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle1"
       id="Toggle1-label"
+      onClick={[Function]}
     >
       Show host
     </label>
@@ -222,6 +223,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
+      onClick={[Function]}
     >
       Render the box below in a Layer and target it at hostId=layerHost0
     </label>
@@ -398,6 +400,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
           }
       htmlFor="Toggle3"
       id="Toggle3-label"
+      onClick={[Function]}
     >
       Render the box below in a Layer without specifying a host, fixing it to the top of the page
     </label>

--- a/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3625,6 +3625,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             }
         htmlFor="Toggle60"
         id="Toggle60-label"
+        onClick={[Function]}
       >
         Enable caching
       </label>
@@ -3754,6 +3755,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             }
         htmlFor="Toggle61"
         id="Toggle61-label"
+        onClick={[Function]}
       >
         Enable onGrowData
       </label>
@@ -3883,6 +3885,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
             }
         htmlFor="Toggle62"
         id="Toggle62-label"
+        onClick={[Function]}
       >
         Buttons checked
       </label>

--- a/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -42,6 +42,7 @@ Array [
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Toggle to load content
     </label>

--- a/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -51,6 +51,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Disable tag picker
     </label>

--- a/packages/react-examples/src/react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/react-examples/src/react/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -67,6 +67,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
           }
       htmlFor="Toggle0"
       id="Toggle0-label"
+      onClick={[Function]}
     >
       Show text fields
     </label>

--- a/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
@@ -136,7 +136,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
 
     return (
       <RootType ref={forwardedRef as React.Ref<HTMLDivElement>} {...slotProps.root}>
-        {label && <Label {...slotProps.label} />}
+        {label && <Label {...slotProps.label} onClick={(ev: React.MouseEvent<HTMLElement>) => {ev.preventDefault();}}/>}
         <div {...slotProps.container}>
           <button {...slotProps.pill}>
             <span {...slotProps.thumb} />

--- a/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
+++ b/packages/react-toggle/src/components/Toggle/Toggle.base.tsx
@@ -93,6 +93,10 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
       }
     };
 
+    const onClickLable = (ev: React.MouseEvent<HTMLElement>) => {
+      ev.preventDefault();
+    };
+
     const slotProps = {
       root: {
         className: classNames.root,
@@ -103,6 +107,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
         className: classNames.label,
         htmlFor: id,
         id: labelId,
+        onClick: onClickLable,
       },
       container: {
         className: classNames.container,
@@ -136,7 +141,7 @@ export const ToggleBase: React.FunctionComponent<IToggleProps> = React.forwardRe
 
     return (
       <RootType ref={forwardedRef as React.Ref<HTMLDivElement>} {...slotProps.root}>
-        {label && <Label {...slotProps.label} onClick={(ev: React.MouseEvent<HTMLElement>) => {ev.preventDefault();}}/>}
+        {label && <Label {...slotProps.label}/>}
         <div {...slotProps.container}>
           <button {...slotProps.pill}>
             <span {...slotProps.thumb} />

--- a/packages/react-toggle/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/react-toggle/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -142,6 +142,7 @@ exports[`Toggle renders toggle correctly 1`] = `
         }
     htmlFor="Toggle0"
     id="Toggle0-label"
+    onClick={[Function]}
   >
     Label
   </label>
@@ -276,6 +277,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
         }
     htmlFor="Toggle0"
     id="Toggle0-label"
+    onClick={[Function]}
   >
     <p>
       Label
@@ -412,6 +414,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
         }
     htmlFor="Toggle0"
     id="Toggle0-label"
+    onClick={[Function]}
   >
     Label
   </label>
@@ -545,6 +548,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
         }
     htmlFor="Toggle0"
     id="Toggle0-label"
+    onClick={[Function]}
   >
     Label
   </label>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #13721
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Prevent clicking on label area from changing the state of toggle.

#### Focus areas to test

(optional)
